### PR TITLE
fix(workflows): workflow-level modelReasoningEffort and webSearchMode now reach Codex

### DIFF
--- a/packages/docs-web/src/content/docs/book/quick-reference.md
+++ b/packages/docs-web/src/content/docs/book/quick-reference.md
@@ -109,8 +109,8 @@ archon workflow run my-workflow "auth refresh-tokens"
 | `nodes` | Yes | array | DAG nodes (see Node Options below) |
 | `provider` | No | string | Registered provider identifier (e.g. `claude`, `codex`). Default: `claude` |
 | `model` | No | string | Model for all nodes (`sonnet`, `opus`, `haiku`, or full model ID) |
-| `modelReasoningEffort` | No | string | Codex only: `minimal` \| `low` \| `medium` \| `high` \| `xhigh` |
-| `webSearchMode` | No | string | Codex only: `disabled` \| `cached` \| `live` |
+| `modelReasoningEffort` | No | string | Codex only, no per-node form: `minimal` \| `low` \| `medium` \| `high` \| `xhigh` |
+| `webSearchMode` | No | string | Codex only, no per-node form. Gates Codex's built-in search tool, not network access: `disabled` \| `cached` \| `live` |
 
 ### Node Options (DAG)
 

--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -123,8 +123,8 @@ description: |
 # Optional workflow-level configuration
 provider: claude
 model: sonnet
-modelReasoningEffort: medium     # Codex only
-webSearchMode: live              # Codex only
+modelReasoningEffort: medium     # Codex only, workflow level only (no per-node form)
+webSearchMode: live              # Codex only, workflow level only (no per-node form)
 interactive: true                # Web only: run in foreground instead of background
 requires: [github]               # Optional: hard-block invocation unless the triggering
                                  #   user has connected their GitHub identity. Enforced only
@@ -1686,10 +1686,19 @@ webSearchMode: live             # 'disabled' | 'cached' | 'live'
 - `medium` - Balanced (default)
 - `high`, `xhigh` - More thorough, expensive
 
-**Web search mode:**
-- `disabled` - No web access (default)
+**Web search mode:** controls Codex's built-in web-search tool. It is not a network
+switch — Codex nodes always run with network access enabled, so `disabled` stops Codex
+from searching, not from reaching the network.
+
+- `disabled` - No built-in web search (default)
 - `cached` - Use cached search results
 - `live` - Real-time web search
+
+Both fields are **workflow-level only** — there is no per-node `modelReasoningEffort:` or
+`webSearchMode:`. Declaring either on a workflow whose node resolves to a provider other
+than Codex logs a warning and applies nothing, the same way any other unsupported option
+does. The reverse also holds: `effort:` on a Codex node warns and is ignored, because Codex
+takes reasoning depth only through `modelReasoningEffort`.
 
 ### Web Execution Mode
 

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -11291,6 +11291,52 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     expect(assistantConfig?.webSearchMode).toBeUndefined();
   });
 
+  it('reports modelReasoningEffort in node_started, not the effort Codex ignores', async () => {
+    // A mixed-provider workflow is told by the authoring guide to set `effort:` for its
+    // Claude/Pi nodes and `modelReasoningEffort:` for Codex. nodeConfig.effort is populated
+    // for every provider and only warned about on Codex, never stripped — so the event
+    // stream must not prefer it over the value Codex actually ran at.
+    mockGetAgentProviderDag.mockImplementation(() => ({
+      sendQuery: mockSendQueryDag,
+      getType: () => 'codex',
+      getCapabilities: mockCodexCapabilities,
+    }));
+    const mockDeps = createMockDeps();
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun();
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-dag',
+      testDir,
+      {
+        name: 'codex-effort-telemetry-test',
+        nodes: [{ id: 'step1', command: 'my-cmd' }],
+        effort: 'max',
+        modelReasoningEffort: 'low',
+      },
+      workflowRun,
+      'codex',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      { ...minimalConfig, assistant: 'codex' }
+    );
+
+    const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
+    const assistantConfig = optionsArg?.assistantConfig as Record<string, unknown>;
+    expect(assistantConfig?.modelReasoningEffort).toBe('low');
+
+    const createEventCalls = (mockDeps.store.createWorkflowEvent as ReturnType<typeof mock>).mock
+      .calls as Array<[{ event_type: string; data?: Record<string, unknown> }]>;
+    const nodeStartedCall = createEventCalls.find(([arg]) => arg.event_type === 'node_started');
+    expect(nodeStartedCall?.[0].data?.effort).toBe('low');
+  });
+
   it('warns when a node in a Codex workflow resolves away to Claude via a tier', async () => {
     // The mixed-provider direction: the workflow-level provider IS codex, so a check
     // against the CONFIGURED provider would stay silent. Only the resolved provider

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -11113,6 +11113,183 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     const warning = messages.find(m => m.includes('effort') && m.toLowerCase().includes('codex'));
     expect(warning).toBeDefined();
   });
+
+  it('forwards workflow-level modelReasoningEffort and webSearchMode to a Codex node', async () => {
+    mockGetAgentProviderDag.mockImplementation(() => ({
+      sendQuery: mockSendQueryDag,
+      getType: () => 'codex',
+      getCapabilities: mockCodexCapabilities,
+    }));
+    const mockDeps = createMockDeps();
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun();
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-dag',
+      testDir,
+      {
+        name: 'codex-workflow-options-test',
+        nodes: [{ id: 'step1', command: 'my-cmd' }],
+        modelReasoningEffort: 'minimal',
+        webSearchMode: 'live',
+      },
+      workflowRun,
+      'codex',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      { ...minimalConfig, assistant: 'codex' }
+    );
+
+    expect(mockSendQueryDag.mock.calls.length).toBeGreaterThan(0);
+    const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
+    const assistantConfig = optionsArg?.assistantConfig as Record<string, unknown>;
+    expect(assistantConfig?.modelReasoningEffort).toBe('minimal');
+    expect(assistantConfig?.webSearchMode).toBe('live');
+  });
+
+  it('workflow-level modelReasoningEffort beats a preset-routed effort, and node_started reports the applied value', async () => {
+    mockGetAgentProviderDag.mockImplementation(() => ({
+      sendQuery: mockSendQueryDag,
+      getType: () => 'codex',
+      getCapabilities: mockCodexCapabilities,
+    }));
+    const mockDeps = createMockDeps();
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun();
+    const aiProfile = buildAiProfile('claude', {
+      repoTiers: {
+        medium: { provider: 'codex', model: 'gpt-5.5', effort: 'medium' },
+      },
+    });
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-dag',
+      testDir,
+      {
+        name: 'codex-workflow-beats-preset-test',
+        nodes: [{ id: 'step1', command: 'my-cmd', model: 'medium' }],
+        modelReasoningEffort: 'xhigh',
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      aiProfile
+    );
+
+    const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
+    const assistantConfig = optionsArg?.assistantConfig as Record<string, unknown>;
+    expect(assistantConfig?.modelReasoningEffort).toBe('xhigh');
+
+    // The write must land BEFORE resolvedEffort is captured, or the audit trail and
+    // console report an effort the node did not run at.
+    const createEventCalls = (mockDeps.store.createWorkflowEvent as ReturnType<typeof mock>).mock
+      .calls as Array<[{ event_type: string; data?: Record<string, unknown> }]>;
+    const nodeStartedCall = createEventCalls.find(([arg]) => arg.event_type === 'node_started');
+    expect(nodeStartedCall?.[0].data?.effort).toBe('xhigh');
+  });
+
+  it('workflow-level modelReasoningEffort does not strip preset effort from a Claude node', async () => {
+    const mockDeps = createMockDeps();
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun();
+    const aiProfile = buildAiProfile('claude', {
+      repoTiers: {
+        medium: { provider: 'claude', model: 'sonnet', effort: 'medium' },
+      },
+    });
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-dag',
+      testDir,
+      {
+        name: 'mixed-provider-preset-effort-test',
+        nodes: [{ id: 'step1', command: 'my-cmd', model: 'medium' }],
+        // Declared for the workflow's Codex nodes; must not affect this Claude node.
+        modelReasoningEffort: 'high',
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      aiProfile
+    );
+
+    const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
+    const nodeConfig = optionsArg?.nodeConfig as Record<string, unknown>;
+    const assistantConfig = optionsArg?.assistantConfig as Record<string, unknown>;
+    expect(nodeConfig?.effort).toBe('medium');
+    expect(assistantConfig?.modelReasoningEffort).toBeUndefined();
+  });
+
+  it('warns when workflow-level Codex options land on a non-Codex node', async () => {
+    const mockDeps = createMockDeps();
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun();
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-dag',
+      testDir,
+      {
+        name: 'codex-options-on-claude-test',
+        nodes: [{ id: 'step1', command: 'my-cmd' }],
+        modelReasoningEffort: 'high',
+        webSearchMode: 'live',
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
+    const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
+    const warning = messages.find(
+      m => m.includes('modelReasoningEffort') && m.includes('webSearchMode')
+    );
+    expect(warning).toBeDefined();
+
+    // Nothing meaningless is written onto a provider that cannot read it.
+    const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
+    const assistantConfig = optionsArg?.assistantConfig as Record<string, unknown>;
+    expect(assistantConfig?.modelReasoningEffort).toBeUndefined();
+    expect(assistantConfig?.webSearchMode).toBeUndefined();
+  });
 });
 
 describe('executeDagWorkflow -- cost tracking', () => {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -11290,6 +11290,61 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     expect(assistantConfig?.modelReasoningEffort).toBeUndefined();
     expect(assistantConfig?.webSearchMode).toBeUndefined();
   });
+
+  it('warns when a node in a Codex workflow resolves away to Claude via a tier', async () => {
+    // The mixed-provider direction: the workflow-level provider IS codex, so a check
+    // against the CONFIGURED provider would stay silent. Only the resolved provider
+    // reveals that this node cannot read either field.
+    const mockDeps = createMockDeps();
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun();
+    const aiProfile = buildAiProfile('codex', {
+      repoTiers: {
+        medium: { provider: 'claude', model: 'sonnet' },
+      },
+    });
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-dag',
+      testDir,
+      {
+        name: 'codex-workflow-node-resolves-to-claude-test',
+        nodes: [{ id: 'step1', command: 'my-cmd', model: 'medium' }],
+        modelReasoningEffort: 'high',
+        webSearchMode: 'live',
+      },
+      workflowRun,
+      'codex',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      aiProfile
+    );
+
+    expect(mockGetAgentProviderDag.mock.calls[0][0]).toBe('claude');
+
+    const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
+    const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
+    const warning = messages.find(
+      m => m.includes('modelReasoningEffort') && m.includes('webSearchMode')
+    );
+    expect(warning).toBeDefined();
+
+    const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
+    const assistantConfig = optionsArg?.assistantConfig as Record<string, unknown>;
+    expect(assistantConfig?.modelReasoningEffort).toBeUndefined();
+    expect(assistantConfig?.webSearchMode).toBeUndefined();
+  });
 });
 
 describe('executeDagWorkflow -- cost tracking', () => {

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -1060,6 +1060,15 @@ async function resolveNodeProviderAndModel(
   // Get provider capabilities for capability warnings (static lookup, no instantiation)
   const caps = getProviderCapabilities(provider);
 
+  // Codex is the only provider that takes reasoning effort and web-search mode from
+  // `assistantConfig` (codex/provider.ts:92-93), and it ignores the node-level `effort:`
+  // field entirely. Three decisions below hang on that one fact — whether to warn, whether
+  // to write, and which field holds the effort that will actually be applied — so it is
+  // named once here rather than spelled as three independent string comparisons that a
+  // later change could update apart. There is deliberately no ProviderCapabilities axis
+  // for this; see #2556.
+  const readsAssistantConfigOptions = provider === 'codex';
+
   // Runtime backstop for container dispatch: the run-start pre-scan
   // (collectContainerIncompatibleProviders) hand-mirrors this same provider
   // resolution, so it could drift. Re-check the RESOLVED provider here, at the
@@ -1103,13 +1112,11 @@ async function resolveNodeProviderAndModel(
     }
   }
 
-  // `modelReasoningEffort`/`webSearchMode` are read only by Codex (codex/provider.ts).
-  // They have no ProviderCapabilities axis, so capChecks above cannot see them — adding
-  // a second effort-shaped axis is the wrong fix and is deliberately deferred to #2556.
-  // Surfacing them here reuses the existing loud-mismatch path so a workflow that
-  // declares either one on a non-Codex node gets the same warning every other
-  // capability mismatch produces, instead of a silent no-op.
-  if (provider !== 'codex') {
+  // `modelReasoningEffort`/`webSearchMode` have no ProviderCapabilities axis, so capChecks
+  // above cannot see them. Surfacing them here reuses the existing loud-mismatch path so a
+  // workflow that declares either one on a node that cannot read them gets the same warning
+  // every other capability mismatch produces, instead of a silent no-op.
+  if (!readsAssistantConfigOptions) {
     if (workflowLevelOptions.modelReasoningEffort !== undefined) {
       unsupported.push('modelReasoningEffort');
     }
@@ -1189,11 +1196,10 @@ async function resolveNodeProviderAndModel(
   // workflow-level > tier preset > config.yaml — and BEFORE the resolvedEffort read
   // below so telemetry reports the value that actually runs.
   //
-  // Gated on the resolved provider: Codex is the only consumer (codex/provider.ts),
-  // and an ungated write would land on Copilot too, which reads the same key from
-  // assistantConfig with a narrower enum. Declaring either field on a non-Codex node
-  // warns via the capability block above rather than silently doing nothing.
-  if (provider === 'codex') {
+  // Gated on the resolved provider: an ungated write would land on Copilot too, which
+  // reads the same key from assistantConfig with a narrower enum. Declaring either field
+  // on a node that cannot read it warns via the capability block above instead.
+  if (readsAssistantConfigOptions) {
     if (workflowLevelOptions.modelReasoningEffort !== undefined) {
       assistantConfig.modelReasoningEffort = workflowLevelOptions.modelReasoningEffort;
     }
@@ -1213,9 +1219,21 @@ async function resolveNodeProviderAndModel(
   // node-level effort: field", not "can apply reasoning effort". Codex is
   // effortControl:false yet applies effort via modelReasoningEffort, so gating
   // on it would drop a real, applied value from node_started.
-  const assistantEffort = assistantConfig.modelReasoningEffort;
-  const resolvedEffort: string | undefined =
-    nodeConfig.effort ?? (typeof assistantEffort === 'string' ? assistantEffort : undefined);
+  //
+  // The branch matters. `nodeConfig.effort` is populated for every provider, and
+  // capChecks only WARNS that Codex ignores it — it never strips it. So on Codex a
+  // plain `nodeConfig.effort ?? assistantEffort` reports the declared-but-ignored
+  // `effort:` in preference to the `modelReasoningEffort` the node actually ran at.
+  // A mixed-provider workflow setting both (which the authoring guide recommends)
+  // hits that directly, and it is the #2395 failure mode: an event stream that does
+  // not say what ran.
+  const assistantEffort =
+    typeof assistantConfig.modelReasoningEffort === 'string'
+      ? assistantConfig.modelReasoningEffort
+      : undefined;
+  const resolvedEffort: string | undefined = readsAssistantConfigOptions
+    ? assistantEffort
+    : (nodeConfig.effort ?? assistantEffort);
 
   const options: SendQueryOptions = {
     ...baseOptions,

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -53,6 +53,8 @@ import type {
   EffortLevel,
   ThinkingConfig,
   SandboxSettings,
+  ModelReasoningEffort,
+  WebSearchMode,
   WorkflowSource,
   WorkflowDefinition,
   LoopGateRunMetadata,
@@ -337,13 +339,22 @@ export async function loadConfiguredMcpServerNames(
   }
 }
 
-/** Workflow-level Claude SDK options — per-node overrides take precedence via ?? */
+/** Workflow-level provider options. The first five have node-level counterparts and
+ *  are resolved as `node.X ?? workflowLevelOptions.X`; the two Codex fields below have
+ *  NO node-level equivalent (they are absent from `dagNodeSchema`), so a workflow-level
+ *  value is the only value. */
 interface WorkflowLevelOptions {
   effort?: EffortLevel;
   thinking?: ThinkingConfig;
   fallbackModel?: string;
   betas?: string[];
   sandbox?: SandboxSettings;
+  /** Codex-only: reasoning effort, consumed as `assistantConfig.modelReasoningEffort`.
+   *  Written only when the resolved provider is Codex — see `resolveNodeProviderAndModel`. */
+  modelReasoningEffort?: ModelReasoningEffort;
+  /** Codex-only: web-search mode, consumed as `assistantConfig.webSearchMode`. Same
+   *  provider gate as `modelReasoningEffort`. */
+  webSearchMode?: WebSearchMode;
   /** Workflow-level tier keyword (when `workflow.model` is small/medium/large), so
    *  nodes that inherit the workflow model can still surface the `← tier` annotation. */
   workflowTier?: 'small' | 'medium' | 'large';
@@ -1092,6 +1103,21 @@ async function resolveNodeProviderAndModel(
     }
   }
 
+  // `modelReasoningEffort`/`webSearchMode` are read only by Codex (codex/provider.ts).
+  // They have no ProviderCapabilities axis, so capChecks above cannot see them — adding
+  // a second effort-shaped axis is the wrong fix and is deliberately deferred to #2556.
+  // Surfacing them here reuses the existing loud-mismatch path so a workflow that
+  // declares either one on a non-Codex node gets the same warning every other
+  // capability mismatch produces, instead of a silent no-op.
+  if (provider !== 'codex') {
+    if (workflowLevelOptions.modelReasoningEffort !== undefined) {
+      unsupported.push('modelReasoningEffort');
+    }
+    if (workflowLevelOptions.webSearchMode !== undefined) {
+      unsupported.push('webSearchMode');
+    }
+  }
+
   if (unsupported.length > 0) {
     getLog().warn({ nodeId: node.id, provider, unsupported }, 'dag.unsupported_capabilities');
     const delivered = await safeSendMessage(
@@ -1158,11 +1184,30 @@ async function resolveNodeProviderAndModel(
     nodeConfig,
     assistantConfig
   );
+  // Workflow-level Codex options (#2246). Applied AFTER applyPresetOptions so an
+  // explicit workflow literal beats a preset-routed effort — precedence is
+  // workflow-level > tier preset > config.yaml — and BEFORE the resolvedEffort read
+  // below so telemetry reports the value that actually runs.
+  //
+  // Gated on the resolved provider: Codex is the only consumer (codex/provider.ts),
+  // and an ungated write would land on Copilot too, which reads the same key from
+  // assistantConfig with a narrower enum. Declaring either field on a non-Codex node
+  // warns via the capability block above rather than silently doing nothing.
+  if (provider === 'codex') {
+    if (workflowLevelOptions.modelReasoningEffort !== undefined) {
+      assistantConfig.modelReasoningEffort = workflowLevelOptions.modelReasoningEffort;
+    }
+    if (workflowLevelOptions.webSearchMode !== undefined) {
+      assistantConfig.webSearchMode = workflowLevelOptions.webSearchMode;
+    }
+  }
+
   // Read POST-routing values only. applyPresetOptions -> routePresetEffort has
   // already placed effort where the provider actually consumes it — nodeConfig
   // for providers taking a node-level `effort:`, assistantConfig for Codex's
-  // modelReasoningEffort — and warned + dropped it where unsupported. So both
-  // reads below hold effort that will genuinely be applied.
+  // modelReasoningEffort — and warned + dropped it where unsupported; the
+  // workflow-level override above has already been applied. So both reads below
+  // hold effort that will genuinely be applied.
   //
   // Do NOT gate this on caps.effortControl: that flag means "accepts the
   // node-level effort: field", not "can apply reasoning effort". Codex is
@@ -8097,6 +8142,8 @@ export async function executeDagWorkflow(
     fallbackModel: workflow.fallbackModel,
     betas: workflow.betas,
     sandbox: workflow.sandbox,
+    modelReasoningEffort: workflow.modelReasoningEffort,
+    webSearchMode: workflow.webSearchMode,
     workflowTier,
   };
   const layers = buildTopologicalLayers(workflow.nodes);


### PR DESCRIPTION
## Problem and outcome

`modelReasoningEffort:` and `webSearchMode:` have been declared on `workflowBaseSchema` and validated by the loader since 2026-03-26, and three places in the docs describe them as working workflow-level options — but the executor never read them off the workflow definition. A workflow that declared either one parsed cleanly, warned about nothing, and ran at the `config.yaml` or SDK default.

- **Outcome:** A workflow declaring `modelReasoningEffort:` / `webSearchMode:` now has that value reach Codex, and declaring either on a non-Codex node produces the same loud capability-mismatch warning every other unsupported field produces.
- **Invariant:** The effort reported in `node_started` is the effort the node actually runs at, and a value declared for one provider never silently changes another provider's behavior.
- **Scope boundary:** No node-level fields added, no `ProviderCapabilities` axis added, `applyPresetOptions` untouched, no provider code touched. `webSearchMode` stays workflow-level with no per-node form — decided and recorded in #2556, not reopened here. Whether reasoning depth should have one workflow-level spelling or two is #2556, not this PR.
- **Root cause:** `workflowLevelOptions` (built at the top of `executeDagWorkflow`) simply never carried the two fields, so `resolveNodeProviderAndModel` had nothing to forward. `assistantConfig` was built purely from `config.assistants[provider]`.

## Review guidance

- **Feedback requested:** Correctness of the provider gate and the write's position relative to the `resolvedEffort` read.
- **Start here:** `packages/workflows/src/dag-executor.ts` — the `if (provider === 'codex')` block in `resolveNodeProviderAndModel`. Its position is load-bearing in both directions: after `applyPresetOptions` so a workflow literal beats a preset-routed effort, before the `resolvedEffort` read so telemetry is not stale.
- **Review order:** the write block → the `provider !== 'codex'` push into `unsupported` → `WorkflowLevelOptions` → the four tests.
- **Lower-attention areas:** the two-line addition to the `workflowLevelOptions` literal and the type import.
- **Known risk or uncertainty:** `resolvedEffort` now branches on the provider, so a Codex node that declares both `effort:` and `modelReasoningEffort:` reports the latter in `node_started` where it previously reported the former. That is the correction (the former is ignored by Codex), but it does change what existing runs emit. Separately, the mismatch warning fires per node, so a multi-node non-Codex workflow that declares one of these repeats it. That matches the existing capability-warning behavior rather than inventing a new one-shot mechanism.

## Solution

Thread both fields from the workflow definition into `workflowLevelOptions`, then write them onto `assistantConfig` in `resolveNodeProviderAndModel` — gated on the **resolved** provider, so a node that resolves to Codex through a tier or `@alias` is covered and a node that resolves away from Codex is not.

Two deliberate non-changes are worth flagging, because the superseded attempt made both:

**`applyPresetOptions` is untouched.** [#2254](https://github.com/coleam00/Archon/pull/2254) added `workflowLevelOptions.modelReasoningEffort !== undefined` to that function's early-return guard. That guard runs before `provider` is consulted, so a workflow declaring `modelReasoningEffort` for its Codex nodes silently suppressed tier/alias preset effort on its Claude and Pi nodes too. Once the write is positioned correctly and gated, the guard is unnecessary — the overwrite already establishes precedence — so the smallest correct change deletes the problem rather than patching it.

**The write is gated on the provider.** An ungated write reaches `parseCopilotConfig` through `resolveCopilotReasoning`, which falls back to `copilotConfig.modelReasoningEffort` when a node sets neither `effort:` nor `thinking:`. Copilot's parser accepts only `low|medium|high|xhigh`, so the documented Codex value `minimal` would silently no-op there while the others silently applied.

The mismatch warning reuses the existing `unsupported` array rather than adding a capability axis, so an author gets one combined message per node instead of a second parallel warning channel. Adding a second effort-shaped `ProviderCapabilities` axis is the wrong fix and is deferred to #2556.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Workflow-level `modelReasoningEffort:` / `webSearchMode:` parsed and were discarded; Codex ran at the config or SDK default | Both reach Codex; workflow literal beats a tier-preset-routed effort; `node_started` carries the applied effort |
| **Failure behavior** | Declaring either field on a non-Codex workflow did nothing, silently | Declaring either on a non-Codex node warns through the existing capability-mismatch message and writes nothing |

### Changed seams

| Boundary or contract | Change | Evidence |
|---|---|---|
| `WorkflowDefinition → workflowLevelOptions` | Both fields now carried; previously dropped | `dag-executor.ts`, test `forwards workflow-level modelReasoningEffort and webSearchMode to a Codex node` |
| `workflowLevelOptions → assistantConfig` | New provider-gated write, ordered against `applyPresetOptions` and the `resolvedEffort` read | tests `workflow-level modelReasoningEffort beats a preset-routed effort…` and `…does not strip preset effort from a Claude node` |
| `resolveNodeProviderAndModel → node_started` | The persisted event now reports the workflow-level value when it wins | assertion on `nodeStartedCall[0].data.effort` |
| `assistantConfig → CodexProvider.parseCodexConfig` | Unchanged — the consumer was already correct | no provider files touched |

## Validation

- `bun run validate` — exit 0, all 9 steps, zero test failures across all packages — proves the change is clean against `dev` @ `ebc0eae5`.
- `bun test src/dag-executor.test.ts` — 457 pass, 0 fail (453 before) — proves the four new cases pass without disturbing the existing suite.
- Each new test was mutation-tested rather than trusted on a green run. Reintroducing #2254's `applyPresetOptions` guard breaks the Claude preset-effort test; moving the write after the `resolvedEffort` read makes `node_started` report `medium` while the node runs `xhigh`; neutering the non-Codex warn breaks the warning test; removing the `provider === 'codex'` gate sets `modelReasoningEffort` on a Claude node. Each mutation breaks exactly the test intended to catch it.
- **Not verified:** no end-to-end run against a real Codex binary. The path from `assistantConfig` through `parseCodexConfig` to `buildThreadOptions` is unchanged by this PR and already covered by the provider's own tests; what this PR adds is upstream of that boundary and is covered by the assertions on `assistantConfig`.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | Workflows that do not declare either field are byte-identical. Workflows that already declare them futilely now have them honored — the behavior the docs already promise | tests; `guides/authoring-workflows.md:126-127` |
| Rollout / rollback | Single commit, no schema or migration change, reverts cleanly | — |
| Observability | A previously silent no-op is now a `dag.unsupported_capabilities` warn plus a user-facing message; `node_started` gains a correct `effort` for this path | test `warns when workflow-level Codex options land on a non-Codex node` |
| Documentation / communication | Corrects a materially false line and records the new author-facing behavior. `authoring-workflows.md` said `webSearchMode: disabled` means "No web access" — it gates Codex's built-in search tool only, since `buildThreadOptions` hard-codes `networkAccessEnabled: true` on every Codex run. Also documents that both fields are workflow-level only and that a mismatch now warns | `providers/src/codex/provider.ts:85-95`; `guides/authoring-workflows.md`, `book/quick-reference.md` |

## Links

- Closes #2246
- Related #2556
- Supersedes #2254
- Supersedes #2020


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workflow-level controls for model reasoning effort and web search behavior.
  * Settings apply to Codex workflows and take precedence over preset reasoning settings.
  * Added provider-aware handling for unsupported settings.
* **Bug Fixes**
  * Added warnings when Codex-specific options are configured for non-Codex workflows.
  * Improved reporting of the effective reasoning effort.
* **Tests**
  * Added coverage for option propagation, precedence, provider handling, telemetry, and warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
