### PR TITLE
fix(slack): resume workflow after a Slack-side gate approval

### DIFF
--- a/packages/adapters/src/chat/slack/adapter.test.ts
+++ b/packages/adapters/src/chat/slack/adapter.test.ts
@@ -439,6 +439,51 @@ describe('SlackAdapter', () => {
     });
   });
 
+  describe('dispatchThreadCommand', () => {
+    test('authorized user dispatches a threaded synthetic command', async () => {
+      const original = process.env.SLACK_ALLOWED_USER_IDS;
+      process.env.SLACK_ALLOWED_USER_IDS = 'U1ALICE';
+      try {
+        const adapter = new SlackAdapter('xoxb-fake', 'xapp-fake');
+        const received: SlackMessageEvent[] = [];
+        adapter.onMessage(async e => {
+          received.push(e);
+        });
+
+        await adapter.dispatchThreadCommand('/workflow resume r1', 'C1', '111.0', 'U1ALICE');
+
+        expect(received).toHaveLength(1);
+        expect(received[0]).toMatchObject({
+          text: '/workflow resume r1',
+          user: 'U1ALICE',
+          channel: 'C1',
+          ts: '111.0',
+          thread_ts: '111.0',
+        });
+      } finally {
+        if (original === undefined) delete process.env.SLACK_ALLOWED_USER_IDS;
+        else process.env.SLACK_ALLOWED_USER_IDS = original;
+      }
+    });
+
+    test('unauthorized user is rejected — messageHandler not called', async () => {
+      const original = process.env.SLACK_ALLOWED_USER_IDS;
+      process.env.SLACK_ALLOWED_USER_IDS = 'U1ALICE';
+      try {
+        const adapter = new SlackAdapter('xoxb-fake', 'xapp-fake');
+        const onMessage = mock(async () => {});
+        adapter.onMessage(onMessage);
+
+        await adapter.dispatchThreadCommand('/workflow resume r1', 'C1', '111.0', 'U2BOB');
+
+        expect(onMessage).not.toHaveBeenCalled();
+      } finally {
+        if (original === undefined) delete process.env.SLACK_ALLOWED_USER_IDS;
+        else process.env.SLACK_ALLOWED_USER_IDS = original;
+      }
+    });
+  });
+
   describe('slash commands', () => {
     function findCommandHandler(name: string): (args: unknown) => Promise<void> {
       const calls = (mockCommand as unknown as Mock<(n: string, h: unknown) => void>).mock.calls;

--- a/packages/adapters/src/chat/slack/adapter.test.ts
+++ b/packages/adapters/src/chat/slack/adapter.test.ts
@@ -450,8 +450,14 @@ describe('SlackAdapter', () => {
           received.push(e);
         });
 
-        await adapter.dispatchThreadCommand('/workflow resume r1', 'C1', '111.0', 'U1ALICE');
+        const accepted = await adapter.dispatchThreadCommand(
+          '/workflow resume r1',
+          'C1',
+          '111.0',
+          'U1ALICE'
+        );
 
+        expect(accepted).toBe(true);
         expect(received).toHaveLength(1);
         expect(received[0]).toMatchObject({
           text: '/workflow resume r1',
@@ -479,8 +485,14 @@ describe('SlackAdapter', () => {
           return new Promise<void>(() => {});
         });
 
-        await adapter.dispatchThreadCommand('/workflow resume r1', 'C1', '111.0', 'U1ALICE');
+        const accepted = await adapter.dispatchThreadCommand(
+          '/workflow resume r1',
+          'C1',
+          '111.0',
+          'U1ALICE'
+        );
 
+        expect(accepted).toBe(true);
         expect(handlerStarted).toBe(true);
       } finally {
         if (original === undefined) delete process.env.SLACK_ALLOWED_USER_IDS;
@@ -496,8 +508,14 @@ describe('SlackAdapter', () => {
         const onMessage = mock(async () => {});
         adapter.onMessage(onMessage);
 
-        await adapter.dispatchThreadCommand('/workflow resume r1', 'C1', '111.0', 'U2BOB');
+        const accepted = await adapter.dispatchThreadCommand(
+          '/workflow resume r1',
+          'C1',
+          '111.0',
+          'U2BOB'
+        );
 
+        expect(accepted).toBe(false);
         expect(onMessage).not.toHaveBeenCalled();
       } finally {
         if (original === undefined) delete process.env.SLACK_ALLOWED_USER_IDS;

--- a/packages/adapters/src/chat/slack/adapter.test.ts
+++ b/packages/adapters/src/chat/slack/adapter.test.ts
@@ -466,6 +466,28 @@ describe('SlackAdapter', () => {
       }
     });
 
+    test('does not block on the resumed run finishing (fire-and-forget)', async () => {
+      const original = process.env.SLACK_ALLOWED_USER_IDS;
+      process.env.SLACK_ALLOWED_USER_IDS = 'U1ALICE';
+      try {
+        const adapter = new SlackAdapter('xoxb-fake', 'xapp-fake');
+        let handlerStarted = false;
+        // A handler whose promise never settles stands in for a long-running
+        // resumed run; before the fix, awaiting it would hang this call.
+        adapter.onMessage(() => {
+          handlerStarted = true;
+          return new Promise<void>(() => {});
+        });
+
+        await adapter.dispatchThreadCommand('/workflow resume r1', 'C1', '111.0', 'U1ALICE');
+
+        expect(handlerStarted).toBe(true);
+      } finally {
+        if (original === undefined) delete process.env.SLACK_ALLOWED_USER_IDS;
+        else process.env.SLACK_ALLOWED_USER_IDS = original;
+      }
+    });
+
     test('unauthorized user is rejected — messageHandler not called', async () => {
       const original = process.env.SLACK_ALLOWED_USER_IDS;
       process.env.SLACK_ALLOWED_USER_IDS = 'U1ALICE';

--- a/packages/adapters/src/chat/slack/adapter.ts
+++ b/packages/adapters/src/chat/slack/adapter.ts
@@ -393,13 +393,19 @@ export class SlackAdapter implements IPlatformAdapter {
    * Slack-side gate approval so the resumed output streams back into the same
    * thread instead of a web worker conversation. Routing through the same
    * `messageHandler` inbound path keeps the run bound to its Slack conversation.
+   *
+   * Resolves to whether the command was *dispatched* — handed off to the
+   * handler — not whether the resumed run finished. `false` means it was never
+   * scheduled (unauthorized actor or no handler); a pre-dispatch failure
+   * rejects. Handler execution stays fire-and-forget once dispatched, so
+   * callers can decide the resolution note from the dispatch outcome alone.
    */
   async dispatchThreadCommand(
     text: string,
     channel: string,
     threadTs: string,
     userId: string
-  ): Promise<void> {
+  ): Promise<boolean> {
     // Authorize at the adapter boundary, like every other messageHandler entry
     // point (app_mention / message.im / slash), so a synthetic command can never
     // bypass the whitelist even if a caller forgets to check. Silent + masked,
@@ -407,9 +413,9 @@ export class SlackAdapter implements IPlatformAdapter {
     if (!isSlackUserAuthorized(userId, this.allowedUserIds)) {
       const maskedId = userId ? `${userId.slice(0, 4)}***` : 'unknown';
       getLog().info({ maskedUserId: maskedId }, 'slack.thread_command_unauthorized');
-      return;
+      return false;
     }
-    if (!this.messageHandler) return;
+    if (!this.messageHandler) return false;
     const displayName = await this.fetchDisplayName(userId);
     const messageEvent: SlackMessageEvent = {
       text,
@@ -423,11 +429,13 @@ export class SlackAdapter implements IPlatformAdapter {
     // paths: messageHandler's promise covers the whole resumed run, so awaiting
     // it would tie this dispatch's lifetime to full workflow execution. Log the
     // dispatch at the send point; a mid-run fault is an execution-domain event,
-    // not a dispatch failure.
+    // not a dispatch failure. Returning here (post-handoff) is the dispatch
+    // acceptance the bridge keys its resolution note off.
     getLog().info({ channel }, 'slack.thread_command_dispatched');
     void this.messageHandler(messageEvent).catch(error => {
       getLog().error({ err: error as Error, channel }, 'slack.thread_command_execution_failed');
     });
+    return true;
   }
 
   /**

--- a/packages/adapters/src/chat/slack/adapter.ts
+++ b/packages/adapters/src/chat/slack/adapter.ts
@@ -385,6 +385,35 @@ export class SlackAdapter implements IPlatformAdapter {
   }
 
   /**
+   * Dispatch a synthetic orchestrator command inside an existing run's thread.
+   *
+   * The server's post-gate auto-resume (`tryAutoResumeAfterGate`) only fires
+   * for web-sourced parents; non-web parents are expected to run their own
+   * re-run flow. The workflow bridge uses this to resume a run after a
+   * Slack-side gate approval so the resumed output streams back into the same
+   * thread instead of a web worker conversation. Routing through the same
+   * `messageHandler` inbound path keeps the run bound to its Slack conversation.
+   */
+  async dispatchThreadCommand(
+    text: string,
+    channel: string,
+    threadTs: string,
+    userId: string
+  ): Promise<void> {
+    if (!this.messageHandler) return;
+    const displayName = await this.fetchDisplayName(userId);
+    const messageEvent: SlackMessageEvent = {
+      text,
+      user: userId,
+      channel,
+      ts: threadTs,
+      thread_ts: threadTs,
+      displayName,
+    };
+    await this.messageHandler(messageEvent);
+  }
+
+  /**
    * Start the bot (connects via Socket Mode)
    */
   async start(): Promise<void> {

--- a/packages/adapters/src/chat/slack/adapter.ts
+++ b/packages/adapters/src/chat/slack/adapter.ts
@@ -410,23 +410,24 @@ export class SlackAdapter implements IPlatformAdapter {
       return;
     }
     if (!this.messageHandler) return;
-    getLog().info({ channel }, 'slack.thread_command_dispatch_started');
-    try {
-      const displayName = await this.fetchDisplayName(userId);
-      const messageEvent: SlackMessageEvent = {
-        text,
-        user: userId,
-        channel,
-        ts: threadTs,
-        thread_ts: threadTs,
-        displayName,
-      };
-      await this.messageHandler(messageEvent);
-      getLog().info({ channel }, 'slack.thread_command_dispatch_completed');
-    } catch (error) {
-      getLog().error({ err: error as Error, channel }, 'slack.thread_command_dispatch_failed');
-      throw error;
-    }
+    const displayName = await this.fetchDisplayName(userId);
+    const messageEvent: SlackMessageEvent = {
+      text,
+      user: userId,
+      channel,
+      ts: threadTs,
+      thread_ts: threadTs,
+      displayName,
+    };
+    // Fire-and-forget, matching the app_mention / message.im / slash inbound
+    // paths: messageHandler's promise covers the whole resumed run, so awaiting
+    // it would tie this dispatch's lifetime to full workflow execution. Log the
+    // dispatch at the send point; a mid-run fault is an execution-domain event,
+    // not a dispatch failure.
+    getLog().info({ channel }, 'slack.thread_command_dispatched');
+    void this.messageHandler(messageEvent).catch(error => {
+      getLog().error({ err: error as Error, channel }, 'slack.thread_command_execution_failed');
+    });
   }
 
   /**

--- a/packages/adapters/src/chat/slack/adapter.ts
+++ b/packages/adapters/src/chat/slack/adapter.ts
@@ -400,17 +400,33 @@ export class SlackAdapter implements IPlatformAdapter {
     threadTs: string,
     userId: string
   ): Promise<void> {
+    // Authorize at the adapter boundary, like every other messageHandler entry
+    // point (app_mention / message.im / slash), so a synthetic command can never
+    // bypass the whitelist even if a caller forgets to check. Silent + masked,
+    // matching the inbound handlers.
+    if (!isSlackUserAuthorized(userId, this.allowedUserIds)) {
+      const maskedId = userId ? `${userId.slice(0, 4)}***` : 'unknown';
+      getLog().info({ maskedUserId: maskedId }, 'slack.thread_command_unauthorized');
+      return;
+    }
     if (!this.messageHandler) return;
-    const displayName = await this.fetchDisplayName(userId);
-    const messageEvent: SlackMessageEvent = {
-      text,
-      user: userId,
-      channel,
-      ts: threadTs,
-      thread_ts: threadTs,
-      displayName,
-    };
-    await this.messageHandler(messageEvent);
+    getLog().info({ channel }, 'slack.thread_command_dispatch_started');
+    try {
+      const displayName = await this.fetchDisplayName(userId);
+      const messageEvent: SlackMessageEvent = {
+        text,
+        user: userId,
+        channel,
+        ts: threadTs,
+        thread_ts: threadTs,
+        displayName,
+      };
+      await this.messageHandler(messageEvent);
+      getLog().info({ channel }, 'slack.thread_command_dispatch_completed');
+    } catch (error) {
+      getLog().error({ err: error as Error, channel }, 'slack.thread_command_dispatch_failed');
+      throw error;
+    }
   }
 
   /**

--- a/packages/adapters/src/chat/slack/workflow-bridge.test.ts
+++ b/packages/adapters/src/chat/slack/workflow-bridge.test.ts
@@ -88,6 +88,12 @@ function makeFakeAdapter(allowedUserIds: string[] = []) {
   const updated: UpdatedMessage[] = [];
   const reactionsAdded: ReactionCall[] = [];
   const reactionsRemoved: ReactionCall[] = [];
+  const resumeDispatches: Array<{
+    text: string;
+    channel: string;
+    threadTs: string;
+    userId: string;
+  }> = [];
   let nextTs = 1;
 
   let registeredActions: Array<{ pattern: RegExp; handler: (args: unknown) => Promise<void> }> = [];
@@ -129,6 +135,11 @@ function makeFakeAdapter(allowedUserIds: string[] = []) {
       triggerMap.delete(id);
     },
     getAllowedUserIds: () => allowedUserIds,
+    dispatchThreadCommand: mock(
+      async (text: string, channel: string, threadTs: string, userId: string) => {
+        resumeDispatches.push({ text, channel, threadTs, userId });
+      }
+    ),
   };
 
   return {
@@ -138,6 +149,7 @@ function makeFakeAdapter(allowedUserIds: string[] = []) {
     updated,
     reactionsAdded,
     reactionsRemoved,
+    resumeDispatches,
     triggerMap,
     actions: () => registeredActions,
     dispatchAction: async (actionId: string, body: Record<string, unknown>) => {
@@ -256,7 +268,8 @@ describe('SlackWorkflowBridge', () => {
   });
 
   test('approve button calls approveWorkflow and edits the message', async () => {
-    const { adapter, posted, updated, triggerMap, dispatchAction } = makeFakeAdapter();
+    const { adapter, posted, updated, triggerMap, dispatchAction, resumeDispatches } =
+      makeFakeAdapter();
     triggerMap.set('C1:111.0', { channel: 'C1', ts: '111.0' });
     mockGetConversationId.mockReturnValue('C1:111.0');
 
@@ -293,6 +306,16 @@ describe('SlackWorkflowBridge', () => {
     expect(headerText).toContain('Approved');
     expect(headerText).toContain('<@U123>');
     expect(headerText).toContain('workflow resumed');
+
+    // The server auto-resumes only web parents, so the Slack bridge must resume
+    // the run itself — dispatched back through the run's own thread as the actor.
+    expect(resumeDispatches).toHaveLength(1);
+    expect(resumeDispatches[0]).toEqual({
+      text: '/workflow resume r1',
+      channel: 'C1',
+      threadTs: '111.0',
+      userId: 'U123',
+    });
   });
 
   test('interactive-loop approval describes the aggregate completion condition', async () => {
@@ -364,7 +387,7 @@ describe('SlackWorkflowBridge', () => {
   });
 
   test('reject button at max attempts notes the run was cancelled', async () => {
-    const { adapter, updated, triggerMap, dispatchAction } = makeFakeAdapter();
+    const { adapter, updated, triggerMap, dispatchAction, resumeDispatches } = makeFakeAdapter();
     triggerMap.set('C1:111.0', { channel: 'C1', ts: '111.0' });
     mockGetConversationId.mockReturnValue('C1:111.0');
     mockRejectWorkflow.mockResolvedValue({ cancelled: true, maxAttemptsReached: true });
@@ -393,6 +416,8 @@ describe('SlackWorkflowBridge', () => {
     const text = (updated[0]?.blocks?.[0] as { text?: { text?: string } } | undefined)?.text?.text;
     expect(text).toContain('Rejected');
     expect(text).toContain('max reject attempts reached');
+    // A cancelling reject ends the run — nothing to resume.
+    expect(resumeDispatches).toHaveLength(0);
   });
 
   test('cancel button calls abandonWorkflow', async () => {

--- a/packages/adapters/src/chat/slack/workflow-bridge.test.ts
+++ b/packages/adapters/src/chat/slack/workflow-bridge.test.ts
@@ -88,6 +88,12 @@ function makeFakeAdapter(allowedUserIds: string[] = []) {
   const updated: UpdatedMessage[] = [];
   const reactionsAdded: ReactionCall[] = [];
   const reactionsRemoved: ReactionCall[] = [];
+  const resumeDispatches: Array<{
+    text: string;
+    channel: string;
+    threadTs: string;
+    userId: string;
+  }> = [];
   let nextTs = 1;
 
   let registeredActions: Array<{ pattern: RegExp; handler: (args: unknown) => Promise<void> }> = [];
@@ -129,6 +135,11 @@ function makeFakeAdapter(allowedUserIds: string[] = []) {
       triggerMap.delete(id);
     },
     getAllowedUserIds: () => allowedUserIds,
+    dispatchThreadCommand: mock(
+      async (text: string, channel: string, threadTs: string, userId: string) => {
+        resumeDispatches.push({ text, channel, threadTs, userId });
+      }
+    ),
   };
 
   return {
@@ -138,6 +149,7 @@ function makeFakeAdapter(allowedUserIds: string[] = []) {
     updated,
     reactionsAdded,
     reactionsRemoved,
+    resumeDispatches,
     triggerMap,
     actions: () => registeredActions,
     dispatchAction: async (actionId: string, body: Record<string, unknown>) => {
@@ -256,7 +268,8 @@ describe('SlackWorkflowBridge', () => {
   });
 
   test('approve button calls approveWorkflow and edits the message', async () => {
-    const { adapter, posted, updated, triggerMap, dispatchAction } = makeFakeAdapter();
+    const { adapter, posted, updated, triggerMap, dispatchAction, resumeDispatches } =
+      makeFakeAdapter();
     triggerMap.set('C1:111.0', { channel: 'C1', ts: '111.0' });
     mockGetConversationId.mockReturnValue('C1:111.0');
 
@@ -293,6 +306,16 @@ describe('SlackWorkflowBridge', () => {
     expect(headerText).toContain('Approved');
     expect(headerText).toContain('<@U123>');
     expect(headerText).toContain('workflow resumed');
+
+    // The server auto-resumes only web parents, so the Slack bridge must resume
+    // the run itself — dispatched back through the run's own thread as the actor.
+    expect(resumeDispatches).toHaveLength(1);
+    expect(resumeDispatches[0]).toEqual({
+      text: '/workflow resume r1',
+      channel: 'C1',
+      threadTs: '111.0',
+      userId: 'U123',
+    });
   });
 
   test('reject button under retry threshold notes workflow will retry', async () => {
@@ -328,7 +351,7 @@ describe('SlackWorkflowBridge', () => {
   });
 
   test('reject button at max attempts notes the run was cancelled', async () => {
-    const { adapter, updated, triggerMap, dispatchAction } = makeFakeAdapter();
+    const { adapter, updated, triggerMap, dispatchAction, resumeDispatches } = makeFakeAdapter();
     triggerMap.set('C1:111.0', { channel: 'C1', ts: '111.0' });
     mockGetConversationId.mockReturnValue('C1:111.0');
     mockRejectWorkflow.mockResolvedValue({ cancelled: true, maxAttemptsReached: true });
@@ -357,6 +380,8 @@ describe('SlackWorkflowBridge', () => {
     const text = (updated[0]?.blocks?.[0] as { text?: { text?: string } } | undefined)?.text?.text;
     expect(text).toContain('Rejected');
     expect(text).toContain('max reject attempts reached');
+    // A cancelling reject ends the run — nothing to resume.
+    expect(resumeDispatches).toHaveLength(0);
   });
 
   test('cancel button calls abandonWorkflow', async () => {

--- a/packages/adapters/src/chat/slack/workflow-bridge.test.ts
+++ b/packages/adapters/src/chat/slack/workflow-bridge.test.ts
@@ -138,6 +138,7 @@ function makeFakeAdapter(allowedUserIds: string[] = []) {
     dispatchThreadCommand: mock(
       async (text: string, channel: string, threadTs: string, userId: string) => {
         resumeDispatches.push({ text, channel, threadTs, userId });
+        return true;
       }
     ),
   };
@@ -341,6 +342,41 @@ describe('SlackWorkflowBridge', () => {
     expect(headerText).toContain('resume manually');
     // Nothing to continue in-process, so no dispatch.
     expect(resumeDispatches).toHaveLength(0);
+  });
+
+  test('approval whose resume dispatch is not accepted reports manual resume', async () => {
+    // Run state exists, so the dispatch is attempted — but the adapter reports it
+    // was not accepted (returns false). The resolution edit must reflect that, not
+    // the unconditional "workflow resumed".
+    const { adapter, updated, triggerMap, dispatchAction } = makeFakeAdapter();
+    triggerMap.set('C1:111.0', { channel: 'C1', ts: '111.0' });
+    mockGetConversationId.mockReturnValue('C1:111.0');
+    adapter.dispatchThreadCommand = mock(async () => false);
+
+    new SlackWorkflowBridge(adapter as never).attach();
+    await dispatchEvent({
+      type: 'workflow_started',
+      runId: 'r1',
+      workflowName: 'assist',
+      conversationId: 'conv-db-uuid',
+    });
+    await dispatchEvent({
+      type: 'approval_pending',
+      runId: 'r1',
+      nodeId: 'review',
+      message: 'Approve?',
+    });
+
+    await dispatchAction('approve:r1:review', {
+      user: { id: 'U123' },
+      channel: { id: 'C1' },
+      message: { ts: '2.000' },
+    });
+
+    const headerText = (updated[0]?.blocks?.[0] as { text?: { text?: string } } | undefined)?.text
+      ?.text;
+    expect(headerText).not.toContain('workflow resumed');
+    expect(headerText).toContain('resume manually');
   });
 
   test('interactive-loop approval describes the aggregate completion condition', async () => {

--- a/packages/adapters/src/chat/slack/workflow-bridge.test.ts
+++ b/packages/adapters/src/chat/slack/workflow-bridge.test.ts
@@ -136,7 +136,7 @@ function makeFakeAdapter(allowedUserIds: string[] = []) {
     },
     getAllowedUserIds: () => allowedUserIds,
     dispatchThreadCommand: mock(
-      async (text: string, channel: string, threadTs: string, userId: string) => {
+      async (text: string, channel: string, threadTs: string, userId: string): Promise<boolean> => {
         resumeDispatches.push({ text, channel, threadTs, userId });
         return true;
       }
@@ -344,14 +344,14 @@ describe('SlackWorkflowBridge', () => {
     expect(resumeDispatches).toHaveLength(0);
   });
 
-  test('approval whose resume dispatch is not accepted reports manual resume', async () => {
+  test('approval whose resume dispatch is not accepted reports manual resume', async (): Promise<void> => {
     // Run state exists, so the dispatch is attempted — but the adapter reports it
     // was not accepted (returns false). The resolution edit must reflect that, not
     // the unconditional "workflow resumed".
     const { adapter, updated, triggerMap, dispatchAction } = makeFakeAdapter();
     triggerMap.set('C1:111.0', { channel: 'C1', ts: '111.0' });
     mockGetConversationId.mockReturnValue('C1:111.0');
-    adapter.dispatchThreadCommand = mock(async () => false);
+    adapter.dispatchThreadCommand = mock(async (): Promise<boolean> => false);
 
     new SlackWorkflowBridge(adapter as never).attach();
     await dispatchEvent({

--- a/packages/adapters/src/chat/slack/workflow-bridge.test.ts
+++ b/packages/adapters/src/chat/slack/workflow-bridge.test.ts
@@ -318,6 +318,31 @@ describe('SlackWorkflowBridge', () => {
     });
   });
 
+  test('approval with no in-process run state reports manual resume, does not claim it resumed', async () => {
+    // No workflow_started / approval_pending events here: this.runs stays empty,
+    // simulating buttons that outlived a server restart. The gate still resolves
+    // against the DB, but nothing in-process can continue the run.
+    const { adapter, updated, dispatchAction, resumeDispatches } = makeFakeAdapter();
+
+    new SlackWorkflowBridge(adapter as never).attach();
+    await dispatchAction('approve:r1:review', {
+      user: { id: 'U123' },
+      channel: { id: 'C1' },
+      message: { ts: '2.000' },
+    });
+
+    expect(mockApproveWorkflow).toHaveBeenCalledWith('r1');
+    expect(updated).toHaveLength(1);
+    const headerText = (updated[0]?.blocks?.[0] as { text?: { text?: string } } | undefined)?.text
+      ?.text;
+    // The note must not claim a resume that never happened; it must point the
+    // user at the only way to continue the run.
+    expect(headerText).not.toContain('workflow resumed');
+    expect(headerText).toContain('resume manually');
+    // Nothing to continue in-process, so no dispatch.
+    expect(resumeDispatches).toHaveLength(0);
+  });
+
   test('interactive-loop approval describes the aggregate completion condition', async () => {
     const { adapter, updated, triggerMap, dispatchAction } = makeFakeAdapter();
     triggerMap.set('C1:111.0', { channel: 'C1', ts: '111.0' });

--- a/packages/adapters/src/chat/slack/workflow-bridge.ts
+++ b/packages/adapters/src/chat/slack/workflow-bridge.ts
@@ -506,29 +506,34 @@ export class SlackWorkflowBridge {
       // in "approved/awaiting resume" with no further output in the thread.
       // Continue it here by dispatching `/workflow resume <id>` back through the
       // Slack conversation, so the remaining nodes and final report stream into
-      // this same thread. Fire-and-forget: the resolution edit below must still
-      // land even if the resume dispatch is slow or fails.
+      // this same thread. We await dispatch *acceptance* (not the resumed run —
+      // that stays fire-and-forget inside dispatchThreadCommand), which is what
+      // lets the resolution note below tell the truth about whether the run was
+      // actually continued.
       if (shouldResume) {
         const runState = this.runs.get(runId);
+        let dispatched = false;
         if (runState && actorId) {
-          void this.adapter
-            .dispatchThreadCommand(
+          try {
+            dispatched = await this.adapter.dispatchThreadCommand(
               `/workflow resume ${runId}`,
               runState.channel,
               runState.threadTs,
               actorId
-            )
-            .catch(err => {
-              getLog().error({ err, runId }, 'slack.bridge_resume_dispatch_failed');
-            });
+            );
+          } catch (err) {
+            getLog().error({ err, runId }, 'slack.bridge_resume_dispatch_failed');
+          }
         } else {
-          // No in-process run state — e.g. after a server restart the buttons
-          // survive in Slack and the gate still resolves against the DB, but
-          // `this.runs` is empty so nothing here can continue the run. This is
-          // the one path where the thread is the user's only signal, so the note
-          // must not claim a resume that never happened.
-          outcomeNote = `recorded — resume manually with \`archon workflow resume ${runId}\` (no active session to continue it here)`;
           getLog().warn({ runId, hasRunState: Boolean(runState) }, 'slack.bridge_resume_skipped');
+        }
+        if (!dispatched) {
+          // The gate resolved in the DB, but nothing here continued the run —
+          // no in-process run state (buttons that outlived a server restart), or
+          // the resume command was never dispatched. This is the path where the
+          // thread is the user's only signal, so the note must not claim a resume
+          // that never happened; point them at the only way to continue it.
+          outcomeNote = `recorded — resume manually with \`archon workflow resume ${runId}\` (nothing continued the run here)`;
         }
       }
 

--- a/packages/adapters/src/chat/slack/workflow-bridge.ts
+++ b/packages/adapters/src/chat/slack/workflow-bridge.ts
@@ -466,6 +466,9 @@ export class SlackWorkflowBridge {
     // block builder or chat.update can throw. Bolt has no app.error registered,
     // so an unhandled rejection here means the user sees nothing.
     let outcomeNote: string | undefined;
+    // Whether the resolved gate leaves the run in a resumable state that the
+    // Slack side must continue itself (see the dispatch below).
+    let shouldResume = false;
     try {
       try {
         if (decision === 'approved') {
@@ -478,6 +481,7 @@ export class SlackWorkflowBridge {
             result.type === 'interactive_loop'
               ? 'recorded — finalizes if the gate paused after a completion condition was met, otherwise the loop runs another iteration on resume'
               : 'workflow resumed';
+          shouldResume = true;
         } else {
           const result = await workflowOperations.rejectWorkflow(runId, 'Rejected');
           outcomeNote = result.cancelled
@@ -487,12 +491,39 @@ export class SlackWorkflowBridge {
             : result.newMode
               ? 'recorded — the run continues'
               : 'recorded — workflow will retry with feedback';
+          // A non-cancelling reject runs the node's on_reject flow on resume.
+          shouldResume = !result.cancelled;
         }
       } catch (error) {
         const err = error as Error;
         getLog().error({ err, runId, nodeId, decision }, 'slack.bridge_approval_action_failed');
         // Keep the user-facing note generic — full error stays in logs.
         outcomeNote = 'error: see server logs';
+      }
+
+      // The server's post-gate auto-resume (`tryAutoResumeAfterGate`) only fires
+      // for web-sourced parents; a Slack-resolved gate otherwise strands the run
+      // in "approved/awaiting resume" with no further output in the thread.
+      // Continue it here by dispatching `/workflow resume <id>` back through the
+      // Slack conversation, so the remaining nodes and final report stream into
+      // this same thread. Fire-and-forget: the resolution edit below must still
+      // land even if the resume dispatch is slow or fails.
+      if (shouldResume) {
+        const runState = this.runs.get(runId);
+        if (runState && actorId) {
+          void this.adapter
+            .dispatchThreadCommand(
+              `/workflow resume ${runId}`,
+              runState.channel,
+              runState.threadTs,
+              actorId
+            )
+            .catch(err => {
+              getLog().error({ err, runId }, 'slack.bridge_resume_dispatch_failed');
+            });
+        } else {
+          getLog().warn({ runId, hasRunState: Boolean(runState) }, 'slack.bridge_resume_skipped');
+        }
       }
 
       await this.applyResolutionEdit({

--- a/packages/adapters/src/chat/slack/workflow-bridge.ts
+++ b/packages/adapters/src/chat/slack/workflow-bridge.ts
@@ -466,6 +466,9 @@ export class SlackWorkflowBridge {
     // block builder or chat.update can throw. Bolt has no app.error registered,
     // so an unhandled rejection here means the user sees nothing.
     let outcomeNote: string | undefined;
+    // Whether the resolved gate leaves the run in a resumable state that the
+    // Slack side must continue itself (see the dispatch below).
+    let shouldResume = false;
     try {
       try {
         if (decision === 'approved') {
@@ -478,6 +481,7 @@ export class SlackWorkflowBridge {
             result.type === 'interactive_loop'
               ? 'recorded — finalizes if the gate paused on a completion signal, otherwise the loop runs another iteration on resume'
               : 'workflow resumed';
+          shouldResume = true;
         } else {
           const result = await workflowOperations.rejectWorkflow(runId);
           outcomeNote = result.cancelled
@@ -485,12 +489,39 @@ export class SlackWorkflowBridge {
               ? 'cancelled — max reject attempts reached'
               : 'cancelled'
             : 'recorded — workflow will retry with feedback';
+          // A non-cancelling reject runs the node's on_reject flow on resume.
+          shouldResume = !result.cancelled;
         }
       } catch (error) {
         const err = error as Error;
         getLog().error({ err, runId, nodeId, decision }, 'slack.bridge_approval_action_failed');
         // Keep the user-facing note generic — full error stays in logs.
         outcomeNote = 'error: see server logs';
+      }
+
+      // The server's post-gate auto-resume (`tryAutoResumeAfterGate`) only fires
+      // for web-sourced parents; a Slack-resolved gate otherwise strands the run
+      // in "approved/awaiting resume" with no further output in the thread.
+      // Continue it here by dispatching `/workflow resume <id>` back through the
+      // Slack conversation, so the remaining nodes and final report stream into
+      // this same thread. Fire-and-forget: the resolution edit below must still
+      // land even if the resume dispatch is slow or fails.
+      if (shouldResume) {
+        const runState = this.runs.get(runId);
+        if (runState && actorId) {
+          void this.adapter
+            .dispatchThreadCommand(
+              `/workflow resume ${runId}`,
+              runState.channel,
+              runState.threadTs,
+              actorId
+            )
+            .catch(err => {
+              getLog().error({ err, runId }, 'slack.bridge_resume_dispatch_failed');
+            });
+        } else {
+          getLog().warn({ runId, hasRunState: Boolean(runState) }, 'slack.bridge_resume_skipped');
+        }
       }
 
       await this.applyResolutionEdit({

--- a/packages/adapters/src/chat/slack/workflow-bridge.ts
+++ b/packages/adapters/src/chat/slack/workflow-bridge.ts
@@ -522,6 +522,12 @@ export class SlackWorkflowBridge {
               getLog().error({ err, runId }, 'slack.bridge_resume_dispatch_failed');
             });
         } else {
+          // No in-process run state — e.g. after a server restart the buttons
+          // survive in Slack and the gate still resolves against the DB, but
+          // `this.runs` is empty so nothing here can continue the run. This is
+          // the one path where the thread is the user's only signal, so the note
+          // must not claim a resume that never happened.
+          outcomeNote = `recorded — resume manually with \`archon workflow resume ${runId}\` (no active session to continue it here)`;
           getLog().warn({ runId, hasRunState: Boolean(runState) }, 'slack.bridge_resume_skipped');
         }
       }


### PR DESCRIPTION
## Summary

- **Problem:** Approving (or non-cancelling reject) a paused workflow gate from Slack marks the gate resolved but never continues the run. It strands in `approved / awaiting resume`, no further nodes run, and no status update or final report reaches the thread — even though the bridge reports `workflow resumed`.
- **Why it matters:** Slack is the most complete chat approval surface, but it's non-functional past the button — finishing a run requires an out-of-band `archon workflow resume <id>`.
- **What changed:** The Slack adapter now runs its own post-gate re-run flow: after approve / non-cancelling reject it dispatches `/workflow resume <id>` back through the run's own Slack thread, so the remaining nodes and the final report stream into that same thread. The new synthetic-command entry point authorizes at the adapter boundary.
- **What did NOT change (scope boundary):** No server-side, web, Telegram, Discord, or CLI behavior; no schema; no new config/env; no change to how gates are *resolved* — only how a resolved gate is *continued* on Slack.

## UX Journey

### Before

```
User                 Slack bridge              Workflow engine
────                 ────────────              ───────────────
click Approve ─────▶ approveWorkflow()  ──────▶ gate resolved (paused)
                     edits msg "Approved"
                     (says "workflow resumed")
                     ✗ nothing dispatched
   run stays paused; thread never updates; no report      ← STUCK
```

### After

```
User                 Slack bridge                 Workflow engine
────                 ────────────                 ───────────────
click Approve ─────▶ approveWorkflow()     ──────▶ gate resolved
                     edits msg "Approved"
                    *dispatchThreadCommand*
                    *"/workflow resume <id>"* ────▶ resumes remaining nodes
   status msg advances ◀──── node events ◀─────────  emits events
   final report in thread ◀── workflow_completed ◀──  run completes
```

## Architecture Diagram

### Before

```
[server] tryAutoResumeAfterGate ──(web only)──▶ dispatchToOrchestrator
   x── non-web parents skip (Slack strands here)

[slack] workflow-bridge.handleApprovalDecision ──▶ approveWorkflow / rejectWorkflow
                                                    (no resume)
```

### After

```
[server] tryAutoResumeAfterGate ──(web only, unchanged)──▶ dispatchToOrchestrator

[slack] workflow-bridge.handleApprovalDecision ──▶ approve/reject
             │
             └==▶ [~] SlackAdapter.dispatchThreadCommand("/workflow resume <id>")
                        └──▶ messageHandler (same inbound path) ──▶ orchestrator resume
```

**Connection inventory:**

| From | To | Status | Notes |
|------|----|--------|-------|
| `workflow-bridge.handleApprovalDecision` | `SlackAdapter.dispatchThreadCommand` | **new** | resume dispatch on resolvable outcomes |
| `SlackAdapter.dispatchThreadCommand` | `messageHandler` (orchestrator) | **new** | synthetic `/workflow resume <id>` in-thread |
| `handleApprovalDecision` | `approveWorkflow` / `rejectWorkflow` | unchanged | |
| server `tryAutoResumeAfterGate` | anything | unchanged | still web-only by design |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: S`
- Scope: `adapters`
- Module: `adapters:slack`

## Change Metadata

- Change type: `bug`
- Primary scope: `adapters`

## Linked Issue

- Related #2008 (resume-after-approval through the originating conversation)
- Closes: none filed

## Validation Evidence (required)

```bash
bun test packages/adapters/src/chat/slack/     # 80 pass, 0 fail (4 files)
bun x tsc --noEmit   (packages/adapters)        # clean
bun x eslint <changed files>                    # clean
bun x prettier --write <changed files>          # formatted
```

- Evidence: new tests assert that approve dispatches `/workflow resume <id>` into the run's thread as the acting user, that a cancelling reject does not dispatch, and that `dispatchThreadCommand` rejects unauthorized users (messageHandler not called).
- Skipped: full-suite `bun run validate` not run (change is confined to the Slack adapter; targeted package tests + typecheck + lint cover it).

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No** (reuses existing Slack Web API / Socket Mode)
- Secrets/tokens handling changed? **No**
- File system access scope changed? **No**
- Note: `dispatchThreadCommand` is a public method that reaches `messageHandler`, so it enforces the same whitelist (`isSlackUserAuthorized`) as the app_mention / message.im / slash inbound paths — silent rejection with a masked user-id log — rather than trusting callers.

## Compatibility / Migration

- Backward compatible? **Yes** — additive; only affects Slack-resolved gates that previously did nothing.
- Config/env changes? **No**
- Database migration needed? **No**

## Human Verification (required)

- Verified scenarios: 80/80 Slack adapter+bridge tests pass; `tsc`/eslint/prettier clean. Built the branch into a standalone darwin-arm64 binary, ran `serve` against a live Slack workspace, confirmed the bridge attaches and a gated workflow runs to its approval gate.
- Edge cases checked (unit): cancelling reject → no resume dispatch; unauthorized actor → no dispatch.
- Not yet verified in this PR: multi-gate workflows and interactive-loop gates (`capture_response` re-run) beyond the single approval gate exercised live.

## Side Effects / Blast Radius (required)

- Affected subsystems: Slack adapter only (`adapters:slack`).
- Potential unintended effects: a second inbound orchestrator turn per resolved gate (the synthetic resume message). Fire-and-forget, so a slow/failed dispatch is logged (`slack.bridge_resume_dispatch_failed`) and never blocks the resolution-message edit.
- Guardrails: structured logs `slack.thread_command_dispatch_{started,completed,failed}` and `slack.bridge_resume_{dispatch_failed,skipped}` make the path observable.

## Rollback Plan (required)

- Fast rollback: revert the two commits on this branch; behavior returns to "approval recorded, no auto-resume" (pre-PR state) with no data effect.
- Feature flags: none.
- Observable failure symptoms: `slack.bridge_resume_dispatch_failed` in logs, or a run staying `paused` after a Slack approval.

## Risks and Mitigations

- Risk: the synthetic resume message double-triggers if a run is somehow resumed twice.
  - Mitigation: `/workflow resume` targets a specific run id and no-ops on non-resumable states; dispatch only fires on approve or a non-cancelling reject.
- Risk: resume output lands in the wrong conversation.
  - Mitigation: dispatch carries the run's own `channel`/`threadTs`, so `getConversationId` maps it back to the same Slack conversation the run started in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slack workflow approvals can automatically resume workflows in their originating thread when an accepted command is available.
  * Authorized users can dispatch commands within Slack threads.
  * Approval messages now indicate when manual resumption is required.

* **Bug Fixes**
  * Prevented unauthorized commands, unavailable workflow runs, and rejected dispatches from triggering workflow resumption.
  * Workflow resumption failures no longer interrupt approval message updates.
  * Cancelled workflows no longer resume after maximum-attempt rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->