### PR TITLE
chore: replace the pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,129 +1,106 @@
-## Summary
+<!--
+Write for a human maintainer and review agents.
 
-Describe this PR in 2-5 bullets:
+Always keep Problem and outcome, Review guidance, Solution, and Validation.
+Include conditional sections only when they add material information. Delete
+unused sections and all instructional comments.
 
-- Problem:
-- Why it matters:
-- What changed:
-- What did **not** change (scope boundary):
+Lead with the problem and outcome, not an implementation inventory. Support
+factual claims with code, tests, logs, traces, screenshots, or linked issues.
+Do not write filler such as "N/A" merely to preserve a section. Link only
+artifacts accessible to reviewers; never include local filesystem paths.
+-->
 
-## UX Journey
+## Problem and outcome
 
-### Before
+{Explain the original problem and why it matters in 1–3 sentences.}
 
+- **Outcome:** {What is observably different after this PR.}
+- **Invariant:** {What must remain true across every acceptable implementation.}
+- **Scope boundary:** {What intentionally did not change.}
+<!-- For bugs only. Delete otherwise. -->
+- **Root cause:** {For bugs only: the proven cause, not the visible symptom.}
+
+## Review guidance
+
+- **Feedback requested:** {Correctness, architecture, security, UX, migration, naming, or a specific question.}
+- **Start here:** `{path:line}` — {Why this is the load-bearing change.}
+- **Review order:** {Short ordered path through the important files or commits.}
+- **Lower-attention areas:** {Generated or mechanical changes and the evidence that verifies them.}
+- **Known risk or uncertainty:** {Concrete concern, or `None`.}
+
+## Solution
+
+{Explain how the change produces the outcome. Focus on behavior, ownership,
+contracts, and the existing primitive being reused or extended. Explain why this
+is the smallest coherent solution when that decision is not obvious.}
+
+<!-- Include when observable user, operator, or system behavior changes. -->
+## Behavior change
+
+| | Before | After |
+|---|---|---|
+| **Observable behavior** | {Previous behavior} | {New behavior} |
+| **Failure behavior** | {Previous failure} | {New failure or recovery} |
+
+<!--
+Include when an interaction or operational journey changes. Prefer one compact
+Mermaid before/after diagram. Add screenshots or video for visible UI changes.
+-->
+### User flow
+
+```mermaid
+flowchart LR
+  subgraph Before
+    B1[User action] --> B2[Previous result]
+  end
+
+  subgraph After
+    A1[User action] --> A2[Changed behavior] --> A3[New result]
+  end
 ```
-(Draw the user-facing flow BEFORE this PR. Show each step the user takes.)
 
-Example:
-  User                   Archon                   AI Client
-  ────                   ──────                   ─────────
-  sends message ──────▶  resolves session
-                         loads context
-                         streams to AI ──────────▶ processes prompt
-                         receives chunks ◀──────── streams response
-  sees reply ◀─────────  sends to platform
+<!--
+Include when module boundaries, ownership, state, persistence, data flow,
+external dependencies, or public contracts change. Diagram only the relevant
+architecture, not every touched file.
+-->
+## Architecture
+
+```mermaid
+flowchart LR
+  A[Entry point] --> B[Owning primitive]
+  B ==> C[Changed boundary]
+  C --> D[Observable result]
 ```
 
-### After
+### Changed seams
 
-```
-(Draw the user-facing flow AFTER this PR. Highlight what changed with [brackets] or asterisks.)
-```
+| Boundary or contract | Change | Evidence |
+|---|---|---|
+| `{producer → consumer}` | {New, removed, or modified behavior} | `{path:line}`, test, trace, or linked specification |
 
-## Architecture Diagram
+## Validation
 
-### Before
+- `{actual command}` — {result} — proves {behavior or invariant}.
+- {Runtime, manual, visual, log, or trace evidence when applicable.}
+- **Not verified:** {Concrete missing verification and why. Use `Nothing material` only when all outcome-relevant behavior is covered, and say why.}
 
-```
-(Map ALL modules touched or connected to this change. Draw lines between them.)
-```
+<!-- Keep only applicable rows. Delete this section when none apply. -->
+## Delivery considerations
 
-### After
+| Concern | Impact and required action | Evidence |
+|---|---|---|
+| Compatibility / migration | {Existing behavior or data transition} | {Evidence} |
+| Security / permissions / data | {Changed exposure and mitigation} | {Evidence} |
+| Rollout / rollback | {Release posture and safe reversal} | {Evidence} |
+| Observability | {How regressions become visible} | {Evidence} |
+| Documentation / communication | {Material that changed or must change} | {Evidence} |
 
-```
-(Same diagram with changes highlighted. Mark new modules with [+], removed with [-],
- modified with [~]. Mark new connections with ===, removed with --x--.)
-```
-
-**Connection inventory** (list every module-to-module edge, mark changes):
-
-| From | To | Status | Notes |
-|------|----|--------|-------|
-| | | unchanged / **new** / **removed** / **modified** | |
-
-## Label Snapshot
-
-- Risk: `risk: low|medium|high`
-- Size: `size: XS|S|M|L|XL`
-- Scope: `core|workflows|isolation|git|adapters|server|web|cli|paths|config|docs|dependencies|ci|tests|skills`
-- Module: `<scope>:<component>` (e.g. `workflows:executor`, `adapters:slack`, `core:orchestrator`)
-
-## Change Metadata
-
-- Change type: `bug|feature|refactor|docs|security|chore`
-- Primary scope: `core|workflows|isolation|git|adapters|server|web|cli|paths|multi`
-
-## Linked Issue
+<!-- Delete unused link types. Omit this section when there are no related items. -->
+## Links
 
 - Closes #
 - Related #
-- Depends on # (if stacked)
-- Supersedes # (if replacing older PR)
-
-## Validation Evidence (required)
-
-Commands and result summary:
-
-```bash
-bun run type-check
-bun run lint
-bun run format:check
-bun run test
-# Or all at once:
-bun run validate
-```
-
-- Evidence provided (test/log/trace/screenshot):
-- If any command is intentionally skipped, explain why:
-
-## Security Impact (required)
-
-- New permissions/capabilities? (`Yes/No`)
-- New external network calls? (`Yes/No`)
-- Secrets/tokens handling changed? (`Yes/No`)
-- File system access scope changed? (`Yes/No`)
-- If any `Yes`, describe risk and mitigation:
-
-## Compatibility / Migration
-
-- Backward compatible? (`Yes/No`)
-- Config/env changes? (`Yes/No`)
-- Database migration needed? (`Yes/No`)
-- If yes, exact upgrade steps:
-
-## Human Verification (required)
-
-What was personally validated beyond CI:
-
-- Verified scenarios:
-- Edge cases checked:
-- What was not verified:
-
-## Side Effects / Blast Radius (required)
-
-- Affected subsystems/workflows:
-- Potential unintended effects:
-- Guardrails/monitoring for early detection:
-
-## Rollback Plan (required)
-
-- Fast rollback command/path:
-- Feature flags or config toggles (if any):
-- Observable failure symptoms:
-
-## Risks and Mitigations
-
-List real risks in this PR (or write `None`).
-
-- Risk:
-  - Mitigation:
+- Depends on #
+- Supersedes #

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ Archon is being positioned as a governed agentic automation engine for business 
 **Git Workflow and Releases**
 - `main` is the release branch. Never commit directly to `main`.
 - `dev` is the working branch. All feature work branches off `dev` and merges back into `dev`.
-- All PRs must use the template at `.github/pull_request_template.md` — fill in every section. When opening a PR via `gh pr create`, copy the template into the body explicitly; GitHub only auto-applies it through the web UI.
+- All PRs must use the template at `.github/pull_request_template.md`. Always keep Problem and outcome, Review guidance, Solution, and Validation; include the conditional sections only when they add material information, and delete the rest along with every instructional comment. Do not write "N/A" to preserve a section. When opening a PR via `gh pr create`, copy the template into the body explicitly; GitHub only auto-applies it through the web UI.
 - Link the issue with `Closes #<number>` (or `Fixes` / `Resolves`) in the PR description so it auto-closes on merge.
 - To release, use the `/release` skill. It compares `dev` to `main`, generates changelog entries, bumps the version, and creates a PR to merge `dev` into `main`.
 - Releases follow Semantic Versioning: `/release` (patch), `/release minor`, `/release major`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ bun run validate
 1. Create a feature branch from `dev`
 2. Make your changes
 3. Ensure all checks pass
-4. Submit a PR using the template at [`.github/pull_request_template.md`](./.github/pull_request_template.md). GitHub fills it in automatically when you open a PR through the web UI. If you use `gh pr create`, copy the template into the body — leaving it empty or partially filled slows review.
+4. Submit a PR using the template at [`.github/pull_request_template.md`](./.github/pull_request_template.md). GitHub fills it in automatically when you open a PR through the web UI. If you use `gh pr create`, copy the template into the body. Always keep Problem and outcome, Review guidance, Solution, and Validation; delete the conditional sections that do not apply rather than filling them with "N/A".
 5. Link the issue your PR addresses with `Closes #<number>` (or `Fixes #<number>` / `Resolves #<number>`) in the description so it auto-closes on merge.
 
 ## Code Style


### PR DESCRIPTION
## Problem and outcome

The PR template asked every author for the same fixed inventory — UX journey, before/after architecture diagrams, label snapshot, change metadata, and five sections marked `(required)` — no matter how small the change was. The predictable result was headings padded with "N/A" and the two or three sections that actually mattered buried among a dozen that did not.

- **Outcome:** the template now leads with the problem and the observable outcome, adds explicit review guidance, and makes every other section conditional — include it when it carries material information, delete it when it does not.
- **Invariant:** Problem and outcome, Review guidance, Solution, and Validation are always present.
- **Scope boundary:** no workflow, CI, or code behavior changes. The maintainer triage workflows read whatever template is on disk, so they pick this up without edits.

## Review guidance

- **Feedback requested:** whether the always-keep set is the right four, and whether anything load-bearing from the old template was dropped rather than made conditional.
- **Start here:** `.github/pull_request_template.md` — the whole change.
- **Lower-attention areas:** the `AGENTS.md` and `CONTRIBUTING.md` edits are one line each, correcting instructions that said to fill in every section.

## Solution

Adopted the template already in use in the `prp` repo. Two ideas carry it: state the problem and what is observably different before describing implementation, and tell the reviewer where to start rather than making them derive it from the diff. Conditional sections keep their structure for the PRs that need them — behavior change, architecture, delivery considerations — without taxing the ones that do not.

## Validation

- `bun x prettier --check` on all three changed files — passes.
- Template copied byte-identical from the source; verified with `diff`.
- Grepped for other references to `pull_request_template`: `AGENTS.md` and `CONTRIBUTING.md` are updated here; the remaining hits are workflow prompts that read the file at runtime and need no change.
- **Not verified:** nothing material — this is documentation with no executable surface.

## Links

- Related #2535

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined the pull request template around problem, outcome, review guidance, solution, and validation.
  * Added clearer instructions for including conditional sections only when relevant and removing unused sections.
  * Updated contribution guidance to reflect the revised pull request requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->