### PR TITLE
marketplace: add archon-self-upgrade

### DIFF
--- a/packages/docs-web/src/data/marketplace.ts
+++ b/packages/docs-web/src/data/marketplace.ts
@@ -215,4 +215,16 @@ export const marketplaceEntries: MarketplaceEntry[] = [
     tags: ['automation', 'development'],
     archonVersionCompat: '>=0.5.0',
   },
+  {
+    slug: 'archon-self-upgrade',
+    name: 'Archon Self-Upgrade',
+    author: 'k4n4lm00n',
+    description:
+      'Hot-upgrade a live, long-running server (e.g. an Archon messenger-integrated bot) to newer code from your fork WITHOUT dropping its active communication link. Ensures the `upstream` and `myfork` remotes (forks `upstream` to create `myfork` if missing), snapshots the live instance as a rollback anchor, stages the target ref in an isolated worktree, installs/type-checks/builds/tests, smoke-boots in isolation, then performs a detached, self-healing cutover that keeps every active integration or rolls back.',
+    sourceUrl:
+      'https://github.com/k4n4lm00n/archon-self-upgrade/blob/25a6b26759166224634c349c1a2289041502fa4e/archon-self-upgrade.yaml',
+    sha: '25a6b26759166224634c349c1a2289041502fa4e',
+    tags: ['automation', 'development'],
+    archonVersionCompat: '>=0.5.0',
+  },
 ];


### PR DESCRIPTION
> **Note — this supersedes #2430.** While updating that PR's branch to repin the
> entry's source SHA, I accidentally force-pushed a commit built from a *shallow*
> clone; it landed as a parentless root commit, which recreated the branch history
> and auto-closed #2430. GitHub then permanently blocks reopening a PR whose branch
> was force-pushed after closing, so I'm re-submitting the same contribution here
> from a clean, correctly-parented branch. **The change is identical to #2430** —
> the only difference is the entry's pinned source SHA now points at the current,
> reachable revision. Apologies for the churn, @coleam00.

---

Adds **archon-self-upgrade** to the marketplace.

**What it does:** hot-upgrades a live, long-running Archon server to newer code from your fork **without dropping its active communication link**:

`preflight` (ensure `upstream` + `myfork` remotes; fork upstream to create `myfork` if missing; resolve the upgrade target from the prompt) → `snapshot` (rollback anchor) → `stage` the target ref in an isolated worktree → `validate` (install/type-check/build/tests) → isolated `smoke` boot (no adapter connects) → detached, self-healing `cutover`.

**Safety model:** the cutover is health-gated and rolls back to the untouched old worktree on any failure. Default gate = "don't regress" — server ready + **platform parity** (every integration active on the old server must reconnect). Operators can add their own rollback constraints (`REQUIRE_LOG`/`FORBID_LOG`, `CUTOVER_DEADLINE`, `HEALTH_CMD`/`HEALTH_HOOK`, a human `CONFIRM_CMD` with a timeout). Messenger-agnostic — no chat platform is named or assumed.

**Targeting from the prompt:** e.g. `self upgrade to dev`, `... to the latest stable release`, `... to v0.5.0`, `... to upstream/dev`, `... to alice/Archon@feat/x`, and `... with live commits` to replay your live branch's commits onto the chosen base.

- Source (SHA-pinned, single self-contained YAML): https://github.com/k4n4lm00n/archon-self-upgrade
- Validated end-to-end against a live server: non-destructive pipeline, a real upgrade-to-newer-code cutover, and the auto-rollback path.
- `bun packages/docs-web/scripts/lint-marketplace.ts` passes (15 entries).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Archon Self Upgrade integration to the marketplace.
  * Included compatibility details for supported Archon versions.
  * Added development and automation tags to make the integration easier to discover.
  * Included verified source information for the marketplace listing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->