### PR TITLE
feat: add deterministic workflow dry-run

### DIFF
--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -22,6 +22,18 @@ describe('CLI help output', () => {
       'workflow resume <run-id>   Resume a failed or paused run from completed nodes'
     );
   });
+
+  it('documents workflow dry-run flags', () => {
+    const result = spawnSync(process.execPath, [join(import.meta.dir, 'cli.ts'), '--help'], {
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('--dry-run');
+    expect(result.stdout).toContain('--stubs <path>');
+    expect(result.stdout).toContain('--exec-code');
+    expect(result.stdout).toContain('--pause-at-gates');
+  });
 });
 
 // Test the argument parsing logic used in cli.ts
@@ -45,6 +57,10 @@ describe('CLI argument parsing', () => {
         verbose: { type: 'boolean', short: 'v' },
         scope: { type: 'string' },
         force: { type: 'boolean' },
+        'dry-run': { type: 'boolean' },
+        stubs: { type: 'string' },
+        'exec-code': { type: 'boolean' },
+        'pause-at-gates': { type: 'boolean' },
       },
       allowPositionals: true,
       strict: false,
@@ -172,6 +188,24 @@ describe('CLI argument parsing', () => {
     it('should parse --base flag for workflow run', () => {
       const result = parseCliArgs(['workflow', 'run', 'assist', '--base', 'epic/foo']);
       expect(result.values.base).toBe('epic/foo');
+    });
+
+    it('parses workflow dry-run flags', () => {
+      const result = parseCliArgs([
+        'workflow',
+        'run',
+        'assist',
+        '--dry-run',
+        '--stubs',
+        'fixtures.yaml',
+        '--exec-code',
+        '--pause-at-gates',
+      ]);
+
+      expect(result.values['dry-run']).toBe(true);
+      expect(result.values.stubs).toBe('fixtures.yaml');
+      expect(result.values['exec-code']).toBe(true);
+      expect(result.values['pause-at-gates']).toBe(true);
     });
   });
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -159,6 +159,10 @@ Options:
   --no-worktree              Run on branch directly without worktree isolation
   --folder                   Register the current non-git directory as a folder project and run in place
   --resume                   Resume the most recent failed or paused run of the workflow (mutually exclusive with --branch)
+  --dry-run                  Simulate workflow DAG control flow without creating a run or contacting a provider
+  --stubs <path>             YAML node-output map for --dry-run
+  --exec-code                Execute trusted bash/script nodes during --dry-run (default: require stubs)
+  --pause-at-gates           Stop a dry-run at approval gates instead of auto-approving
   --spawn                    Open setup wizard in a new terminal window (for setup command)
   --quiet, -q                Reduce log verbosity to warnings and errors only
   --verbose, -v              Show debug-level output
@@ -185,6 +189,7 @@ Examples:
   archon workflow run quick-fix --no-worktree "Fix typo"
   archon workflow run assist --folder "List every repo under this multi-repo root"
   archon workflow run archon-assist --detach "Investigate the flaky test"
+  archon workflow run assist --dry-run --stubs ./stubs.yaml --json
   archon workflow runs --json
   archon workflow get <run-id> --json
   archon workflow resume <run-id>
@@ -310,6 +315,10 @@ async function main(): Promise<number> {
         limit: { type: 'string' },
         effort: { type: 'string' },
         full: { type: 'boolean' },
+        'dry-run': { type: 'boolean' },
+        stubs: { type: 'string' },
+        'exec-code': { type: 'boolean' },
+        'pause-at-gates': { type: 'boolean' },
       },
       allowPositionals: true,
       strict: false, // Allow unknown flags to pass through
@@ -336,6 +345,10 @@ async function main(): Promise<number> {
   const spawnFlag = values.spawn as boolean | undefined;
   const jsonFlag = values.json as boolean | undefined;
   const detachFlag = values.detach as boolean | undefined;
+  const dryRunFlag = values['dry-run'] as boolean | undefined;
+  const stubsPath = values.stubs as string | undefined;
+  const execCodeFlag = values['exec-code'] as boolean | undefined;
+  const pauseAtGatesFlag = values['pause-at-gates'] as boolean | undefined;
   // Handle help flag
   if (values.help) {
     printUsage();
@@ -412,6 +425,10 @@ async function main(): Promise<number> {
       if (repoRoot) {
         // Use repo root as working directory (handles subdirectory case)
         effectiveCwd = repoRoot;
+      } else if (dryRunFlag && command === 'workflow' && subcommand === 'run') {
+        // Dry-run only discovers workflow files and simulates in memory. It does
+        // not need project registration, a database lookup, or a git worktree.
+        effectiveCwd = cwd;
       } else {
         // Not a git repo. It may still be a registered FOLDER project (a
         // multi-repo root or plain ops folder). Consult the DB before rejecting.
@@ -583,6 +600,10 @@ async function main(): Promise<number> {
               conversationId: values['conversation-id'] as string | undefined,
               detach: detachFlag,
               json: jsonFlag,
+              dryRun: dryRunFlag,
+              stubsPath,
+              execCode: execCodeFlag,
+              pauseAtGates: pauseAtGatesFlag,
             };
             await workflowRunCommand(effectiveCwd, workflowName, userMessage, options);
             break;

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -543,7 +543,7 @@ describe('workflowRunCommand — dry-run', () => {
       json: true,
     });
 
-    expect(dryRun.loadDryRunStubs).toHaveBeenCalledWith('/test/path/fixtures.yaml');
+    expect(dryRun.loadDryRunStubs).toHaveBeenCalledWith(join('/test/path', 'fixtures.yaml'));
     expect(dryRun.dryRunWorkflow).toHaveBeenCalledWith(
       expect.objectContaining({
         userMessage: 'hello',

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -115,6 +115,28 @@ mock.module('@archon/workflows/executor', () => ({
   executeWorkflow: mock(() => Promise.resolve({ success: true, workflowRunId: 'test-run-id' })),
   hydrateResumableRun: mock(() => Promise.resolve(null)),
 }));
+mock.module('@archon/workflows/dry-run', () => ({
+  loadDryRunStubs: mock(() => Promise.resolve({ node: 'stubbed output' })),
+  dryRunWorkflow: mock(() =>
+    Promise.resolve({
+      workflow: 'plan',
+      outcome: 'completed',
+      trace: [
+        {
+          nodeId: 'node',
+          nodeType: 'command',
+          state: 'stubbed',
+          resolvedText: 'command:test-command',
+          output: 'stubbed output',
+        },
+      ],
+      missingStubs: [],
+      unusedStubs: [],
+      summary: 'stubbed output',
+    })
+  ),
+  formatDryRunTrace: mock(() => 'DRY RUN TRACE'),
+}));
 
 // Capture the subscription handler so tests can trigger events
 let capturedSubscribeHandler: ((event: WorkflowEmitterEvent) => void) | null = null;
@@ -473,6 +495,110 @@ describe('workflowListCommand', () => {
     // alone is the signal.
     expect(parsed.workflows[0].parseWarnings).toBeUndefined();
     expect(parsed.workflows[1].parseWarnings).toEqual(["dropped 'interactive'"]);
+  });
+});
+
+describe('workflowRunCommand — dry-run', () => {
+  let stdoutSpy: ReturnType<typeof spyOn>;
+  let consoleSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(async () => {
+    stdoutSpy = spyOnJsonStdout();
+    consoleSpy = spyOn(console, 'log').mockImplementation(() => {});
+    const { executeWorkflow } = await import('@archon/workflows/executor');
+    const dryRun = await import('@archon/workflows/dry-run');
+    (executeWorkflow as ReturnType<typeof mock>).mockClear();
+    (dryRun.loadDryRunStubs as ReturnType<typeof mock>).mockClear();
+    (dryRun.dryRunWorkflow as ReturnType<typeof mock>).mockClear();
+    (dryRun.formatDryRunTrace as ReturnType<typeof mock>).mockClear();
+    (dryRun.dryRunWorkflow as ReturnType<typeof mock>).mockResolvedValue({
+      workflow: 'plan',
+      outcome: 'completed',
+      trace: [],
+      missingStubs: [],
+      unusedStubs: [],
+      summary: 'done',
+    });
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'plan' }, 'project')],
+      errors: [],
+    });
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    consoleSpy.mockRestore();
+  });
+
+  it('runs the simulator before real-run setup and writes one JSON document', async () => {
+    const { executeWorkflow } = await import('@archon/workflows/executor');
+    const dryRun = await import('@archon/workflows/dry-run');
+
+    await workflowRunCommand('/test/path', 'plan', 'hello', {
+      dryRun: true,
+      stubsPath: 'fixtures.yaml',
+      execCode: true,
+      pauseAtGates: true,
+      json: true,
+    });
+
+    expect(dryRun.loadDryRunStubs).toHaveBeenCalledWith('/test/path/fixtures.yaml');
+    expect(dryRun.dryRunWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userMessage: 'hello',
+        cwd: '/test/path',
+        execCode: true,
+        pauseAtGates: true,
+      })
+    );
+    expect(executeWorkflow).not.toHaveBeenCalled();
+    expect(stdoutSpy).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(firstJsonPayload(stdoutSpy))).toMatchObject({
+      workflow: 'plan',
+      outcome: 'completed',
+    });
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  it('writes the human trace through guaranteed stdout delivery', async () => {
+    const dryRun = await import('@archon/workflows/dry-run');
+
+    await workflowRunCommand('/test/path', 'plan', '', { dryRun: true });
+
+    expect(dryRun.formatDryRunTrace).toHaveBeenCalled();
+    expect(firstJsonPayload(stdoutSpy)).toBe('DRY RUN TRACE');
+  });
+
+  it('rejects dry-run-only and incompatible lifecycle flags', async () => {
+    await expect(
+      workflowRunCommand('/test/path', 'plan', '', { stubsPath: 'fixtures.yaml' })
+    ).rejects.toThrow('--stubs requires --dry-run');
+
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'plan' }, 'project')],
+      errors: [],
+    });
+    await expect(
+      workflowRunCommand('/test/path', 'plan', '', { dryRun: true, detach: true })
+    ).rejects.toThrow('--dry-run cannot be combined with --detach');
+  });
+
+  it('emits failure JSON before returning a nonzero-worthy error', async () => {
+    const dryRun = await import('@archon/workflows/dry-run');
+    (dryRun.dryRunWorkflow as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflow: 'plan',
+      outcome: 'failed',
+      trace: [],
+      missingStubs: ['node'],
+      unusedStubs: [],
+    });
+
+    await expect(
+      workflowRunCommand('/test/path', 'plan', '', { dryRun: true, json: true })
+    ).rejects.toThrow('missing stubs: node');
+    expect(JSON.parse(firstJsonPayload(stdoutSpy))).toMatchObject({ outcome: 'failed' });
   });
 });
 

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -35,7 +35,7 @@ import {
   readTierNoticeState,
   markTierNoticeShown,
 } from '@archon/paths';
-import { join } from 'node:path';
+import { isAbsolute, join } from 'node:path';
 import { mkdirSync, openSync, closeSync, readFileSync, writeSync } from 'node:fs';
 import { spawn, type ChildProcess } from 'node:child_process';
 import { createWorkflowDeps } from '@archon/core/workflows/store-adapter';
@@ -43,6 +43,7 @@ import { createChildWorktreeResolver } from '@archon/core/workflows/child-isolat
 import { discoverWorkflowsWithConfig } from '@archon/workflows/workflow-discovery';
 import { resolveWorkflowName } from '@archon/workflows/router';
 import { executeWorkflow, hydrateResumableRun } from '@archon/workflows/executor';
+import { dryRunWorkflow, formatDryRunTrace, loadDryRunStubs } from '@archon/workflows/dry-run';
 import { assertWorkflowRequirementsMet } from '@archon/workflows/utils/workflow-requirements';
 import {
   getWorkflowEventEmitter,
@@ -210,6 +211,14 @@ export interface WorkflowRunOptions {
    * `--json` alone still suppresses CLI logs but does not change the output).
    */
   json?: boolean;
+  /** Simulate deterministic DAG control flow without creating run state or contacting a provider. */
+  dryRun?: boolean;
+  /** YAML mapping of node ids to scalar or structured simulated outputs. */
+  stubsPath?: string;
+  /** Execute reachable bash/script nodes locally instead of requiring stubs. */
+  execCode?: boolean;
+  /** Stop at the first approval gate instead of auto-approving it. */
+  pauseAtGates?: boolean;
 }
 
 /**
@@ -919,6 +928,61 @@ export async function workflowRunCommand(
   // reaches an agent driving runs through `--json`. Not gated on --quiet — a
   // dropped key can be a gate the author believes is protecting the run.
   emitParseWarnings(workflowEntry?.parseWarnings, workflow.name);
+
+  const dryRunOnlyOptions = [
+    ['--stubs', options.stubsPath !== undefined],
+    ['--exec-code', options.execCode === true],
+    ['--pause-at-gates', options.pauseAtGates === true],
+  ] as const;
+  const optionWithoutDryRun = dryRunOnlyOptions.find(([, present]) => present)?.[0];
+  if (!options.dryRun && optionWithoutDryRun) {
+    throw new Error(`${optionWithoutDryRun} requires --dry-run.`);
+  }
+
+  if (options.dryRun) {
+    const incompatible = [
+      ['--branch', options.branchName !== undefined],
+      ['--from/--from-branch', options.fromBranch !== undefined],
+      ['--base', options.baseBranch !== undefined],
+      ['--no-worktree', options.noWorktree === true],
+      ['--folder', options.folder === true],
+      ['--container', options.container === true],
+      ['--resume', options.resume === true],
+      ['--detach', options.detach === true],
+    ] as const;
+    const incompatibleFlag = incompatible.find(([, present]) => present)?.[0];
+    if (incompatibleFlag) {
+      throw new Error(`--dry-run cannot be combined with ${incompatibleFlag}.`);
+    }
+
+    const stubsPath = options.stubsPath
+      ? isAbsolute(options.stubsPath)
+        ? options.stubsPath
+        : join(effectiveDiscoveryCwd, options.stubsPath)
+      : undefined;
+    const stubs = await loadDryRunStubs(stubsPath);
+    const result = await dryRunWorkflow({
+      workflow,
+      userMessage,
+      cwd: effectiveDiscoveryCwd,
+      stubs,
+      execCode: options.execCode,
+      pauseAtGates: options.pauseAtGates,
+    });
+    if (options.json) {
+      await writeJsonLine(result);
+    } else {
+      await writeStdout(`${formatDryRunTrace(result)}\n`);
+    }
+    if (result.outcome === 'failed') {
+      throw new Error(
+        result.missingStubs.length > 0
+          ? `Dry-run failed; missing stubs: ${result.missingStubs.join(', ')}`
+          : 'Dry-run failed. See the trace for details.'
+      );
+    }
+    return;
+  }
 
   // Validate mutually exclusive flags (defensive — cli.ts checks these for UX, but
   // workflowRunCommand is the authoritative boundary for programmatic callers)

--- a/packages/docs-web/src/content/docs/reference/cli.md
+++ b/packages/docs-web/src/content/docs/reference/cli.md
@@ -202,7 +202,7 @@ Progress events (node start/complete/fail/skip, approval gates) are written to s
 
 If the workflow's YAML declares keys the engine ignores, a warning naming each one is written to **stderr before the run starts**. This matters to `--detach --json` callers: `--json` silences all logging, so stderr is the only channel left, and it keeps stdout to exactly the JSON payload.
 
-Note that `run` emits a JSON payload **only** under `--detach`. Without it, `--json` suppresses logs but the command still prints human progress to stdout (`Running workflow: …`), so do not pipe plain `run --json` into a parser. See [Unknown keys](/guides/authoring-workflows/#unknown-keys-are-reported-not-rejected).
+Note that a real `run` emits a JSON payload **only** under `--detach`. Without it, `--json` suppresses logs but the command still prints human progress to stdout (`Running workflow: …`), so do not pipe a plain real `run --json` into a parser. The side-effect-free `--dry-run --json` mode below is the other exception: it emits exactly one complete trace document. See [Unknown keys](/guides/authoring-workflows/#unknown-keys-are-reported-not-rejected).
 
 **Flags:**
 
@@ -219,6 +219,36 @@ Note that `run` emits a JSON payload **only** under `--detach`. Without it, `--j
 | `--quiet`, `-q` | Suppress all progress output to stderr |
 | `--verbose`, `-v` | Also show tool-level events (tool name and duration) |
 | `--detach` | Run in a detached background child and return immediately. The child does all the work; find it later with `workflow runs`/`workflow get`. Child stdout/stderr is captured to `~/.archon/logs/detached-run-<id>.log`. Combine with `--json` for a machine-readable ack. |
+| `--dry-run` | Simulate deterministic DAG control flow in memory. Creates no run, worktree, session, event, artifact, or provider request. |
+| `--stubs <path>` | YAML mapping of node ids to scalar or structured outputs for `--dry-run`. Relative paths resolve from `--cwd`. |
+| `--exec-code` | During `--dry-run`, execute trusted `bash:`/`script:` nodes locally instead of requiring stubs. Default is no code execution. |
+| `--pause-at-gates` | During `--dry-run`, stop at the first approval gate instead of auto-approving it. |
+
+#### Deterministic dry-run
+
+Use dry-run to test DAG routing, joins, loops, `when:`, strict output fields, and variable substitution without starting a real workflow:
+
+```bash
+cat > stubs.yaml <<'YAML'
+classify:
+  issue_type: bug
+  severity: high
+investigate: "Root cause: stale cache"
+YAML
+
+archon workflow run triage --cwd /path/to/repo \
+  --dry-run --stubs stubs.yaml "Issue #2100"
+
+# One complete JSON document, safe to pipe in CI
+archon workflow run triage --cwd /path/to/repo \
+  --dry-run --stubs stubs.yaml --json | jq '.trace, .outcome'
+```
+
+The stub file must contain one YAML mapping. Each value is either a string or an object. Object stubs are preserved as structured output, so downstream `$classify.output.severity` references behave like live structured producers. A reachable AI, bash, or script node without a stub fails the simulation and appears in `missingStubs`; stubs for unknown or unreachable nodes appear in `unusedStubs`. Whole-output references retain their normal lenient behavior, while invalid strict `$node.output.field` references fail the consuming node exactly as they do in a real run. See [Node Output References](/reference/variables/#node-output-references).
+
+By default, bash and script nodes are never executed. `--exec-code` is an explicit opt-in for trusted local workflow code and is the only dry-run mode that can cause code-level side effects. Approval nodes auto-complete unless `--pause-at-gates` is set. Runtime `workflow:` sub-runs are reported as unsupported instead of being launched. Dry-run is incompatible with lifecycle and isolation flags such as `--branch`, `--no-worktree`, `--folder`, `--container`, `--resume`, and `--detach`.
+
+The ordered trace records each node as completed, stubbed, skipped, failed, or paused, including its reason, resolved text, safe output, and final outcome. This validates deterministic engine wiring; it does not validate model reasoning. It adds no workflow-YAML language surface and follows the [workflow language constitution](/reference/workflow-language-constitution/): YAML coordinates, code computes, and agents judge.
 
 **Default (no flags):**
 - Creates worktree with auto-generated branch (`archon/task-<workflow>-<timestamp>`)

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -16,12 +16,13 @@
     "./command-validation": "./src/command-validation.ts",
     "./defaults": "./src/defaults/bundled-defaults.ts",
     "./validator": "./src/validator.ts",
+    "./dry-run": "./src/dry-run.ts",
     "./utils/tool-formatter": "./src/utils/tool-formatter.ts",
     "./utils/workflow-requirements": "./src/utils/workflow-requirements.ts",
     "./test-utils": "./src/test-utils.ts"
   },
   "scripts": {
-    "test": "bun test src/dag-executor.test.ts && bun test src/loader.test.ts src/include-expander.test.ts && bun test src/logger.test.ts && bun test src/condition-evaluator.test.ts && bun test src/output-ref.test.ts && bun test src/event-emitter.test.ts && bun test src/executor-shared.test.ts && bun test src/load-command-prompt.test.ts && bun test src/load-command-prompt-bundled.test.ts && bun test src/executor.test.ts && bun test src/subrun.test.ts && bun test src/executor-preamble.test.ts && bun test src/defaults/ src/model-validation.test.ts src/router.test.ts src/utils/ src/hooks.test.ts && bun test src/validation-parser.test.ts src/schemas.test.ts src/command-validation.test.ts src/packaged-workflow.test.ts && bun test src/validator.test.ts && bun test src/script-discovery.test.ts && bun test src/bundled-script-materialization.test.ts && bun test src/runtime-check.test.ts && bun test src/script-node-deps.test.ts && bun test src/artifacts-index.test.ts && bun test src/state-migration.test.ts",
+    "test": "bun test src/dag-executor.test.ts && bun test src/loader.test.ts src/include-expander.test.ts && bun test src/logger.test.ts && bun test src/condition-evaluator.test.ts && bun test src/output-ref.test.ts && bun test src/event-emitter.test.ts && bun test src/executor-shared.test.ts && bun test src/load-command-prompt.test.ts && bun test src/load-command-prompt-bundled.test.ts && bun test src/executor.test.ts && bun test src/subrun.test.ts && bun test src/executor-preamble.test.ts && bun test src/defaults/ src/model-validation.test.ts src/router.test.ts src/utils/ src/hooks.test.ts && bun test src/validation-parser.test.ts src/schemas.test.ts src/command-validation.test.ts src/packaged-workflow.test.ts && bun test src/validator.test.ts && bun test src/script-discovery.test.ts && bun test src/bundled-script-materialization.test.ts && bun test src/runtime-check.test.ts && bun test src/script-node-deps.test.ts && bun test src/artifacts-index.test.ts && bun test src/state-migration.test.ts src/dry-run.test.ts",
     "type-check": "bun x tsc --noEmit"
   },
   "dependencies": {

--- a/packages/workflows/src/dry-run.test.ts
+++ b/packages/workflows/src/dry-run.test.ts
@@ -1,0 +1,360 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { makeTestWorkflow } from './test-utils';
+import { dryRunWorkflow, formatDryRunTrace, loadDryRunStubs } from './dry-run';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function temporaryFile(content: string): string {
+  const directory = mkdtempSync(join(tmpdir(), 'archon-dry-run-'));
+  temporaryDirectories.push(directory);
+  const path = join(directory, 'stubs.yaml');
+  writeFileSync(path, content);
+  return path;
+}
+
+describe('loadDryRunStubs', () => {
+  test('loads scalar and structured node outputs', async () => {
+    const result = await loadDryRunStubs(
+      temporaryFile('classify: BUG\ndetails:\n  severity: high\n  count: 2\n')
+    );
+
+    expect(result).toEqual({ classify: 'BUG', details: { severity: 'high', count: 2 } });
+  });
+
+  test('rejects missing, list, multi-document, and invalid-value files', async () => {
+    await expect(loadDryRunStubs('/definitely/missing/stubs.yaml')).rejects.toThrow(
+      'Dry-run stub file not found'
+    );
+    await expect(loadDryRunStubs(temporaryFile('- one\n- two\n'))).rejects.toThrow(
+      'expected one YAML mapping'
+    );
+    await expect(loadDryRunStubs(temporaryFile('one: value\n---\ntwo: value\n'))).rejects.toThrow(
+      'expected one YAML mapping'
+    );
+    await expect(loadDryRunStubs(temporaryFile('node: 42\n'))).rejects.toThrow(
+      'Invalid dry-run stub file'
+    );
+  });
+});
+
+describe('dryRunWorkflow', () => {
+  test('hydrates object stubs and resolves workflow and strict output variables', async () => {
+    const workflow = makeTestWorkflow({
+      name: 'structured',
+      nodes: [
+        {
+          id: 'classify',
+          prompt: 'Classify $ARGUMENTS',
+          output_format: { type: 'object', properties: { kind: { type: 'string' } } },
+        },
+        {
+          id: 'use',
+          prompt: 'Handle $classify.output.kind for $USER_MESSAGE',
+          depends_on: ['classify'],
+        },
+      ],
+    });
+
+    const result = await dryRunWorkflow({
+      workflow,
+      userMessage: 'issue 2100',
+      cwd: process.cwd(),
+      stubs: { classify: { kind: 'BUG' }, use: 'done' },
+    });
+
+    expect(result.outcome).toBe('completed');
+    expect(result.trace[1]?.resolvedText).toBe('Handle BUG for issue 2100');
+    expect(result.summary).toBe('done');
+  });
+
+  test('loads and resolves command-file prompt text', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'archon-dry-run-command-'));
+    temporaryDirectories.push(cwd);
+    mkdirSync(join(cwd, '.archon', 'commands'), { recursive: true });
+    writeFileSync(join(cwd, '.archon', 'commands', 'inspect.md'), 'Inspect $ARGUMENTS');
+    const workflow = makeTestWorkflow({
+      name: 'command-text',
+      nodes: [{ id: 'inspect', command: 'inspect' }],
+    });
+
+    const result = await dryRunWorkflow({
+      workflow,
+      userMessage: 'issue 2100',
+      cwd,
+      stubs: { inspect: 'done' },
+    });
+
+    expect(result.trace[0]?.resolvedText).toBe('Inspect issue 2100');
+  });
+
+  test('distinguishes false and malformed when expressions', async () => {
+    const workflow = makeTestWorkflow({
+      name: 'conditions',
+      nodes: [
+        { id: 'source', prompt: 'source' },
+        { id: 'false', prompt: 'false', depends_on: ['source'], when: "$source.output == 'NO'" },
+        { id: 'malformed', prompt: 'bad', depends_on: ['source'], when: '$source ???' },
+      ],
+    });
+    const result = await dryRunWorkflow({
+      workflow,
+      userMessage: '',
+      cwd: process.cwd(),
+      stubs: { source: 'YES' },
+    });
+
+    expect(result.trace.map(entry => [entry.nodeId, entry.state, entry.reason])).toEqual([
+      ['source', 'stubbed', undefined],
+      ['false', 'skipped', 'when_condition_false'],
+      ['malformed', 'skipped', 'when_condition_parse_error'],
+    ]);
+    expect(result.missingStubs).toEqual([]);
+  });
+
+  test('applies all trigger rules after failed and skipped upstream nodes', async () => {
+    const workflow = makeTestWorkflow({
+      name: 'triggers',
+      nodes: [
+        { id: 'ok', prompt: 'ok' },
+        { id: 'skip', prompt: 'skip', when: "$ok.output == 'never'" },
+        { id: 'fail', prompt: 'missing' },
+        { id: 'all_success', prompt: 'a', depends_on: ['ok', 'skip'] },
+        { id: 'one_success', prompt: 'b', depends_on: ['ok', 'fail'], trigger_rule: 'one_success' },
+        {
+          id: 'none_failed',
+          prompt: 'c',
+          depends_on: ['ok', 'skip'],
+          trigger_rule: 'none_failed_min_one_success',
+        },
+        { id: 'all_done', prompt: 'd', depends_on: ['skip', 'fail'], trigger_rule: 'all_done' },
+      ],
+    });
+    const result = await dryRunWorkflow({
+      workflow,
+      userMessage: '',
+      cwd: process.cwd(),
+      stubs: { ok: 'yes', one_success: 'one', none_failed: 'none', all_done: 'done' },
+    });
+    const states = Object.fromEntries(result.trace.map(entry => [entry.nodeId, entry.state]));
+
+    expect(states.all_success).toBe('skipped');
+    expect(states.one_success).toBe('stubbed');
+    expect(states.none_failed).toBe('stubbed');
+    expect(states.all_done).toBe('stubbed');
+  });
+
+  test('keeps whole-output references lenient and fails strict unknown fields', async () => {
+    const workflow = makeTestWorkflow({
+      name: 'strict-refs',
+      nodes: [
+        { id: 'producer', prompt: 'p', output_format: { type: 'object', properties: { ok: {} } } },
+        { id: 'whole', prompt: 'whole=$unknown.output', depends_on: ['producer'] },
+        { id: 'strict', prompt: 'strict=$producer.output.typo', depends_on: ['producer'] },
+      ],
+    });
+    const result = await dryRunWorkflow({
+      workflow,
+      userMessage: '',
+      cwd: process.cwd(),
+      stubs: { producer: { ok: true }, whole: 'ok', strict: 'unused' },
+    });
+
+    expect(result.trace.find(entry => entry.nodeId === 'whole')?.resolvedText).toBe('whole=');
+    expect(result.trace.find(entry => entry.nodeId === 'strict')).toMatchObject({
+      state: 'failed',
+      reason: expect.stringContaining('not declared'),
+    });
+    expect(result.unusedStubs).toEqual(['strict']);
+  });
+
+  test('requires stubs only for reachable AI and default code nodes', async () => {
+    const workflow = makeTestWorkflow({
+      name: 'reachable',
+      nodes: [
+        { id: 'gate', prompt: 'gate' },
+        { id: 'unreachable', prompt: 'no', depends_on: ['gate'], when: "$gate.output == 'NO'" },
+        { id: 'code', bash: 'printf hello', depends_on: ['gate'] },
+      ],
+    });
+    const result = await dryRunWorkflow({
+      workflow,
+      userMessage: '',
+      cwd: process.cwd(),
+      stubs: { gate: 'YES' },
+    });
+
+    expect(result.missingStubs).toEqual(['code']);
+    expect(result.trace.find(entry => entry.nodeId === 'unreachable')?.state).toBe('skipped');
+  });
+
+  test('executes bash only with execCode and captures failures', async () => {
+    const success = makeTestWorkflow({
+      name: 'bash-ok',
+      nodes: [{ id: 'code', bash: 'printf hello' }],
+    });
+    const successResult = await dryRunWorkflow({
+      workflow: success,
+      userMessage: '',
+      cwd: process.cwd(),
+      execCode: true,
+    });
+    expect(successResult).toMatchObject({ outcome: 'completed', summary: 'hello' });
+    expect(successResult.trace[0]).toMatchObject({
+      state: 'completed',
+      reason: 'executed locally',
+    });
+
+    const failure = makeTestWorkflow({
+      name: 'bash-fail',
+      nodes: [{ id: 'code', bash: 'echo nope >&2; exit 7' }],
+    });
+    const failureResult = await dryRunWorkflow({
+      workflow: failure,
+      userMessage: '',
+      cwd: process.cwd(),
+      execCode: true,
+    });
+    expect(failureResult.outcome).toBe('failed');
+    expect(failureResult.trace[0]).toMatchObject({ state: 'failed', reason: 'nope' });
+  });
+
+  test('auto-approves or pauses approval gates', async () => {
+    const workflow = makeTestWorkflow({
+      name: 'approval',
+      nodes: [
+        { id: 'before', prompt: 'before' },
+        { id: 'gate', approval: { message: 'Review $before.output' }, depends_on: ['before'] },
+        { id: 'after', prompt: 'after', depends_on: ['gate'] },
+      ],
+    });
+    const automatic = await dryRunWorkflow({
+      workflow,
+      userMessage: '',
+      cwd: process.cwd(),
+      stubs: { before: 'result', after: 'done' },
+    });
+    expect(automatic.trace.find(entry => entry.nodeId === 'gate')).toMatchObject({
+      state: 'completed',
+      reason: 'auto-approved',
+    });
+
+    const paused = await dryRunWorkflow({
+      workflow,
+      userMessage: '',
+      cwd: process.cwd(),
+      stubs: { before: 'result', after: 'unused' },
+      pauseAtGates: true,
+    });
+    expect(paused.outcome).toBe('paused');
+    expect(paused.trace.at(-1)).toMatchObject({ nodeId: 'gate', state: 'paused' });
+    expect(paused.unusedStubs).toEqual(['after']);
+  });
+
+  test('simulates loop completion and max-iteration failure', async () => {
+    const completing = makeTestWorkflow({
+      name: 'loop-ok',
+      nodes: [
+        {
+          id: 'review',
+          loop: { prompt: 'Review $LOOP_PREV_OUTPUT', until: 'DONE', max_iterations: 3 },
+        },
+      ],
+    });
+    const completed = await dryRunWorkflow({
+      workflow: completing,
+      userMessage: '',
+      cwd: process.cwd(),
+      stubs: { review: '<promise>DONE</promise>' },
+    });
+    expect(completed.trace[0]).toMatchObject({
+      state: 'stubbed',
+      reason: 'completion signal after 1 iteration(s)',
+    });
+
+    const failed = await dryRunWorkflow({
+      workflow: completing,
+      userMessage: '',
+      cwd: process.cwd(),
+      stubs: { review: 'keep going' },
+    });
+    expect(failed.outcome).toBe('failed');
+    expect(failed.trace[0]?.reason).toContain('exceeded max iterations (3)');
+  });
+
+  test('simulates loop-group body outputs without leaking iteration state', async () => {
+    const workflow = makeTestWorkflow({
+      name: 'loop-group',
+      nodes: [
+        {
+          id: 'group',
+          loop_group: {
+            until: 'DONE',
+            max_iterations: 2,
+            nodes: [
+              { id: 'draft', prompt: 'draft' },
+              { id: 'finish', prompt: 'finish $draft.output', depends_on: ['draft'] },
+            ],
+          },
+        },
+      ],
+    });
+    const result = await dryRunWorkflow({
+      workflow,
+      userMessage: '',
+      cwd: process.cwd(),
+      stubs: { draft: 'fresh', finish: 'DONE' },
+    });
+
+    expect(result.outcome).toBe('completed');
+    expect(result.trace.map(entry => entry.nodeId)).toEqual(['draft', 'finish', 'group']);
+    expect(result.trace[1]?.resolvedText).toBe('finish fresh');
+  });
+
+  test('represents cancellation and unsupported subworkflows visibly', async () => {
+    const cancelled = makeTestWorkflow({
+      name: 'cancel',
+      nodes: [
+        { id: 'stop', cancel: 'not safe' },
+        { id: 'later', prompt: 'later', depends_on: ['stop'] },
+      ],
+    });
+    const cancelledResult = await dryRunWorkflow({
+      workflow: cancelled,
+      userMessage: '',
+      cwd: process.cwd(),
+    });
+    expect(cancelledResult.outcome).toBe('cancelled');
+    expect(cancelledResult.trace).toHaveLength(1);
+
+    const child = makeTestWorkflow({ name: 'child', nodes: [{ id: 'child', workflow: 'other' }] });
+    const childResult = await dryRunWorkflow({
+      workflow: child,
+      userMessage: '',
+      cwd: process.cwd(),
+    });
+    expect(childResult).toMatchObject({ outcome: 'failed' });
+    expect(childResult.trace[0]?.reason).toContain('does not execute reachable workflow nodes');
+  });
+
+  test('formats a stable human trace', async () => {
+    const workflow = makeTestWorkflow({ name: 'format', nodes: [{ id: 'node', prompt: 'hello' }] });
+    const result = await dryRunWorkflow({
+      workflow,
+      userMessage: '',
+      cwd: process.cwd(),
+      stubs: { node: 'world' },
+    });
+
+    expect(formatDryRunTrace(result)).toContain('STUBBED   node (prompt)');
+    expect(formatDryRunTrace(result)).toContain('Outcome: completed');
+  });
+});

--- a/packages/workflows/src/dry-run.ts
+++ b/packages/workflows/src/dry-run.ts
@@ -1,0 +1,633 @@
+/** Side-effect-free workflow DAG simulation with caller-supplied node outputs. */
+import { z } from '@hono/zod-openapi';
+import { execFileAsync, resolveBashPath } from '@archon/git';
+import { join } from 'node:path';
+import { buildTopologicalLayers, checkTriggerRule, substituteNodeOutputRefs } from './dag-executor';
+import { evaluateCondition } from './condition-evaluator';
+import { declaredFieldsFromSchema } from './output-ref';
+import { discoverScriptsForCwd } from './script-discovery';
+import {
+  detectCompletionSignal,
+  isInlineScript,
+  loadCommandPrompt,
+  substituteWorkflowVariables,
+} from './executor-shared';
+import {
+  isApprovalNode,
+  isBashNode,
+  isCancelNode,
+  isCommandNode,
+  isIncludeNode,
+  isLoopGroupNode,
+  isLoopNode,
+  isScriptNode,
+  isWorkflowNode,
+  type DagNode,
+  type NodeOutput,
+  type WorkflowDefinition,
+} from './schemas';
+
+export const dryRunStubValueSchema = z.union([z.string(), z.record(z.string(), z.unknown())]);
+export const dryRunStubsSchema = z.record(z.string(), dryRunStubValueSchema);
+export type DryRunStubValue = z.infer<typeof dryRunStubValueSchema>;
+export type DryRunStubs = z.infer<typeof dryRunStubsSchema>;
+
+const dryRunNodeTypeSchema = z.enum([
+  'command',
+  'prompt',
+  'bash',
+  'script',
+  'loop',
+  'loop_group',
+  'approval',
+  'cancel',
+  'include',
+  'workflow',
+]);
+
+const dryRunTraceBaseSchema = z.object({
+  nodeId: z.string(),
+  nodeType: dryRunNodeTypeSchema,
+  resolvedText: z.string().optional(),
+  output: z.string().optional(),
+  iteration: z.number().int().positive().optional(),
+});
+
+export const dryRunTraceEntrySchema = z.discriminatedUnion('state', [
+  dryRunTraceBaseSchema.extend({
+    state: z.literal('completed'),
+    reason: z.string().optional(),
+  }),
+  dryRunTraceBaseSchema.extend({
+    state: z.literal('stubbed'),
+    reason: z.string().optional(),
+  }),
+  dryRunTraceBaseSchema.extend({
+    state: z.literal('skipped'),
+    reason: z.string(),
+  }),
+  dryRunTraceBaseSchema.extend({
+    state: z.literal('failed'),
+    reason: z.string(),
+  }),
+  dryRunTraceBaseSchema.extend({
+    state: z.literal('paused'),
+    reason: z.string(),
+  }),
+]);
+export type DryRunTraceEntry = z.infer<typeof dryRunTraceEntrySchema>;
+
+export const dryRunResultSchema = z.object({
+  workflow: z.string(),
+  outcome: z.enum(['completed', 'failed', 'paused', 'cancelled']),
+  trace: z.array(dryRunTraceEntrySchema),
+  missingStubs: z.array(z.string()),
+  unusedStubs: z.array(z.string()),
+  summary: z.string().optional(),
+});
+export type DryRunResult = z.infer<typeof dryRunResultSchema>;
+
+export async function loadDryRunStubs(path?: string): Promise<DryRunStubs> {
+  if (!path) return {};
+  const file = Bun.file(path);
+  if (!(await file.exists())) {
+    throw new Error(`Dry-run stub file not found: ${path}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = Bun.YAML.parse(await file.text());
+  } catch (error) {
+    throw new Error(`Failed to parse dry-run stub file '${path}': ${(error as Error).message}`);
+  }
+
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(
+      `Invalid dry-run stub file '${path}': expected one YAML mapping of node ids to outputs`
+    );
+  }
+  const result = dryRunStubsSchema.safeParse(parsed);
+  if (!result.success) {
+    const issues = result.error.issues
+      .map(issue => `${issue.path.join('.') || '<root>'}: ${issue.message}`)
+      .join('; ');
+    throw new Error(`Invalid dry-run stub file '${path}': ${issues}`);
+  }
+  return result.data;
+}
+
+function nodeType(node: DagNode): z.infer<typeof dryRunNodeTypeSchema> {
+  if (isCommandNode(node)) return 'command';
+  if (isBashNode(node)) return 'bash';
+  if (isScriptNode(node)) return 'script';
+  if (isLoopNode(node)) return 'loop';
+  if (isLoopGroupNode(node)) return 'loop_group';
+  if (isApprovalNode(node)) return 'approval';
+  if (isCancelNode(node)) return 'cancel';
+  if (isIncludeNode(node)) return 'include';
+  if (isWorkflowNode(node)) return 'workflow';
+  return 'prompt';
+}
+
+function completedOutput(node: DagNode, stub: DryRunStubValue): NodeOutput {
+  const declaredFields = declaredFieldsFromSchema(node.output_format);
+  if (typeof stub === 'string') {
+    return {
+      state: 'completed',
+      output: stub,
+      ...(declaredFields !== undefined ? { declaredFields } : {}),
+    };
+  }
+  return {
+    state: 'completed',
+    output: JSON.stringify(stub),
+    structuredOutput: stub,
+    ...(declaredFields !== undefined ? { declaredFields } : {}),
+  };
+}
+
+interface DryRunContext {
+  workflow: WorkflowDefinition;
+  userMessage: string;
+  cwd: string;
+  stubs: DryRunStubs;
+  execCode: boolean;
+  pauseAtGates: boolean;
+  trace: DryRunTraceEntry[];
+  consumedStubs: Set<string>;
+  missingStubs: Set<string>;
+  halted?: 'paused' | 'cancelled';
+}
+
+async function loadDryRunCommand(cwd: string, command: string): Promise<string> {
+  const result = await loadCommandPrompt(
+    {
+      loadConfig: async () => ({
+        assistant: 'claude',
+        commands: {},
+        assistants: { claude: {}, codex: {} },
+        defaults: { loadDefaultCommands: true },
+      }),
+    },
+    cwd,
+    command
+  );
+  if (!result.success) throw new Error(result.message);
+  return result.content;
+}
+
+function resolveText(
+  text: string,
+  ctx: DryRunContext,
+  outputs: Map<string, NodeOutput>,
+  shellSafe = false,
+  loopPrevOutput = '',
+  escapeNodeOutputs = shellSafe
+): string {
+  const artifactsDir = join(ctx.cwd, '.archon', 'dry-run', 'artifacts');
+  const stateDir = join(ctx.cwd, '.archon', 'dry-run', 'state');
+  const docsDir = join(ctx.cwd, 'docs');
+  const substituted = substituteWorkflowVariables(
+    text,
+    'dry-run',
+    ctx.userMessage,
+    artifactsDir,
+    'dry-run-base',
+    docsDir,
+    undefined,
+    undefined,
+    undefined,
+    loopPrevOutput,
+    { shellSafe, stateDir }
+  ).prompt;
+  return substituteNodeOutputRefs(substituted, outputs, escapeNodeOutputs);
+}
+
+function recordSkipped(
+  node: DagNode,
+  outputs: Map<string, NodeOutput>,
+  ctx: DryRunContext,
+  reason: string,
+  iteration?: number
+): void {
+  outputs.set(node.id, { state: 'skipped', output: '' });
+  ctx.trace.push({
+    nodeId: node.id,
+    nodeType: nodeType(node),
+    state: 'skipped',
+    reason,
+    ...(iteration ? { iteration } : {}),
+  });
+}
+
+function recordFailed(
+  node: DagNode,
+  outputs: Map<string, NodeOutput>,
+  ctx: DryRunContext,
+  reason: string,
+  resolvedText?: string,
+  iteration?: number
+): void {
+  outputs.set(node.id, { state: 'failed', output: '', error: reason });
+  ctx.trace.push({
+    nodeId: node.id,
+    nodeType: nodeType(node),
+    state: 'failed',
+    reason,
+    ...(resolvedText !== undefined ? { resolvedText } : {}),
+    ...(iteration ? { iteration } : {}),
+  });
+}
+
+async function executeCodeNode(
+  node: DagNode,
+  code: string,
+  ctx: DryRunContext
+): Promise<{ output: string } | { error: string }> {
+  try {
+    let command: string;
+    let args: string[];
+    if (isBashNode(node)) {
+      command = resolveBashPath();
+      args = ['-c', code];
+    } else if (isScriptNode(node)) {
+      if (isInlineScript(code)) {
+        if (node.runtime === 'bun') {
+          command = 'bun';
+          args = ['--no-env-file', '-e', code];
+        } else {
+          command = 'uv';
+          args = [
+            'run',
+            ...(node.deps ?? []).flatMap(dep => ['--with', dep]),
+            'python',
+            '-c',
+            code,
+          ];
+        }
+      } else {
+        const script = (await discoverScriptsForCwd(ctx.cwd)).get(code);
+        if (!script) return { error: `Named script '${code}' was not found` };
+        command = script.runtime === 'bun' ? 'bun' : 'uv';
+        args =
+          script.runtime === 'bun'
+            ? ['--no-env-file', 'run', script.path]
+            : ['run', ...(node.deps ?? []).flatMap(dep => ['--with', dep]), script.path];
+      }
+    } else {
+      return { error: `Node '${node.id}' is not executable code` };
+    }
+    const result = await execFileAsync(command, args, {
+      cwd: ctx.cwd,
+      timeout: node.timeout ?? 300_000,
+      env: {
+        ...process.env,
+        USER_MESSAGE: ctx.userMessage,
+        ARGUMENTS: ctx.userMessage,
+        ARTIFACTS_DIR: join(ctx.cwd, '.archon', 'dry-run', 'artifacts'),
+        STATE_DIR: join(ctx.cwd, '.archon', 'dry-run', 'state'),
+      },
+    });
+    return { output: result.stdout.replace(/\n$/, '') };
+  } catch (error) {
+    const err = error as Error & { stderr?: string };
+    return { error: err.stderr?.trim() || err.message };
+  }
+}
+
+function stubFor(node: DagNode, ctx: DryRunContext): DryRunStubValue | undefined {
+  const stub = ctx.stubs[node.id];
+  if (stub !== undefined) ctx.consumedStubs.add(node.id);
+  return stub;
+}
+
+async function simulateLoop(
+  node: DagNode,
+  outputs: Map<string, NodeOutput>,
+  ctx: DryRunContext,
+  iteration?: number
+): Promise<void> {
+  if (!isLoopNode(node)) return;
+  let previous = '';
+  const template = node.loop.prompt ?? (await loadDryRunCommand(ctx.cwd, node.loop.command ?? ''));
+  let resolvedText = template;
+  for (let current = 1; current <= node.loop.max_iterations; current++) {
+    resolvedText = resolveText(template, ctx, outputs, false, previous);
+    const stub = stubFor(node, ctx);
+    if (stub === undefined) {
+      ctx.missingStubs.add(node.id);
+      recordFailed(
+        node,
+        outputs,
+        ctx,
+        `Missing reachable stub for node '${node.id}'`,
+        resolvedText,
+        iteration
+      );
+      return;
+    }
+    const hydrated = completedOutput(node, stub);
+    previous = hydrated.output;
+    if (detectCompletionSignal(previous, node.loop.until)) {
+      outputs.set(node.id, hydrated);
+      ctx.trace.push({
+        nodeId: node.id,
+        nodeType: 'loop',
+        state: 'stubbed',
+        reason: `completion signal after ${String(current)} iteration(s)`,
+        resolvedText,
+        output: previous,
+        ...(iteration ? { iteration } : {}),
+      });
+      return;
+    }
+  }
+  recordFailed(
+    node,
+    outputs,
+    ctx,
+    `Loop exceeded max iterations (${String(node.loop.max_iterations)}) without completion signal '${node.loop.until}'`,
+    resolvedText,
+    iteration
+  );
+}
+
+async function simulateLoopGroup(
+  node: DagNode,
+  outputs: Map<string, NodeOutput>,
+  ctx: DryRunContext,
+  iteration?: number
+): Promise<void> {
+  if (!isLoopGroupNode(node)) return;
+  let lastOutput = '';
+  for (let current = 1; current <= node.loop_group.max_iterations; current++) {
+    const bodyOutputs = new Map(outputs);
+    await simulateNodes(node.loop_group.nodes, bodyOutputs, ctx, current);
+    const bodyDependencies = new Set(node.loop_group.nodes.flatMap(body => body.depends_on ?? []));
+    lastOutput =
+      node.loop_group.nodes
+        .filter(body => !bodyDependencies.has(body.id))
+        .map(body => bodyOutputs.get(body.id))
+        .find(output => output?.state === 'completed' && output.output.trim())?.output ?? '';
+    const failed = node.loop_group.nodes.some(body => bodyOutputs.get(body.id)?.state === 'failed');
+    if (failed) {
+      recordFailed(
+        node,
+        outputs,
+        ctx,
+        `Loop group body failed at iteration ${String(current)}`,
+        undefined,
+        iteration
+      );
+      return;
+    }
+    if (ctx.halted) return;
+    if (detectCompletionSignal(lastOutput, node.loop_group.until)) {
+      outputs.set(node.id, { state: 'completed', output: lastOutput });
+      ctx.trace.push({
+        nodeId: node.id,
+        nodeType: 'loop_group',
+        state: 'completed',
+        reason: `completion signal after ${String(current)} iteration(s)`,
+        output: lastOutput,
+        ...(iteration ? { iteration } : {}),
+      });
+      return;
+    }
+  }
+  recordFailed(
+    node,
+    outputs,
+    ctx,
+    `Loop group exceeded max iterations (${String(node.loop_group.max_iterations)}) without completion signal '${node.loop_group.until}'`,
+    undefined,
+    iteration
+  );
+}
+
+async function simulateNode(
+  node: DagNode,
+  outputs: Map<string, NodeOutput>,
+  ctx: DryRunContext,
+  iteration?: number
+): Promise<void> {
+  if (checkTriggerRule(node, outputs) === 'skip') {
+    recordSkipped(node, outputs, ctx, 'trigger_rule', iteration);
+    return;
+  }
+  if (node.when) {
+    try {
+      const condition = evaluateCondition(node.when, outputs);
+      if (!condition.parsed) {
+        recordSkipped(node, outputs, ctx, 'when_condition_parse_error', iteration);
+        return;
+      }
+      if (!condition.result) {
+        recordSkipped(node, outputs, ctx, 'when_condition_false', iteration);
+        return;
+      }
+    } catch (error) {
+      recordFailed(node, outputs, ctx, (error as Error).message, undefined, iteration);
+      return;
+    }
+  }
+
+  try {
+    if (isLoopNode(node)) {
+      await simulateLoop(node, outputs, ctx, iteration);
+      return;
+    }
+    if (isLoopGroupNode(node)) {
+      await simulateLoopGroup(node, outputs, ctx, iteration);
+      return;
+    }
+    if (isApprovalNode(node)) {
+      const resolvedText = resolveText(node.approval.message, ctx, outputs);
+      if (ctx.pauseAtGates) {
+        outputs.set(node.id, { state: 'pending', output: '' });
+        ctx.trace.push({
+          nodeId: node.id,
+          nodeType: 'approval',
+          state: 'paused',
+          reason: 'approval gate',
+          resolvedText,
+          ...(iteration ? { iteration } : {}),
+        });
+        ctx.halted = 'paused';
+      } else {
+        outputs.set(node.id, { state: 'completed', output: 'approved' });
+        ctx.trace.push({
+          nodeId: node.id,
+          nodeType: 'approval',
+          state: 'completed',
+          reason: 'auto-approved',
+          resolvedText,
+          output: 'approved',
+          ...(iteration ? { iteration } : {}),
+        });
+      }
+      return;
+    }
+    if (isCancelNode(node)) {
+      const resolvedText = resolveText(node.cancel, ctx, outputs);
+      outputs.set(node.id, { state: 'completed', output: resolvedText });
+      ctx.trace.push({
+        nodeId: node.id,
+        nodeType: 'cancel',
+        state: 'completed',
+        reason: 'workflow cancelled',
+        resolvedText,
+        output: resolvedText,
+        ...(iteration ? { iteration } : {}),
+      });
+      ctx.halted = 'cancelled';
+      return;
+    }
+    if (isIncludeNode(node) || isWorkflowNode(node)) {
+      recordFailed(
+        node,
+        outputs,
+        ctx,
+        `Dry-run does not execute reachable ${nodeType(node)} nodes`,
+        undefined,
+        iteration
+      );
+      return;
+    }
+
+    const sourceText = isCommandNode(node)
+      ? await loadDryRunCommand(ctx.cwd, node.command)
+      : isBashNode(node)
+        ? node.bash
+        : isScriptNode(node)
+          ? node.script
+          : node.prompt;
+    const resolvedText = isScriptNode(node)
+      ? resolveText(sourceText, ctx, outputs, true, '', false)
+      : resolveText(sourceText, ctx, outputs, isBashNode(node));
+    const stub = stubFor(node, ctx);
+    if (stub !== undefined) {
+      const hydrated = completedOutput(node, stub);
+      outputs.set(node.id, hydrated);
+      ctx.trace.push({
+        nodeId: node.id,
+        nodeType: nodeType(node),
+        state: 'stubbed',
+        resolvedText,
+        output: hydrated.output,
+        ...(iteration ? { iteration } : {}),
+      });
+      return;
+    }
+    if ((isBashNode(node) || isScriptNode(node)) && ctx.execCode) {
+      const executed = await executeCodeNode(node, resolvedText, ctx);
+      if ('error' in executed) {
+        recordFailed(node, outputs, ctx, executed.error, resolvedText, iteration);
+      } else {
+        outputs.set(node.id, { state: 'completed', output: executed.output });
+        ctx.trace.push({
+          nodeId: node.id,
+          nodeType: nodeType(node),
+          state: 'completed',
+          reason: 'executed locally',
+          resolvedText,
+          output: executed.output,
+          ...(iteration ? { iteration } : {}),
+        });
+      }
+      return;
+    }
+    ctx.missingStubs.add(node.id);
+    recordFailed(
+      node,
+      outputs,
+      ctx,
+      `Missing reachable stub for node '${node.id}'`,
+      resolvedText,
+      iteration
+    );
+  } catch (error) {
+    recordFailed(node, outputs, ctx, (error as Error).message, undefined, iteration);
+  }
+}
+
+async function simulateNodes(
+  nodes: readonly DagNode[],
+  outputs: Map<string, NodeOutput>,
+  ctx: DryRunContext,
+  iteration?: number
+): Promise<void> {
+  for (const layer of buildTopologicalLayers(nodes)) {
+    for (const node of layer) {
+      if (ctx.halted) return;
+      await simulateNode(node, outputs, ctx, iteration);
+    }
+  }
+}
+
+export async function dryRunWorkflow(options: {
+  workflow: WorkflowDefinition;
+  userMessage: string;
+  cwd: string;
+  stubs?: DryRunStubs;
+  execCode?: boolean;
+  pauseAtGates?: boolean;
+}): Promise<DryRunResult> {
+  const ctx: DryRunContext = {
+    workflow: options.workflow,
+    userMessage: options.userMessage,
+    cwd: options.cwd,
+    stubs: options.stubs ?? {},
+    execCode: options.execCode ?? false,
+    pauseAtGates: options.pauseAtGates ?? false,
+    trace: [],
+    consumedStubs: new Set<string>(),
+    missingStubs: new Set<string>(),
+  };
+  const outputs = new Map<string, NodeOutput>();
+  await simulateNodes(options.workflow.nodes, outputs, ctx);
+
+  const dependencies = new Set(options.workflow.nodes.flatMap(node => node.depends_on ?? []));
+  const summary = options.workflow.nodes
+    .filter(node => !dependencies.has(node.id))
+    .map(node => outputs.get(node.id))
+    .find(output => output?.state === 'completed' && output.output.trim())?.output;
+  const anyFailed = [...outputs.values()].some(output => output.state === 'failed');
+  const outcome =
+    ctx.halted === 'paused'
+      ? 'paused'
+      : ctx.halted === 'cancelled'
+        ? 'cancelled'
+        : anyFailed
+          ? 'failed'
+          : 'completed';
+  return dryRunResultSchema.parse({
+    workflow: options.workflow.name,
+    outcome,
+    trace: ctx.trace,
+    missingStubs: [...ctx.missingStubs].sort(),
+    unusedStubs: Object.keys(ctx.stubs)
+      .filter(id => !ctx.consumedStubs.has(id))
+      .sort(),
+    ...(summary ? { summary } : {}),
+  });
+}
+
+export function formatDryRunTrace(result: DryRunResult): string {
+  const lines = [`Dry-run: ${result.workflow}`, ''];
+  for (const entry of result.trace) {
+    const suffix = entry.reason ? ` — ${entry.reason}` : '';
+    const iteration = entry.iteration ? ` [iteration ${String(entry.iteration)}]` : '';
+    lines.push(
+      `${entry.state.toUpperCase().padEnd(9)} ${entry.nodeId} (${entry.nodeType})${iteration}${suffix}`
+    );
+    if (entry.resolvedText) lines.push(`  resolved: ${entry.resolvedText}`);
+    if (entry.output !== undefined) lines.push(`  output: ${entry.output}`);
+  }
+  lines.push('', `Outcome: ${result.outcome}`);
+  if (result.missingStubs.length > 0)
+    lines.push(`Missing stubs: ${result.missingStubs.join(', ')}`);
+  if (result.unusedStubs.length > 0) lines.push(`Unused stubs: ${result.unusedStubs.join(', ')}`);
+  if (result.summary) lines.push(`Summary: ${result.summary}`);
+  return lines.join('\n');
+}

--- a/packages/workflows/src/executor-shared.ts
+++ b/packages/workflows/src/executor-shared.ts
@@ -261,7 +261,7 @@ export function detectCreditExhaustion(text: string): string | null {
  * @returns On success: `{ success: true, content }`. On failure: `{ success: false, reason, message }`.
  */
 export async function loadCommandPrompt(
-  deps: WorkflowDeps,
+  deps: Pick<WorkflowDeps, 'loadConfig'>,
   cwd: string,
   commandName: string,
   configuredFolder?: string


### PR DESCRIPTION
## Summary

- Problem: Workflow authors had to launch a provider-backed, persistent run to validate deterministic DAG routing, strict output references, gates, and loops.
- Why it matters: Discovering those errors consumed provider cost and could create run state, events, sessions, or worktrees.
- What changed: Added `archon workflow run <name> --dry-run` with optional stubs, code execution, and approval-pause controls, backed by an in-memory simulator and deterministic human/JSON trace.
- What did **not** change (scope boundary): No workflow-language, provider, database, API/web, worktree, artifact, or persisted-run behavior changed; code nodes remain stubbed unless explicitly enabled with `--exec-code`.

## UX Journey

### Before

```
  Workflow author          Archon                    Provider / persistence
  ───────────────          ──────                    ──────────────────────
  edits workflow ───────▶  validates static shape
  starts real run ───────▶ creates run/worktree ───▶ invokes provider
  inspects outcome ◀─────  stores events/sessions ◀─ receives execution result
```

### After

```
  Workflow author          Archon                     Provider / persistence
  ───────────────          ──────                     ──────────────────────
  edits workflow + stubs ▶ [--dry-run simulator]
                            [evaluates DAG control flow]
  inspects trace/JSON ◀── [returns in-memory outcome]    (not contacted)
```

## Architecture Diagram

### Before

```
CLI workflow run ───────▶ workflow command ───────▶ executeWorkflow/DAG executor
                                                        ├── workflow store/events
                                                        ├── isolation/worktree
                                                        └── AI providers
```

### After

```
CLI argument parser [~] ───▶ workflow command [~] ===▶ dry-run engine [+]
                                                        ├── shared DAG condition/reference helpers [~]
                                                        ├── YAML stub loader [+]
                                                        └── deterministic trace formatter [+]

CLI workflow run ──────────▶ real executor (unchanged; selected without --dry-run)
```

**Connection inventory** (list every module-to-module edge, mark changes):

| From | To | Status | Notes |
|------|----|--------|-------|
| `packages/cli/src/cli.ts` | `packages/cli/src/commands/workflow.ts` | **modified** | Parses and forwards dry-run flags. |
| `packages/cli/src/commands/workflow.ts` | `@archon/workflows/dry-run` | **new** | Runs the simulator before real-run setup. |
| `packages/workflows/src/dry-run.ts` | DAG condition, trigger, substitution helpers | **new** | Reuses deterministic workflow semantics in memory. |
| `packages/workflows/src/dry-run.ts` | `executor-shared.ts` | **modified** | Reuses command prompt loading with its narrowed dependency contract. |
| `packages/cli/src/commands/workflow.ts` | real workflow executor | unchanged | Used only for non-dry-run executions. |
| CLI documentation | dry-run CLI contract | **new** | Documents stubs, safety boundary, trace, and CI JSON output. |

## Label Snapshot

- Risk: `risk: medium`
- Size: `size: L`
- Scope: `workflows`, `cli`, `docs`, `tests`
- Module: `workflows:dry-run`

## Change Metadata

- Change type: `feature`
- Primary scope: `multi`

## Linked Issue

- Closes #2100
- Related # None
- Depends on # None
- Supersedes # None

## Validation Evidence (required)

Commands and result summary:

```bash
bun run type-check
bun run lint --max-warnings 0
bun run format:check
bun --cwd packages/workflows test src/dry-run.test.ts
bun --cwd packages/cli test src/commands/workflow.test.ts
bun --cwd packages/cli test src/cli.test.ts
bun run validate
bun run build
```

- Evidence provided (test/log/trace/screenshot): type check, lint with zero warnings, formatting, focused dry-run and CLI tests, build, and full `bun run validate` all passed in a clean detached worktree at this commit. The focused results included 14 dry-run tests, 215 workflow-command tests, and 54 CLI parser/help tests.
- If any command is intentionally skipped, explain why: none. The direct implementation worktree's initial validate attempt encountered an ignored local `.archon/workflows/widing-labs/` fixture that is outside the change; validation was rerun successfully in a clean tracked worktree.

## Security Impact (required)

- New permissions/capabilities? (`Yes`) A local dry-run may execute workflow bash/script nodes only when the user explicitly supplies `--exec-code`.
- New external network calls? (`No`)
- Secrets/tokens handling changed? (`No`)
- File system access scope changed? (`Yes`) Stub files are read from a user-provided path; `--exec-code` uses existing host shell/script execution conventions.
- If any `Yes`, describe risk and mitigation: normal dry-runs are side-effect-free and stub code nodes by default. `--exec-code` is explicit and incompatible with real-run lifecycle/isolation flags; the simulator does not create runs, worktrees, artifacts, sessions, or provider calls.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Database migration needed? (`No`)
- If yes, exact upgrade steps: not applicable.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: inspected a manual human-readable and one-document JSON dry-run trace; verified missing reachable AI stubs fail with a nonzero outcome.
- Edge cases checked: scalar/object stub hydration, `when:` and trigger-rule skipping, strict output-field errors, approvals, cancellation, loops, and default code stubbing versus `--exec-code` are covered by focused tests.
- What was not verified: no live provider, database, artifact, or worktree execution was performed, by design.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: CLI workflow-run argument handling, workflow DAG helper reuse, workflow package exports, and CLI reference documentation.
- Potential unintended effects: incorrectly modeled simulator semantics could cause a dry-run trace to differ from a live DAG's deterministic control flow; `--exec-code` can run local workflow code when requested.
- Guardrails/monitoring for early detection: focused regression tests cover the control-flow matrix; dry-run is isolated from production execution and fails visibly for missing reachable stubs and strict reference errors.

## Rollback Plan (required)

- Fast rollback command/path: revert commit `bafdeb5c` (or disable use of `--dry-run` by reverting the CLI flag wiring and `@archon/workflows/dry-run` export).
- Feature flags or config toggles (if any): no feature flag; dry-run is opt-in via `--dry-run`, and local code execution additionally requires `--exec-code`.
- Observable failure symptoms: unexpected dry-run trace outcomes, invalid JSON output in CI, or accidental code execution only when `--exec-code` is explicitly set.

## Risks and Mitigations

- Risk: Simulation diverges from live deterministic DAG behavior.
  - Mitigation: Reuses existing topology, trigger-rule, condition, variable-substitution, and output-reference helpers; tests cover routing, strict fields, gates, loops, and terminal outcomes.
- Risk: Users expect dry-run to execute code or invoke AI.
  - Mitigation: Documentation and trace semantics state that AI and code nodes are stubbed by default; only explicit `--exec-code` runs local code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic workflow dry runs through the CLI.
  * Supports stubbed outputs, optional local code execution, approval-gate pausing, JSON results, and human-readable traces.
  * Reports missing or unused stubs and failed workflow outcomes.
  * Allows dry runs outside Git repositories.

* **Documentation**
  * Added CLI guidance, usage examples, supported options, validation rules, and limitations.

* **Tests**
  * Added comprehensive coverage for dry-run execution, branching, loops, gates, cancellation, outputs, and CLI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->