### PR TITLE
fix(core): refuse a chat turn whose worktree is gone

### DIFF
--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -277,8 +277,12 @@ mock.module('@archon/git', () => ({
   hasUncommittedChanges: mock(() => Promise.resolve(false)),
 }));
 
+// Hoisted so individual tests can make a specific path report as missing (the
+// conversation-cwd guard in handleMessage). Default: everything exists.
+const mockExistsSync = mock((_path: string) => true);
+
 mock.module('fs', () => ({
-  existsSync: mock(() => true),
+  existsSync: mockExistsSync,
   // token-crypto.ts imports these from node:fs for the auto-provisioned credential
   // key. readFileSync returns a valid 64-hex key so getEncryptionKey() resolves
   // without any real disk write when the per-user credential path is exercised.
@@ -1403,6 +1407,7 @@ describe('provider cwd resolution', () => {
     mockSendQuery.mockClear();
     mockEnsureArchonWorkspacesPath.mockClear();
     mockLogger.warn.mockClear();
+    mockExistsSync.mockImplementation(() => true);
     mockGetOrCreateConversation.mockImplementation(() => Promise.resolve(null));
     mockGetCodebase.mockImplementation(() => Promise.resolve(null));
     mockListCodebases.mockImplementation(() => Promise.resolve([]));
@@ -1441,6 +1446,63 @@ describe('provider cwd resolution', () => {
 
     expect(getSendQueryCwd()).toBe('/worktrees/feature-branch');
     expect(mockEnsureArchonWorkspacesPath).not.toHaveBeenCalled();
+  });
+
+  test('scoped chat refuses the turn when conversation.cwd no longer exists', async () => {
+    const codebase = makeCodebaseForSync();
+    const conversation = makeConversation({
+      codebase_id: 'codebase-1',
+      cwd: '/worktrees/deleted-branch',
+      isolation_env_id: 'env-gone',
+    });
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(codebase));
+    mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
+    mockExistsSync.mockImplementation((p: string) => p !== '/worktrees/deleted-branch');
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', 'hello');
+
+    // Never reaches the provider: spawning there fails ENOENT and the Claude
+    // SDK misreports it as a binary/libc mismatch.
+    expect(mockSendQuery).not.toHaveBeenCalled();
+    const sent = (platform.sendMessage as ReturnType<typeof mock>).mock.calls[0][1] as string;
+    expect(sent).toContain('/worktrees/deleted-branch');
+    expect(sent).toContain('/setproject');
+  });
+
+  test('missing conversation.cwd does not silently fall back to default_cwd', async () => {
+    const codebase = makeCodebaseForSync();
+    const conversation = makeConversation({
+      codebase_id: 'codebase-1',
+      cwd: '/worktrees/deleted-branch',
+    });
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(codebase));
+    mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
+    mockExistsSync.mockImplementation((p: string) => p !== '/worktrees/deleted-branch');
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', 'hello');
+
+    // Relocating the agent into the live checkout would widen its write scope
+    // without the user asking for it.
+    expect(mockSendQuery).not.toHaveBeenCalled();
+  });
+
+  test('unscoped chat ignores a missing conversation.cwd', async () => {
+    const conversation = makeConversation({ codebase_id: null, cwd: '/worktrees/deleted-branch' });
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+    mockListCodebases.mockReturnValueOnce(Promise.resolve([]));
+    mockExistsSync.mockImplementation((p: string) => p !== '/worktrees/deleted-branch');
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', 'hello');
+
+    // With no codebase scoped, cwd is never consulted — the workspaces path wins,
+    // so a stale override must not block the turn.
+    expect(mockEnsureArchonWorkspacesPath).toHaveBeenCalled();
+    expect(mockSendQuery).toHaveBeenCalled();
   });
 
   test('unscoped chat uses ensureArchonWorkspacesPath result', async () => {

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -346,6 +346,19 @@ function makeCodebase(name: string, id = `id-${name}`): Codebase {
   };
 }
 
+// `existsSync` is one shared mock for the whole file, so whatever predicate the
+// last test left behind is what the next one inherits. Resetting it inside a
+// single describe is not enough: everything below that block would run against a
+// leaked predicate, including the `/setproject` and `/update-project` suites,
+// which drive the existsSync call sites in handleSetProject and
+// handleUpdateProject. Today a leak is survivable only because the predicates
+// here reject one literal path — that is luck, not a guarantee, and it stops
+// being true the moment a test rejects something broader. Reset before every
+// test so no describe can poison another.
+beforeEach(() => {
+  mockExistsSync.mockImplementation(() => true);
+});
+
 // ─── parseOrchestratorCommands ────────────────────────────────────────────────
 
 describe('parseOrchestratorCommands', () => {
@@ -1407,7 +1420,7 @@ describe('provider cwd resolution', () => {
     mockSendQuery.mockClear();
     mockEnsureArchonWorkspacesPath.mockClear();
     mockLogger.warn.mockClear();
-    mockExistsSync.mockImplementation(() => true);
+    // existsSync is reset by the top-level beforeEach, which covers every describe.
     mockGetOrCreateConversation.mockImplementation(() => Promise.resolve(null));
     mockGetCodebase.mockImplementation(() => Promise.resolve(null));
     mockListCodebases.mockImplementation(() => Promise.resolve([]));
@@ -1468,6 +1481,50 @@ describe('provider cwd resolution', () => {
     expect(mockSendQuery).not.toHaveBeenCalled();
     const sent = (platform.sendMessage as ReturnType<typeof mock>).mock.calls[0][1] as string;
     expect(sent).toContain('/worktrees/deleted-branch');
+    expect(sent).toContain('/setproject');
+  });
+
+  test('suggests detaching the worktree only while one is still attached', async () => {
+    const codebase = makeCodebaseForSync();
+    const conversation = makeConversation({
+      codebase_id: 'codebase-1',
+      cwd: '/worktrees/deleted-branch',
+      isolation_env_id: 'env-gone',
+    });
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(codebase));
+    mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
+    mockExistsSync.mockImplementation((p: string) => p !== '/worktrees/deleted-branch');
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', 'hello');
+
+    const sent = (platform.sendMessage as ReturnType<typeof mock>).mock.calls[0][1] as string;
+    expect(sent).toContain('/worktree remove');
+    expect(sent).toContain('/setproject');
+  });
+
+  test('drops the worktree advice once isolation_env_id is already cleared', async () => {
+    const codebase = makeCodebaseForSync();
+    const conversation = makeConversation({
+      codebase_id: 'codebase-1',
+      cwd: '/worktrees/deleted-branch',
+      isolation_env_id: null,
+    });
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(codebase));
+    mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
+    mockExistsSync.mockImplementation((p: string) => p !== '/worktrees/deleted-branch');
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', 'hello');
+
+    const sent = (platform.sendMessage as ReturnType<typeof mock>).mock.calls[0][1] as string;
+    // Reachable via the stale_cleaned branch in validateAndResolveIsolation, which
+    // clears isolation_env_id and leaves cwd set. `/worktree remove` answers "This
+    // conversation is not using a worktree." here, so suggesting it dead-ends.
+    expect(sent).not.toContain('/worktree remove');
+    expect(sent).not.toContain('isolated worktree was removed');
     expect(sent).toContain('/setproject');
   });
 

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -1419,6 +1419,44 @@ export async function handleMessage(
       }
     }
 
+    // A conversation's `cwd` override can outlive the directory it names. Every
+    // path that tears a worktree down (`archon isolation cleanup`, the periodic
+    // reaper, the isolation API route, a user's own `rm -rf`) marks the env row
+    // destroyed without touching the conversation row, so `cwd` keeps pointing at
+    // a path that is gone. Only the WORKFLOW path re-resolves isolation and
+    // notices; a chat turn reads `cwd` verbatim and hands it to the provider,
+    // which spawns its subprocess there and fails ENOENT — an error the Claude
+    // SDK reports as a binary/libc mismatch, sending the operator after entirely
+    // the wrong thing.
+    //
+    // Deliberately does NOT fall back to codebase.default_cwd: this conversation
+    // asked to work in an isolated worktree, and quietly relocating the agent
+    // into the live checkout would widen its write scope without consent. Runs
+    // before the persist below so a refused turn leaves no `user` row without its
+    // `assistant` pair, and after the deterministic-command early-returns above
+    // so `/worktree remove` and `/setproject` — the way out of this state — keep
+    // working.
+    if (conversation.codebase_id !== null && conversation.cwd !== null) {
+      if (!existsSync(conversation.cwd)) {
+        getLog().warn(
+          {
+            conversationId: conversation.id,
+            cwd: conversation.cwd,
+            isolationEnvId: conversation.isolation_env_id,
+          },
+          'orchestrator.conversation_cwd_missing'
+        );
+        await platform.sendMessage(
+          conversationId,
+          `This conversation's working directory no longer exists:\n\`${conversation.cwd}\`\n\n` +
+            'Its isolated worktree was removed after this conversation was bound to it. ' +
+            'Run `/worktree remove` to detach and go back to the project root, or ' +
+            '`/setproject <name>` to rebind this conversation to a project.'
+        );
+        return;
+      }
+    }
+
     // Persist the inbound user message for non-web platforms (Slack/Telegram/
     // GitHub/Discord/CLI) — the web adapter's route persists web turns itself.
     // Placed AFTER the deterministic-command and approval early-returns so only

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -1433,9 +1433,9 @@ export async function handleMessage(
     // asked to work in an isolated worktree, and quietly relocating the agent
     // into the live checkout would widen its write scope without consent. Runs
     // before the persist below so a refused turn leaves no `user` row without its
-    // `assistant` pair, and after the deterministic-command early-returns above
-    // so `/worktree remove` and `/setproject` — the way out of this state — keep
-    // working.
+    // `assistant` pair, and after the deterministic-command early-returns above so
+    // the commands that get out of this state keep working. Which of them applies
+    // depends on `isolation_env_id` — see the message branch below.
     if (conversation.codebase_id !== null && conversation.cwd !== null) {
       if (!existsSync(conversation.cwd)) {
         getLog().warn(
@@ -1446,12 +1446,24 @@ export async function handleMessage(
           },
           'orchestrator.conversation_cwd_missing'
         );
+        // The recovery advice branches on whether a worktree is still attached,
+        // because `/worktree remove` hard-returns "This conversation is not using
+        // a worktree." when `isolation_env_id` is null (command-handler.ts:428).
+        // That state is reachable, not hypothetical: the `stale_cleaned` branch in
+        // validateAndResolveIsolation (orchestrator.ts:204) clears
+        // `isolation_env_id` and leaves `cwd` set, so a workflow run can strand a
+        // conversation exactly here and the next chat turn would be told to run a
+        // command that dead-ends. `/setproject` clears the cwd override and works
+        // in both states, so it is the one suggestion that always applies.
         await platform.sendMessage(
           conversationId,
           `This conversation's working directory no longer exists:\n\`${conversation.cwd}\`\n\n` +
-            'Its isolated worktree was removed after this conversation was bound to it. ' +
-            'Run `/worktree remove` to detach and go back to the project root, or ' +
-            '`/setproject <name>` to rebind this conversation to a project.'
+            (conversation.isolation_env_id !== null
+              ? 'Its isolated worktree was removed after this conversation was bound to it. ' +
+                'Run `/worktree remove` to detach and go back to the project root, or ' +
+                '`/setproject <name>` to rebind this conversation to a project.'
+              : 'This conversation is not bound to an isolated workspace, so there is nothing ' +
+                'to detach. Run `/setproject <name>` to rebind this conversation to a project.')
         );
         return;
       }

--- a/packages/core/src/services/cleanup-service.test.ts
+++ b/packages/core/src/services/cleanup-service.test.ts
@@ -1662,6 +1662,70 @@ describe('onConversationClosed', () => {
       deleteRemoteBranch: undefined,
     });
   });
+
+  test('clears cwd when it points at the environment being removed', async () => {
+    mockGetConversationByPlatformId.mockResolvedValueOnce({
+      id: 'conv-cwd',
+      isolation_env_id: 'env-cwd',
+      cwd: '/workspace/worktrees/pr-300',
+    });
+    mockGetActiveSession.mockResolvedValueOnce(null);
+
+    const env = {
+      id: 'env-cwd',
+      codebase_id: 'codebase-1',
+      working_path: '/workspace/worktrees/pr-300',
+      branch_name: 'feature-z',
+      status: 'active',
+    };
+    mockGetById.mockResolvedValueOnce(env);
+    mockGetConversationsUsingEnv.mockResolvedValueOnce([]);
+    mockGetById.mockResolvedValueOnce(env);
+    mockGetCodebase.mockResolvedValueOnce({
+      id: 'codebase-1',
+      name: 'test-repo',
+      default_cwd: '/workspace/repo',
+    });
+
+    await onConversationClosed('github', 'owner/repo#300');
+
+    // Leaving cwd set would strand the conversation on a deleted directory.
+    expect(mockUpdateConversation).toHaveBeenCalledWith('conv-cwd', {
+      isolation_env_id: null,
+      cwd: null,
+    });
+  });
+
+  test('leaves an unrelated cwd untouched', async () => {
+    mockGetConversationByPlatformId.mockResolvedValueOnce({
+      id: 'conv-other-cwd',
+      isolation_env_id: 'env-other',
+      cwd: '/somewhere/else',
+    });
+    mockGetActiveSession.mockResolvedValueOnce(null);
+
+    const env = {
+      id: 'env-other',
+      codebase_id: 'codebase-1',
+      working_path: '/workspace/worktrees/pr-301',
+      branch_name: 'feature-w',
+      status: 'active',
+    };
+    mockGetById.mockResolvedValueOnce(env);
+    mockGetConversationsUsingEnv.mockResolvedValueOnce([]);
+    mockGetById.mockResolvedValueOnce(env);
+    mockGetCodebase.mockResolvedValueOnce({
+      id: 'codebase-1',
+      name: 'test-repo',
+      default_cwd: '/workspace/repo',
+    });
+
+    await onConversationClosed('github', 'owner/repo#301');
+
+    expect(mockUpdateConversation).toHaveBeenCalledWith('conv-other-cwd', {
+      isolation_env_id: null,
+    });
+  });
 });
 
 describe('cleanupStaleWorktrees', () => {

--- a/packages/core/src/services/cleanup-service.ts
+++ b/packages/core/src/services/cleanup-service.ts
@@ -264,9 +264,19 @@ export async function onConversationClosed(
     return;
   }
 
-  // Clear this conversation's reference (best-effort - conversation may be deleted)
+  // Clear this conversation's reference (best-effort - conversation may be deleted).
+  // `cwd` is cleared alongside it when it names the environment being torn down:
+  // leaving it set would strand the conversation on a directory that is about to
+  // be deleted, and a chat turn uses `cwd` verbatim (the orchestrator refuses the
+  // turn outright once the path is gone). Null means "no override" — the
+  // conversation falls back to codebase.default_cwd, the same end state
+  // /setproject produces. A cwd pointing somewhere else is left untouched.
+  const cwdBelongsToEnv = conversation.cwd === env.working_path;
   await conversationDb
-    .updateConversation(conversation.id, { isolation_env_id: null })
+    .updateConversation(conversation.id, {
+      isolation_env_id: null,
+      ...(cwdBelongsToEnv ? { cwd: null } : {}),
+    })
     .catch(err => {
       if (!(err instanceof ConversationNotFoundError)) throw err;
     });

--- a/packages/docs-web/src/content/docs/reference/troubleshooting.md
+++ b/packages/docs-web/src/content/docs/reference/troubleshooting.md
@@ -365,3 +365,20 @@ ARCHON_CLAUDE_FIRST_EVENT_TIMEOUT_MS=120000 archon workflow run ...
 - `path contains a full git checkout, not a worktree`: something non-Archon created a full git repo at the worktree path. Remove or move it.
 - `.git pointer is not a git-worktree reference`: the `.git` file at that path points somewhere unexpected (submodule, malformed). Inspect it with `cat <path>/.git` and clean up manually.
 - `Cannot verify worktree ownership`: filesystem permission or I/O error reading `<path>/.git`. Check `ls -la <path>` and file permissions on `~/.archon/workspaces`.
+
+## Chat Says the Working Directory No Longer Exists
+
+**Symptom:** A chat message in a project-scoped conversation is refused with:
+
+- `This conversation's working directory no longer exists: <path>`
+
+**Cause:** The conversation carries a working-directory override (`cwd`) pointing at a directory that has since been removed — an isolated worktree torn down by `archon isolation cleanup`, the periodic reaper, the Environments list in the web UI, or your own `rm -rf`. The override outlives the directory. Only workflow runs re-resolve isolation; a chat turn uses the recorded path as-is.
+
+Archon refuses the turn instead of passing the missing path to the AI provider. It does not silently fall back to the project root, because relocating the agent into the live checkout would widen its write scope without you asking for it. Before this check existed, the provider spawned into the missing directory and the failure surfaced as an unrelated error — `posix_spawn` reports a missing *working directory* as `ENOENT` against the *executable's* path, so Codex reported `No such file or directory (os error 2)` and Claude reported a libc/architecture mismatch. Neither named the directory.
+
+**Fix — follow the message:**
+
+1. **`/setproject <name>`** clears the stale override and rebinds the conversation to a project. This always works and is the suggestion you will always be offered.
+2. **`/worktree remove`** is offered *only* when the conversation is still bound to an isolation environment. It detaches and returns you to the project root. When the environment reference has already been cleared, this command reports `This conversation is not using a worktree.`, which is why it is not suggested in that state.
+
+The refusal writes nothing and changes no state, so a transient cause (a mount blip, a directory mid-move) costs one refused message and nothing else — the next turn re-evaluates from scratch. Operators can find these events in the logs under `orchestrator.conversation_cwd_missing`, which records the conversation id, the path, and the isolation environment id.

--- a/packages/providers/src/claude/provider.test.ts
+++ b/packages/providers/src/claude/provider.test.ts
@@ -1149,6 +1149,52 @@ describe('ClaudeProvider', () => {
       expect(mockQuery).toHaveBeenCalledTimes(1);
     });
 
+    // The SDK reports a spawn failure caused by a MISSING WORKING DIRECTORY as a
+    // libc/architecture mismatch, because posix_spawn returns ENOENT against the
+    // executable's path and the SDK only checks that the executable exists.
+    test('reports a missing working directory instead of the SDK libc message', async () => {
+      const error = new Error(
+        'Claude Code native binary at /pkg/claude exists but failed to launch. ' +
+          "This usually means the binary does not match this system's libc."
+      );
+      mockQuery.mockImplementation(async function* () {
+        throw error;
+      });
+
+      const consumeGenerator = async () => {
+        for await (const _ of client.sendQuery('test', '/worktrees/removed-by-cleanup')) {
+          // consume
+        }
+      };
+
+      await expect(consumeGenerator()).rejects.toThrow(
+        /working directory "\/worktrees\/removed-by-cleanup" does not exist/
+      );
+      // The message names libc only to tell the operator to disregard it.
+      await expect(consumeGenerator()).rejects.toThrow(/The binary is fine/);
+      expect(mockQuery).toHaveBeenCalledTimes(2);
+    });
+
+    test('keeps the original launch error when the working directory exists', async () => {
+      const error = new Error(
+        'Claude Code native binary at /pkg/claude exists but failed to launch. ' +
+          "This usually means the binary does not match this system's libc."
+      );
+      mockQuery.mockImplementation(async function* () {
+        throw error;
+      });
+
+      const consumeGenerator = async () => {
+        // process.cwd() is a real directory, so the cwd explanation does not apply
+        // and a genuine libc mismatch must still surface as itself.
+        for await (const _ of client.sendQuery('test', process.cwd())) {
+          // consume
+        }
+      };
+
+      await expect(consumeGenerator()).rejects.toThrow(/failed to launch/);
+    });
+
     test('classifies "Operation aborted" errors as crash and retries', async () => {
       const error = new Error('Operation aborted');
       mockQuery.mockImplementation(async function* () {

--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -48,7 +48,7 @@ import type {
 import { parseClaudeConfig } from './config';
 import { CLAUDE_CAPABILITIES } from './capabilities';
 import { buildContainerSpawn } from './container-spawn';
-import { resolveClaudeBinaryPath } from './binary-resolver';
+import { resolveClaudeBinaryPath, pathKind } from './binary-resolver';
 import { buildArchonMcpServer, ARCHON_TOOL_SERVER } from './native-tools';
 import { createLogger } from '@archon/paths';
 import { loadMcpConfig } from '../mcp/config';
@@ -246,6 +246,19 @@ const AUTH_PATTERNS = [
   '403',
 ];
 const SUBPROCESS_CRASH_PATTERNS = ['exited with code', 'killed', 'signal', 'operation aborted'];
+
+/**
+ * Errors that mean "the subprocess never started", as opposed to "it started
+ * and then failed". Both spellings name the EXECUTABLE even when the executable
+ * is fine, because `posix_spawn` reports a missing working directory as ENOENT
+ * against the path it was asked to run — see the cwd check in
+ * classifyAndEnrichError for why that distinction matters.
+ *
+ * 'failed to launch' is the Claude Agent SDK's own wording (it wraps the spawn
+ * error after confirming the binary exists on disk, and concludes libc
+ * mismatch); 'enoent' is the raw Node/Bun spawn error when nothing wraps it.
+ */
+const SPAWN_FAILURE_PATTERNS = ['failed to launch', 'enoent'];
 
 function classifySubprocessError(
   errorMessage: string,
@@ -1210,11 +1223,18 @@ async function* streamClaudeMessages(
 /**
  * Classify a subprocess error and enrich with stderr context.
  * Returns null if the error should be retried (caller handles retry logic).
+ *
+ * `hostCwd` is the directory the subprocess was to be spawned in, and only when
+ * that directory is on THIS host — container runs pass undefined, because their
+ * cwd names a path inside the container that is not expected to exist here.
+ * It is inspected only on the spawn-failure path (see the SPAWN_FAILURE_PATTERNS
+ * branch), so the happy path pays no filesystem cost.
  */
 function classifyAndEnrichError(
   error: Error,
   stderrLines: string[],
-  controller: AbortController
+  controller: AbortController,
+  hostCwd: string | undefined
 ): { enrichedError: Error; errorClass: string; shouldRetry: boolean } {
   // If the controller was aborted by withFirstMessageTimeout, the original
   // timeout error carries the diagnostic message and #1067 breadcrumb.
@@ -1256,6 +1276,35 @@ function classifyAndEnrichError(
 
   const stderrContext = stderrLines.join('\n');
   const errorClass = classifySubprocessError(error.message, stderrContext);
+
+  // A spawn that fails because the WORKING DIRECTORY is gone reports ENOENT
+  // against the executable's path, not the cwd's. The SDK sees that, confirms
+  // the executable does exist on disk, and concludes the binary must be built
+  // for the wrong libc — so the operator is told to go chase musl-vs-glibc
+  // while the actual cause is a deleted worktree. Ask the one question the SDK
+  // never asks, and report what is really wrong.
+  if (
+    hostCwd !== undefined &&
+    SPAWN_FAILURE_PATTERNS.some(p => error.message.toLowerCase().includes(p))
+  ) {
+    const kind = pathKind(hostCwd);
+    if (kind !== 'directory') {
+      const detail =
+        kind === 'file'
+          ? 'is a file, not a directory'
+          : 'does not exist (it may have been removed)';
+      const enrichedError = new Error(
+        `Claude Code could not be started: its working directory "${hostCwd}" ${detail}. ` +
+          'A process cannot be spawned in a missing directory, and the failure is reported ' +
+          'against the executable rather than the directory — so the underlying SDK error ' +
+          'names the Claude Code binary and blames a libc mismatch. The binary is fine. ' +
+          'If this was an isolated worktree, recreate it or point this run at a directory ' +
+          'that exists.'
+      );
+      enrichedError.cause = error;
+      return { enrichedError, errorClass: 'cwd_missing', shouldRetry: false };
+    }
+  }
 
   if (errorClass === 'auth') {
     const enrichedError = new Error(
@@ -1455,7 +1504,8 @@ export class ClaudeProvider implements IAgentProvider {
         const { enrichedError, errorClass, shouldRetry } = classifyAndEnrichError(
           err,
           stderrLines,
-          controller
+          controller,
+          isContainerRun ? undefined : cwd
         );
 
         getLog().error(


### PR DESCRIPTION
## Problem and outcome

A conversation whose isolated worktree has been removed keeps its `cwd` pointing at the deleted path, and every subsequent chat message fails with an error that blames the wrong thing entirely: the Claude Agent SDK reports `Claude Code native binary at … exists but failed to launch. This usually means the binary does not match this system's libc — e.g. spawning a musl-linked binary on a glibc Linux host`. The binary is fine. It is a deleted directory, on macOS, with no libc involved.

- **Outcome:** the chat turn is refused up front, naming the missing directory and the two commands that recover from it, instead of reaching the provider and surfacing a libc red herring.
- **Invariant:** a conversation bound to an isolated worktree never silently executes in the live checkout instead.
- **Scope boundary:** the several other call sites that mark an isolation env destroyed (`packages/cli/src/commands/isolation.ts`, `packages/server/src/routes/api.ts`, `packages/isolation/src/resolver.ts`, the periodic reaper) still leave `cwd` set. Fixing the read site covers all of them, including causes no write site can see — a user's own `rm -rf`.
- **Root cause:** `posix_spawn` reports a missing *working directory* as `ENOENT` against the **executable's** path. The SDK's handler checks only whether the executable exists on disk; it does, so it concludes a libc/architecture mismatch. Reproduced directly:

  ```js
  spawn('/…/claude-agent-sdk-darwin-arm64/claude', ['--version'], { cwd: '<deleted worktree>' })
  // → SPAWN ERROR: ENOENT posix_spawn '/…/claude'   ← names the binary, not the cwd
  ```

  The same binary runs fine from a shell (`2.1.209 (Claude Code)`), which is what makes the SDK's message so misleading.

## Review guidance

- **Feedback requested:** correctness of the refuse-vs-fallback decision in the orchestrator, and whether `SPAWN_FAILURE_PATTERNS` is scoped tightly enough.
- **Start here:** `packages/core/src/orchestrator/orchestrator-agent.ts` — the guard placement is the load-bearing part: after the deterministic-command early-returns so `/worktree remove` and `/setproject` still work in this state, before the user-message persist so a refused turn leaves no `user` row without its `assistant` pair.
- **Review order:** orchestrator-agent (the guard) → claude/provider (the error message) → cleanup-service (the write site) → the three test files.
- **Lower-attention areas:** none; every hunk is hand-written and small.
- **Known risk or uncertainty:** the provider check matches on error text (`failed to launch`, `enoent`) before consulting the filesystem. Text matching is inherently brittle across SDK versions, but a miss degrades to today's behavior — the original error — rather than to a wrong answer. Container runs pass `undefined` so the check cannot misfire on a path that legitimately exists only inside the container.

## Solution

Three changes on one story, each at a different layer:

**Read site (the durable fix).** `handleMessage` checks `conversation.cwd` before the AI call. It deliberately does **not** fall back to `codebase.default_cwd`: the conversation asked to work in an isolated worktree, and quietly relocating the agent into the live checkout would widen its write scope without consent. Only the workflow path re-resolves isolation through `validateAndResolveIsolation`; a chat turn reads `cwd` verbatim, which is why this gap existed.

**Error message.** `classifyAndEnrichError` gains the spawn cwd and, on a spawn-failure error only, asks the one question the SDK never asks — does the working directory exist? The check is on the error path, so the happy path pays no filesystem cost. A genuine launch failure with a valid cwd still surfaces as itself.

**Write site.** `onConversationClosed` cleared `isolation_env_id` but left `cwd` naming the directory it was about to delete. It now clears both, and only when `cwd` actually names that environment — an unrelated `cwd` is untouched.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Chat message to a conversation whose worktree was removed returns a libc/architecture error naming the Claude binary | Chat turn is refused with the missing path and the recovery commands (`/worktree remove`, `/setproject`) |
| **Failure behavior** | Provider spawns into a nonexistent directory; error class `unknown`; the operator investigates musl-vs-glibc | Fails before the provider; logged as `orchestrator.conversation_cwd_missing` with `conversationId`, `cwd`, `isolationEnvId` |

## Validation

- `bun run validate` — exits 0 — proves generated-file checks, type-check, lint at `--max-warnings 0`, format, and the full per-package suite all pass.
- `bun test src/claude/provider.test.ts` — 136 pass / 0 fail — covers both the reclassified spawn failure and the case where the cwd exists and the original launch error must survive unchanged.
- `bun test src/orchestrator/orchestrator-agent.test.ts` — 218 pass / 0 fail — includes a test asserting the provider is never called when `cwd` is missing, and one asserting the unscoped-chat path is unaffected (with no codebase scoped, `cwd` is never consulted).
- `bun test src/services/cleanup-service.test.ts` — 55 pass / 0 fail — covers both clearing a matching `cwd` and leaving an unrelated one alone.
- Root cause reproduced directly with `child_process.spawn` against a deleted worktree path (transcript in the Problem section).
- **Not verified:** the end-to-end Telegram path against a live bot after the fix. The refusal branch is covered by unit tests at the orchestrator seam, which is where the decision is made; the adapter below it is a pass-through for `sendMessage`.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | None. No schema change; `cwd: null` is an existing valid state that `/setproject` already produces. | `handleSetProject` writes the same `cwd: null` |
| Rollout / rollback | Fully reversible — three isolated hunks, no persisted state introduced. | Single commit, 6 files |
| Observability | A stale conversation now emits `orchestrator.conversation_cwd_missing` (warn) with the conversation id, path, and isolation env id, instead of being indistinguishable from a provider crash. | `orchestrator-agent.ts` guard |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Project-scoped conversations now stop gracefully when their working directory is missing, with appropriate recovery guidance.
  * Conversations no longer fall back to an incorrect project directory or retain stale working-directory settings after cleanup.
  * Closing a conversation correctly clears its associated working-directory information.
  * Claude launch errors now identify missing or invalid working directories instead of showing misleading system errors.
  * Genuine Claude runtime errors continue to display their original diagnostics.

* **Documentation**
  * Added troubleshooting guidance for missing conversation working directories and recovery options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->