### PR TITLE
feat(workflows): add the short-form video workflow pack

### DIFF
--- a/.archon/scripts/_common.py
+++ b/.archon/scripts/_common.py
@@ -1,0 +1,107 @@
+"""Shared helpers for the Archon video pack scripts.
+
+Named Archon script nodes execute as `uv run <path>`, so the script's own
+directory is on sys.path and this module imports cleanly from siblings.
+(Inline `script: |` nodes run via `python -c` and could NOT import this.)
+
+Node-to-node data moves through files under the run's work directory rather
+than through `$nodeId.output`: named scripts don't get output substitution,
+and the payloads here are media files anyway.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import sys
+
+# .archon/scripts/_common.py -> parents[2] is the project root
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+def log(msg: str) -> None:
+    """Progress goes to stderr; stdout is the node's captured output."""
+    print(msg, file=sys.stderr, flush=True)
+
+
+def load_env() -> dict[str, str]:
+    """Read .env from the project root, letting the real environment win.
+
+    Archon injects managed per-project env vars into script subprocesses, so
+    once this project is registered the .env file becomes a local-dev
+    convenience rather than the source of truth.
+    """
+    env: dict[str, str] = {}
+    f = ROOT / ".env"
+    if f.exists():
+        for line in f.read_text().splitlines():
+            line = line.strip()
+            if line and not line.startswith("#") and "=" in line:
+                k, v = line.split("=", 1)
+                env[k.strip()] = v.strip()
+    for k in list(env):
+        if os.environ.get(k):
+            env[k] = os.environ[k]
+    return env
+
+
+def require_key(env: dict[str, str], name: str) -> str:
+    val = env.get(name) or os.environ.get(name, "")
+    if not val:
+        raise SystemExit(f"{name} is not set (add it to {ROOT / '.env'})")
+    return val
+
+
+def work_dir() -> pathlib.Path:
+    """The run's working directory.
+
+    Inside Archon this is $ARTIFACTS_DIR (pre-created by the executor, and
+    outside the repo so nothing lands in git status). Standalone runs fall
+    back to ./work/local so the scripts stay testable without the engine.
+    """
+    d = os.environ.get("ARTIFACTS_DIR") or str(ROOT / "work" / "local")
+    p = pathlib.Path(d)
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def read_json(name: str) -> dict:
+    p = work_dir() / name
+    if not p.exists():
+        raise SystemExit(f"missing {p} — an upstream node did not produce it")
+    return json.loads(p.read_text())
+
+
+def write_json(name: str, data: object) -> pathlib.Path:
+    p = work_dir() / name
+    p.write_text(json.dumps(data, indent=2))
+    return p
+
+
+def run(cmd: list[str], quiet: bool = False) -> str:
+    """Run a subprocess, failing loudly with the tail of stderr."""
+    if not quiet:
+        log(f"$ {cmd[0]} {' '.join(cmd[1:4])} …")
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    if r.returncode != 0:
+        log(r.stderr[-3000:])
+        raise SystemExit(f"{cmd[0]} failed with exit {r.returncode}")
+    return r.stdout
+
+
+def probe(path: pathlib.Path) -> dict:
+    """ffprobe a media file into a dict."""
+    out = run(
+        [
+            "ffprobe", "-v", "error", "-print_format", "json",
+            "-show_format", "-show_streams", str(path),
+        ],
+        quiet=True,
+    )
+    return json.loads(out)
+
+
+def media_duration(path: pathlib.Path) -> float:
+    return float(probe(path)["format"]["duration"])

--- a/.archon/scripts/build-captions.py
+++ b/.archon/scripts/build-captions.py
@@ -1,0 +1,121 @@
+"""Turn Cartesia word timings into karaoke-style ASS captions.
+
+Words are grouped into short chunks; every word gets its own event showing the
+whole chunk with the active word highlighted. That is the read-along look
+short-form viewers expect, and it comes straight from the TTS timings.
+
+Reads  : words.json, brief.json (optional caption_style)
+Writes : captions.ass
+"""
+
+from __future__ import annotations
+
+import re
+
+from _common import read_json, work_dir
+
+PLAY_W, PLAY_H = 1080, 1920
+FONT = "Arial Black"
+FONT_SIZE = 82
+MARGIN_V = 520          # distance up from the bottom edge
+MAX_WORDS_PER_CHUNK = 3
+MAX_CHARS_PER_CHUNK = 18   # ~940px safe area at 82px Arial Black
+
+WHITE = "&HFFFFFF&"
+HIGHLIGHT = "&H00FFFF&"  # ASS inline colour is &HBBGGRR& -> this is yellow
+
+HEADER = f"""[Script Info]
+ScriptType: v4.00+
+PlayResX: {PLAY_W}
+PlayResY: {PLAY_H}
+WrapStyle: 0
+ScaledBorderAndShadow: yes
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+Style: Cap,{FONT},{FONT_SIZE},&H00FFFFFF,&H000000FF,&H00000000,&H96000000,-1,0,0,0,100,100,0,0,1,7,4,2,70,70,{MARGIN_V},1
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+"""
+
+
+def fmt_time(seconds: float) -> str:
+    """ASS timestamps are H:MM:SS.cc (centiseconds)."""
+    seconds = max(0.0, seconds)
+    cs = int(round(seconds * 100))
+    h, cs = divmod(cs, 360000)
+    m, cs = divmod(cs, 6000)
+    s, cs = divmod(cs, 100)
+    return f"{h}:{m:02d}:{s:02d}.{cs:02d}"
+
+
+def chunk_words(words: list[dict]) -> list[list[dict]]:
+    """Group words into short, readable phrases that break on punctuation."""
+    chunks: list[list[dict]] = []
+    current: list[dict] = []
+    length = 0
+    for w in words:
+        text = w["word"]
+        if current and (
+            len(current) >= MAX_WORDS_PER_CHUNK or length + len(text) + 1 > MAX_CHARS_PER_CHUNK
+        ):
+            chunks.append(current)
+            current, length = [], 0
+        current.append(w)
+        length += len(text) + 1
+        if re.search(r"[.!?,;:]$", text):
+            chunks.append(current)
+            current, length = [], 0
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def escape(text: str) -> str:
+    return text.replace("\\", "").replace("{", "").replace("}", "")
+
+
+def main() -> None:
+    data = read_json("words.json")
+    words = data["words"]
+    if not words:
+        raise SystemExit("words.json contains no timings")
+
+    lines: list[str] = []
+    chunks = chunk_words(words)
+    for c, chunk in enumerate(chunks):
+        # Never let a chunk's last word bleed past the next chunk's first word:
+        # overlapping ASS events render stacked on top of each other.
+        next_start = chunks[c + 1][0]["start"] if c + 1 < len(chunks) else None
+        for i, active in enumerate(chunk):
+            rendered = " ".join(
+                (
+                    f"{{\\c{HIGHLIGHT}}}{escape(w['word'].upper())}{{\\c{WHITE}}}"
+                    if j == i
+                    else escape(w["word"].upper())
+                )
+                for j, w in enumerate(chunk)
+            )
+            start = active["start"]
+            if i + 1 < len(chunk):
+                end = chunk[i + 1]["start"]
+            else:
+                # Hold the final word a beat so it doesn't flash away, but stop
+                # before the next chunk appears.
+                end = active["end"] + 0.12
+                if next_start is not None:
+                    end = min(end, next_start)
+            if end <= start:
+                end = start + 0.08
+            lines.append(
+                f"Dialogue: 0,{fmt_time(start)},{fmt_time(end)},Cap,,0,0,0,,{rendered}"
+            )
+
+    path = work_dir() / "captions.ass"
+    path.write_text(HEADER + "\n".join(lines) + "\n")
+    print(f"wrote {len(lines)} caption events")
+
+
+if __name__ == "__main__":
+    main()

--- a/.archon/scripts/compose-video.py
+++ b/.archon/scripts/compose-video.py
@@ -1,0 +1,113 @@
+"""Assemble clips + narration + music + captions into the finished short.
+
+One ffmpeg invocation does the whole job: each clip is looped to fill its
+segment, cropped to 1080x1920, concatenated, captioned, and mixed against a
+ducked music bed.
+
+Reads  : clips.json, words.json, narration.wav, captions.ass, brief.json
+Writes : video.mp4
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import random
+
+from _common import ROOT, log, read_json, run, work_dir
+
+OUT_W, OUT_H, FPS = 1080, 1920, 30
+SECONDS_PER_CLIP = 4.0      # preferred visual cut cadence
+MAX_SECONDS_PER_CLIP = 6.5  # slower than this and a shot starts to drag
+TAIL_PADDING = 0.45         # breathing room after the last word
+MUSIC_VOLUME = 0.10
+
+
+def pick_music() -> pathlib.Path | None:
+    d = ROOT / "assets" / "music"
+    tracks = sorted(p for p in d.glob("*") if p.suffix.lower() in {".mp3", ".wav", ".m4a"})
+    return random.choice(tracks) if tracks else None
+
+
+def main() -> None:
+    wd = work_dir()
+    clips = read_json("clips.json")
+    words = read_json("words.json")
+
+    narration = wd / "narration.wav"
+    captions = wd / "captions.ass"
+    for required in (narration, captions):
+        if not required.exists():
+            raise SystemExit(f"missing {required}")
+
+    total = float(words["duration"]) + TAIL_PADDING
+    ideal = max(1, round(total / SECONDS_PER_CLIP))
+    if len(clips) >= ideal:
+        chosen = clips[:ideal]
+    elif total / len(clips) <= MAX_SECONDS_PER_CLIP:
+        # Slightly longer shots beat showing the same footage twice.
+        chosen = list(clips)
+    else:
+        # Genuinely not enough footage — cycle, and say so.
+        chosen = [clips[i % len(clips)] for i in range(ideal)]
+        log(f"WARN  only {len(clips)} clips for {ideal} segments — footage will repeat")
+    seg = total / len(chosen)
+    log(f"composing {total:.2f}s from {len(chosen)} segments of {seg:.2f}s")
+
+    music = pick_music()
+    args: list[str] = ["ffmpeg", "-y", "-loglevel", "error"]
+    for clip in chosen:
+        args += ["-stream_loop", "-1", "-t", f"{seg:.3f}", "-i", str(wd / clip["path"])]
+    args += ["-i", str(narration)]
+    narration_idx = len(chosen)
+    if music:
+        log(f"music bed: {music.name}")
+        args += ["-stream_loop", "-1", "-i", str(music)]
+
+    parts: list[str] = []
+    for i in range(len(chosen)):
+        parts.append(
+            f"[{i}:v]scale={OUT_W}:{OUT_H}:force_original_aspect_ratio=increase,"
+            f"crop={OUT_W}:{OUT_H},fps={FPS},setsar=1,format=yuv420p[v{i}]"
+        )
+    parts.append("".join(f"[v{i}]" for i in range(len(chosen)))
+                 + f"concat=n={len(chosen)}:v=1:a=0[vcat]")
+    # ass= takes a bare filename; we chdir to the work dir so no path escaping is needed.
+    parts.append(f"[vcat]ass={captions.name}[vout]")
+
+    if music:
+        parts.append(f"[{narration_idx}:a]aresample=44100,volume=1.0[na]")
+        parts.append(
+            f"[{narration_idx + 1}:a]aresample=44100,volume={MUSIC_VOLUME},"
+            f"afade=t=out:st={max(0.0, total - 1.2):.3f}:d=1.2[ma]"
+        )
+        parts.append("[na][ma]amix=inputs=2:duration=first:dropout_transition=0,"
+                     "alimiter=limit=0.89:level=disabled[aout]")
+    else:
+        parts.append(f"[{narration_idx}:a]aresample=44100,alimiter=limit=0.89:level=disabled[aout]")
+
+    out = wd / "video.mp4"
+    args += [
+        "-filter_complex", ";".join(parts),
+        "-map", "[vout]", "-map", "[aout]",
+        "-t", f"{total:.3f}",
+        "-c:v", "libx264", "-preset", "medium", "-crf", "20",
+        "-pix_fmt", "yuv420p", "-r", str(FPS),
+        "-c:a", "aac", "-b:a", "192k",
+        "-movflags", "+faststart",
+        str(out),
+    ]
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(wd)
+        run(args)
+    finally:
+        os.chdir(cwd)
+
+    size_mb = out.stat().st_size / 1e6
+    print(f"video.mp4 {size_mb:.1f}MB, {total:.2f}s, {len(chosen)} segments")
+
+
+if __name__ == "__main__":
+    main()

--- a/.archon/scripts/fetch-clips.py
+++ b/.archon/scripts/fetch-clips.py
@@ -1,0 +1,111 @@
+"""Download portrait stock clips from Pexels for the current brief.
+
+Reads  : brief.json           (keywords)
+Writes : clips/NN-<id>.mp4, clips.json
+"""
+
+from __future__ import annotations
+
+import requests
+
+from _common import load_env, log, read_json, require_key, work_dir, write_json
+
+MAX_CLIPS = 8
+TARGET_W, TARGET_H = 1080, 1920
+
+
+def pick_file(video: dict) -> dict | None:
+    """Prefer the smallest portrait rendition that still covers 1080x1920."""
+    portrait = [f for f in video["video_files"] if f.get("height", 0) > f.get("width", 0)]
+    if not portrait:
+        return None
+    covering = [f for f in portrait if f["height"] >= TARGET_H and f["width"] >= TARGET_W]
+    if covering:
+        return min(covering, key=lambda f: f["width"] * f["height"])
+    return max(portrait, key=lambda f: f["width"] * f["height"])
+
+
+def main() -> None:
+    env = load_env()
+    key = require_key(env, "PEXELS_API_KEY")
+    brief = read_json("brief.json")
+    keywords: list[str] = [k for k in brief.get("keywords", []) if k.strip()]
+    if not keywords:
+        raise SystemExit("brief.json has no keywords")
+
+    out_dir = work_dir() / "clips"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    session = requests.Session()
+    session.headers["Authorization"] = key
+
+    manifest: list[dict] = []
+    seen: set[int] = set()
+
+    for kw in keywords:
+        if len(manifest) >= MAX_CLIPS:
+            break
+        try:
+            r = session.get(
+                "https://api.pexels.com/videos/search",
+                params={
+                    "query": kw,
+                    "per_page": 8,
+                    "orientation": "portrait",
+                    "size": "medium",
+                },
+                timeout=30,
+            )
+            r.raise_for_status()
+        except requests.RequestException as err:
+            # One dead keyword shouldn't sink the run — but say so loudly.
+            log(f"WARN  search failed for {kw!r}: {err}")
+            continue
+
+        for video in r.json().get("videos", []):
+            if video["id"] in seen:
+                continue
+            # Very short clips produce visible stutter once looped to fill a segment.
+            if video.get("duration", 0) < 5:
+                continue
+            f = pick_file(video)
+            if not f:
+                continue
+
+            dest = out_dir / f"{len(manifest):02d}-{video['id']}.mp4"
+            try:
+                with session.get(f["link"], stream=True, timeout=120) as resp:
+                    resp.raise_for_status()
+                    with dest.open("wb") as fh:
+                        for chunk in resp.iter_content(1 << 16):
+                            fh.write(chunk)
+            except requests.RequestException as err:
+                log(f"WARN  download failed for video {video['id']}: {err}")
+                dest.unlink(missing_ok=True)
+                continue
+
+            seen.add(video["id"])
+            manifest.append(
+                {
+                    "keyword": kw,
+                    "pexels_id": video["id"],
+                    "path": str(dest.relative_to(work_dir())),
+                    "duration": video["duration"],
+                    "width": f["width"],
+                    "height": f["height"],
+                    "credit": video.get("user", {}).get("name", "unknown"),
+                    "url": video.get("url", ""),
+                }
+            )
+            log(f"  got {kw!r} -> {dest.name} ({f['width']}x{f['height']}, {video['duration']}s)")
+            break  # one clip per keyword keeps the visuals varied
+
+    if not manifest:
+        raise SystemExit("no usable portrait clips found for any keyword")
+
+    write_json("clips.json", manifest)
+    print(f"downloaded {len(manifest)} clips")
+
+
+if __name__ == "__main__":
+    main()

--- a/.archon/scripts/quality-check.py
+++ b/.archon/scripts/quality-check.py
@@ -1,0 +1,136 @@
+"""Technical QC on the finished video, plus frame stills for visual review.
+
+This node judges only what is objectively measurable — geometry, sync, audio
+levels, dead frames. Whether the video is any *good* is the vision node's job;
+mixing the two would let a model talk us out of a real defect.
+
+Reads  : video.mp4, words.json
+Writes : quality.json, frames/frame-N.jpg
+Exits non-zero on defects that make the video unusable.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+
+from _common import log, probe, read_json, work_dir, write_json
+
+EXPECT_W, EXPECT_H = 1080, 1920
+DURATION_TOLERANCE = 1.0   # seconds of drift from the narration we accept
+MIN_MEAN_DB = -32.0        # quieter than this and the voice is inaudible
+MAX_PEAK_DB = -0.5         # louder than this and we are clipping
+N_FRAMES = 6
+
+
+def ffmpeg_stderr(args: list[str]) -> str:
+    return subprocess.run(
+        ["ffmpeg", "-hide_banner", *args], capture_output=True, text=True
+    ).stderr
+
+
+def main() -> None:
+    wd = work_dir()
+    video = wd / "video.mp4"
+    if not video.exists():
+        raise SystemExit("video.mp4 was not produced")
+
+    words = read_json("words.json")
+    meta = probe(video)
+    vstream = next((s for s in meta["streams"] if s["codec_type"] == "video"), None)
+    astream = next((s for s in meta["streams"] if s["codec_type"] == "audio"), None)
+
+    checks: list[dict] = []
+
+    def check(name: str, ok: bool, detail: str, fatal: bool = False) -> None:
+        checks.append({"check": name, "ok": ok, "detail": detail, "fatal": fatal})
+        log(f"  [{'ok ' if ok else 'FAIL'}] {name}: {detail}")
+
+    if not vstream:
+        raise SystemExit("no video stream")
+    w, h = vstream["width"], vstream["height"]
+    check("resolution", (w, h) == (EXPECT_W, EXPECT_H), f"{w}x{h}", fatal=True)
+
+    num, den = (vstream.get("r_frame_rate") or "0/1").split("/")
+    fps = float(num) / float(den or 1)
+    check("framerate", 29.0 <= fps <= 31.0, f"{fps:.2f} fps")
+
+    duration = float(meta["format"]["duration"])
+    expected = float(words["duration"])
+    drift = duration - expected
+    check(
+        "duration_vs_narration",
+        abs(drift) <= DURATION_TOLERANCE,
+        f"video {duration:.2f}s vs narration {expected:.2f}s (drift {drift:+.2f}s)",
+        fatal=True,
+    )
+
+    check("audio_stream", astream is not None, astream["codec_name"] if astream else "missing",
+          fatal=True)
+
+    vol = ffmpeg_stderr(["-i", str(video), "-af", "volumedetect", "-f", "null", "-"])
+    mean = re.search(r"mean_volume:\s*(-?[\d.]+) dB", vol)
+    peak = re.search(r"max_volume:\s*(-?[\d.]+) dB", vol)
+    mean_db = float(mean.group(1)) if mean else -99.0
+    peak_db = float(peak.group(1)) if peak else -99.0
+    check("audio_level", mean_db >= MIN_MEAN_DB, f"mean {mean_db:.1f} dB", fatal=True)
+    check("no_clipping", peak_db <= MAX_PEAK_DB, f"peak {peak_db:.1f} dB")
+
+    black = ffmpeg_stderr(
+        ["-i", str(video), "-vf", "blackdetect=d=0.4:pix_th=0.10", "-an", "-f", "null", "-"]
+    )
+    black_spans = re.findall(r"black_start:([\d.]+) black_end:([\d.]+)", black)
+    check(
+        "no_dead_frames",
+        not black_spans,
+        f"{len(black_spans)} black span(s)" + (f" at {black_spans[0][0]}s" if black_spans else ""),
+    )
+
+    frames_dir = wd / "frames"
+    frames_dir.mkdir(exist_ok=True)
+    for old in frames_dir.glob("frame-*.jpg"):
+        old.unlink()
+    for i in range(N_FRAMES):
+        # Sample inside the body of the video, skipping the very first/last frame.
+        t = duration * (i + 0.5) / N_FRAMES
+        subprocess.run(
+            ["ffmpeg", "-hide_banner", "-loglevel", "error", "-y", "-ss", f"{t:.2f}",
+             "-i", str(video), "-frames:v", "1", "-q:v", "3",
+             str(frames_dir / f"frame-{i + 1}.jpg")],
+            check=True,
+        )
+
+    failures = [c for c in checks if not c["ok"]]
+    fatal = [c for c in failures if c["fatal"]]
+    report = {
+        "video": str(video.relative_to(wd)),
+        "duration": duration,
+        "narration_duration": expected,
+        "resolution": f"{w}x{h}",
+        "fps": round(fps, 2),
+        "mean_db": mean_db,
+        "peak_db": peak_db,
+        "size_mb": round(video.stat().st_size / 1e6, 2),
+        "frames": sorted(str(p.relative_to(wd)) for p in frames_dir.glob("frame-*.jpg")),
+        "checks": checks,
+        "passed": not failures,
+    }
+    write_json("quality.json", report)
+
+    print(json.dumps({
+        "passed": not failures,
+        "fatal": len(fatal),
+        "warnings": len(failures) - len(fatal),
+        "duration": round(duration, 2),
+        "resolution": f"{w}x{h}",
+    }))
+
+    if fatal:
+        raise SystemExit(
+            "fatal QC failures: " + "; ".join(f"{c['check']} ({c['detail']})" for c in fatal)
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/.archon/scripts/tts-narrate.py
+++ b/.archon/scripts/tts-narrate.py
@@ -1,0 +1,112 @@
+"""Narrate the brief with Cartesia, capturing word-level timestamps.
+
+Because Cartesia returns word timings alongside the audio, there is no
+transcription stage: no Whisper model, no STT provider, and no risk of the
+captions disagreeing with a script we already know verbatim.
+
+Reads  : brief.json           (narration)
+Writes : narration.wav, words.json
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import requests
+
+from _common import load_env, log, read_json, require_key, run, work_dir, write_json
+
+API = "https://api.cartesia.ai/tts/sse"
+API_VERSION = "2026-03-01"
+MODEL = "sonic-3.5"
+DEFAULT_VOICE = "db6b0ed5-d5d3-463d-ae85-518a07d3c2b4"  # Skylar - Friendly Guide
+SAMPLE_RATE = 44100
+
+
+def main() -> None:
+    env = load_env()
+    key = require_key(env, "CARTESIA_API_KEY")
+    brief = read_json("brief.json")
+
+    transcript = (brief.get("narration") or "").strip()
+    if not transcript:
+        raise SystemExit("brief.json has no narration")
+    voice = brief.get("voice_id") or env.get("CARTESIA_VOICE_ID") or DEFAULT_VOICE
+
+    log(f"synthesising {len(transcript.split())} words with {MODEL}")
+    resp = requests.post(
+        API,
+        headers={
+            "X-API-Key": key,
+            "Cartesia-Version": API_VERSION,
+            "Content-Type": "application/json",
+        },
+        json={
+            "model_id": MODEL,
+            "transcript": transcript,
+            "voice": {"mode": "id", "id": voice},
+            # SSE only serves raw PCM; ffmpeg gives it a container below.
+            "output_format": {
+                "container": "raw",
+                "encoding": "pcm_f32le",
+                "sample_rate": SAMPLE_RATE,
+            },
+            "language": "en",
+            "add_timestamps": True,
+        },
+        timeout=180,
+        stream=True,
+    )
+    if not resp.ok:
+        raise SystemExit(f"Cartesia returned {resp.status_code}: {resp.text[:400]}")
+
+    pcm = bytearray()
+    words: list[dict] = []
+    for line in resp.iter_lines():
+        if not line or not line.startswith(b"data:"):
+            continue
+        try:
+            event = json.loads(line[5:].strip())
+        except json.JSONDecodeError:
+            continue
+        kind = event.get("type")
+        if kind == "chunk":
+            pcm += base64.b64decode(event["data"])
+        elif kind == "timestamps":
+            wt = event.get("word_timestamps", {})
+            words += [
+                {"word": w, "start": s, "end": e}
+                for w, s, e in zip(wt.get("words", []), wt.get("start", []), wt.get("end", []))
+            ]
+        elif kind == "error":
+            raise SystemExit(f"Cartesia stream error: {event.get('error')}")
+
+    if not pcm:
+        raise SystemExit("Cartesia returned no audio")
+    if not words:
+        raise SystemExit("Cartesia returned no word timestamps — captions would be guesswork")
+
+    wd = work_dir()
+    raw = wd / "narration.pcm"
+    raw.write_bytes(bytes(pcm))
+    wav = wd / "narration.wav"
+    run(
+        [
+            "ffmpeg", "-y", "-loglevel", "error",
+            "-f", "f32le", "-ar", str(SAMPLE_RATE), "-ac", "1", "-i", str(raw),
+            "-c:a", "pcm_s16le", str(wav),
+        ]
+    )
+    raw.unlink()
+
+    duration = len(pcm) / 4 / SAMPLE_RATE
+    write_json(
+        "words.json",
+        {"duration": duration, "voice_id": voice, "model": MODEL, "words": words},
+    )
+    print(f"narration {duration:.2f}s, {len(words)} word timings")
+
+
+if __name__ == "__main__":
+    main()

--- a/.archon/workflows/video/README.md
+++ b/.archon/workflows/video/README.md
@@ -1,0 +1,114 @@
+# Video workflow pack
+
+Short-form vertical video production as governed workflows. Topic in, finished
+1080x1920 MP4 out — narration, karaoke captions, and per-platform post copy —
+stored, logged, and reviewable.
+
+**It does not publish.** Runs stop at `store`.
+
+| Workflow | For | Voice |
+|---|---|---|
+| `social-short` | General-interest, insight-driven shorts | Third person, essayistic. No CTA. |
+| `ugc-video` | Testimonial / creator-style clips | First person, unpolished, keeps its caveats. No CTA. |
+| `product-video` | Marketing a product | Problem-first, one benefit, names the product. **CTA allowed.** |
+| `video-quality-review` | Craft review of a finished video | Human-gated; evolves the playbooks. |
+| `video-render-block` | Building block — **not run directly** | Included by the three above. |
+
+```bash
+archon workflow run social-short  "Why cities can feel lonelier than small towns"
+archon workflow run ugc-video     "I switched to a standing desk for 30 days"
+archon workflow run product-video "<what it is, who it's for, the one benefit>"
+archon workflow run video-quality-review        # reviews the most recent
+```
+
+## Setup — two keys and ffmpeg
+
+The scripts read these from the **repo-root `.env`** (or Archon-managed
+per-project env vars, which take precedence). They are deliberately not in this
+repo's `.env`, so an unconfigured run fails immediately and by name:
+
+```
+PEXELS_API_KEY is not set (add it to /path/to/repo/.env)
+```
+
+| Variable | Service | Cost |
+|---|---|---|
+| `PEXELS_API_KEY` | https://www.pexels.com/api/ — stock footage | free |
+| `CARTESIA_API_KEY` | https://cartesia.ai — TTS with word timestamps | ~$0.02–0.15/video |
+| `CARTESIA_VOICE_ID` | optional voice override | — |
+
+Also needs `ffmpeg` and `uv` on PATH. **No LLM key of its own** — script and copy
+generation use whatever provider Archon is configured with, via the `large` and
+`medium` tiers rather than pinned model names.
+
+`video-quality-review` is the one exception: it pins `provider: claude` because
+it must open the frame stills and judge them. Without a vision-capable provider
+that node fails loudly, which is correct — the alternative is a text-only model
+returning a confident verdict about images it never saw.
+
+## Shape
+
+```
+read-strategy ─> gen-brief ─┬─> write-brief ──┐
+                            └─> write-copy ─> save-copy ─┤
+                                                         ▼
+                                        include: video-render-block
+                    fetch-clips ─┐
+                    narrate ─> captions ─┴─> compose ─> qc ─> store
+```
+
+`video-render-block` makes no editorial decisions, which is why all three kinds
+reuse it unchanged. It holds **no references** to the including workflow's nodes
+— it reads `brief.json` and `copy.json` from `$ARTIFACTS_DIR` — so it survives
+the `<includeId>__<nodeId>` renaming that include expansion applies, and works
+on any provider.
+
+## No transcription stage
+
+Cartesia `sonic-3.5` returns word-level timestamps with the audio, so captions
+are built from timings for a script already known verbatim. No Whisper model, no
+STT bill, and no way for captions to disagree with the narration. Swapping TTS
+for a provider without word timings brings that whole stage back.
+
+## Per-kind playbooks
+
+The review loop maintains **separate** playbooks per kind plus a shared one:
+
+```
+$STATE_DIR/content/
+  strategy-common.md        craft mechanics only — caption legibility, audio, repetition
+  strategy-social-short.md  }
+  strategy-ugc.md           } voice, pacing, CTA policy, what copy may claim
+  strategy-product.md       }
+```
+
+This is not incidental. The three kinds have deliberately opposing rules — a
+first-person UGC clip and a benefit-led product ad disagree about hook, person,
+and permitted claims — so a craft lesson from one is frequently wrong for
+another. A single shared playbook let a product review silently rewrite the UGC
+rules, and `strategy_version` incremented through both so attribution looked
+clean while the content thrashed. The reviewer reads the kind from the video's
+`meta.json` and declares `target: kind | common`; it writes exactly one file.
+
+## Output
+
+Nothing lands in this repo. Per-run scratch is `$ARTIFACTS_DIR`; the durable
+library is `$STATE_DIR/content/videos/<run-id>/` with a `library.jsonl` ledger.
+`store` stages to `<run-id>.partial` and moves into place, so a failure part-way
+cannot leave a half-populated directory that looks stored.
+
+## Authoring gotchas these workflows encode
+
+- Media nodes **must** set `timeout:` — the subprocess default is 2 minutes and
+  an encode blows through it in a way that reads like a hang.
+- `worktree.enabled: false` is required, not an optimisation: `.env` is
+  gitignored, so an isolated checkout would not contain the API keys.
+- Consume an output ref as a **bare** shell word (`x=$node.output`). The engine
+  already shell-quotes it; adding your own quotes, or pasting it into a heredoc,
+  writes literal quote characters into the value.
+- `WORKFLOW_ID` is a substitution variable. Export it before any Python that
+  reads `os.environ` (see PR #2511, which also delivers it as a real env var).
+- Don't put a tier keyword in `model:` on a node that pins `provider:` — the
+  tier resolves its own provider and wins. Archon warns; read the warning.
+- OpenAI-backed providers require `required` to list **every** property in an
+  `output_format` schema.

--- a/.archon/workflows/video/product-video.yaml
+++ b/.archon/workflows/video/product-video.yaml
@@ -1,0 +1,171 @@
+# Product marketing video — benefit-led, names the product, CTA allowed.
+#
+#   archon workflow run product-video "Archon — a self-hostable engine that runs
+#   AI coding agents against your repos with approval gates and full audit trails.
+#   For engineering leads who won't let an agent merge unreviewed."
+#
+# Give it: what it is, who it's for, and the one benefit that matters. The more
+# specific the input, the less the model has to invent — and invented product
+# claims are the failure mode this workflow is most exposed to.
+name: product-video
+description: "Product description -> benefit-led marketing 1080x1920 short with narration, captions and post copy. Stores the file; does not publish."
+
+worktree:
+  enabled: false
+
+nodes:
+  # Two playbooks, deliberately: rules that are universal (caption legibility,
+  # audio levels, footage repetition) live in strategy-common.md, while rules
+  # specific to this kind live in its own file. A single shared playbook would
+  # let a lesson learned from a product ad silently rewrite the UGC rules, and
+  # those two have opposite instructions for hook, pacing and claims.
+  - id: read-strategy
+    bash: |
+      common="$STATE_DIR/content/strategy-common.md"
+      mine="$STATE_DIR/content/strategy-product.md"
+      found=0
+      if [ -f "$common" ]; then echo "## Universal craft rules"; cat "$common"; echo; found=1; fi
+      if [ -f "$mine" ]; then echo "## Rules for this video kind (product)"; cat "$mine"; found=1; fi
+      if [ "$found" -eq 0 ]; then
+        echo "(No playbook yet for product — this is the first run. Use your own judgement.)"
+      fi
+
+  # The script is the highest-leverage output in the pack, so it gets the
+  # top tier. Tiers (not literal model strings) keep this portable: another
+  # install maps `large` to whatever it actually has.
+  - id: gen-brief
+    model: large
+    depends_on: [read-strategy]
+    prompt: |
+      Write a script for a 30-40 second vertical product marketing video.
+
+      THE PRODUCT (everything you are allowed to claim comes from here):
+
+      $ARGUMENTS
+
+      Follow the current house playbook:
+      ---
+      $read-strategy.output
+      ---
+
+      **Invent nothing.** No statistics, awards, customer counts, pricing, or
+      capabilities that are not in the product description above. If you want a
+      number and were not given one, write the sentence without it. A fabricated
+      product claim is not a style problem, it is a false advertisement.
+
+      Requirements for the narration:
+      - 75-100 words. Read aloud at roughly 150 wpm.
+      - Open on the PROBLEM the viewer already feels, not the product. Earn the
+        product's entrance — name it only once the pain is on the table.
+      - One core benefit, developed properly. A list of five features is a
+        thirty-second video nobody remembers.
+      - Concrete over abstract. Name a specific moment in the viewer's actual
+        week that gets better, in your own words — not vague benefit-speak like
+        "streamline your workflow". Do not reuse any example phrasing from these
+        instructions; write the moment yourself or the line will sound canned.
+      - Name the product at least once, naturally.
+      - Write out numbers and symbols as words ("ninety percent", not "90%").
+      - No superlatives ("the best", "revolutionary") and no hype verbs
+        ("unlock", "supercharge", "transform").
+      - End with ONE clear, low-friction call to action. This is the one video
+        kind in this pack where a CTA belongs.
+
+      Requirements for the keywords — fed verbatim to a stock footage search:
+      - 6 to 8 keywords, each 1-3 words.
+      - Show the CONTEXT the product lives in, since stock footage will not
+        contain your actual product: "developer at laptop", "team standup
+        meeting", "server room racks".
+      - Concrete and filmable. Never abstract concepts.
+      - Track the narrative in order: problem scenes first, resolution later.
+    output_format:
+      type: object
+      properties:
+        title: { type: string }
+        hook: { type: string }
+        narration: { type: string }
+        keywords:
+          type: array
+          items: { type: string }
+        visual_notes: { type: string }
+      required: [title, hook, narration, keywords, visual_notes]
+
+  - id: write-brief
+    depends_on: [gen-brief]
+    bash: |
+      set -euo pipefail
+      mkdir -p "$ARTIFACTS_DIR"
+      # Output refs are shell-quoted by the engine — consume as a shell word.
+      brief=$gen-brief.output
+      printf '%s' "$brief" > "$ARTIFACTS_DIR/brief.json"
+      python3 -c "import json,os;d=json.load(open(os.environ['ARTIFACTS_DIR']+'/brief.json'));print('brief ok —',len(d['narration'].split()),'words,',len(d['keywords']),'keywords')"
+
+  # Copy follows tight rules against a script that already exists — it does
+  # not need the tier that writes the script. Pinned rather than inherited.
+  - id: write-copy
+    model: medium
+    depends_on: [gen-brief]
+    prompt: |
+      Write the marketing copy for this product short.
+
+      TITLE: $gen-brief.output.title
+      NARRATION: $gen-brief.output.narration
+
+      **Claim only what the narration claims.** Do not add features, numbers,
+      integrations, or pricing that the script did not state. If the script
+      hedged, the copy hedges too.
+
+      Write for someone evaluating a solution, not browsing:
+      - Lead with the problem or the outcome, not the product category.
+      - Use the words a buyer would search, including comparison and
+        alternative-seeking forms.
+      - One CTA, plain and specific. No "link in bio" (this pack does not publish).
+
+      Per platform:
+      - youtube_title: <=70 chars, benefit-led and searchable, product named.
+      - youtube_description: 2-3 short paragraphs. First line carries the hook.
+        State the core benefit plainly, then who it is for. End with 3-5
+        plain-text search phrases on their own lines.
+      - youtube_tags: 8-12 lowercase tags, no "#".
+      - tiktok_caption: <=150 chars including hashtags, plain-spoken not salesy.
+      - instagram_caption: 1-2 sentences plus a line of hashtags.
+      - hashtags: 6-10, mixed broad and niche, no "#" prefix in the values.
+      - search_keywords: 6-10 phrases a buyer would literally type, including
+        intent forms ("<category> with approval gates", "self-hosted <category>").
+        Model-derived, NOT volume-validated — never invent numbers.
+      - alt_text: one sentence describing the visuals for accessibility.
+    output_format:
+      type: object
+      properties:
+        youtube_title: { type: string }
+        youtube_description: { type: string }
+        youtube_tags:
+          type: array
+          items: { type: string }
+        tiktok_caption: { type: string }
+        instagram_caption: { type: string }
+        hashtags:
+          type: array
+          items: { type: string }
+        search_keywords:
+          type: array
+          items: { type: string }
+        alt_text: { type: string }
+      required:
+        [youtube_title, youtube_description, youtube_tags, tiktok_caption,
+         instagram_caption, hashtags, search_keywords, alt_text]
+
+  - id: save-copy
+    depends_on: [write-copy]
+    bash: |
+      set -euo pipefail
+      mkdir -p "$ARTIFACTS_DIR"
+      copy=$write-copy.output
+      printf '%s' "$copy" > "$ARTIFACTS_DIR/copy.json"
+      python3 -c "import json,os;d=json.load(open(os.environ['ARTIFACTS_DIR']+'/copy.json'));print('copy ok —',d['youtube_title'])"
+
+  - id: render
+    depends_on: [write-brief, save-copy]
+    trigger_rule: all_success
+    include: video-render-block
+    with:
+      kind: product

--- a/.archon/workflows/video/social-short.yaml
+++ b/.archon/workflows/video/social-short.yaml
@@ -1,0 +1,161 @@
+# Social short — general-interest, insight-driven vertical video.
+#
+#   archon workflow run social-short "Why cities can feel lonelier than small towns"
+name: social-short
+description: "Topic -> insight-driven 1080x1920 short with narration, captions and post copy. Stores the file; does not publish."
+
+worktree:
+  enabled: false
+
+nodes:
+  # The playbook the quality-review loop maintains. Absent on the first run.
+  # Two playbooks, deliberately: rules that are universal (caption legibility,
+  # audio levels, footage repetition) live in strategy-common.md, while rules
+  # specific to this kind live in its own file. A single shared playbook would
+  # let a lesson learned from a product ad silently rewrite the UGC rules, and
+  # those two have opposite instructions for hook, pacing and claims.
+  - id: read-strategy
+    bash: |
+      common="$STATE_DIR/content/strategy-common.md"
+      mine="$STATE_DIR/content/strategy-social-short.md"
+      found=0
+      if [ -f "$common" ]; then echo "## Universal craft rules"; cat "$common"; echo; found=1; fi
+      if [ -f "$mine" ]; then echo "## Rules for this video kind (social-short)"; cat "$mine"; found=1; fi
+      if [ "$found" -eq 0 ]; then
+        echo "(No playbook yet for social-short — this is the first run. Use your own judgement.)"
+      fi
+
+  # The script is the highest-leverage output in the pack, so it gets the
+  # top tier. Tiers (not literal model strings) keep this portable: another
+  # install maps `large` to whatever it actually has.
+  - id: gen-brief
+    model: large
+    depends_on: [read-strategy]
+    prompt: |
+      Write a script for a 35-45 second vertical short about:
+
+      $ARGUMENTS
+
+      Follow the current house playbook:
+      ---
+      $read-strategy.output
+      ---
+
+      Requirements for the narration:
+      - 85-110 words. It will be read aloud at roughly 150 wpm.
+      - Open with a hook in the first sentence that creates an open loop —
+        a question, a contradiction, or a surprising claim. No throat-clearing
+        ("In this video...", "Have you ever wondered...").
+      - Plain spoken English. Short sentences. No markdown, no emoji, no stage
+        directions, no speaker labels — every character gets read aloud.
+      - Write out numbers and symbols as words ("ninety percent", not "90%").
+      - End on a resonant closing line, not a call to action.
+
+      Requirements for the keywords — these are the single biggest lever on how
+      the video looks, because they are fed verbatim to a stock footage search:
+      - 6 to 8 keywords, each 1-3 words.
+      - Every one must be a CONCRETE, FILMABLE scene: "waves crashing rocks",
+        "person typing laptop night", "city traffic timelapse".
+      - Never abstract concepts: not "innovation", "success", "the future" —
+        those return generic, lifeless corporate stock.
+      - They should track the narrative in order, so the visuals follow the story.
+    output_format:
+      type: object
+      properties:
+        title: { type: string }
+        hook: { type: string }
+        narration: { type: string }
+        keywords:
+          type: array
+          items: { type: string }
+        visual_notes: { type: string }
+      # Every property must be listed: OpenAI-backed providers reject a
+      # structured-output schema whose `required` omits any key in `properties`,
+      # so a partially-required schema works on Claude and 400s on Codex.
+      required: [title, hook, narration, keywords, visual_notes]
+
+  # Named script nodes do NOT get output substitution (only inline ones do), so
+  # the brief is persisted once here and every script reads it from disk.
+  - id: write-brief
+    depends_on: [gen-brief]
+    bash: |
+      set -euo pipefail
+      mkdir -p "$ARTIFACTS_DIR"
+      # The engine shell-quotes upstream output refs (and may spill large ones
+      # to a cat subshell), so a ref must be consumed as a shell WORD. Pasting
+      # one into a heredoc writes the surrounding quotes into the file.
+      # NB: node refs are matched inside comments too — don't spell one here.
+      brief=$gen-brief.output
+      printf '%s' "$brief" > "$ARTIFACTS_DIR/brief.json"
+      python3 -c "import json,os;d=json.load(open(os.environ['ARTIFACTS_DIR']+'/brief.json'));print('brief ok —',len(d['narration'].split()),'words,',len(d['keywords']),'keywords')"
+
+  # Copy follows tight rules against a script that already exists — it does
+  # not need the tier that writes the script. Pinned rather than inherited.
+  - id: write-copy
+    model: medium
+    depends_on: [gen-brief]
+    prompt: |
+      Write the social copy for this finished short.
+
+      TITLE: $gen-brief.output.title
+      NARRATION: $gen-brief.output.narration
+
+      The single hardest rule: **only promise what the narration delivers.**
+      A description offering "5 ways to fix it" for a video containing no five
+      ways is a lie that costs you the retention it buys. If the narration is
+      reflective rather than practical, sell the *insight*, not a checklist.
+
+      Within that constraint, write for search and for a reason to care:
+      - Lead with the value or the tension, not a summary.
+      - Use the words a person would actually type into a search box.
+      - No engagement-bait ("comment below!", "you won't believe").
+
+      Per platform:
+      - youtube_title: <=70 chars, searchable, no punctuation spam.
+      - youtube_description: 2-3 short paragraphs. The first line carries the
+        hook because it is all that shows before "more". End with 3-5 plain-text
+        search phrases on their own lines.
+      - youtube_tags: 8-12 lowercase tags, no "#".
+      - tiktok_caption: <=150 chars including hashtags, conversational.
+      - instagram_caption: 1-2 sentences plus a line of hashtags.
+      - hashtags: 6-10, mixed broad and niche, no "#" prefix in the values.
+      - search_keywords: 6-10 phrases someone would literally type. These are
+        model-derived, NOT validated against real search volume — never invent
+        volume numbers for them.
+      - alt_text: one sentence describing the visuals for accessibility.
+    output_format:
+      type: object
+      properties:
+        youtube_title: { type: string }
+        youtube_description: { type: string }
+        youtube_tags:
+          type: array
+          items: { type: string }
+        tiktok_caption: { type: string }
+        instagram_caption: { type: string }
+        hashtags:
+          type: array
+          items: { type: string }
+        search_keywords:
+          type: array
+          items: { type: string }
+        alt_text: { type: string }
+      required:
+        [youtube_title, youtube_description, youtube_tags, tiktok_caption,
+         instagram_caption, hashtags, search_keywords, alt_text]
+
+  - id: save-copy
+    depends_on: [write-copy]
+    bash: |
+      set -euo pipefail
+      mkdir -p "$ARTIFACTS_DIR"
+      copy=$write-copy.output
+      printf '%s' "$copy" > "$ARTIFACTS_DIR/copy.json"
+      python3 -c "import json,os;d=json.load(open(os.environ['ARTIFACTS_DIR']+'/copy.json'));print('copy ok —',d['youtube_title'])"
+
+  - id: render
+    depends_on: [write-brief, save-copy]
+    trigger_rule: all_success
+    include: video-render-block
+    with:
+      kind: social-short

--- a/.archon/workflows/video/ugc-video.yaml
+++ b/.archon/workflows/video/ugc-video.yaml
@@ -1,0 +1,166 @@
+# UGC video — first-person, unpolished, sounds like a real person talking.
+#
+#   archon workflow run ugc-video "I switched to a standing desk for 30 days"
+#
+# The whole point of UGC is that it does NOT sound produced. The prompt below
+# fights the model's instinct to write marketing copy, because a UGC script
+# that sounds like an ad performs worse than no UGC at all.
+name: ugc-video
+description: "Experience or product angle -> first-person UGC-style 1080x1920 short with narration, captions and post copy. Stores the file; does not publish."
+
+worktree:
+  enabled: false
+
+nodes:
+  # Two playbooks, deliberately: rules that are universal (caption legibility,
+  # audio levels, footage repetition) live in strategy-common.md, while rules
+  # specific to this kind live in its own file. A single shared playbook would
+  # let a lesson learned from a product ad silently rewrite the UGC rules, and
+  # those two have opposite instructions for hook, pacing and claims.
+  - id: read-strategy
+    bash: |
+      common="$STATE_DIR/content/strategy-common.md"
+      mine="$STATE_DIR/content/strategy-ugc.md"
+      found=0
+      if [ -f "$common" ]; then echo "## Universal craft rules"; cat "$common"; echo; found=1; fi
+      if [ -f "$mine" ]; then echo "## Rules for this video kind (ugc)"; cat "$mine"; found=1; fi
+      if [ "$found" -eq 0 ]; then
+        echo "(No playbook yet for ugc — this is the first run. Use your own judgement.)"
+      fi
+
+  # The script is the highest-leverage output in the pack, so it gets the
+  # top tier. Tiers (not literal model strings) keep this portable: another
+  # install maps `large` to whatever it actually has.
+  - id: gen-brief
+    model: large
+    depends_on: [read-strategy]
+    prompt: |
+      Write a first-person UGC script for a 30-40 second vertical video about:
+
+      $ARGUMENTS
+
+      Follow the current house playbook:
+      ---
+      $read-strategy.output
+      ---
+
+      This must sound like ONE REAL PERSON talking to their phone camera — not
+      a brand, not a narrator, not an ad. Judge every sentence by: would someone
+      actually say this out loud to a friend?
+
+      Requirements for the narration:
+      - 75-100 words. Read aloud at roughly 150 wpm.
+      - First person throughout. "I", "me", "my". Never "you should" or "we".
+      - Open mid-thought, the way a real clip starts: "Okay so I did not expect
+        this to work." Not "Today I want to talk about..."
+      - Include ONE specific, concrete detail that a generic script could never
+        contain — a number, a time of day, a small annoyance. Specificity is the
+        entire difference between authentic and synthetic.
+      - Allow ordinary spoken imperfection: a short sentence fragment, a "honestly",
+        a mild self-correction. Do not overdo it into parody.
+      - Be honest. If the thing has a downside, say it — a UGC clip with one
+        real caveat is more persuasive than an unbroken rave.
+      - No marketing verbs: "elevate", "unlock", "game-changer", "obsessed".
+      - Write out numbers and symbols as words ("ninety percent", not "90%").
+      - End on a plain verdict, not a call to action.
+
+      Requirements for the keywords — fed verbatim to a stock footage search:
+      - 6 to 8 keywords, each 1-3 words.
+      - Favour ORDINARY HUMAN scenes over polished product shots: "person at
+        desk morning", "hands holding coffee", "messy home office".
+      - Concrete and filmable. Never abstract concepts.
+      - They should track the story in order.
+    output_format:
+      type: object
+      properties:
+        title: { type: string }
+        hook: { type: string }
+        narration: { type: string }
+        keywords:
+          type: array
+          items: { type: string }
+        visual_notes: { type: string }
+      required: [title, hook, narration, keywords, visual_notes]
+
+  - id: write-brief
+    depends_on: [gen-brief]
+    bash: |
+      set -euo pipefail
+      mkdir -p "$ARTIFACTS_DIR"
+      # Output refs are shell-quoted by the engine — consume as a shell word.
+      brief=$gen-brief.output
+      printf '%s' "$brief" > "$ARTIFACTS_DIR/brief.json"
+      python3 -c "import json,os;d=json.load(open(os.environ['ARTIFACTS_DIR']+'/brief.json'));print('brief ok —',len(d['narration'].split()),'words,',len(d['keywords']),'keywords')"
+
+  # Copy follows tight rules against a script that already exists — it does
+  # not need the tier that writes the script. Pinned rather than inherited.
+  - id: write-copy
+    model: medium
+    depends_on: [gen-brief]
+    prompt: |
+      Write the social copy for this UGC clip.
+
+      TITLE: $gen-brief.output.title
+      NARRATION: $gen-brief.output.narration
+
+      Match the clip's voice: first person, casual, honest. Copy that reads like
+      an ad under a video that sounds like a person is the single fastest way to
+      destroy the credibility the clip just earned.
+
+      Rules:
+      - **Only claim what the narration actually says.** No invented results,
+        no numbers that are not in the script.
+      - Keep any caveat the narration made. Do not sand it off for the caption.
+      - Lowercase-leaning, conversational. Contractions are good.
+      - No engagement-bait, no "link in bio" (this pack does not publish).
+
+      Per platform:
+      - youtube_title: <=70 chars, sounds like a person, searchable.
+      - youtube_description: 2 short paragraphs in the same first-person voice.
+        First line carries the hook. End with 3-5 plain-text search phrases on
+        their own lines.
+      - youtube_tags: 8-12 lowercase tags, no "#".
+      - tiktok_caption: <=150 chars including hashtags. This is the most
+        important field for UGC — make it sound typed by a human, not written.
+      - instagram_caption: 1-2 sentences plus a line of hashtags.
+      - hashtags: 6-10, mixed broad and niche, no "#" prefix in the values.
+      - search_keywords: 6-10 phrases someone would literally type, including
+        review-intent forms ("is X worth it", "X after 30 days"). Model-derived,
+        NOT volume-validated — never invent numbers.
+      - alt_text: one sentence describing the visuals for accessibility.
+    output_format:
+      type: object
+      properties:
+        youtube_title: { type: string }
+        youtube_description: { type: string }
+        youtube_tags:
+          type: array
+          items: { type: string }
+        tiktok_caption: { type: string }
+        instagram_caption: { type: string }
+        hashtags:
+          type: array
+          items: { type: string }
+        search_keywords:
+          type: array
+          items: { type: string }
+        alt_text: { type: string }
+      required:
+        [youtube_title, youtube_description, youtube_tags, tiktok_caption,
+         instagram_caption, hashtags, search_keywords, alt_text]
+
+  - id: save-copy
+    depends_on: [write-copy]
+    bash: |
+      set -euo pipefail
+      mkdir -p "$ARTIFACTS_DIR"
+      copy=$write-copy.output
+      printf '%s' "$copy" > "$ARTIFACTS_DIR/copy.json"
+      python3 -c "import json,os;d=json.load(open(os.environ['ARTIFACTS_DIR']+'/copy.json'));print('copy ok —',d['youtube_title'])"
+
+  - id: render
+    depends_on: [write-brief, save-copy]
+    trigger_rule: all_success
+    include: video-render-block
+    with:
+      kind: ugc

--- a/.archon/workflows/video/video-quality-review.yaml
+++ b/.archon/workflows/video/video-quality-review.yaml
@@ -1,0 +1,234 @@
+# Outer loop: judge finished videos on CRAFT and evolve the house playbook.
+#
+# This reviews quality, not performance. There are no view counts here — the
+# question is whether the video is well made, which is answerable from the
+# artifact itself and doesn't require waiting on an algorithm.
+#
+# It deliberately edits a strategy DOCUMENT, never the workflow YAML. Keeping
+# the DAG static is what preserves reproducibility and a meaningful audit trail:
+# every video can be attributed to the playbook version that produced it.
+name: video-quality-review
+description: "Review stored shorts for craft quality and propose one change to the house playbook. Human-gated."
+
+worktree:
+  enabled: false
+
+# Approval gates need a foreground run on the web surface.
+interactive: true
+
+nodes:
+  # $ARGUMENTS may name a run id; otherwise review the most recent video.
+  - id: pick-video
+    bash: |
+      set -euo pipefail
+      lib="$STATE_DIR/content/videos"
+      arg=$ARGUMENTS
+      if [ -n "$arg" ] && [ -d "$lib/$arg" ]; then
+        target="$lib/$arg"
+      else
+        target="$(ls -1dt "$lib"/*/ 2>/dev/null | head -1)"
+      fi
+      if [ -z "${target:-}" ] || [ ! -d "$target" ]; then
+        echo "No stored videos found under $lib — run social-short, ugc-video or product-video first." >&2
+        exit 1
+      fi
+      target="${target%/}"
+      # Refuse a second review of the same artifact unless explicitly asked for
+      # it by run id: two reviews of one video stack two playbook changes.
+      if [ -z "$arg" ] && [ -f "$STATE_DIR/content/reviews.jsonl" ]; then
+        if grep -q "\"video_run_id\": \"$(basename "$target")\"" "$STATE_DIR/content/reviews.jsonl"; then
+          echo "Newest video $(basename "$target") is already reviewed. Make a new video, or pass a run id to re-review deliberately." >&2
+          exit 1
+        fi
+      fi
+      printf '%s' "$target"
+
+  - id: gather
+    depends_on: [pick-video]
+    bash: |
+      set -euo pipefail
+      # Assign bare: the engine already shell-quotes an output ref, so adding
+      # our own quotes around it puts literal quote characters in the value.
+      t=$pick-video.output
+      kind="$(python3 -c "import json,sys;print(json.load(open('$t/meta.json'))['kind'])" 2>/dev/null || echo unknown)"
+      echo "=== TARGET ==="; echo "$t"
+      echo "=== VIDEO KIND ==="; echo "$kind"
+      echo "=== BRIEF ==="; cat "$t/brief.json"
+      # copy.json is governed content with its own playbook rules, so it has to
+      # be reviewable — otherwise the copy rules are the one part of the strategy
+      # with no feedback path.
+      echo "=== POST COPY ==="; cat "$t/copy.json" 2>/dev/null || echo "(none — predates the write-copy node)"
+      echo "=== TECHNICAL QC ==="; cat "$t/quality.json"
+      echo "=== FRAMES ==="; ls -1 "$t/frames"/*.jpg
+      echo "=== UNIVERSAL PLAYBOOK (strategy-common.md) ==="
+      cat "$STATE_DIR/content/strategy-common.md" 2>/dev/null || echo "(none yet)"
+      echo "=== PLAYBOOK FOR THIS KIND (strategy-$kind.md) ==="
+      cat "$STATE_DIR/content/strategy-$kind.md" 2>/dev/null || echo "(none yet — you would be writing version 1)"
+      echo "=== LIBRARY SIZE ==="
+      wc -l < "$STATE_DIR/content/library.jsonl" 2>/dev/null || echo 0
+
+  # Vision review needs a provider that can actually open the frame stills.
+  #
+  # Do NOT set `model:` to a tier keyword here. A tier resolves its own
+  # provider and silently overrides the explicit `provider:` above — with
+  # `large` pinned to codex, this node ran on Codex and never opened a single
+  # frame, yet still returned a confident verdict. Leave the model unset so the
+  # configured Claude default applies.
+  - id: review
+    provider: claude
+    depends_on: [gather]
+    prompt: |
+      You are reviewing a finished vertical short for CRAFT QUALITY. Judge the
+      artifact in front of you. Do not speculate about views, engagement, or
+      the algorithm — no performance data exists and inventing it is worse
+      than saying nothing.
+
+      $gather.output
+
+      Read every frame image listed above with the Read tool before judging.
+      You are looking specifically for:
+      - Caption legibility: size, contrast against the footage behind it,
+        position, and whether any line is clipped or collides with the frame edge.
+      - Footage relevance: does each shot plausibly illustrate the line being
+        spoken over it, or is it generic filler?
+      - Footage repetition: does the same shot appear more than once?
+      - Visual coherence: do the clips look like they belong in one video, or
+        is it a grab bag of mismatched colour and grade?
+      - Script craft: is the hook a real open loop? Does the narration earn its
+        ending, or trail off?
+      - Copy honesty: does the description promise something the narration does
+        NOT deliver? A caption offering "5 ways" over a video with no five ways
+        buys a click and loses the viewer — the worst trade in short form. Also
+        check the copy claims nothing (numbers, features, results) absent from
+        the script.
+
+      You are also the only node in this system that can see the frames, so you
+      pick the thumbnail. Return `thumbnail_frame` as the 1-based index of the
+      frame that would best stop a scroll.
+
+      Note the VIDEO KIND above. There are three kinds in this system with
+      deliberately opposing rules — a social short is third-person and takes no
+      CTA, a UGC clip is first-person and keeps its caveats, a product video is
+      benefit-led and does take a CTA. A lesson from one is frequently WRONG for
+      another, so your change is scoped:
+
+      - `target: kind` — the default. The change lands only in this kind's
+        playbook and cannot affect the other two.
+      - `target: common` — ONLY for rules that are genuinely universal because
+        they are about craft mechanics, not voice: caption legibility, audio
+        levels, footage repetition, shot-to-line relevance. If a rule mentions
+        tone, person, CTA policy or what may be claimed, it is NOT common.
+
+      Then propose EXACTLY ONE change to that one playbook. One. Not a list.
+      Pick the single change with the largest expected effect on quality, and
+      say what you would look at in the next video to tell whether it worked.
+      If the video is already good and you have no high-confidence change,
+      say so and set `proposed_change` to "none" — "no change" is a respectable
+      answer and inventing churn to look useful is a failure.
+
+      Write `new_strategy_markdown` as the COMPLETE new content of the file you
+      targeted (it overwrites that file, and only that file), starting with a
+      `# vN` version heading that increments that file's current version. If
+      proposing no change, return that file unchanged with the same version.
+    output_format:
+      type: object
+      properties:
+        verdict:
+          type: string
+          enum: ["good", "acceptable", "needs_work"]
+        strengths:
+          type: array
+          items:
+            type: string
+        defects:
+          type: array
+          items:
+            type: string
+        proposed_change:
+          type: string
+        rationale:
+          type: string
+        what_to_watch_next:
+          type: string
+        new_strategy_markdown:
+          type: string
+        thumbnail_frame:
+          type: integer
+        target:
+          type: string
+          enum: ["kind", "common"]
+      required:
+        [verdict, strengths, defects, proposed_change, rationale,
+         what_to_watch_next, new_strategy_markdown, thumbnail_frame, target]
+
+  - id: approve-strategy
+    depends_on: [review]
+    approval:
+      message: |
+        Quality review of $pick-video.output
+
+        VERDICT: $review.output.verdict
+
+        Writing to: $review.output.target playbook
+
+        Proposed single change:
+        $review.output.proposed_change
+
+        Why: $review.output.rationale
+        Watch next: $review.output.what_to_watch_next
+
+        Approve to write this into the house playbook; reject to discard it.
+
+  - id: apply-strategy
+    depends_on: [approve-strategy]
+    bash: |
+      set -euo pipefail
+      mkdir -p "$STATE_DIR/content"
+      # Consumed as a shell word — see the note in social-short.yaml write-brief.
+      export RUN_ID="$WORKFLOW_ID"
+      video_dir=$pick-video.output
+      export VIDEO_DIR="$video_dir"
+      review=$review.output
+      printf '%s' "$review" > "$ARTIFACTS_DIR/review.json"
+      python3 - <<'__ARCHON_APPLY__'
+      import json, os, pathlib, datetime, shutil
+      state = pathlib.Path(os.environ["STATE_DIR"]) / "content"
+      review = json.loads((pathlib.Path(os.environ["ARTIFACTS_DIR"]) / "review.json").read_text())
+      vid = pathlib.Path(os.environ["VIDEO_DIR"])
+      meta_path = vid / "meta.json"
+      kind = json.loads(meta_path.read_text())["kind"] if meta_path.exists() else "unknown"
+      # Write back to exactly one playbook — the one the reviewer targeted.
+      target = review.get("target", "kind")
+      strategy = state / ("strategy-common.md" if target == "common" else f"strategy-{kind}.md")
+      if strategy.exists():
+          hist = state / "strategy-history"
+          hist.mkdir(exist_ok=True)
+          stamp = datetime.datetime.now().astimezone().strftime("%Y%m%d-%H%M%S")
+          # Stem-prefixed: strategy-history/ holds four playbooks now, and a bare
+          # strategy-<stamp>.md says nothing about which one it is a version of
+          # (and two archives in the same second overwrote each other).
+          shutil.copy2(strategy, hist / f"{strategy.stem}-{stamp}.md")
+      strategy.write_text(review["new_strategy_markdown"].rstrip() + "\n")
+      log = state / "reviews.jsonl"
+      with log.open("a") as fh:
+          fh.write(json.dumps({
+              "reviewed_at": datetime.datetime.now().astimezone().isoformat(timespec="seconds"),
+              "review_run_id": os.environ["RUN_ID"],
+              "video_run_id": pathlib.Path(os.environ["VIDEO_DIR"]).name,
+              "kind": kind,
+              "playbook": strategy.name,
+              "verdict": review["verdict"],
+              "change": review["proposed_change"],
+              "watch": review["what_to_watch_next"],
+          }) + "\n")
+      # The reviewer is the only thing that sees the frames, so its thumbnail
+      # pick belongs beside the video it describes.
+      cp = vid / "copy.json"
+      if cp.exists() and isinstance(review.get("thumbnail_frame"), int):
+          data = json.loads(cp.read_text())
+          data["thumbnail_frame"] = review["thumbnail_frame"]
+          cp.write_text(json.dumps(data, indent=2))
+          print(f"thumbnail_frame={review['thumbnail_frame']} -> {cp}")
+      print(f"playbook updated -> {strategy}  (kind={kind}, target={target})")
+      print(f"change: {review['proposed_change']}")
+      __ARCHON_APPLY__

--- a/.archon/workflows/video/video-render-block.yaml
+++ b/.archon/workflows/video/video-render-block.yaml
@@ -1,0 +1,113 @@
+# Shared render block — included by every video workflow in this pack.
+#
+# Everything here is MECHANICAL: footage, narration, captions, encode, QC,
+# store. Nothing in it makes an editorial decision, which is why all three
+# video kinds can share it unchanged.
+#
+# It deliberately holds NO references to the including workflow's nodes. It
+# reads `brief.json` and `copy.json` from $ARTIFACTS_DIR, which the parent
+# wrote. That keeps the block provider-agnostic and immune to the node
+# renaming that include-time namespacing applies (`<includeId>__<nodeId>`).
+#
+# Not run directly. Pull it in with:
+#   - id: render
+#     depends_on: [save-copy]
+#     include: video-render-block
+#     with:
+#       kind: social-short
+name: video-render-block
+description: "Building block — footage, narration, captions, encode, QC, store. Included by the video workflows; not run on its own."
+
+# No workflow-level keys here: include-time expansion drops them (the including
+# workflow owns isolation policy), and the engine warns when it has to.
+
+nodes:
+  # Footage and narration are independent, so they share a topological layer
+  # and the executor runs them concurrently.
+  - id: fetch-clips
+    script: fetch-clips
+    runtime: uv
+    deps: [requests]
+    timeout: 420000
+
+  - id: narrate
+    script: tts-narrate
+    runtime: uv
+    deps: [requests]
+    timeout: 300000
+
+  - id: captions
+    script: build-captions
+    runtime: uv
+    timeout: 60000
+    depends_on: [narrate]
+
+  # Media nodes must set `timeout:` — the subprocess default is 2 minutes,
+  # which a 1080x1920 encode will blow straight through.
+  - id: compose
+    script: compose-video
+    runtime: uv
+    timeout: 900000
+    depends_on: [fetch-clips, captions]
+    trigger_rule: all_success
+
+  - id: qc
+    script: quality-check
+    runtime: uv
+    timeout: 300000
+    depends_on: [compose]
+
+  - id: store
+    depends_on: [qc]
+    bash: |
+      set -euo pipefail
+      # WORKFLOW_ID is a substitution variable, not an env var: it interpolates
+      # into this text but is absent from os.environ, so export it for python.
+      export RUN_ID="$WORKFLOW_ID"
+      export VIDEO_KIND="$INPUTS.kind"
+      mkdir -p "$STATE_DIR/content"
+      final="$STATE_DIR/content/videos/$RUN_ID"
+      # Stage into a temp dir and move into place, so a failure part-way through
+      # cannot leave a half-populated directory that looks stored.
+      dest="$final.partial"
+      rm -rf "$dest"; mkdir -p "$dest"
+      cp "$ARTIFACTS_DIR/video.mp4" "$dest/"
+      cp "$ARTIFACTS_DIR/quality.json" "$dest/"
+      cp "$ARTIFACTS_DIR/brief.json" "$dest/"
+      cp "$ARTIFACTS_DIR/copy.json" "$dest/"
+      cp -R "$ARTIFACTS_DIR/frames" "$dest/frames"
+      printf '{"kind": "%s", "run_id": "%s"}\n' "$VIDEO_KIND" "$RUN_ID" > "$dest/meta.json"
+      rm -rf "$final"; mv "$dest" "$final"
+      ln -sfn "$final" "$STATE_DIR/content/latest"
+      python3 - <<'__ARCHON_LEDGER__'
+      import json, os, pathlib, datetime
+      state = pathlib.Path(os.environ["STATE_DIR"]) / "content"
+      dest = state / "videos" / os.environ["RUN_ID"]
+      brief = json.loads((dest / "brief.json").read_text())
+      qc = json.loads((dest / "quality.json").read_text())
+      copy = json.loads((dest / "copy.json").read_text())
+      kind = os.environ["VIDEO_KIND"]
+      version = "none"
+      strategy = state / f"strategy-{kind}.md"
+      if strategy.exists():
+          first = strategy.read_text().splitlines()[0]
+          version = first.strip("# ").strip() or "unversioned"
+      row = {
+          "run_id": os.environ["RUN_ID"],
+          "kind": kind,
+          "created_at": datetime.datetime.now().astimezone().isoformat(timespec="seconds"),
+          "title": brief.get("title", ""),
+          "hook": brief.get("hook", ""),
+          "keywords": brief.get("keywords", []),
+          "youtube_title": copy.get("youtube_title", ""),
+          "hashtags": copy.get("hashtags", []),
+          "search_keywords": copy.get("search_keywords", []),
+          "duration": qc.get("duration"),
+          "qc_passed": qc.get("passed"),
+          "strategy_version": version,
+          "path": str(dest / "video.mp4"),
+      }
+      with (state / "library.jsonl").open("a") as fh:
+          fh.write(json.dumps(row) + "\n")
+      print(f"stored [{row['kind']}] {row['title']!r} -> {row['path']}")
+      __ARCHON_LEDGER__


### PR DESCRIPTION
## Summary

- Problem: Archon positions itself as a governed automation engine beyond coding, but the repo carries no worked example of a non-coding, media-producing automation with human review loops.
- Why it matters: the video pack is a concrete ops-automation proof — topic in, finished 1080x1920 MP4 + per-platform post copy out, with artifacts, state, and an approval-gated review loop that evolves per-kind playbooks.
- What changed: adds `.archon/workflows/video/` (three producer workflows: `social-short`, `ugc-video`, `product-video`; a human-gated `video-quality-review`; a shared `video-render-block` include) and five `uv`-runtime Python scripts under `.archon/scripts/` (Pexels clip fetch, Cartesia TTS with word timestamps, ASS karaoke captions, ffmpeg compose, quality gate) plus `_common.py`.
- What did **not** change (scope boundary): zero engine/package code — no `packages/` changes, no bundled defaults (`workflows/defaults/` untouched, no `generate:bundled` needed), no schema, no API. Publishing/posting is explicitly out of scope; runs stop at `store`.

## UX Journey

### Before

```
  User                          Archon
  ────                          ──────
  wants a short-form video ──▶  (nothing — no media workflows in repo)
  produces video by hand
```

### After

```
  User                          Archon                              External services
  ────                          ──────                              ─────────────────
  workflow run social-short ──▶ read-strategy ($STATE_DIR playbook)
                                gen-brief / write-copy (LLM tiers)
                                [include: video-render-block]
                                  fetch-clips ──────────────────▶  Pexels API
                                  narrate ─────────────────────▶  Cartesia TTS (word timestamps)
                                  captions → compose → qc          (local ffmpeg)
                                store ──▶ $STATE_DIR/content/videos/<run-id>/
  gets MP4 + post copy ◀──────  (never publishes)

  workflow run video-quality-review ──▶ frame stills → vision review (Claude)
                                        [approval gate] ──▶ playbook update (one file, per kind)
```

## Architecture Diagram

### Before

```
.archon/workflows/   (coding-oriented workflows only)
.archon/scripts/     (no media scripts)
```

### After

```
[+] .archon/workflows/video/social-short.yaml ──┐
[+] .archon/workflows/video/ugc-video.yaml ─────┼── include: ═══▶ [+] video-render-block.yaml
[+] .archon/workflows/video/product-video.yaml ─┘                     │ bash/script nodes
[+] .archon/workflows/video/video-quality-review.yaml                 ▼
[+] .archon/scripts/{fetch-clips,tts-narrate,build-captions,compose-video,quality-check,_common}.py
        │ reads/writes                                          reads .env keys
        ▼                                                       (PEXELS_API_KEY, CARTESIA_API_KEY)
    $ARTIFACTS_DIR (per-run scratch) / $STATE_DIR/content/ (playbooks + video library)
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| producer workflows ×3 | video-render-block | **new** | load-time `include:` expansion; block reads `brief.json`/`copy.json` from `$ARTIFACTS_DIR`, no node refs into the parent |
| video-render-block | .archon/scripts/*.py | **new** | `script:` nodes, `runtime: uv`, explicit `timeout:` |
| scripts | Pexels / Cartesia APIs | **new** | keys from repo-root `.env` or Archon-managed env vars; fail fast by name when unset |
| video-quality-review | $STATE_DIR/content/ playbooks | **new** | approval-gated; per-kind playbook files, writes exactly one file per run |
| workflow engine / packages | anything here | unchanged | pure content addition — engine sees ordinary workflows |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: L`
- Scope: `workflows`
- Module: `workflows:examples`

## Change Metadata

- Change type: `feature`
- Primary scope: `workflows`

## Linked Issue

- Closes #
- Related #2511 (delivers `WORKFLOW_ID` as a real env var; these workflows export it manually until then)
- Depends on #
- Supersedes #

## Validation Evidence (required)

Commands and result summary:

```bash
bun run validate   # full suite — passed (type-check, lint, format, tests, bundled/schema/capability checks)
```

- Evidence provided (test/log/trace/screenshot): full `bun run validate` pass on this branch; the diff touches no TypeScript, so the suite guards against accidental engine/bundle drift. Workflows load through normal discovery (`archon workflow list`).
- If any command is intentionally skipped, explain why: n/a

## Security Impact (required)

- New permissions/capabilities? (`No`)
- New external network calls? (`Yes`)
- Secrets/tokens handling changed? (`No`)
- File system access scope changed? (`No`)
- If any `Yes`, describe risk and mitigation: scripts call Pexels (stock footage) and Cartesia (TTS) with user-supplied API keys read from `.env`/managed env vars. Keys are never logged or written to artifacts; an unset key fails immediately by name. Both calls happen only inside runs of these opt-in workflows.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`Yes` — two new optional env vars, `PEXELS_API_KEY` and `CARTESIA_API_KEY` (+ optional `CARTESIA_VOICE_ID`), needed only to run this pack; `ffmpeg` and `uv` on PATH)
- Database migration needed? (`No`)
- If yes, exact upgrade steps: add the two keys to the repo `.env` (or Archon per-project env vars) before first run.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: end-to-end runs of the producer workflows (real Pexels + Cartesia + ffmpeg) producing stored MP4s with karaoke captions and post copy; `video-quality-review` run against a finished video including the approval gate and a per-kind playbook write.
- Edge cases checked: unset API key fails fast by name; `store` staging via `<run-id>.partial` so an interrupted run can't leave a half-populated library entry; tier/provider interaction warnings (README "Authoring gotchas").
- What was not verified: non-Claude providers for the vision review node (deliberately pinned to `provider: claude`; other providers fail loudly there), Cartesia voices other than the default.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: none outside this pack — additive content in `.archon/`; engine, defaults bundle, and all existing workflows untouched.
- Potential unintended effects: workflow discovery now lists five more workflows in this repo; runs consume Cartesia credits (~$0.02–0.15/video).
- Guardrails/monitoring for early detection: quality-check node gates compose output; runs stop at `store` (no publishing surface exists); all output lands under `$STATE_DIR`/`$ARTIFACTS_DIR`, never in the repo.

## Rollback Plan (required)

- Fast rollback command/path: revert the single commit (`git revert 58196a5f`) — no state, schema, or generated files to unwind.
- Feature flags or config toggles (if any): none needed; workflows simply disappear from discovery on revert.
- Observable failure symptoms: failed runs of the video workflows; nothing else can be affected.

## Risks and Mitigations

- Risk: external API drift (Pexels/Cartesia response shapes) breaking scripts silently.
  - Mitigation: scripts fail loudly on unexpected responses; quality-check node validates the composed artifact before `store`.
- Risk: per-kind playbooks drifting into contradiction over time.
  - Mitigation: reviewer declares `target: kind | common` and writes exactly one file per run; human approval gates every playbook change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added workflows for product marketing videos, social shorts, and UGC videos.
  - Generate vertical 1080×1920 videos with narration, captions, stock footage, music, and platform-specific copy.
  - Added automated video quality checks covering dimensions, timing, audio, frame rate, and visual issues.
  - Added a human-gated quality review workflow with thumbnail selection and strategy updates.
  - Video outputs and supporting artifacts are stored in a searchable library without automatic publishing.

- **Documentation**
  - Added setup, execution, review, and authoring guidance for the video workflow pack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->