### PR TITLE
feat(workflows): a workflow that declares required inputs can now be run directly

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -158,6 +158,7 @@ Options:
   --base <branch>            Per-dispatch base override for epic slices (worktree cut-from + PR target)
   --no-worktree              Run on branch directly without worktree isolation
   --folder                   Register the current non-git directory as a folder project and run in place
+  --input <name>=<value>     Supply a declared workflow input; repeat per input (mutually exclusive with --resume)
   --resume                   Resume the most recent failed or paused run of the workflow (mutually exclusive with --branch)
   --dry-run                  Simulate workflow DAG control flow without creating a run or contacting a provider
   --stubs <path>             YAML node-output map for --dry-run
@@ -319,6 +320,8 @@ async function main(): Promise<number> {
         stubs: { type: 'string' },
         'exec-code': { type: 'boolean' },
         'pause-at-gates': { type: 'boolean' },
+        // Repeatable: `--input a=1 --input b=2` yields ['a=1', 'b=2'] (#2554).
+        input: { type: 'string', multiple: true },
       },
       allowPositionals: true,
       strict: false, // Allow unknown flags to pass through
@@ -604,6 +607,8 @@ async function main(): Promise<number> {
               stubsPath,
               execCode: execCodeFlag,
               pauseAtGates: pauseAtGatesFlag,
+              // Raw `name=value` assignments; parsed at the invocation gate (#2554).
+              inputs: values.input as string[] | undefined,
             };
             await workflowRunCommand(effectiveCwd, workflowName, userMessage, options);
             break;

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -853,6 +853,27 @@ describe('workflowRunCommand — --input declared inputs (#2554)', () => {
     expect(executeWorkflow).not.toHaveBeenCalled();
   });
 
+  it('rejects --input with --dry-run instead of simulating with empty inputs', async () => {
+    // The dry-run engine has no $INPUTS support: a bash node reading $INPUTS_SCOPE would
+    // expand an unset var to '', producing a trace that reads as a valid simulation of a
+    // run that never happened. Every other flag dry-run cannot honor is rejected the same
+    // way, so this closes the one hole in that list.
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    const dryRun = await import('@archon/workflows/dry-run');
+    await stubInputWorkflow();
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockClear();
+    (dryRun.dryRunWorkflow as ReturnType<typeof mock>).mockClear();
+
+    await expect(
+      workflowRunCommand('/repo/root', 'review-block', 'go', {
+        dryRun: true,
+        inputs: ['diff=D1'],
+      })
+    ).rejects.toThrow(/--dry-run cannot be combined with --input/);
+
+    expect(dryRun.dryRunWorkflow).not.toHaveBeenCalled();
+  });
+
   it('does not re-gate a --resume of a required-input workflow', async () => {
     // The gate is deliberately skipped on resume: the run row already carries inputs
     // validated at creation, and a resume supplies nothing. A refactor that hoists

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -763,6 +763,113 @@ describe('workflowRunCommand — requires: [github] gate', () => {
   });
 });
 
+describe('workflowRunCommand — --input declared inputs (#2554)', () => {
+  let consoleSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(async () => {
+    consoleSpy = spyOn(console, 'log').mockImplementation(() => {});
+    const { executeWorkflow } = await import('@archon/workflows/executor');
+    (executeWorkflow as ReturnType<typeof mock>).mockClear();
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  /** Stub discovery with one workflow declaring a required + a defaulted input. */
+  async function stubInputWorkflow(): Promise<void> {
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [
+        makeTestWorkflowWithSource(
+          {
+            name: 'review-block',
+            inputs: { diff: { required: true }, style: { default: 'strict' } },
+          },
+          'project'
+        ),
+      ],
+      errors: [],
+    });
+  }
+
+  it('runs a required-input workflow when --input supplies the value', async () => {
+    const { executeWorkflow } = await import('@archon/workflows/executor');
+    await stubInputWorkflow();
+    (executeWorkflow as ReturnType<typeof mock>).mockResolvedValueOnce({
+      success: true,
+      workflowRunId: 'run-ok',
+    });
+
+    await workflowRunCommand('/repo/root', 'review-block', 'go', {
+      noWorktree: true,
+      inputs: ['diff=D1'],
+    });
+
+    expect(executeWorkflow).toHaveBeenCalledTimes(1);
+    // Only the supplied value is threaded through; `style` stays a derived default.
+    const opts = (executeWorkflow as ReturnType<typeof mock>).mock.calls[0][7] as {
+      inputs?: Record<string, string>;
+    };
+    expect(opts.inputs).toEqual({ diff: 'D1' });
+  });
+
+  it('still refuses a required-input workflow when nothing is supplied, before any cost', async () => {
+    const { executeWorkflow } = await import('@archon/workflows/executor');
+    await stubInputWorkflow();
+
+    await expect(
+      workflowRunCommand('/repo/root', 'review-block', 'go', { noWorktree: true })
+    ).rejects.toThrow(/requires input 'diff'/);
+
+    expect(executeWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('rejects an undeclared --input name before any cost', async () => {
+    const { executeWorkflow } = await import('@archon/workflows/executor');
+    await stubInputWorkflow();
+
+    await expect(
+      workflowRunCommand('/repo/root', 'review-block', 'go', {
+        noWorktree: true,
+        inputs: ['diff=D1', 'stlye=terse'],
+      })
+    ).rejects.toThrow(/does not declare input 'stlye'/);
+
+    expect(executeWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed --input assignment before any cost', async () => {
+    const { executeWorkflow } = await import('@archon/workflows/executor');
+    await stubInputWorkflow();
+
+    await expect(
+      workflowRunCommand('/repo/root', 'review-block', 'go', {
+        noWorktree: true,
+        inputs: ['diff'],
+      })
+    ).rejects.toThrow(/expected 'name=value'/);
+
+    expect(executeWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('rejects --input combined with --resume rather than silently ignoring it', async () => {
+    const { executeWorkflow } = await import('@archon/workflows/executor');
+    // Flag validation runs after name resolution (as every other flag check does),
+    // so discovery still has to resolve for the conflict to be reached.
+    await stubInputWorkflow();
+
+    await expect(
+      workflowRunCommand('/repo/root', 'review-block', 'go', {
+        resume: true,
+        inputs: ['diff=D1'],
+      })
+    ).rejects.toThrow(/--resume and --input are mutually exclusive/);
+
+    expect(executeWorkflow).not.toHaveBeenCalled();
+  });
+});
+
 describe('workflowRunCommand', () => {
   let consoleSpy: ReturnType<typeof spyOn>;
 
@@ -4362,6 +4469,36 @@ describe('buildDetachedRunCmd', () => {
   // fixture modelled a compiled argv with no argv[1] at all, which is why
   // #2248 (detached child dies with `Unknown command: B:/~BUN/root/...`)
   // shipped green.
+  // `--input` is the first repeatable flag in the tree (#2554). Nothing here handles
+  // repetition specially — argv is forwarded verbatim — so this pins the property a
+  // future change to the argv rebuild could silently break, turning a detached run into
+  // one that starts with its inputs missing instead of failing.
+  it('forwards every repeated --input to the detached child', () => {
+    const cmd = buildDetachedRunCmd(
+      false,
+      '/path/to/bun',
+      [
+        '/path/to/bun',
+        '/abs/cli.ts',
+        'workflow',
+        'run',
+        'review-block',
+        '--input',
+        'diff=D1',
+        '--input',
+        'style=terse',
+        '--detach',
+      ],
+      '/abs/cwd',
+      []
+    );
+
+    expect(cmd.filter(arg => arg === '--input')).toHaveLength(2);
+    expect(cmd).toContain('diff=D1');
+    expect(cmd).toContain('style=terse');
+    expect(cmd).not.toContain('--detach');
+  });
+
   it('binary mode: uses [execPath] only (no duplicated entry arg), drops the Bun SFE virtual argv[1]', () => {
     const cmd = buildDetachedRunCmd(
       true,

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -853,6 +853,54 @@ describe('workflowRunCommand — --input declared inputs (#2554)', () => {
     expect(executeWorkflow).not.toHaveBeenCalled();
   });
 
+  it('does not re-gate a --resume of a required-input workflow', async () => {
+    // The gate is deliberately skipped on resume: the run row already carries inputs
+    // validated at creation, and a resume supplies nothing. A refactor that hoists
+    // `resolveTopLevelInputs` out of the `if (!options.resume)` guard would make every
+    // CLI resume of a required-input workflow throw instead — this is what catches it.
+    // (The `--input` + `--resume` test below cannot: it fails on the mutual-exclusion
+    // check before ever reaching the gate.)
+    const { executeWorkflow, hydrateResumableRun } = await import('@archon/workflows/executor');
+    const conversationDb = await import('@archon/core/db/conversations');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    const workflowDb = await import('@archon/core/db/workflows');
+    await stubInputWorkflow();
+
+    (hydrateResumableRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      preCreatedRun: { id: 'run-prior', workflow_name: 'review-block' },
+      priorCompletedNodes: new Map([['node-a', 'done']]),
+    });
+    (conversationDb.getOrCreateConversation as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'conv-resume',
+    });
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'cb-resume',
+      default_cwd: '/repo/root',
+      default_branch: 'develop',
+    });
+    // working_path null keeps the resume on the caller cwd, skipping the existsSync probe.
+    (workflowDb.findResumableRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'run-prior',
+      working_path: null,
+      workflow_name: 'review-block',
+    });
+    (conversationDb.updateConversation as ReturnType<typeof mock>).mockResolvedValueOnce(undefined);
+    (executeWorkflow as ReturnType<typeof mock>).mockResolvedValueOnce({
+      success: true,
+      workflowRunId: 'run-prior',
+    });
+
+    // No --input, and the workflow declares a required one: this must NOT throw.
+    await workflowRunCommand('/repo/root', 'review-block', 'go', { resume: true });
+
+    expect(executeWorkflow).toHaveBeenCalledTimes(1);
+    // The resume branch carries the row's own inputs; it never re-stamps from a flag.
+    const opts = (executeWorkflow as ReturnType<typeof mock>).mock.calls[0][7] as {
+      inputs?: Record<string, string>;
+    };
+    expect(opts.inputs).toBeUndefined();
+  });
+
   it('rejects --input combined with --resume rather than silently ignoring it', async () => {
     const { executeWorkflow } = await import('@archon/workflows/executor');
     // Flag validation runs after name resolution (as every other flag check does),

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -961,6 +961,12 @@ export async function workflowRunCommand(
       ['--container', options.container === true],
       ['--resume', options.resume === true],
       ['--detach', options.detach === true],
+      // The dry-run engine has no `$INPUTS` support at all — it never substitutes
+      // `$INPUTS.<name>` and never sets `INPUTS_<UPPER_SNAKE>` in a code node's env.
+      // Accepting the flag would silently simulate with EMPTY inputs: a bash node
+      // reading `$INPUTS_SCOPE` expands an unset var to '', so the trace reads as a
+      // valid simulation of a run that never happened. Reject rather than mislead.
+      ['--input', options.inputs !== undefined && options.inputs.length > 0],
     ] as const;
     const incompatibleFlag = incompatible.find(([, present]) => present)?.[0];
     if (incompatibleFlag) {

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -45,8 +45,9 @@ import { resolveWorkflowName } from '@archon/workflows/router';
 import { executeWorkflow, hydrateResumableRun } from '@archon/workflows/executor';
 import {
   assertWorkflowRequirementsMet,
-  assertWorkflowInputsSatisfiable,
+  resolveTopLevelInputs,
 } from '@archon/workflows/utils/workflow-requirements';
+import { parseInputAssignments } from '@archon/workflows/workflow-inputs';
 import { dryRunWorkflow, formatDryRunTrace, loadDryRunStubs } from '@archon/workflows/dry-run';
 import {
   getWorkflowEventEmitter,
@@ -222,6 +223,14 @@ export interface WorkflowRunOptions {
   execCode?: boolean;
   /** Stop at the first approval gate instead of auto-approving it. */
   pauseAtGates?: boolean;
+  /**
+   * Raw `--input name=value` assignments (#2554), one per occurrence of the flag.
+   * Parsed and validated against the workflow's declared `inputs:` at the invocation
+   * gate — before the `--detach` fork and before any worktree, clone, or AI cost.
+   * Kept as raw strings here so the grammar has exactly one parser
+   * (`parseInputAssignments` in `@archon/workflows`).
+   */
+  inputs?: string[];
 }
 
 /**
@@ -1015,6 +1024,13 @@ export async function workflowRunCommand(
         '  Remove --branch when using --resume.'
     );
   }
+  if (options.resume && options.inputs !== undefined && options.inputs.length > 0) {
+    throw new Error(
+      '--resume and --input are mutually exclusive.\n' +
+        "  A resume replays the original invocation's inputs, recorded on the run.\n" +
+        '  Drop --input to resume, or start a fresh run to supply different values.'
+    );
+  }
 
   // Per-dispatch --base override, normalized once. Wins over repo config + the
   // codebase default for both the worktree cut-from (the provider request's
@@ -1081,10 +1097,21 @@ export async function workflowRunCommand(
   assertNoWorktreeOptionsForFolder(options.folder === true, options);
   assertWorkflowNotWorktreePinnedForFolder(options.folder === true, pinnedEnabled, workflow.name);
 
-  // Signature gate (#2470): a workflow declaring `required` inputs is a reusable block —
-  // only a caller's `with:` can satisfy them, so a bare top-level run fails here, before
-  // the --detach fork and any worktree/clone/AI cost. It still lists/loads normally.
-  assertWorkflowInputsSatisfiable(workflow);
+  // Signature gate (#2470, #2554): resolve this invocation's declared inputs from the
+  // `--input name=value` flags against the workflow's `inputs:` block, here — before the
+  // --detach fork and any worktree/clone/AI cost — so a bad name, a missing required
+  // input, or a malformed assignment costs nothing.
+  //
+  // Skipped on --resume: the resumable run is not resolved until later in this function,
+  // and its inputs were validated when its row was created. Re-gating with nothing
+  // supplied would make every resume of a required-input run impossible.
+  let resolvedInputs: Record<string, string> | undefined;
+  if (!options.resume) {
+    resolvedInputs = resolveTopLevelInputs(
+      workflow,
+      options.inputs ? parseInputAssignments(options.inputs) : undefined
+    );
+  }
 
   // Capability gate: hard-fail before the --detach fork and any worktree/clone/
   // AI cost if the workflow declares `requires: [github]` and the acting CLI
@@ -1912,6 +1939,8 @@ export async function workflowRunCommand(
           execContext,
           container: containerRunCtx,
           resolveChildIsolation,
+          // Fresh run only: a resume (`prepared`) replays the inputs already on its row.
+          inputs: resolvedInputs,
         };
     result = await executeWorkflow(
       deps,

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -1496,13 +1496,24 @@ describe('workflow dispatch routing — interactive flag', () => {
 
   function makeWorkflowResult(
     interactive?: boolean,
-    options: { force?: boolean; resumeRunId?: string; resumeRun?: WorkflowRun; args?: string } = {}
+    options: {
+      force?: boolean;
+      resumeRunId?: string;
+      resumeRun?: WorkflowRun;
+      args?: string;
+      /** Declared `inputs:` on the resolved workflow (#2554). */
+      inputs?: Record<string, { required?: boolean; default?: string }>;
+    } = {}
   ) {
     return {
       success: true,
       message: 'ok',
       workflow: {
-        definition: makeTestWorkflow({ name: 'test-workflow', interactive }),
+        definition: makeTestWorkflow({
+          name: 'test-workflow',
+          interactive,
+          ...(options.inputs ? { inputs: options.inputs } : {}),
+        }),
         args: options.args ?? 'test message',
         force: options.force,
         resumeRunId: options.resumeRunId,
@@ -1875,6 +1886,105 @@ describe('workflow dispatch routing — interactive flag', () => {
 
     expect(mockDispatchBackgroundWorkflow).toHaveBeenCalled();
     expect(mockExecuteWorkflow).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Declared inputs supplied by the run route (#2554)
+  // -------------------------------------------------------------------------
+
+  test('threads context.workflowInputs into executeWorkflow for a fresh foreground run', async () => {
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    mockHandleCommand.mockReturnValueOnce(
+      Promise.resolve(makeWorkflowResult(true, { inputs: { diff: { required: true } } }))
+    );
+
+    await handleMessage(makePlatform(), 'conv-1', '/workflow run test-workflow', {
+      workflowInputs: { diff: 'D1' },
+    });
+
+    expect(mockExecuteWorkflow).toHaveBeenCalled();
+    const opts = mockExecuteWorkflow.mock.calls[0][7] as { inputs?: Record<string, string> };
+    expect(opts.inputs).toEqual({ diff: 'D1' });
+  });
+
+  test('threads context.workflowInputs into dispatchBackgroundWorkflow — the console default path', async () => {
+    // Web non-interactive runs never touch the executeWorkflow branches, so dropping
+    // the map here would ship a console run form that silently does nothing.
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    mockHandleCommand.mockReturnValueOnce(
+      Promise.resolve(makeWorkflowResult(undefined, { inputs: { diff: { required: true } } }))
+    );
+
+    await handleMessage(makePlatform(), 'conv-1', '/workflow run test-workflow', {
+      workflowInputs: { diff: 'D1' },
+    });
+
+    expect(mockDispatchBackgroundWorkflow).toHaveBeenCalled();
+    const ctx = mockDispatchBackgroundWorkflow.mock.calls[0][0] as {
+      inputs?: Record<string, string>;
+    };
+    expect(ctx.inputs).toEqual({ diff: 'D1' });
+  });
+
+  test('refuses a required-input workflow when nothing is supplied, starting nothing', async () => {
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    mockHandleCommand.mockReturnValueOnce(
+      Promise.resolve(makeWorkflowResult(true, { inputs: { diff: { required: true } } }))
+    );
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/workflow run test-workflow');
+
+    expect(mockExecuteWorkflow).not.toHaveBeenCalled();
+    expect(mockDispatchBackgroundWorkflow).not.toHaveBeenCalled();
+    const sent = platform.sendMessage.mock.calls.map(c => String(c[1])).join('\n');
+    expect(sent).toContain("requires input 'diff'");
+    expect(sent).toContain('--input');
+    expect(sent).not.toContain('reusable block');
+  });
+
+  test('refuses an undeclared supplied key, starting nothing', async () => {
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    mockHandleCommand.mockReturnValueOnce(
+      Promise.resolve(makeWorkflowResult(true, { inputs: { diff: { required: true } } }))
+    );
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/workflow run test-workflow', {
+      workflowInputs: { diff: 'D1', stlye: 'terse' },
+    });
+
+    expect(mockExecuteWorkflow).not.toHaveBeenCalled();
+    const sent = platform.sendMessage.mock.calls.map(c => String(c[1])).join('\n');
+    expect(sent).toContain('stlye');
+  });
+
+  test('a resume of a required-input workflow is not re-gated', async () => {
+    // The row already carries inputs validated at creation; re-gating with nothing
+    // supplied would make every such resume impossible — a regression this feature
+    // would otherwise introduce.
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    mockHandleCommand.mockReturnValueOnce(
+      Promise.resolve(
+        makeWorkflowResult(true, {
+          inputs: { diff: { required: true } },
+          resumeRunId: 'resumable-run-1',
+          resumeRun: makeResumableRun({ status: 'paused' }),
+        })
+      )
+    );
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/workflow run test-workflow');
+
+    const sent = platform.sendMessage.mock.calls.map(c => String(c[1])).join('\n');
+    expect(sent).not.toContain("requires input 'diff'");
+    expect(mockExecuteWorkflow).toHaveBeenCalled();
   });
 
   test('web non-interactive workflow with resumable run resumes foreground (not background)', async () => {

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -2061,10 +2061,11 @@ describe('workflow dispatch routing — interactive flag', () => {
     expect(mockExecuteWorkflow).not.toHaveBeenCalled();
   });
 
-  test('still reports a deferred input error when the resume race is lost', async () => {
-    // The last exit that can abandon the dispatch after the gate deferred. Losing the
-    // race to another surface means the held error is never re-raised anywhere else, so
-    // it has to ride along here — otherwise an actionable, already-computed error dies.
+  /** Drive the lost-resume-race path with an optional supplied-input map. */
+  async function dispatchLosingResumeRace(
+    platform: ReturnType<typeof makePlatform>,
+    workflowInputs?: Record<string, string>
+  ): Promise<void> {
     // `mock.module` MERGES, so `WorkflowNotResumableError` is the real class here.
     const { WorkflowNotResumableError } = await import('../db/workflows');
     mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
@@ -2084,13 +2085,39 @@ describe('workflow dispatch routing — interactive flag', () => {
     mockHydrateResumableRun.mockReturnValueOnce(
       Promise.reject(new WorkflowNotResumableError('raced-run-1', 'running'))
     );
+    await handleMessage(
+      platform,
+      'conv-1',
+      '/workflow run test-workflow',
+      workflowInputs ? { workflowInputs } : undefined
+    );
+  }
 
+  test('reports a deferred input error on a lost resume race when values were supplied', async () => {
+    // The last exit that can abandon the dispatch after the gate deferred. The caller
+    // supplied an undeclared key, so the violation is about something they actually did
+    // and is worth surfacing — it is never re-raised anywhere else on this path.
     const platform = makePlatform();
-    await handleMessage(platform, 'conv-1', '/workflow run test-workflow');
+    await dispatchLosingResumeRace(platform, { stlye: 'terse' });
 
     const sent = platform.sendMessage.mock.calls.map(c => String(c[1])).join('\n');
     expect(sent).toContain('already being resumed');
-    expect(sent).toContain("requires input 'diff'");
+    expect(sent).toContain('stlye');
+    expect(mockExecuteWorkflow).not.toHaveBeenCalled();
+  });
+
+  test('stays quiet about the deferred error on a lost race when nothing was supplied', async () => {
+    // With nothing supplied the deferred violation is just "you must supply X", which is
+    // moot when nothing will run. Appending it unconditionally produced nonsense on chat:
+    // a demand to pass `--input`, immediately followed by a note that chat cannot, tacked
+    // onto a message whose first line is already "No action taken".
+    const platform = makePlatform();
+    await dispatchLosingResumeRace(platform);
+
+    const sent = platform.sendMessage.mock.calls.map(c => String(c[1])).join('\n');
+    expect(sent).toContain('already being resumed');
+    expect(sent).not.toContain('--input');
+    expect(sent).not.toContain("requires input 'diff'");
     expect(mockExecuteWorkflow).not.toHaveBeenCalled();
   });
 

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -1963,6 +1963,71 @@ describe('workflow dispatch routing — interactive flag', () => {
     expect(sent).toContain('stlye');
   });
 
+  test('an IMPLICIT auto-resume of a required-input workflow is not re-gated', async () => {
+    // The dangerous case: a plain `/workflow run <name>` (no resumeRunId/resumeRun) on a
+    // workflow with a paused run. `dispatchOrchestratorWorkflow` auto-detects that run
+    // for every platform, so gating only against an EXPLICIT resume refused a legitimate
+    // continuation — the run row already holds its validated inputs, and a user saying
+    // "run it" again supplies nothing. Reachable from chat and from a repeat
+    // POST /api/workflows/:name/run that reuses a conversation id.
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    mockHandleCommand.mockReturnValueOnce(
+      Promise.resolve(makeWorkflowResult(true, { inputs: { diff: { required: true } } }))
+    );
+    mockFindResumableRunByParentConversation.mockReturnValueOnce(
+      Promise.resolve({
+        id: 'implicit-resume-1',
+        workflow_name: 'test-workflow',
+        working_path: '/repos/test-repo/worktrees/paused',
+        parent_conversation_id: 'conv-1',
+        status: 'paused',
+      })
+    );
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/workflow run test-workflow');
+
+    const sent = platform.sendMessage.mock.calls.map(c => String(c[1])).join('\n');
+    expect(sent).not.toContain("requires input 'diff'");
+    expect(mockExecuteWorkflow).toHaveBeenCalled();
+    expect(mockExecuteWorkflow.mock.calls[0][3]).toBe('/repos/test-repo/worktrees/paused');
+  });
+
+  test('tells the caller when supplied inputs could not be applied to an auto-resumed run', async () => {
+    // The resume replays its own row's inputs; values supplied on this call cannot
+    // reach it. Accepting them and silently running something else is the failure this
+    // guards — the caller gets a 200 and no way to tell their values were dropped.
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    mockHandleCommand.mockReturnValueOnce(
+      Promise.resolve(makeWorkflowResult(true, { inputs: { diff: { required: true } } }))
+    );
+    mockFindResumableRunByParentConversation.mockReturnValueOnce(
+      Promise.resolve({
+        id: 'implicit-resume-2',
+        workflow_name: 'test-workflow',
+        working_path: '/repos/test-repo/worktrees/paused',
+        parent_conversation_id: 'conv-1',
+        status: 'paused',
+      })
+    );
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/workflow run test-workflow', {
+      workflowInputs: { diff: 'D-new' },
+    });
+
+    const sent = platform.sendMessage.mock.calls.map(c => String(c[1])).join('\n');
+    expect(sent).toContain('not applied');
+    expect(sent).toContain('diff');
+    expect(sent).toContain('implicit-resume-2');
+    // Names only — a supplied value is user content and must never be echoed back.
+    expect(sent).not.toContain('D-new');
+    // The resume still proceeds; the run holds real work and a worktree.
+    expect(mockExecuteWorkflow).toHaveBeenCalled();
+  });
+
   test('a resume of a required-input workflow is not re-gated', async () => {
     // The row already carries inputs validated at creation; re-gating with nothing
     // supplied would make every such resume impossible — a regression this feature

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -2061,6 +2061,39 @@ describe('workflow dispatch routing — interactive flag', () => {
     expect(mockExecuteWorkflow).not.toHaveBeenCalled();
   });
 
+  test('still reports a deferred input error when the resume race is lost', async () => {
+    // The last exit that can abandon the dispatch after the gate deferred. Losing the
+    // race to another surface means the held error is never re-raised anywhere else, so
+    // it has to ride along here — otherwise an actionable, already-computed error dies.
+    // `mock.module` MERGES, so `WorkflowNotResumableError` is the real class here.
+    const { WorkflowNotResumableError } = await import('../db/workflows');
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    mockHandleCommand.mockReturnValueOnce(
+      Promise.resolve(makeWorkflowResult(true, { inputs: { diff: { required: true } } }))
+    );
+    mockFindResumableRunByParentConversation.mockReturnValueOnce(
+      Promise.resolve({
+        id: 'raced-run-1',
+        workflow_name: 'test-workflow',
+        working_path: '/repos/test-repo/worktrees/paused',
+        parent_conversation_id: 'conv-1',
+        status: 'paused',
+      })
+    );
+    mockHydrateResumableRun.mockReturnValueOnce(
+      Promise.reject(new WorkflowNotResumableError('raced-run-1', 'running'))
+    );
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/workflow run test-workflow');
+
+    const sent = platform.sendMessage.mock.calls.map(c => String(c[1])).join('\n');
+    expect(sent).toContain('already being resumed');
+    expect(sent).toContain("requires input 'diff'");
+    expect(mockExecuteWorkflow).not.toHaveBeenCalled();
+  });
+
   test('refuses immediately when the resumable run is not a continuation candidate', async () => {
     // A FAILED (non-paused) prior run is not continued — the user gets a
     // resume/abandon/force menu. Deferring the gate for that case swallowed the input

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -2028,6 +2028,69 @@ describe('workflow dispatch routing — interactive flag', () => {
     expect(mockExecuteWorkflow).toHaveBeenCalled();
   });
 
+  test('re-raises the deferred input error when hydration finds nothing to resume', async () => {
+    // The gate defers a contract violation while a continuation looks possible. This is
+    // the ONE branch where that prediction turns out wrong — hydration returns null, so
+    // a FRESH run row gets created after all — and the deferred error has to come back.
+    // Without the re-raise, a required-input workflow would silently start with the
+    // input never supplied and never validated: neither a safe refusal nor a real resume.
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    mockHandleCommand.mockReturnValueOnce(
+      Promise.resolve(makeWorkflowResult(true, { inputs: { diff: { required: true } } }))
+    );
+    mockFindResumableRunByParentConversation.mockReturnValueOnce(
+      Promise.resolve({
+        id: 'nothing-to-resume-1',
+        workflow_name: 'test-workflow',
+        working_path: '/repos/test-repo/worktrees/paused',
+        parent_conversation_id: 'conv-1',
+        status: 'paused',
+      })
+    );
+    // Nothing worth resuming → the fresh-run fallthrough.
+    mockHydrateResumableRun.mockReturnValueOnce(Promise.resolve(null));
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/workflow run test-workflow');
+
+    const sent = platform.sendMessage.mock.calls.map(c => String(c[1])).join('\n');
+    expect(sent).toContain("requires input 'diff'");
+    // Must NOT reach the generic "starting fresh in the same worktree" dispatch.
+    expect(sent).not.toContain('starting fresh in the same worktree');
+    expect(mockExecuteWorkflow).not.toHaveBeenCalled();
+  });
+
+  test('refuses immediately when the resumable run is not a continuation candidate', async () => {
+    // A FAILED (non-paused) prior run is not continued — the user gets a
+    // resume/abandon/force menu. Deferring the gate for that case swallowed the input
+    // error entirely: the caller saw a generic menu and was never told which input was
+    // wrong. Such an invocation must be refused up front, before isolation resolution.
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    mockHandleCommand.mockReturnValueOnce(
+      Promise.resolve(makeWorkflowResult(true, { inputs: { diff: { required: true } } }))
+    );
+    mockFindResumableRunByParentConversation.mockReturnValueOnce(
+      Promise.resolve({
+        id: 'failed-prior-1',
+        workflow_name: 'test-workflow',
+        working_path: '/repos/test-repo/worktrees/failed',
+        parent_conversation_id: 'conv-1',
+        status: 'failed',
+      })
+    );
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/workflow run test-workflow');
+
+    const sent = platform.sendMessage.mock.calls.map(c => String(c[1])).join('\n');
+    expect(sent).toContain("requires input 'diff'");
+    expect(mockExecuteWorkflow).not.toHaveBeenCalled();
+    // Refused at the gate, so the resume menu never rendered and no isolation ran.
+    expect(mockHydrateResumableRun).not.toHaveBeenCalled();
+  });
+
   test('a resume of a required-input workflow is not re-gated', async () => {
     // The row already carries inputs validated at creation; re-gating with nothing
     // supplied would make every such resume impossible — a regression this feature

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -781,9 +781,13 @@ async function dispatchOrchestratorWorkflow(
   //
   // It does NOT mirror the other refusal exit below — an explicit resume naming a run
   // with no `working_path` is now preempted by the gate instead of reaching that check.
-  // That is a behaviour change and it is deliberate: every row-creation site records a
-  // real `working_path`, so a NULL one means a row predating the column, which predates
-  // `inputs:` entirely and therefore cannot reach the gate with a violation to defer.
+  // That is a behaviour change and it is deliberate. Every row-creation site records a
+  // real `working_path`, so a NULL one means a row predating the column; reaching the
+  // gate with a violation to defer additionally needs that ancient run's workflow to
+  // have since gained a required input, and someone to resume it explicitly. (The gate
+  // judges the CURRENT YAML, not the row's vintage, so that combination is improbable
+  // rather than impossible.) Both exits refuse at zero cost, so which message wins is a
+  // wording question, not a correctness one.
   const willContinueExistingRun =
     Boolean(resumableRun?.working_path) &&
     (resumableRun?.status === 'paused' || resumableRun?.id === options?.resumeRunId);

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -771,10 +771,16 @@ async function dispatchOrchestratorWorkflow(
         conversation.id,
         codebase.id
       )));
-  // A candidate with a working path means this dispatch continues existing work rather
-  // than creating a fresh run row — either resuming it, or (for a non-paused one)
-  // showing the user the resume/abandon/force choice.
-  const willContinueExistingRun = Boolean(resumableRun?.working_path);
+  // Whether this dispatch will CONTINUE existing work rather than create a fresh run
+  // row. Deliberately mirrors the resume branch's own condition below: a candidate that
+  // is neither paused nor the explicitly-targeted run does not continue — it shows the
+  // resume/abandon/force choice and returns. Only a genuine continuation may defer the
+  // signature gate, so an invocation that was never going to continue is still refused
+  // immediately, with the specific input error rather than a generic menu, and before
+  // isolation resolution can create a worktree.
+  const willContinueExistingRun =
+    Boolean(resumableRun?.working_path) &&
+    (resumableRun?.status === 'paused' || resumableRun?.id === options?.resumeRunId);
 
   // Signature gate (#2470, #2554): resolve this invocation's declared inputs from the
   // values its channel supplied — the run route's `inputs` map today; chat platforms
@@ -968,7 +974,11 @@ async function dispatchOrchestratorWorkflow(
         await platform.sendMessage(
           conversationId,
           `⚠️ **${workflow.name}** is already being resumed (status: ${err.currentStatus}). ` +
-            'No action taken — follow the existing run for progress.'
+            'No action taken — follow the existing run for progress.' +
+            // The gate deferred a contract violation because this looked like a
+            // continuation; losing the race means it never got surfaced anywhere else.
+            // Say it here rather than let an already-computed, actionable error die.
+            (deferredInputError ? `\n\nAlso note: ${deferredInputError.message}` : '')
         );
         return;
       }

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -772,12 +772,18 @@ async function dispatchOrchestratorWorkflow(
         codebase.id
       )));
   // Whether this dispatch will CONTINUE existing work rather than create a fresh run
-  // row. Deliberately mirrors the resume branch's own condition below: a candidate that
-  // is neither paused nor the explicitly-targeted run does not continue — it shows the
-  // resume/abandon/force choice and returns. Only a genuine continuation may defer the
+  // row. Deliberately the exact negation of the resume/abandon/force menu's condition
+  // below: a candidate that is neither paused nor the explicitly-targeted run does not
+  // continue — it shows that menu and returns. Only a genuine continuation may defer the
   // signature gate, so an invocation that was never going to continue is still refused
   // immediately, with the specific input error rather than a generic menu, and before
   // isolation resolution can create a worktree.
+  //
+  // It does NOT mirror the other refusal exit below — an explicit resume naming a run
+  // with no `working_path` is now preempted by the gate instead of reaching that check.
+  // That is a behaviour change and it is deliberate: every row-creation site records a
+  // real `working_path`, so a NULL one means a row predating the column, which predates
+  // `inputs:` entirely and therefore cannot reach the gate with a violation to defer.
   const willContinueExistingRun =
     Boolean(resumableRun?.working_path) &&
     (resumableRun?.status === 'paused' || resumableRun?.id === options?.resumeRunId);
@@ -978,7 +984,9 @@ async function dispatchOrchestratorWorkflow(
             // The gate deferred a contract violation because this looked like a
             // continuation; losing the race means it never got surfaced anywhere else.
             // Say it here rather than let an already-computed, actionable error die.
-            (deferredInputError ? `\n\nAlso note: ${deferredInputError.message}` : '')
+            (deferredInputError && options?.inputs && Object.keys(options.inputs).length > 0
+              ? `\n\nAlso note: ${deferredInputError.message}`
+              : '')
         );
         return;
       }

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -44,9 +44,10 @@ import { executeWorkflow, hydrateResumableRun } from '@archon/workflows/executor
 import {
   assertWorkflowRequirementsMet,
   WorkflowRequirementError,
-  assertWorkflowInputsSatisfiable,
+  resolveTopLevelInputs,
   WorkflowMissingInputsError,
 } from '@archon/workflows/utils/workflow-requirements';
+import { WorkflowInputContractError } from '@archon/workflows/workflow-inputs';
 import type {
   WorkflowDefinition,
   WorkflowWithSource,
@@ -629,6 +630,13 @@ interface WorkflowDispatchOptions {
    * picker.
    */
   parseWarnings?: readonly string[];
+  /**
+   * Declared inputs supplied by the caller (#2554), already carried this far by
+   * `HandleMessageContext.workflowInputs`. Populated only by the run route; chat
+   * platforms have no channel and leave it unset, so their behaviour is unchanged.
+   * Validated at the dispatch gate before any worktree/clone/AI cost.
+   */
+  inputs?: Readonly<Record<string, string>>;
 }
 
 const FAILED_RUN_PROMPT_PREVIEW_MAX = 160;
@@ -739,21 +747,37 @@ async function dispatchOrchestratorWorkflow(
         })
       : undefined;
 
-  // Signature gate (#2470): a workflow declaring `required` inputs is a reusable block —
-  // only a caller's `with:` satisfies them, so a bare top-level invocation fails here,
-  // before any worktree/clone/AI cost. It still lists/loads normally (builder + discovery).
-  try {
-    assertWorkflowInputsSatisfiable(workflow);
-  } catch (err) {
-    if (err instanceof WorkflowMissingInputsError) {
-      getLog().info(
-        { workflowName: workflow.name, missing: err.missing },
-        'workflow.required_inputs_unsatisfiable'
-      );
-      await platform.sendMessage(conversationId, err.message);
-      return;
+  // Signature gate (#2470, #2554): resolve this invocation's declared inputs from the
+  // values its channel supplied — the run route's `inputs` map today; chat platforms
+  // supply nothing and so still refuse a required-input workflow here, before any
+  // worktree/clone/AI cost. The workflow still lists/loads normally either way.
+  //
+  // Skipped on a resume: the run row already carries the inputs validated when it was
+  // created, and re-gating with nothing supplied would make every resume of a
+  // required-input run impossible.
+  const isResumeDispatch = options?.resumeRunId !== undefined || options?.resumeRun !== undefined;
+  let resolvedInputs: Record<string, string> | undefined;
+  if (!isResumeDispatch) {
+    try {
+      resolvedInputs = resolveTopLevelInputs(workflow, options?.inputs);
+    } catch (err) {
+      // Both are user-facing contract violations: a missing required input, and — now
+      // that a caller can supply values — a key the workflow does not declare.
+      if (err instanceof WorkflowMissingInputsError || err instanceof WorkflowInputContractError) {
+        getLog().info(
+          {
+            workflowName: workflow.name,
+            // Names only, never values — a supplied value is user content (logging rules).
+            missing: err instanceof WorkflowMissingInputsError ? err.missing : undefined,
+            suppliedKeys: options?.inputs ? Object.keys(options.inputs) : [],
+          },
+          'workflow.required_inputs_unsatisfiable'
+        );
+        await platform.sendMessage(conversationId, err.message);
+        return;
+      }
+      throw err;
     }
-    throw err;
   }
 
   // Capability gate: hard-fail before any worktree/clone/AI cost if the
@@ -966,11 +990,16 @@ async function dispatchOrchestratorWorkflow(
           parseWarnings: options?.parseWarnings,
           baseBranch: codebaseBaseBranch,
           resolveChildIsolation,
+          // This branch creates a FRESH run row (the prior run had nothing to resume),
+          // so the supplied inputs still need stamping.
+          inputs: resolvedInputs,
         }
       );
     }
   } else if (platform.getPlatformType() === 'web' && !workflow.interactive) {
-    // Background dispatch: web-only, non-interactive workflows with no resumable run
+    // Background dispatch: web-only, non-interactive workflows with no resumable run.
+    // This is the console's default path, so it is exactly where a console-supplied
+    // input map must not be dropped.
     await dispatchBackgroundWorkflow(
       {
         platform,
@@ -984,6 +1013,7 @@ async function dispatchOrchestratorWorkflow(
         userId,
         source,
         parseWarnings: options?.parseWarnings,
+        inputs: resolvedInputs,
       },
       workflow
     );
@@ -1005,6 +1035,7 @@ async function dispatchOrchestratorWorkflow(
         parseWarnings: options?.parseWarnings,
         baseBranch: codebaseBaseBranch,
         resolveChildIsolation,
+        inputs: resolvedInputs,
       }
     );
   }
@@ -1412,6 +1443,9 @@ export async function handleMessage(
               resumeRunId: result.workflow.resumeRunId,
               resumeRun: result.workflow.resumeRun,
               parseWarnings: result.workflow.parseWarnings,
+              // Declared inputs (#2554) arrive on the request context, not in the
+              // command text — the run route is the only caller that sets them.
+              inputs: context?.workflowInputs,
             }
           );
         }

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -747,35 +747,67 @@ async function dispatchOrchestratorWorkflow(
         })
       : undefined;
 
+  // Resume detection, hoisted above the signature gate ON PURPOSE (#2554).
+  //
+  // This function continues an existing run in TWO ways: an explicit
+  // `/workflow resume <id>` (which arrives as `resumeRunId`/`resumeRun`), and an
+  // IMPLICIT auto-detection that fires for a plain `/workflow run <name>` on every
+  // platform — the lookup that used to live further down, next to the dispatch. The
+  // gate below has to know about both: gating only against the explicit form wrongly
+  // refused a required-input workflow that was merely being continued (the run row
+  // already holds its validated inputs, and the caller supplies nothing when they
+  // just say "run it" again).
+  //
+  // It has to be hoisted rather than the gate pushed down: `validateAndResolveIsolation`
+  // sits between here and the old lookup site and CREATES WORKTREES, so gating after it
+  // would forfeit the pre-cost refusal. This lookup is a single indexed DB read — no
+  // worktree, no clone, no AI — so it is safe to do before gating. Its inputs
+  // (`conversation.id`, `codebase.id`) are parameters and nothing below mutates them.
+  const resumableRun = options?.force
+    ? null
+    : (options?.resumeRun ??
+      (await workflowDb.findResumableRunByParentConversation(
+        workflow.name,
+        conversation.id,
+        codebase.id
+      )));
+  // A candidate with a working path means this dispatch continues existing work rather
+  // than creating a fresh run row — either resuming it, or (for a non-paused one)
+  // showing the user the resume/abandon/force choice.
+  const willContinueExistingRun = Boolean(resumableRun?.working_path);
+
   // Signature gate (#2470, #2554): resolve this invocation's declared inputs from the
   // values its channel supplied — the run route's `inputs` map today; chat platforms
   // supply nothing and so still refuse a required-input workflow here, before any
   // worktree/clone/AI cost. The workflow still lists/loads normally either way.
-  //
-  // Skipped on a resume: the run row already carries the inputs validated when it was
-  // created, and re-gating with nothing supplied would make every resume of a
-  // required-input run impossible.
-  const isResumeDispatch = options?.resumeRunId !== undefined || options?.resumeRun !== undefined;
   let resolvedInputs: Record<string, string> | undefined;
-  if (!isResumeDispatch) {
-    try {
-      resolvedInputs = resolveTopLevelInputs(workflow, options?.inputs);
-    } catch (err) {
-      // Both are user-facing contract violations: a missing required input, and — now
-      // that a caller can supply values — a key the workflow does not declare.
-      if (err instanceof WorkflowMissingInputsError || err instanceof WorkflowInputContractError) {
-        getLog().info(
-          {
-            workflowName: workflow.name,
-            // Names only, never values — a supplied value is user content (logging rules).
-            missing: err instanceof WorkflowMissingInputsError ? err.missing : undefined,
-            suppliedKeys: options?.inputs ? Object.keys(options.inputs) : [],
-          },
-          'workflow.required_inputs_unsatisfiable'
-        );
+  // A contract violation held back because a resume may make it moot. Only the one
+  // branch below that falls through to a FRESH run row (hydration found nothing worth
+  // resuming) still needs it; every other continuation path never reads inputs from
+  // this invocation at all.
+  let deferredInputError: Error | undefined;
+  try {
+    resolvedInputs = resolveTopLevelInputs(workflow, options?.inputs);
+  } catch (err) {
+    // Both are user-facing contract violations: a missing required input, and — now
+    // that a caller can supply values — a key the workflow does not declare.
+    if (err instanceof WorkflowMissingInputsError || err instanceof WorkflowInputContractError) {
+      getLog().info(
+        {
+          workflowName: workflow.name,
+          // Names only, never values — a supplied value is user content (logging rules).
+          missing: err instanceof WorkflowMissingInputsError ? err.missing : undefined,
+          suppliedKeys: options?.inputs ? Object.keys(options.inputs) : [],
+          deferred: willContinueExistingRun,
+        },
+        'workflow.required_inputs_unsatisfiable'
+      );
+      if (!willContinueExistingRun) {
         await platform.sendMessage(conversationId, err.message);
         return;
       }
+      deferredInputError = err;
+    } else {
       throw err;
     }
   }
@@ -867,19 +899,12 @@ async function dispatchOrchestratorWorkflow(
   }
 
   // Dispatch workflow.
-  // Resume detection runs for ALL platforms: check if a prior run for this workflow
-  // is in a resumable state (paused — including approved-awaiting-resume — or failed)
-  // in this conversation+codebase
-  // before dispatching fresh. This ensures chat platforms (slack, telegram, discord,
-  // github) resume after approval gates just like web does.
-  const resumableRun = options?.force
-    ? null
-    : (options?.resumeRun ??
-      (await workflowDb.findResumableRunByParentConversation(
-        workflow.name,
-        conversation.id,
-        codebase.id
-      )));
+  // `resumableRun` was resolved above the signature gate (see the comment there):
+  // resume detection runs for ALL platforms, so a prior run for this workflow in a
+  // resumable state (paused — including approved-awaiting-resume — or failed) in this
+  // conversation+codebase is continued rather than dispatched fresh. This ensures chat
+  // platforms (slack, telegram, discord, github) resume after approval gates just like
+  // web does.
   if (options?.resumeRun && !options.resumeRun.working_path) {
     getLog().warn(
       {
@@ -950,6 +975,23 @@ async function dispatchOrchestratorWorkflow(
       throw err;
     }
     if (prepared) {
+      // A resume replays the inputs stamped on its own row; values supplied on THIS
+      // call cannot reach it (the row already exists, so the executor's stamp never
+      // fires). Say so rather than accepting them and quietly running something else.
+      if (options?.inputs && Object.keys(options.inputs).length > 0) {
+        const ignored = Object.keys(options.inputs).sort().join(', ');
+        getLog().info(
+          { workflowName: workflow.name, resumableRunId: resumableRun.id, ignoredKeys: ignored },
+          'orchestrator.resume_ignored_supplied_inputs'
+        );
+        await platform.sendMessage(
+          conversationId,
+          `▶️ Resuming the paused run of **${workflow.name}** (\`${resumableRun.id}\`), which ` +
+            `keeps the inputs it started with — the values you supplied now (${ignored}) were ` +
+            'not applied. To run fresh with them instead, abandon that run first ' +
+            `(\`/workflow abandon ${resumableRun.id}\`) and re-invoke.`
+        );
+      }
       await executeWorkflow(
         deps,
         platform,
@@ -970,6 +1012,13 @@ async function dispatchOrchestratorWorkflow(
         }
       );
     } else {
+      // Hydration found nothing worth resuming, so this is the ONE continuation path
+      // that creates a fresh run row — which means a contract violation deferred at the
+      // gate is live again and must be surfaced before any AI cost.
+      if (deferredInputError) {
+        await platform.sendMessage(conversationId, deferredInputError.message);
+        return;
+      }
       await platform.sendMessage(
         conversationId,
         `⚠️ Prior run for **${workflow.name}** had no completed nodes; starting fresh in the same worktree.`

--- a/packages/core/src/orchestrator/orchestrator-isolation.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-isolation.test.ts
@@ -330,7 +330,7 @@ describe('dispatchBackgroundWorkflow', () => {
     } as WorkflowDefinition;
   }
 
-  function makeRoutingCtx(): WorkflowRoutingContext {
+  function makeRoutingCtx(overrides?: Partial<WorkflowRoutingContext>): WorkflowRoutingContext {
     return {
       platform,
       conversationId: 'parent-conv',
@@ -339,6 +339,7 @@ describe('dispatchBackgroundWorkflow', () => {
       conversationDbId: 'parent-db-id',
       codebaseId: 'cb-1',
       availableWorkflows: [],
+      ...overrides,
     };
   }
 
@@ -377,6 +378,40 @@ describe('dispatchBackgroundWorkflow', () => {
       { workflowName: 'bg-workflow', conversationId: 'parent-conv', codebaseId: 'cb-1' },
       'workflow.worktree_disabled_by_policy'
     );
+
+    await flushBackgroundExecution();
+  });
+
+  // This path PRE-CREATES the run row (so the console can fetch it immediately), which
+  // means the executor's own `if (!workflowRun)` stamp never fires here — the values
+  // have to be written onto the row below. It is also the console's default path for
+  // non-interactive workflows, so losing the stamp would silently start every
+  // console-supplied run with its inputs missing rather than failing (#2554).
+  test('stamps caller-supplied declared inputs onto the pre-created run row', async () => {
+    const workflow = makeWorkflow({ worktree: { enabled: false } });
+
+    await dispatchBackgroundWorkflow(makeRoutingCtx({ inputs: { diff: 'D1' } }), workflow);
+
+    expect(mockCreateWorkflowRun).toHaveBeenCalledTimes(1);
+    const runRow = mockCreateWorkflowRun.mock.calls[0]?.[0] as unknown as {
+      metadata?: Record<string, unknown>;
+    };
+    expect(runRow.metadata?.inputs).toEqual({ diff: 'D1' });
+
+    await flushBackgroundExecution();
+  });
+
+  test('writes no inputs key on the pre-created row when none are supplied', async () => {
+    // Bare-run parity with the executor-level row: a run that supplied nothing must
+    // look exactly as it did before #2554.
+    const workflow = makeWorkflow({ worktree: { enabled: false } });
+
+    await dispatchBackgroundWorkflow(makeRoutingCtx(), workflow);
+
+    const runRow = mockCreateWorkflowRun.mock.calls[0]?.[0] as unknown as {
+      metadata?: Record<string, unknown>;
+    };
+    expect(runRow.metadata).not.toHaveProperty('inputs');
 
     await flushBackgroundExecution();
   });

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -49,6 +49,7 @@ import { createIsolationStore } from '../db/isolation-environments';
 import { toError } from '../utils/error';
 import { getCodebase } from '../db/codebases';
 import { executeWorkflow } from '@archon/workflows/executor';
+import { SUBRUN_METADATA_KEYS } from '@archon/workflows/schemas/workflow-run';
 import type { WorkflowDefinition, WorkflowSource } from '@archon/workflows/schemas/workflow';
 import { createWorkflowDeps } from '../workflows/store-adapter';
 import { createChildWorktreeResolver } from '../workflows/child-isolation-resolver';
@@ -290,6 +291,14 @@ export interface WorkflowRoutingContext {
    * other, independently of the chat notification.
    */
   readonly parseWarnings?: readonly string[];
+  /**
+   * Declared inputs supplied by the caller (#2554), already validated at the dispatch
+   * gate. This path PRE-CREATES the run row (so the UI can fetch it immediately), which
+   * means the executor's own row-creation branch never runs — the values are stamped on
+   * the pre-created row below, and also passed to `executeWorkflow` for the fallback
+   * path where pre-creation failed and the executor creates the row itself.
+   */
+  readonly inputs?: Readonly<Record<string, string>>;
 }
 
 /**
@@ -432,7 +441,15 @@ export async function dispatchBackgroundWorkflow(
       codebase_id: ctx.codebaseId,
       user_message: ctx.originalMessage,
       working_path: workerCwd,
-      metadata: ctx.issueContext ? { github_context: ctx.issueContext } : {},
+      metadata: {
+        ...(ctx.issueContext ? { github_context: ctx.issueContext } : {}),
+        // Declared inputs supplied by this invocation (#2554). Stamped here because the
+        // executor only writes them when IT creates the row, and this path hands it a
+        // pre-created one.
+        ...(ctx.inputs && Object.keys(ctx.inputs).length > 0
+          ? { [SUBRUN_METADATA_KEYS.inputs]: { ...ctx.inputs } }
+          : {}),
+      },
       parent_conversation_id: ctx.conversationDbId,
       user_id: ctx.userId,
     });
@@ -465,6 +482,10 @@ export async function dispatchBackgroundWorkflow(
             parseWarnings: ctx.parseWarnings,
             baseBranch: codebaseBaseBranch,
             resolveChildIsolation,
+            // Only consumed when `preCreatedRun` is undefined (pre-creation failed and
+            // the executor creates the row itself); otherwise the row above already
+            // carries them.
+            inputs: ctx.inputs,
           }
         );
         // Surface workflow output to parent conversation as a result card

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -54,6 +54,16 @@ export interface HandleMessageContext {
    * own auth flows are wired.
    */
   readonly userId?: string;
+  /**
+   * Declared workflow inputs supplied by the caller (#2554), keyed by input name.
+   *
+   * Set ONLY by the `POST /api/workflows/:name/run` route, whose body carries an
+   * `inputs` map. It rides the context rather than the message text so a supplied value
+   * is never confused with `$ARGUMENTS`, and so chat platforms — which have no channel
+   * for it and never populate this field — keep their existing behaviour unchanged
+   * (#2555 tracks giving them one).
+   */
+  readonly workflowInputs?: Readonly<Record<string, string>>;
 }
 
 export interface CommandResult {

--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -1164,6 +1164,15 @@ map goes through — so a map accepted when composing is accepted here:
 - both refusals happen **before any worktree, clone, or AI cost**;
 - supplied values are recorded on the run, so a resume replays exactly what the run started with.
 
+One consequence worth knowing on **chat, the run route, and the console** — the surfaces that reuse a
+conversation. Invoking a workflow there when a resumable run of it already exists in that
+conversation *continues that run* rather than starting a new one, without any resume vocabulary
+(see [DAG Resume on Failure](#dag-resume-on-failure)). New `inputs` values passed on such a call are
+**not applied** — the continued run keeps what it started with, and Archon says so, naming the
+values it ignored. To run fresh with different values, abandon the existing run first
+(`/workflow abandon <id>`) and invoke again. The CLI has no such implicit continuation: a plain
+`archon workflow run` always starts fresh, and `--input` with `--resume` is rejected outright.
+
 Chat platforms (Slack, Telegram, Discord, GitHub) have **no** channel for inputs yet: they carry
 only a trigger message, so a required-input workflow invoked there still refuses up front and
 points at the CLI and console. That gap is tracked in

--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -1143,7 +1143,8 @@ archon workflow run archon-review-block --input diff=... "focus on the auth chan
 In the **web console**, a workflow that declares `inputs:` renders a field per input in the run
 card — description as help text, `default:` as the placeholder, `*` on the required ones. The
 Start button stays disabled, and says which input it is waiting for, until every required field
-has a value.
+has a value. A field left blank is **omitted**, so it falls back to its declared `default:`;
+the console therefore cannot send a deliberate empty string, where `--input name=` can.
 
 The grammar is deliberately small:
 

--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -1059,7 +1059,7 @@ reusable block has an explicit, caller-facing contract instead of relying on pos
 accidents. Two workflow-level fields:
 
 ```yaml
-name: archon-review-block
+name: review-block
 description: Reviews a diff — composes into a parent, and runs on its own
 inputs:
   diff:
@@ -1087,7 +1087,9 @@ nodes:
   inputs](#running-a-workflow-that-declares-inputs)). Whichever channel supplies them, the same
   contract applies: a missing **required** input and an **undeclared** key are both rejected, and
   a declared `default:` fills an omitted input. A workflow with **no** `inputs:` keeps the old
-  lenient behavior (unknown caller keys ignored).
+  lenient behavior: supplied keys **pass through unvalidated** — they are recorded on the run
+  and still resolve as `$INPUTS.<name>` / `INPUTS_<UPPER_SNAKE>`, they are simply never checked
+  against a declaration, because there isn't one.
 - **`returns:`** — the **node id** whose output IS the workflow's result. It selects by id, so
   it works for any node type and even a **non-sink** node (a node other nodes depend on). For an
   `include:` block, `$blk.output` resolves to the `returns:` node; `depends_on: [blk]` still
@@ -1134,10 +1136,10 @@ composes into any number of parents — supply the values at invocation:
 
 ```bash
 # one flag per input; repeat it
-archon workflow run archon-review-block --input diff="$(git diff)" --input style=terse
+archon workflow run review-block --input diff="$(git diff)" --input style=terse
 
 # the trailing message is still $ARGUMENTS, independent of --input
-archon workflow run archon-review-block --input diff=... "focus on the auth changes"
+archon workflow run review-block --input diff=... "focus on the auth changes"
 ```
 
 In the **web console**, a workflow that declares `inputs:` renders a field per input in the run

--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -1060,7 +1060,7 @@ accidents. Two workflow-level fields:
 
 ```yaml
 name: archon-review-block
-description: Reusable review block (building block — not for standalone runs)
+description: Reviews a diff — composes into a parent, and runs on its own
 inputs:
   diff:
     required: true
@@ -1081,18 +1081,20 @@ nodes:
 
 - **`inputs:`** — a map of input name → `{ required?, default?, description? }`. `required: true`
   and `default:` are mutually exclusive (a required input has no default; declaring both drops
-  the key at load with a warning). A caller supplies values with `with:` on the `include:` or
-  `workflow:` node that references this workflow. When a block declares `inputs:`, callers are
-  validated: a missing **required** input and an **undeclared** caller key are both load errors,
-  and a declared `default:` fills an omitted input. A workflow with **no** `inputs:` keeps the
-  old lenient behavior (unknown caller keys ignored).
+  the key at load with a warning). Values come from `with:` on the `include:`/`workflow:` node
+  that references this workflow, or — for a direct run — from `--input name=value` on the CLI or
+  the run form in the web console (see [Running a workflow that declares
+  inputs](#running-a-workflow-that-declares-inputs)). Whichever channel supplies them, the same
+  contract applies: a missing **required** input and an **undeclared** key are both rejected, and
+  a declared `default:` fills an omitted input. A workflow with **no** `inputs:` keeps the old
+  lenient behavior (unknown caller keys ignored).
 - **`returns:`** — the **node id** whose output IS the workflow's result. It selects by id, so
   it works for any node type and even a **non-sink** node (a node other nodes depend on). For an
   `include:` block, `$blk.output` resolves to the `returns:` node; `depends_on: [blk]` still
   waits on every terminal node. For a `workflow:` sub-run child, the child's terminal output
   (threaded back as `$node.output`) becomes the `returns:` node's output.
 
-### Binding time: includes resolve at load, sub-runs at runtime
+### Binding time: includes resolve at load, runs at runtime
 
 `$INPUTS.<name>` is delivered by **two deliberately separate paths**, and the difference decides
 which surfaces can read it:
@@ -1101,6 +1103,7 @@ which surfaces can read it:
 |--------|-------------------------|-------------------------------------|--------------------------------|
 | `include:` | **Load time** (the block and command bodies are compiled into the flat DAG) | Yes | **Yes** — resolved command bodies receive the same input binding before execution |
 | `workflow:` sub-run | **Runtime** (values become `$INPUTS` variables on the child run) | Yes | **Yes** — every child node flows through runtime substitution |
+| direct run (`--input` / console form) | **Runtime** — the same path as a sub-run; supplied values are persisted to the run's own metadata, so `$INPUTS` reconstitutes on a cold resume | Yes | **Yes** — every node flows through runtime substitution |
 
 Both composition paths support command-backed prompts; their binding time differs. Includes
 snapshot and bind the resolved command body at load time, while sub-runs resolve inputs at
@@ -1124,12 +1127,44 @@ nodes:
       echo "planning: $INPUTS_PLAN"     # NOT $INPUTS.plan — bash reads the env var
 ```
 
-### Bare runs of a required-input block fail fast
+### Running a workflow that declares inputs
 
-A workflow that declares a **required** input is a reusable block: only a caller's `with:` can
-satisfy it. It still **loads and lists** (the builder and discovery need it visible), but a bare
-**top-level** run fails immediately — before any worktree, clone, or AI cost — naming the missing
-inputs and pointing at `include:`/`workflow:`. Reference it from another workflow instead.
+Declaring `inputs:` does not make a workflow callable-only. The same file runs on its own **and**
+composes into any number of parents — supply the values at invocation:
+
+```bash
+# one flag per input; repeat it
+archon workflow run archon-review-block --input diff="$(git diff)" --input style=terse
+
+# the trailing message is still $ARGUMENTS, independent of --input
+archon workflow run archon-review-block --input diff=... "focus on the auth changes"
+```
+
+In the **web console**, a workflow that declares `inputs:` renders a field per input in the run
+card — description as help text, `default:` as the placeholder, `*` on the required ones. The
+Start button stays disabled, and says which input it is waiting for, until every required field
+has a value.
+
+The grammar is deliberately small:
+
+- `--input name=value` splits on the **first** `=`, so `--input msg=a=b` gives `a=b`.
+- Values are plain strings. `--input name=` supplies a deliberate empty string.
+- Repeat the flag per input; supplying the same name twice is an error, not last-wins.
+- Omit an input to take its `default:`. Omitting one with no default and no `required: true`
+  leaves it unset, and a body referencing it fails at the reference site.
+
+Whatever supplies the values, they go through **one contract** — the same code a caller's `with:`
+map goes through — so a map accepted when composing is accepted here:
+
+- a **required** input with no value is refused, naming it;
+- an **undeclared** key is refused, naming it and listing what the workflow does declare;
+- both refusals happen **before any worktree, clone, or AI cost**;
+- supplied values are recorded on the run, so a resume replays exactly what the run started with.
+
+Chat platforms (Slack, Telegram, Discord, GitHub) have **no** channel for inputs yet: they carry
+only a trigger message, so a required-input workflow invoked there still refuses up front and
+points at the CLI and console. That gap is tracked in
+[#2555](https://github.com/coleam00/Archon/issues/2555).
 
 ---
 
@@ -1339,7 +1374,7 @@ The way to avoid it is to declare what the child does, on the child workflow its
 ```yaml
 # review-block.yaml — reads the repo, writes only to $ARTIFACTS_DIR
 name: review-block
-description: Reviews the diff and writes findings. Building block — not for standalone runs.
+description: Reviews the diff and writes findings. Composes into a parent; also runs on its own.
 mutates_checkout: false      # skips the path lock: N of these coexist in one checkout
 nodes:
   - id: review

--- a/packages/docs-web/src/content/docs/reference/api.md
+++ b/packages/docs-web/src/content/docs/reference/api.md
@@ -291,6 +291,25 @@ curl -X POST http://localhost:3090/api/workflows/archon-assist/run \
   -F "files=@screenshot.png"
 ```
 
+**Supplying declared inputs.** A workflow that declares [`inputs:`](/guides/authoring-workflows/#running-a-workflow-that-declares-inputs) takes their values through an optional `inputs` map — a flat object of string values. Omit a name to take its declared `default:`.
+
+```bash
+# JSON: inputs is a nested object
+curl -X POST http://localhost:3090/api/workflows/review-block/run \
+  -H "Content-Type: application/json" \
+  -d '{"message": "review it", "conversationId": "conv-123",
+       "inputs": {"diff": "...", "style": "terse"}}'
+
+# multipart: form fields are strings, so the same map travels JSON-encoded
+curl -X POST http://localhost:3090/api/workflows/review-block/run \
+  -F "conversationId=conv-123" \
+  -F "message=review it" \
+  -F 'inputs={"diff":"...","style":"terse"}' \
+  -F "files=@context.md"
+```
+
+Values are validated against the workflow's declaration before any worktree, clone, or AI cost: a missing **required** input and an **undeclared** name are both refused up front, through the same contract a composing `with:` map goes through. `400` if `inputs` is not an object of strings (or, on multipart, not valid JSON). An empty object is the same as omitting the field.
+
 #### List Run Artifacts
 
 ```bash

--- a/packages/docs-web/src/content/docs/reference/cli.md
+++ b/packages/docs-web/src/content/docs/reference/cli.md
@@ -196,6 +196,10 @@ archon workflow run assist --cwd /path/to/repo "What does this function do?"
 
 # With isolation
 archon workflow run plan --cwd /path/to/repo --branch feature-x "Add caching"
+
+# Supplying a workflow's declared inputs (one flag per input)
+archon workflow run review-block --cwd /path/to/repo \
+  --input diff="$(git diff)" --input style=terse "focus on the auth changes"
 ```
 
 Progress events (node start/complete/fail/skip, approval gates) are written to stderr during execution.
@@ -215,6 +219,7 @@ Note that a real `run` emits a JSON payload **only** under `--detach`. Without i
 | `--no-worktree` | Opt out of isolation -- run directly in live checkout |
 | `--folder` | Register the current non-git directory as a folder project (first use) and run in place -- no worktree. Rejects `--branch`/`--from`/`--base`. |
 | `--container` | Run a **folder project** inside an overlay-isolated Docker container instead of in place (writes land in an overlay, not the live root, until an approval-gated write-back). Folder-only; a repo project errors. Requires the runner image (`bun run build:runner-image`). Pauses `docker stop` the container; `--resume`/`approve`/`reject` rediscover and restart it. See the [Container isolation guide](/guides/container-isolation/) and [configuration](/reference/configuration/#container-isolation-folder-projects). |
+| `--input <name>=<value>` | Supply one value for the workflow's declared `inputs:`. **Repeat the flag per input.** Splits on the first `=`, so the value may itself contain `=`; `--input name=` supplies an empty string. Omitted inputs take their declared `default:`. A missing **required** input or an **undeclared** name is refused before any worktree, clone, or AI cost, through the same contract a composing `with:` map goes through. Rejected with `--resume` (a resume replays the inputs recorded on the run). See [Running a workflow that declares inputs](/guides/authoring-workflows/#running-a-workflow-that-declares-inputs). |
 | `--resume` | Resume from last failed run at the working path (skips completed nodes) |
 | `--quiet`, `-q` | Suppress all progress output to stderr |
 | `--verbose`, `-v` | Also show tool-level events (tool name and duration) |

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -843,9 +843,12 @@ const runWorkflowRoute = createRoute({
   tags: ['Workflows'],
   summary: 'Run a workflow via the orchestrator (JSON or multipart with file uploads)',
   description:
-    'Accepts `application/json` with `{ conversationId, message }` or ' +
-    '`multipart/form-data` with `conversationId`, `message`, and optional file ' +
-    'attachments (max 5 files, 10 MB each).',
+    'Accepts `application/json` with `{ conversationId, message, inputs? }` or ' +
+    '`multipart/form-data` with `conversationId`, `message`, an optional `inputs` field ' +
+    'holding the same map JSON-encoded, and optional file attachments (max 5 files, ' +
+    "10 MB each). `inputs` supplies values for the workflow's declared `inputs:` " +
+    '(#2554); it is validated against the declaration before any worktree, clone, or AI ' +
+    'cost, so a missing required input or an undeclared key is refused up front.',
   request: {
     params: z.object({ name: z.string() }),
   },
@@ -1547,6 +1550,33 @@ export function registerApiRoutes(
     detail?: string
   ): Response {
     return c.json({ error: message, ...(detail ? { detail } : {}) }, status);
+  }
+
+  /**
+   * Validate a run request's declared-inputs map (#2554): a flat object whose every
+   * value is a string, which is exactly the shape `readSubrunMetadata` will accept back
+   * off the run row. Refuse anything else here rather than let it be persisted into a
+   * shape the engine silently reads as absent.
+   *
+   * An empty object resolves to `undefined` so a caller sending `{}` is treated as
+   * having supplied nothing, taking every declared default.
+   */
+  function parseRunInputsField(
+    raw: unknown
+  ): { ok: true; inputs?: Record<string, string> } | { ok: false; error: string } {
+    if (raw === undefined || raw === null) return { ok: true };
+    if (typeof raw !== 'object' || Array.isArray(raw)) {
+      return { ok: false, error: 'inputs must be an object mapping input names to strings' };
+    }
+    const entries = Object.entries(raw as Record<string, unknown>);
+    const badKey = entries.find(([, value]) => typeof value !== 'string')?.[0];
+    if (badKey !== undefined) {
+      return { ok: false, error: `inputs value for '${badKey}' must be a string` };
+    }
+    return {
+      ok: true,
+      inputs: entries.length > 0 ? (raw as Record<string, string>) : undefined,
+    };
   }
 
   /**
@@ -3199,6 +3229,7 @@ export function registerApiRoutes(
 
     let message: string;
     let conversationId: string;
+    let workflowInputs: Record<string, string> | undefined;
     let savedFiles: AttachedFile[] = [];
     let uploadDir = '';
 
@@ -3224,6 +3255,26 @@ export function registerApiRoutes(
       message = rawMessage;
       conversationId = rawConv;
 
+      // Declared inputs (#2554). A form field can only be a string, so the map travels
+      // JSON-encoded. A malformed field is refused rather than ignored — silently
+      // dropping it would start the run without the values the caller thought it sent.
+      const rawInputs = body.inputs;
+      if (rawInputs !== undefined) {
+        if (typeof rawInputs !== 'string') {
+          return apiError(c, 400, 'inputs must be a JSON-encoded object of string values');
+        }
+        let decoded: unknown;
+        try {
+          decoded = JSON.parse(rawInputs);
+        } catch (parseErr: unknown) {
+          getLog().warn({ err: parseErr, workflowName }, 'run_workflow.inputs_parse_failed');
+          return apiError(c, 400, 'inputs must be a JSON-encoded object of string values');
+        }
+        const parsed = parseRunInputsField(decoded);
+        if (!parsed.ok) return apiError(c, 400, parsed.error);
+        workflowInputs = parsed.inputs;
+      }
+
       const rawFiles = body.files;
       const fileList: (string | File)[] = Array.isArray(rawFiles)
         ? rawFiles
@@ -3245,7 +3296,7 @@ export function registerApiRoutes(
         );
       }
     } else {
-      let body: { conversationId?: unknown; message?: unknown };
+      let body: { conversationId?: unknown; message?: unknown; inputs?: unknown };
       try {
         body = await c.req.json();
       } catch (parseErr: unknown) {
@@ -3258,6 +3309,9 @@ export function registerApiRoutes(
       if (typeof body.message !== 'string' || !body.message) {
         return apiError(c, 400, 'message must be a non-empty string');
       }
+      const parsed = parseRunInputsField(body.inputs);
+      if (!parsed.ok) return apiError(c, 400, parsed.error);
+      workflowInputs = parsed.inputs;
       conversationId = body.conversationId;
       message = body.message;
     }
@@ -3306,9 +3360,15 @@ export function registerApiRoutes(
         }
       }
 
+      // Declared inputs ride the context, never `fullMessage` — encoding them into the
+      // command string would make a supplied value indistinguishable from $ARGUMENTS
+      // and would amount to inventing a chat grammar as a side effect (#2554/#2555).
       const fullMessage = `/workflow run ${workflowName} ${message}`;
-      const extraContext: Omit<HandleMessageContext, 'isolationHints'> =
-        savedFiles.length > 0 ? { userId, attachedFiles: savedFiles } : { userId };
+      const extraContext: Omit<HandleMessageContext, 'isolationHints'> = {
+        userId,
+        ...(savedFiles.length > 0 ? { attachedFiles: savedFiles } : {}),
+        ...(workflowInputs ? { workflowInputs } : {}),
+      };
       const filesToCleanup = savedFiles.length > 0 ? { files: savedFiles, uploadDir } : undefined;
       const result = await dispatchToOrchestrator(
         conversationId,

--- a/packages/server/src/routes/api.workflow-runs.test.ts
+++ b/packages/server/src/routes/api.workflow-runs.test.ts
@@ -722,6 +722,32 @@ describe('POST /api/workflows/:name/run', () => {
     expect(mockHandleMessage).not.toHaveBeenCalled();
   });
 
+  test('treats an explicit empty `inputs` object as nothing supplied', async () => {
+    // `{}` is valid, not an error — it means "take every declared default", so the
+    // context must carry no workflowInputs rather than an empty map.
+    mockFindConversationByPlatformId.mockImplementationOnce(async () => MOCK_CONV);
+    mockAddMessage.mockImplementationOnce(async () => ({
+      id: 'msg-1',
+      conversation_id: MOCK_CONV.id,
+      role: 'user' as const,
+      content: 'Go',
+      metadata: '{}',
+      created_at: NOW,
+    }));
+    mockHandleMessage.mockImplementationOnce(async () => {});
+
+    const { app } = makeApp();
+    const response = await app.request('/api/workflows/deploy/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ conversationId: 'web-test-abc', message: 'Go', inputs: {} }),
+    });
+    expect(response.status).toBe(200);
+
+    const ctx = mockHandleMessage.mock.calls[0][3] as Record<string, unknown>;
+    expect(ctx).not.toHaveProperty('workflowInputs');
+  });
+
   test('accepts a multipart `inputs` field carrying the map JSON-encoded', async () => {
     mockFindConversationByPlatformId.mockImplementationOnce(async () => MOCK_CONV);
     mockAddMessage.mockImplementationOnce(async () => ({

--- a/packages/server/src/routes/api.workflow-runs.test.ts
+++ b/packages/server/src/routes/api.workflow-runs.test.ts
@@ -645,6 +645,129 @@ describe('POST /api/workflows/:name/run', () => {
     });
     expect(response.status).toBe(400);
   });
+
+  // -------------------------------------------------------------------------
+  // Declared inputs (#2554)
+  // -------------------------------------------------------------------------
+
+  test('forwards a JSON `inputs` map on the context, never in the message text', async () => {
+    mockFindConversationByPlatformId.mockImplementationOnce(async () => MOCK_CONV);
+    mockAddMessage.mockImplementationOnce(async () => ({
+      id: 'msg-1',
+      conversation_id: MOCK_CONV.id,
+      role: 'user' as const,
+      content: 'Review it',
+      metadata: '{}',
+      created_at: NOW,
+    }));
+    mockHandleMessage.mockImplementationOnce(async () => {});
+
+    const { app } = makeApp();
+    const response = await app.request('/api/workflows/review-block/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        conversationId: 'web-test-abc',
+        message: 'Review it',
+        inputs: { diff: 'D1', style: 'terse' },
+      }),
+    });
+    expect(response.status).toBe(200);
+
+    expect(mockHandleMessage).toHaveBeenCalledWith(
+      expect.anything(),
+      'web-test-abc',
+      // The command text is untouched — a supplied value must never be confusable
+      // with $ARGUMENTS, and this route must not invent a chat grammar.
+      '/workflow run review-block Review it',
+      expect.objectContaining({ workflowInputs: { diff: 'D1', style: 'terse' } })
+    );
+  });
+
+  test('omits workflowInputs entirely when no inputs are supplied', async () => {
+    mockFindConversationByPlatformId.mockImplementationOnce(async () => MOCK_CONV);
+    mockAddMessage.mockImplementationOnce(async () => ({
+      id: 'msg-1',
+      conversation_id: MOCK_CONV.id,
+      role: 'user' as const,
+      content: 'Go',
+      metadata: '{}',
+      created_at: NOW,
+    }));
+    mockHandleMessage.mockImplementationOnce(async () => {});
+
+    const { app } = makeApp();
+    await app.request('/api/workflows/deploy/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ conversationId: 'web-test-abc', message: 'Go' }),
+    });
+
+    const ctx = mockHandleMessage.mock.calls[0][3] as Record<string, unknown>;
+    expect(ctx).not.toHaveProperty('workflowInputs');
+  });
+
+  test('returns 400 when `inputs` is not an object of strings', async () => {
+    const { app } = makeApp();
+    for (const inputs of [['a'], 'nope', { diff: 5 }, { diff: null }]) {
+      const response = await app.request('/api/workflows/deploy/run', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ conversationId: 'web-test-abc', message: 'Go', inputs }),
+      });
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toContain('inputs');
+    }
+    expect(mockHandleMessage).not.toHaveBeenCalled();
+  });
+
+  test('accepts a multipart `inputs` field carrying the map JSON-encoded', async () => {
+    mockFindConversationByPlatformId.mockImplementationOnce(async () => MOCK_CONV);
+    mockAddMessage.mockImplementationOnce(async () => ({
+      id: 'msg-1',
+      conversation_id: MOCK_CONV.id,
+      role: 'user' as const,
+      content: 'Review it',
+      metadata: '{}',
+      created_at: NOW,
+    }));
+    mockHandleMessage.mockImplementationOnce(async () => {});
+
+    const form = new FormData();
+    form.append('conversationId', 'web-test-abc');
+    form.append('message', 'Review it');
+    form.append('inputs', JSON.stringify({ diff: 'D1' }));
+
+    const { app } = makeApp();
+    const response = await app.request('/api/workflows/review-block/run', {
+      method: 'POST',
+      body: form,
+    });
+    expect(response.status).toBe(200);
+
+    expect(mockHandleMessage).toHaveBeenCalledWith(
+      expect.anything(),
+      'web-test-abc',
+      '/workflow run review-block Review it',
+      expect.objectContaining({ workflowInputs: { diff: 'D1' } })
+    );
+  });
+
+  test('returns 400 for a malformed multipart `inputs` field rather than dropping it', async () => {
+    const form = new FormData();
+    form.append('conversationId', 'web-test-abc');
+    form.append('message', 'Review it');
+    form.append('inputs', 'not json {{{');
+
+    const { app } = makeApp();
+    const response = await app.request('/api/workflows/review-block/run', {
+      method: 'POST',
+      body: form,
+    });
+    expect(response.status).toBe(400);
+    expect(mockHandleMessage).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/server/src/routes/schemas/workflow.schemas.ts
+++ b/packages/server/src/routes/schemas/workflow.schemas.ts
@@ -226,6 +226,16 @@ export const runWorkflowBodySchema = z
   .object({
     conversationId: z.string(),
     message: z.string(),
+    /**
+     * Values for the workflow's declared `inputs:` (#2554), keyed by input name.
+     * Validated against the declaration before any worktree, clone, or AI cost; a
+     * missing required input or an undeclared key is refused. Omit for a workflow that
+     * declares no inputs, or to take every declared default.
+     *
+     * In a `multipart/form-data` request the same map travels as a single `inputs` form
+     * field holding this object JSON-encoded (form fields can only be strings).
+     */
+    inputs: z.record(z.string(), z.string()).optional(),
   })
   .openapi('RunWorkflowBody');
 

--- a/packages/server/src/routes/schemas/workflow.schemas.ts
+++ b/packages/server/src/routes/schemas/workflow.schemas.ts
@@ -221,7 +221,20 @@ export const dashboardRunsResponseSchema = z
   })
   .openapi('DashboardRunsResponse');
 
-/** POST /api/workflows/:name/run request body. */
+/**
+ * POST /api/workflows/:name/run request body.
+ *
+ * NOT WIRED, and deliberately so: `runWorkflowRoute` omits `request.body` because this
+ * route also accepts `multipart/form-data`, which Zod would reject against a JSON schema
+ * (the documented multipart-or-JSON exception in AGENTS.md). Nothing references this
+ * schema, so it contributes nothing to `/api/openapi.json` — `RunWorkflowBody` does not
+ * appear in the generated spec or in `api.generated.d.ts`. The route's real contract is
+ * the hand-written validation in the handler plus the route `description` string; those
+ * are what a caller and the generated client actually see.
+ *
+ * It is kept as the declared shape of the JSON body for a reader, and must be updated
+ * alongside the handler — but do not add a field here believing that publishes it.
+ */
 export const runWorkflowBodySchema = z
   .object({
     conversationId: z.string(),

--- a/packages/web/src/experiments/console/components/DraftRunCard.tsx
+++ b/packages/web/src/experiments/console/components/DraftRunCard.tsx
@@ -13,6 +13,7 @@ import { useEntity, invalidate } from '../store/cache';
 import { K } from '../store/keys';
 import * as skill from '../skills';
 import { orderWithRecommended } from '../lib/recommended';
+import { missingRequiredInputs, collectSuppliedInputs } from '../lib/workflow-inputs';
 
 interface DraftRunCardProps {
   projectId: string;
@@ -81,6 +82,10 @@ export function DraftRunCard({ projectId, projectCwd }: DraftRunCardProps): Reac
   const [dragOver, setDragOver] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Values for the selected workflow's declared `inputs:` (#2554), keyed by input name.
+  // Cleared whenever the selected workflow changes so one workflow's values can never
+  // be submitted against another's declaration.
+  const [inputValues, setInputValues] = useState<Record<string, string>>({});
 
   // Pre-fill from `?rerun=1&workflow=…&message=…` query params (set by the
   // ↻ rerun button on RecentRunRow). Reacts to searchParams so the card
@@ -144,6 +149,17 @@ export function DraftRunCard({ projectId, projectCwd }: DraftRunCardProps): Reac
     if (pick !== undefined) setWorkflowName(pick.name);
   }, [sortedWorkflows, workflowName]);
 
+  // Declared inputs of the selected workflow (#2554). Empty for the overwhelming
+  // majority of workflows, which declare none and render exactly as before.
+  const declaredInputs = sortedWorkflows.find(w => w.name === workflowName)?.inputs ?? [];
+  const missingRequired = missingRequiredInputs(declaredInputs, inputValues);
+
+  // Switching workflows discards values collected for the previous one — they were
+  // typed against a different declaration and would be rejected as undeclared keys.
+  useEffect(() => {
+    setInputValues({});
+  }, [workflowName]);
+
   // Global `N` keybind: expand + open the workflow picker so the user can
   // pick a workflow without first reaching for the mouse.
   useEffect(() => {
@@ -189,8 +205,15 @@ export function DraftRunCard({ projectId, projectCwd }: DraftRunCardProps): Reac
       setError('Pick a workflow first.');
       return;
     }
+    if (missingRequired.length > 0) {
+      setError(
+        `Fill in ${missingRequired.map(n => `"${n}"`).join(', ')} before starting this run.`
+      );
+      return;
+    }
     setError(null);
     setSubmitting(true);
+    const suppliedInputs = collectSuppliedInputs(declaredInputs, inputValues);
     try {
       writeLastWorkflow(workflowName);
       await skill.startRun({
@@ -198,12 +221,14 @@ export function DraftRunCard({ projectId, projectCwd }: DraftRunCardProps): Reac
         workflow: workflowName,
         message: context,
         files: files.length > 0 ? files : undefined,
+        inputs: Object.keys(suppliedInputs).length > 0 ? suppliedInputs : undefined,
       });
       // Dispatch is fire-and-forget — the orchestrator creates the run row
       // asynchronously. Nudge the runs feed so the new card appears as soon
       // as the row exists, instead of waiting for the next 3s poll tick.
       setContext('');
       setFiles([]);
+      setInputValues({});
       setMode('collapsed');
       invalidate('runs');
     } catch (err: unknown) {
@@ -216,6 +241,7 @@ export function DraftRunCard({ projectId, projectCwd }: DraftRunCardProps): Reac
   const collapse = (): void => {
     setMode('collapsed');
     setFiles([]);
+    setInputValues({});
     setError(null);
   };
 
@@ -358,6 +384,46 @@ export function DraftRunCard({ projectId, projectCwd }: DraftRunCardProps): Reac
           </button>
         </div>
 
+        {/* Declared inputs (#2554) — only for workflows that declare a signature.
+            Values are validated server-side against the same contract a composing
+            `with:` map goes through, before any worktree, clone, or AI cost. */}
+        {declaredInputs.length > 0 ? (
+          <div className="mt-3 space-y-2.5 rounded-[10px] border border-border bg-surface-inset px-3 py-2.5">
+            <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-text-tertiary">
+              Inputs
+            </p>
+            {declaredInputs.map(declared => (
+              <label key={declared.name} className="block">
+                <span className="flex items-baseline gap-1.5 font-mono text-[11px] text-text-secondary">
+                  {declared.name}
+                  {declared.required ? (
+                    <span className="text-[color:var(--brand-magenta)]" title="Required">
+                      *
+                    </span>
+                  ) : null}
+                </span>
+                {declared.description !== null ? (
+                  <span className="mt-0.5 block text-[11px] leading-snug text-text-tertiary">
+                    {declared.description}
+                  </span>
+                ) : null}
+                <input
+                  type="text"
+                  value={inputValues[declared.name] ?? ''}
+                  onChange={e => {
+                    const { value } = e.target;
+                    setInputValues(prev => ({ ...prev, [declared.name]: value }));
+                    if (error !== null) setError(null);
+                  }}
+                  placeholder={declared.default ?? (declared.required ? 'required' : 'optional')}
+                  disabled={submitting}
+                  className="mt-1 w-full rounded-[8px] border border-border bg-surface px-2.5 py-1.5 font-mono text-[12px] text-text-primary placeholder:text-text-tertiary focus:border-accent-bright/50 focus:outline-none focus:ring-[3px] focus:ring-accent-bright/10 disabled:opacity-50"
+                />
+              </label>
+            ))}
+          </div>
+        ) : null}
+
         {/* Body: context textarea */}
         <div className="mt-3">
           <textarea
@@ -463,7 +529,12 @@ export function DraftRunCard({ projectId, projectCwd }: DraftRunCardProps): Reac
             <button
               type="button"
               onClick={() => void submit()}
-              disabled={submitting || workflowName.length === 0}
+              disabled={submitting || workflowName.length === 0 || missingRequired.length > 0}
+              title={
+                missingRequired.length > 0
+                  ? `Fill in ${missingRequired.join(', ')} first`
+                  : undefined
+              }
               className="brand-bar flex items-center gap-1.5 rounded-[9px] px-[15px] py-[9px] text-[13px] font-bold text-white shadow-[0_6px_18px_-8px_color-mix(in_oklch,var(--brand-magenta),transparent_30%)] transition-all hover:-translate-y-px hover:brightness-110 active:brightness-95 disabled:translate-y-0 disabled:opacity-50 disabled:shadow-none"
             >
               {submitting ? 'Starting…' : 'Start run'}
@@ -472,6 +543,14 @@ export function DraftRunCard({ projectId, projectCwd }: DraftRunCardProps): Reac
               </span>
             </button>
           </div>
+
+          {/* Say WHY the button is disabled — a dead control with no reason is the
+              failure mode this replaces. */}
+          {error === null && missingRequired.length > 0 ? (
+            <p className="mt-1 font-mono text-[11px] text-text-tertiary">
+              needs {missingRequired.join(', ')}
+            </p>
+          ) : null}
 
           {error !== null ? <p className="mt-1 font-mono text-[11px] text-error">{error}</p> : null}
         </div>

--- a/packages/web/src/experiments/console/components/DraftRunCard.tsx
+++ b/packages/web/src/experiments/console/components/DraftRunCard.tsx
@@ -221,7 +221,8 @@ export function DraftRunCard({ projectId, projectCwd }: DraftRunCardProps): Reac
         workflow: workflowName,
         message: context,
         files: files.length > 0 ? files : undefined,
-        inputs: Object.keys(suppliedInputs).length > 0 ? suppliedInputs : undefined,
+        // startRun already treats an empty map as "nothing supplied".
+        inputs: suppliedInputs,
       });
       // Dispatch is fire-and-forget — the orchestrator creates the run row
       // asynchronously. Nudge the runs feed so the new card appears as soon

--- a/packages/web/src/experiments/console/lib/recommended.test.ts
+++ b/packages/web/src/experiments/console/lib/recommended.test.ts
@@ -3,7 +3,7 @@ import { orderWithRecommended } from './recommended';
 import type { Workflow } from '../primitives/workflow';
 
 function wf(name: string, source: Workflow['source'] = 'bundled'): Workflow {
-  return { name, description: null, source, parseWarnings: [] };
+  return { name, description: null, source, parseWarnings: [], inputs: [] };
 }
 
 describe('orderWithRecommended', () => {

--- a/packages/web/src/experiments/console/lib/workflow-inputs.test.ts
+++ b/packages/web/src/experiments/console/lib/workflow-inputs.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect } from 'bun:test';
+import { missingRequiredInputs, collectSuppliedInputs } from './workflow-inputs';
+import type { WorkflowInput } from '../primitives/workflow';
+
+function input(over: Partial<WorkflowInput> & { name: string }): WorkflowInput {
+  return { required: false, default: null, description: null, ...over };
+}
+
+const DECLARED: WorkflowInput[] = [
+  input({ name: 'diff', required: true }),
+  input({ name: 'style', default: 'strict' }),
+  input({ name: 'notes' }),
+];
+
+describe('missingRequiredInputs', () => {
+  test('names required inputs with no value, in declaration order', () => {
+    const declared = [
+      input({ name: 'diff', required: true }),
+      input({ name: 'style' }),
+      input({ name: 'plan', required: true }),
+    ];
+    expect(missingRequiredInputs(declared, {})).toEqual(['diff', 'plan']);
+  });
+
+  test('treats a whitespace-only value as unfilled', () => {
+    expect(missingRequiredInputs(DECLARED, { diff: '   ' })).toEqual(['diff']);
+  });
+
+  test('is empty once every required input has a value', () => {
+    expect(missingRequiredInputs(DECLARED, { diff: 'D1' })).toEqual([]);
+  });
+
+  test('never blocks on an optional input, defaulted or not', () => {
+    expect(missingRequiredInputs([input({ name: 'style', default: 'strict' })], {})).toEqual([]);
+  });
+
+  test('is empty for a workflow declaring no inputs', () => {
+    expect(missingRequiredInputs([], {})).toEqual([]);
+  });
+});
+
+describe('collectSuppliedInputs', () => {
+  test('sends only the filled inputs', () => {
+    expect(collectSuppliedInputs(DECLARED, { diff: 'D1', style: '', notes: 'n' })).toEqual({
+      diff: 'D1',
+      notes: 'n',
+    });
+  });
+
+  test('omits an untouched defaulted input so its declared default still applies', () => {
+    // Sending `style: ''` would override `default: strict` with nothing — the exact
+    // silent-wrong-value bug this omission prevents.
+    expect(collectSuppliedInputs(DECLARED, { diff: 'D1' })).toEqual({ diff: 'D1' });
+  });
+
+  test('ignores values for names the workflow does not declare', () => {
+    // A stale value from a previously selected workflow must never be submitted:
+    // the server rejects undeclared keys, so this would fail the whole run.
+    expect(collectSuppliedInputs(DECLARED, { diff: 'D1', stlye: 'terse' })).toEqual({ diff: 'D1' });
+  });
+
+  test('preserves whitespace inside a value it does send', () => {
+    expect(collectSuppliedInputs(DECLARED, { diff: '  padded  ' })).toEqual({
+      diff: '  padded  ',
+    });
+  });
+
+  test('is empty when nothing is filled', () => {
+    expect(collectSuppliedInputs(DECLARED, {})).toEqual({});
+  });
+});

--- a/packages/web/src/experiments/console/lib/workflow-inputs.ts
+++ b/packages/web/src/experiments/console/lib/workflow-inputs.ts
@@ -1,0 +1,46 @@
+/**
+ * The two decisions the run form makes about declared workflow inputs (#2554).
+ *
+ * Kept out of the component so they are provable without a React DOM harness — the
+ * console's existing convention (see `lib/recommended.ts`) is that the interesting
+ * decision is a pure function and the component only renders it.
+ */
+import type { WorkflowInput } from '../primitives/workflow';
+
+/**
+ * Required inputs the user has not filled, in declaration order.
+ *
+ * Whitespace is not a value: a field holding only spaces reads as unfilled, so the
+ * form cannot start a run that would immediately be refused server-side.
+ */
+export function missingRequiredInputs(
+  declared: readonly WorkflowInput[],
+  values: Readonly<Record<string, string>>
+): string[] {
+  return declared
+    .filter(input => input.required && (values[input.name] ?? '').trim().length === 0)
+    .map(input => input.name);
+}
+
+/**
+ * The map to send: only inputs the user actually filled.
+ *
+ * An untouched optional field must be OMITTED, not sent as `''` — sending the empty
+ * string would override the workflow's declared `default:` with nothing. The cost is
+ * that the form cannot express a deliberate empty string; the CLI's `--input name=`
+ * can, and that is the right trade for the common case.
+ *
+ * Values are sent verbatim (never trimmed) — leading or trailing whitespace can be
+ * meaningful inside a value, even though it does not count as *filling* a field.
+ */
+export function collectSuppliedInputs(
+  declared: readonly WorkflowInput[],
+  values: Readonly<Record<string, string>>
+): Record<string, string> {
+  const supplied: Record<string, string> = {};
+  for (const input of declared) {
+    const value = values[input.name] ?? '';
+    if (value.trim().length > 0) supplied[input.name] = value;
+  }
+  return supplied;
+}

--- a/packages/web/src/experiments/console/primitives/workflow.test.ts
+++ b/packages/web/src/experiments/console/primitives/workflow.test.ts
@@ -37,3 +37,35 @@ describe('toWorkflow — parseWarnings (#2213)', () => {
     expect(w.parseWarnings).toEqual([]);
   });
 });
+
+describe('toWorkflow — declared inputs (#2554)', () => {
+  test('flattens the declared map into an ordered list, preserving declaration order', () => {
+    const w = toWorkflow({
+      workflow: {
+        name: 'review-block',
+        inputs: {
+          diff: { required: true, description: 'the diff to review' },
+          style: { default: 'strict' },
+        },
+      },
+      source: 'project',
+    });
+    expect(w.inputs).toEqual([
+      { name: 'diff', required: true, default: null, description: 'the diff to review' },
+      { name: 'style', required: false, default: 'strict', description: null },
+    ]);
+  });
+
+  test('defaults to an empty array when the workflow declares none', () => {
+    // The run card reads `.length` to decide whether to render the form at all.
+    expect(toWorkflow({ workflow: { name: 'plain' }, source: 'project' }).inputs).toEqual([]);
+  });
+
+  test('treats an absent required flag as optional rather than truthy-coercing it', () => {
+    const w = toWorkflow({
+      workflow: { name: 'w', inputs: { a: {}, b: { required: false } } },
+      source: 'project',
+    });
+    expect(w.inputs.map(i => i.required)).toEqual([false, false]);
+  });
+});

--- a/packages/web/src/experiments/console/primitives/workflow.ts
+++ b/packages/web/src/experiments/console/primitives/workflow.ts
@@ -1,5 +1,17 @@
 export type WorkflowSource = 'project' | 'global' | 'bundled';
 
+/**
+ * One entry of a workflow's declared `inputs:` signature (#2470), flattened for
+ * rendering. A run supplies values for these; an omitted name takes `default`, and a
+ * `required` one with no value is refused before the run starts (#2554).
+ */
+export interface WorkflowInput {
+  name: string;
+  required: boolean;
+  default: string | null;
+  description: string | null;
+}
+
 export interface Workflow {
   name: string;
   description: string | null;
@@ -10,12 +22,18 @@ export interface Workflow {
    * was ignored, which can include a gate the author believed they had.
    */
   parseWarnings: string[];
+  /** Declared `inputs:` in declaration order; empty when the workflow declares none. */
+  inputs: WorkflowInput[];
 }
 
 interface RawWorkflowEntry {
   workflow: {
     name: string;
     description?: string | null;
+    inputs?: Record<
+      string,
+      { required?: boolean; default?: string; description?: string } | null | undefined
+    >;
   };
   source: string;
   parseWarnings?: string[];
@@ -28,10 +46,19 @@ export function toWorkflow(raw: RawWorkflowEntry): Workflow {
   // demoted home-scoped workflows and rendered them with the wrong badge.
   const src: WorkflowSource =
     raw.source === 'project' ? 'project' : raw.source === 'global' ? 'global' : 'bundled';
+  // Object key order preserves the YAML's declaration order for string keys, so the
+  // run form renders inputs in the order the author wrote them.
+  const inputs: WorkflowInput[] = Object.entries(raw.workflow.inputs ?? {}).map(([name, spec]) => ({
+    name,
+    required: spec?.required === true,
+    default: spec?.default ?? null,
+    description: spec?.description ?? null,
+  }));
   return {
     name: raw.workflow.name,
     description: raw.workflow.description ?? null,
     source: src,
     parseWarnings: raw.parseWarnings ?? [],
+    inputs,
   };
 }

--- a/packages/web/src/experiments/console/primitives/workflow.ts
+++ b/packages/web/src/experiments/console/primitives/workflow.ts
@@ -26,15 +26,26 @@ export interface Workflow {
   inputs: WorkflowInput[];
 }
 
+/**
+ * The workflow object as `GET /api/workflows` sends it, for the fields the console
+ * reads. Exported because `skills/workflows.ts` describes the same wire shape for its
+ * own `listWorkflows`/`getWorkflowGraph` calls — two hand-rolled copies drifted once
+ * already (its copy never learned about `inputs`, which type-checked silently because
+ * a missing optional property still satisfies the parameter type, and would have gone
+ * on compiling while the run form quietly stopped rendering).
+ */
+export interface RawWorkflowShape {
+  name: string;
+  description?: string | null;
+  inputs?: Record<
+    string,
+    { required?: boolean; default?: string; description?: string } | null | undefined
+  >;
+  returns?: string;
+}
+
 interface RawWorkflowEntry {
-  workflow: {
-    name: string;
-    description?: string | null;
-    inputs?: Record<
-      string,
-      { required?: boolean; default?: string; description?: string } | null | undefined
-    >;
-  };
+  workflow: RawWorkflowShape;
   source: string;
   parseWarnings?: string[];
 }

--- a/packages/web/src/experiments/console/skills/startRun.test.ts
+++ b/packages/web/src/experiments/console/skills/startRun.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Request-shape tests for startRun's declared-inputs channel (#2554).
+ *
+ * The JSON and multipart branches carry the same map two different ways, and the
+ * multipart encoding has to agree byte-for-byte with what the run route's multipart
+ * branch parses — a disagreement there is invisible until a real run silently starts
+ * without its inputs.
+ */
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { startRun } from './startRun';
+
+interface Captured {
+  url: string;
+  init: RequestInit | undefined;
+}
+
+const originalFetch = globalThis.fetch;
+let calls: Captured[] = [];
+
+function stubFetch(): void {
+  calls = [];
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    calls.push({ url, init });
+    const payload = url.includes('/api/conversations')
+      ? { conversationId: 'web-test-1' }
+      : { accepted: true, status: 'started' };
+    return Promise.resolve(
+      new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+  }) as typeof fetch;
+}
+
+/** The run dispatch is the second call; the first creates the conversation. */
+function runCall(): Captured {
+  const call = calls.find(c => c.url.includes('/run'));
+  if (call === undefined) throw new Error('no run dispatch captured');
+  return call;
+}
+
+describe('startRun — declared inputs (#2554)', () => {
+  beforeEach(() => {
+    stubFetch();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test('JSON branch carries `inputs` alongside the message', async () => {
+    await startRun({
+      projectId: 'p1',
+      workflow: 'review-block',
+      message: 'go',
+      inputs: { diff: 'D1', style: 'terse' },
+    });
+
+    const body = JSON.parse(String(runCall().init?.body)) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      conversationId: 'web-test-1',
+      message: 'go',
+      inputs: { diff: 'D1', style: 'terse' },
+    });
+  });
+
+  test('JSON branch omits `inputs` entirely when none are supplied', async () => {
+    await startRun({ projectId: 'p1', workflow: 'plain', message: 'go' });
+
+    const body = JSON.parse(String(runCall().init?.body)) as Record<string, unknown>;
+    expect(body).not.toHaveProperty('inputs');
+  });
+
+  test('JSON branch omits `inputs` for an empty map rather than sending {}', async () => {
+    await startRun({ projectId: 'p1', workflow: 'plain', message: 'go', inputs: {} });
+
+    const body = JSON.parse(String(runCall().init?.body)) as Record<string, unknown>;
+    expect(body).not.toHaveProperty('inputs');
+  });
+
+  test('multipart branch carries `inputs` as one JSON-encoded form field', async () => {
+    // A form field can only be a string — this is the encoding the run route's
+    // multipart branch JSON.parses back.
+    await startRun({
+      projectId: 'p1',
+      workflow: 'review-block',
+      message: 'go',
+      files: [new File(['x'], 'a.txt', { type: 'text/plain' })],
+      inputs: { diff: 'D1' },
+    });
+
+    const form = runCall().init?.body as FormData;
+    expect(form).toBeInstanceOf(FormData);
+    expect(JSON.parse(String(form.get('inputs')))).toEqual({ diff: 'D1' });
+    expect(form.get('message')).toBe('go');
+    expect(form.getAll('files')).toHaveLength(1);
+  });
+
+  test('multipart branch omits the `inputs` field when none are supplied', async () => {
+    await startRun({
+      projectId: 'p1',
+      workflow: 'plain',
+      message: 'go',
+      files: [new File(['x'], 'a.txt', { type: 'text/plain' })],
+    });
+
+    const form = runCall().init?.body as FormData;
+    expect(form.get('inputs')).toBeNull();
+  });
+});

--- a/packages/web/src/experiments/console/skills/startRun.ts
+++ b/packages/web/src/experiments/console/skills/startRun.ts
@@ -22,6 +22,12 @@ export interface StartRunArgs {
   workflow: string;
   message: string;
   files?: File[];
+  /**
+   * Values for the workflow's declared `inputs:` (#2554), keyed by input name.
+   * Omitted names take their declared default; a missing required input is refused by
+   * the server before any worktree, clone, or AI cost.
+   */
+  inputs?: Record<string, string>;
 }
 
 interface CreateConversationResponse {
@@ -33,6 +39,7 @@ export async function startRun({
   workflow,
   message,
   files,
+  inputs,
 }: StartRunArgs): Promise<void> {
   const conv = await requestJson<CreateConversationResponse>('/api/conversations', {
     method: 'POST',
@@ -41,10 +48,16 @@ export async function startRun({
 
   const url = `/api/workflows/${encodeURIComponent(workflow)}/run`;
 
+  const hasInputs = inputs !== undefined && Object.keys(inputs).length > 0;
+
   if (files === undefined || files.length === 0) {
     await requestJson<{ accepted: boolean; status: string }>(url, {
       method: 'POST',
-      body: JSON.stringify({ conversationId: conv.conversationId, message }),
+      body: JSON.stringify({
+        conversationId: conv.conversationId,
+        message,
+        ...(hasInputs ? { inputs } : {}),
+      }),
     });
     return;
   }
@@ -53,6 +66,11 @@ export async function startRun({
   const form = new FormData();
   form.append('conversationId', conv.conversationId);
   form.append('message', message);
+  // A form field can only be a string, so the input map travels JSON-encoded — the
+  // shape the multipart branch of the run route parses.
+  if (hasInputs) {
+    form.append('inputs', JSON.stringify(inputs));
+  }
   for (const file of files) {
     form.append('files', file, file.name);
   }

--- a/packages/web/src/experiments/console/skills/workflows.test.ts
+++ b/packages/web/src/experiments/console/skills/workflows.test.ts
@@ -1,5 +1,5 @@
-import { describe, test, expect } from 'bun:test';
-import { buildWorkflowPath, buildSavePath } from './workflows';
+import { describe, test, expect, afterEach } from 'bun:test';
+import { buildWorkflowPath, buildSavePath, listWorkflows } from './workflows';
 
 describe('buildWorkflowPath', () => {
   test('encodes both name and cwd', () => {
@@ -28,5 +28,46 @@ describe('buildSavePath', () => {
     expect(buildSavePath('my-flow', '/repo', 'global')).toBe(
       '/api/workflows/my-flow?cwd=%2Frepo&source=global'
     );
+  });
+});
+
+describe('listWorkflows — declared inputs survive the wire mapping (#2554)', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("carries a workflow's declared inputs through to the console primitive", async () => {
+    // The console's run form depends on this field surviving `listWorkflows`, and the
+    // wire shape here is hand-rolled — it once omitted `inputs` entirely and still
+    // compiled, because a missing optional property satisfies the parameter type. This
+    // is the regression guard the compiler cannot be.
+    globalThis.fetch = ((_input: RequestInfo | URL, _init?: RequestInit) =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            workflows: [
+              {
+                workflow: {
+                  name: 'review-block',
+                  description: 'reviews a diff',
+                  inputs: { diff: { required: true }, style: { default: 'strict' } },
+                },
+                source: 'project',
+              },
+            ],
+            recommended: [],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      )) as typeof fetch;
+
+    const result = await listWorkflows('/repo');
+
+    expect(result.workflows[0].inputs).toEqual([
+      { name: 'diff', required: true, default: null, description: null },
+      { name: 'style', required: false, default: 'strict', description: null },
+    ]);
   });
 });

--- a/packages/web/src/experiments/console/skills/workflows.ts
+++ b/packages/web/src/experiments/console/skills/workflows.ts
@@ -1,5 +1,10 @@
 import { requestJson } from '../lib/http';
-import { toWorkflow, type Workflow, type WorkflowSource } from '../primitives/workflow';
+import {
+  toWorkflow,
+  type Workflow,
+  type WorkflowSource,
+  type RawWorkflowShape,
+} from '../primitives/workflow';
 import type { WorkflowGraphNode } from '../primitives/workflow-graph';
 import type { WireWorkflowDefinition } from '../builder/types/wire';
 
@@ -15,11 +20,16 @@ interface RawNode {
   script?: unknown;
 }
 
-interface RawWorkflow {
-  name: string;
-  description?: string;
+/**
+ * Shares `RawWorkflowShape` with `toWorkflow`'s own wire type rather than re-declaring
+ * the common fields: `listWorkflows` feeds these entries straight into `toWorkflow`, so
+ * a field this copy omitted (as it once omitted `inputs`) would still compile and still
+ * arrive at runtime, leaving the type quietly wrong. `nodes` is the one field only this
+ * side needs — `getWorkflowGraph` reads it.
+ */
+type RawWorkflow = RawWorkflowShape & {
   nodes?: RawNode[];
-}
+};
 
 interface WorkflowListEntry {
   workflow: RawWorkflow;

--- a/packages/web/src/lib/api.generated.d.ts
+++ b/packages/web/src/lib/api.generated.d.ts
@@ -1515,7 +1515,7 @@ export interface paths {
     put?: never;
     /**
      * Run a workflow via the orchestrator (JSON or multipart with file uploads)
-     * @description Accepts `application/json` with `{ conversationId, message }` or `multipart/form-data` with `conversationId`, `message`, and optional file attachments (max 5 files, 10 MB each).
+     * @description Accepts `application/json` with `{ conversationId, message, inputs? }` or `multipart/form-data` with `conversationId`, `message`, an optional `inputs` field holding the same map JSON-encoded, and optional file attachments (max 5 files, 10 MB each). `inputs` supplies values for the workflow's declared `inputs:` (#2554); it is validated against the declaration before any worktree, clone, or AI cost, so a missing required input or an undeclared key is refused up front.
      */
     post: {
       parameters: {
@@ -3357,6 +3357,14 @@ export interface components {
       persist_sessions?: boolean;
       tags?: string[];
       requires?: 'github'[];
+      inputs?: {
+        [key: string]: {
+          required?: boolean;
+          default?: string;
+          description?: string;
+        };
+      };
+      returns?: string;
       nodes: components['schemas']['DagNode'][];
     };
     DagNode: {

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -19,10 +19,11 @@
     "./dry-run": "./src/dry-run.ts",
     "./utils/tool-formatter": "./src/utils/tool-formatter.ts",
     "./utils/workflow-requirements": "./src/utils/workflow-requirements.ts",
+    "./workflow-inputs": "./src/workflow-inputs.ts",
     "./test-utils": "./src/test-utils.ts"
   },
   "scripts": {
-    "test": "bun test src/dag-executor.test.ts && bun test src/loader.test.ts src/include-expander.test.ts && bun test src/workflow-discovery-command-scan.test.ts && bun test src/logger.test.ts && bun test src/condition-evaluator.test.ts && bun test src/output-ref.test.ts && bun test src/event-emitter.test.ts && bun test src/executor-shared.test.ts && bun test src/load-command-prompt.test.ts && bun test src/load-command-prompt-bundled.test.ts && bun test src/executor.test.ts && bun test src/subrun.test.ts && bun test src/executor-preamble.test.ts && bun test src/defaults/ src/model-validation.test.ts src/router.test.ts src/utils/ src/hooks.test.ts && bun test src/validation-parser.test.ts src/schemas.test.ts src/command-validation.test.ts src/packaged-workflow.test.ts && bun test src/validator.test.ts && bun test src/script-discovery.test.ts && bun test src/bundled-script-materialization.test.ts && bun test src/runtime-check.test.ts && bun test src/script-node-deps.test.ts && bun test src/artifacts-index.test.ts && bun test src/state-migration.test.ts src/dry-run.test.ts",
+    "test": "bun test src/dag-executor.test.ts && bun test src/loader.test.ts src/include-expander.test.ts && bun test src/workflow-discovery-command-scan.test.ts && bun test src/logger.test.ts && bun test src/condition-evaluator.test.ts && bun test src/output-ref.test.ts && bun test src/event-emitter.test.ts && bun test src/executor-shared.test.ts && bun test src/load-command-prompt.test.ts && bun test src/load-command-prompt-bundled.test.ts && bun test src/executor.test.ts && bun test src/subrun.test.ts && bun test src/executor-preamble.test.ts && bun test src/defaults/ src/model-validation.test.ts src/router.test.ts src/utils/ src/hooks.test.ts src/workflow-inputs.test.ts && bun test src/validation-parser.test.ts src/schemas.test.ts src/command-validation.test.ts src/packaged-workflow.test.ts && bun test src/validator.test.ts && bun test src/script-discovery.test.ts && bun test src/bundled-script-materialization.test.ts && bun test src/runtime-check.test.ts && bun test src/script-node-deps.test.ts && bun test src/artifacts-index.test.ts && bun test src/state-migration.test.ts src/dry-run.test.ts",
     "type-check": "bun x tsc --noEmit"
   },
   "dependencies": {

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -539,6 +539,23 @@ export type ExecuteWorkflowOptions = ResumePayload & {
    * fallback). Threaded into the child-spawn closure.
    */
   resolveChildIsolation?: ChildIsolationResolver;
+  /**
+   * Declared inputs supplied by a DIRECT top-level invocation (#2554) — the CLI's
+   * `--input name=value`, the run route's `inputs` map, or the console's run form.
+   * Stamped onto the fresh run row's `metadata.inputs`, the same key a `workflow:`
+   * parent writes for its child, so every existing delivery path (`$INPUTS.<name>` on
+   * AI/prompt surfaces, `INPUTS_<UPPER_SNAKE>` for bash/script) works unchanged and the
+   * values survive a cold resume.
+   *
+   * ALREADY RESOLVED by the invocation gate (`resolveTopLevelInputs`), which validates
+   * against the workflow's declared `inputs:` before any worktree, clone, or AI cost —
+   * like `baseOverride` and `parseWarnings`, this is a caller-resolved value. The
+   * executor does not re-validate: it would run after the cost the gate exists to
+   * prevent, and its message would be shaped for the wrong surface.
+   *
+   * Ignored on a resume: the row already carries the inputs validated at creation.
+   */
+  inputs?: Readonly<Record<string, string>>;
 };
 
 /**
@@ -1145,6 +1162,7 @@ export async function executeWorkflow(
     execContext = { kind: 'host' },
     container: containerCtx,
     resolveChildIsolation,
+    inputs: suppliedInputs,
   } = opts;
 
   // Guard: a container run MUST be resumed with its container rewired (the CLI does
@@ -1369,6 +1387,13 @@ export async function executeWorkflow(
           ...(issueContext ? { github_context: issueContext } : {}),
           ...(execContext.kind === 'container' ? { isolation: 'container' } : {}),
           ...(containerCtx ? { isolation_env_id: containerCtx.envId } : {}),
+          // Declared inputs supplied by a direct top-level invocation (#2554), already
+          // validated by the invocation gate. Written here — inside `if (!workflowRun)` —
+          // so a resume, which arrives with `preCreatedRun` set and never enters this
+          // branch, can never re-stamp or clobber what the original invocation supplied.
+          ...(suppliedInputs && Object.keys(suppliedInputs).length > 0
+            ? { [SUBRUN_METADATA_KEYS.inputs]: { ...suppliedInputs } }
+            : {}),
         },
         parent_conversation_id: parentConversationId,
         user_id: userId,

--- a/packages/workflows/src/subrun.test.ts
+++ b/packages/workflows/src/subrun.test.ts
@@ -4138,6 +4138,216 @@ nodes:
     expect((await store.getWorkflowRun(child!.id))?.status).toBe('completed');
     expect(prompts.some(p => p.includes('resumed in terse style'))).toBe(true);
   });
+
+  // -------------------------------------------------------------------------
+  // Direct top-level invocation supplying its own inputs (#2554)
+  // -------------------------------------------------------------------------
+
+  it('delivers directly-supplied inputs to BOTH the AI and shell surfaces of a top-level run', async () => {
+    // No parent anywhere: the values come from `opts.inputs` (the CLI's --input / the
+    // run route's `inputs` map) and must reach the same two surfaces a child's do.
+    await writeWorkflow(
+      'direct-inputs',
+      `
+name: direct-inputs
+description: runs on its own with a required input
+inputs:
+  diff:
+    required: true
+  style:
+    default: strict
+nodes:
+  - id: shell
+    bash: echo "diff=$INPUTS_DIFF style=$INPUTS_STYLE"
+  - id: ai
+    prompt: "review $INPUTS.diff in $INPUTS.style style"
+    depends_on: [shell]
+`
+    );
+
+    const store = new InMemoryStore();
+    const { deps, prompts } = makeRecordingDeps(store);
+    const result = await executeWorkflow(
+      deps,
+      makePlatform(),
+      'conv-plat',
+      cwd,
+      await discover('direct-inputs'),
+      'goal',
+      'conv-db',
+      { inputs: { diff: 'D1', style: 'terse' } }
+    );
+
+    expect(result.success).toBe(true);
+    // Shell surface: env vars, never $INPUTS text spliced into shell source.
+    const shellOut = store.events.find(
+      e => e.event_type === 'node_completed' && e.step_name === 'shell'
+    );
+    expect(String(shellOut?.data?.node_output)).toContain('diff=D1 style=terse');
+    // AI surface: substituted text, literal token never reaches the model.
+    expect(prompts.some(p => p.includes('review D1 in terse style'))).toBe(true);
+    expect(prompts.some(p => p.includes('$INPUTS.diff'))).toBe(false);
+  });
+
+  it('persists ONLY the supplied values on a top-level run, letting defaults stay derived', async () => {
+    await writeWorkflow(
+      'direct-persist',
+      `
+name: direct-persist
+description: one supplied input, one defaulted
+inputs:
+  diff:
+    required: true
+  style:
+    default: strict
+nodes:
+  - id: emit
+    bash: echo "style=$INPUTS_STYLE"
+`
+    );
+
+    const store = new InMemoryStore();
+    const result = await executeWorkflow(
+      makeDeps(store),
+      makePlatform(),
+      'conv-plat',
+      cwd,
+      await discover('direct-persist'),
+      'goal',
+      'conv-db',
+      { inputs: { diff: 'D1' } }
+    );
+
+    expect(result.success).toBe(true);
+    const run = [...store.runs.values()].find(r => r.workflow_name === 'direct-persist');
+    // `style` is NOT on the row — freezing a derived default would make the row lie
+    // about what the invocation supplied, and pin a stale default across a resume.
+    expect(run?.metadata?.inputs).toEqual({ diff: 'D1' });
+    // …yet the default still reaches the node, layered under the persisted map.
+    const emitted = store.events.find(e => e.event_type === 'node_completed');
+    expect(String(emitted?.data?.node_output)).toContain('style=strict');
+  });
+
+  it('a supplied value overrides the declared default on a top-level run', async () => {
+    await writeWorkflow(
+      'direct-override',
+      `
+name: direct-override
+description: supplied value beats the declared default
+inputs:
+  style:
+    default: strict
+nodes:
+  - id: emit
+    bash: echo "style=$INPUTS_STYLE"
+`
+    );
+
+    const store = new InMemoryStore();
+    const result = await executeWorkflow(
+      makeDeps(store),
+      makePlatform(),
+      'conv-plat',
+      cwd,
+      await discover('direct-override'),
+      'goal',
+      'conv-db',
+      { inputs: { style: 'terse' } }
+    );
+
+    expect(result.success).toBe(true);
+    const emitted = store.events.find(e => e.event_type === 'node_completed');
+    expect(String(emitted?.data?.node_output)).toContain('style=terse');
+  });
+
+  it('writes no inputs key for a bare top-level run, preserving pre-#2554 behaviour', async () => {
+    await writeWorkflow(
+      'direct-bare',
+      `
+name: direct-bare
+description: defaulted input, nothing supplied
+inputs:
+  style:
+    default: strict
+nodes:
+  - id: emit
+    bash: echo "style=$INPUTS_STYLE"
+`
+    );
+
+    const store = new InMemoryStore();
+    await executeWorkflow(
+      makeDeps(store),
+      makePlatform(),
+      'conv-plat',
+      cwd,
+      await discover('direct-bare'),
+      'goal',
+      'conv-db'
+    );
+
+    const run = [...store.runs.values()].find(r => r.workflow_name === 'direct-bare');
+    expect(run?.metadata?.inputs).toBeUndefined();
+  });
+
+  it('reconstitutes directly-supplied inputs on a COLD resume of a top-level run', async () => {
+    // The invocation channel is gone by resume time — the CLI process exited, the HTTP
+    // request completed. Only the run row can carry the values forward.
+    await writeWorkflow(
+      'direct-cold',
+      `
+name: direct-cold
+description: gated top-level run reading an input AFTER the gate
+interactive: true
+inputs:
+  style:
+    default: strict
+nodes:
+  - id: gate
+    approval:
+      message: "hold"
+  - id: after-gate
+    prompt: "resumed in $INPUTS.style style"
+    depends_on: [gate]
+`
+    );
+
+    const store = new InMemoryStore();
+    const { deps, prompts } = makeRecordingDeps(store);
+    await executeWorkflow(
+      deps,
+      makePlatform(),
+      'conv-plat',
+      cwd,
+      await discover('direct-cold'),
+      'goal',
+      'conv-db',
+      { inputs: { style: 'terse' } }
+    );
+
+    const run = [...store.runs.values()].find(r => r.workflow_name === 'direct-cold');
+    expect(run?.status).toBe('paused');
+    expect(run?.metadata?.inputs).toEqual({ style: 'terse' });
+
+    // Cold path: approve, hydrate from the persisted row alone, re-drive — and pass NO
+    // `inputs` this time, exactly as a resume does.
+    store.approveGate(run!.id);
+    const hydrated = await hydrateResumableRun(deps, (await store.getWorkflowRun(run!.id))!);
+    expect(hydrated).not.toBeNull();
+    await executeWorkflow(
+      deps,
+      makePlatform(),
+      'conv-plat',
+      cwd,
+      await discover('direct-cold'),
+      run!.user_message,
+      'conv-db',
+      { ...hydrated! }
+    );
+
+    expect((await store.getWorkflowRun(run!.id))?.status).toBe('completed');
+    expect(prompts.some(p => p.includes('resumed in terse style'))).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/workflows/src/utils/workflow-requirements.test.ts
+++ b/packages/workflows/src/utils/workflow-requirements.test.ts
@@ -2,9 +2,10 @@ import { describe, test, expect } from 'bun:test';
 import {
   assertWorkflowRequirementsMet,
   WorkflowRequirementError,
-  assertWorkflowInputsSatisfiable,
+  resolveTopLevelInputs,
   WorkflowMissingInputsError,
 } from './workflow-requirements';
+import { WorkflowInputContractError } from '../workflow-inputs';
 
 describe('assertWorkflowRequirementsMet', () => {
   test('passes when there are no requirements', () => {
@@ -34,33 +35,94 @@ describe('assertWorkflowRequirementsMet', () => {
   });
 });
 
-describe('assertWorkflowInputsSatisfiable (#2470)', () => {
-  test('passes with no declared inputs', () => {
-    expect(() => assertWorkflowInputsSatisfiable({})).not.toThrow();
-    expect(() => assertWorkflowInputsSatisfiable({ inputs: {} })).not.toThrow();
+describe('resolveTopLevelInputs (#2470, #2554)', () => {
+  test('returns undefined with no declared inputs and nothing supplied', () => {
+    expect(resolveTopLevelInputs({}, undefined)).toBeUndefined();
+    expect(resolveTopLevelInputs({ inputs: {} }, undefined)).toBeUndefined();
   });
 
   test('passes when all declared inputs are optional or defaulted', () => {
-    expect(() =>
-      assertWorkflowInputsSatisfiable({
-        inputs: { a: { default: 'x' }, b: { description: 'optional' } },
-      })
-    ).not.toThrow();
+    expect(
+      resolveTopLevelInputs(
+        { inputs: { a: { default: 'x' }, b: { description: 'opt' } } },
+        undefined
+      )
+    ).toBeUndefined();
   });
 
-  test('throws naming missing required inputs on a bare top-level run', () => {
+  test('returns ONLY the supplied values — declared defaults stay derived at execution', () => {
+    // `style` has a default, but nothing was supplied for it, so it must not appear here:
+    // persisting a derived default would freeze a snapshot of the workflow's current YAML.
+    expect(
+      resolveTopLevelInputs(
+        { name: 'block', inputs: { diff: { required: true }, style: { default: 'strict' } } },
+        { diff: 'D' }
+      )
+    ).toEqual({ diff: 'D' });
+  });
+
+  test('a required input that IS supplied satisfies the gate — the whole point of #2554', () => {
+    expect(
+      resolveTopLevelInputs(
+        { name: 'block', inputs: { diff: { required: true }, plan: { required: true } } },
+        { diff: 'D', plan: 'P' }
+      )
+    ).toEqual({ diff: 'D', plan: 'P' });
+  });
+
+  test('throws naming missing required inputs, and names the channels that can supply them', () => {
     let thrown: unknown;
     try {
-      assertWorkflowInputsSatisfiable({
-        name: 'block',
-        inputs: { diff: { required: true }, plan: { required: true }, style: { default: 's' } },
-      });
+      resolveTopLevelInputs(
+        {
+          name: 'block',
+          inputs: { diff: { required: true }, plan: { required: true }, style: { default: 's' } },
+        },
+        undefined
+      );
     } catch (err) {
       thrown = err;
     }
     expect(thrown).toBeInstanceOf(WorkflowMissingInputsError);
-    expect((thrown as WorkflowMissingInputsError).missing).toEqual(['diff', 'plan']);
-    expect((thrown as WorkflowMissingInputsError).message).toContain("'diff', 'plan'");
-    expect((thrown as WorkflowMissingInputsError).message).toContain('with:');
+    const err = thrown as WorkflowMissingInputsError;
+    expect(err.missing).toEqual(['diff', 'plan']);
+    expect(err.message).toContain("'diff', 'plan'");
+    expect(err.message).toContain('--input');
+    expect(err.message).toContain('console');
+    // The framing this issue removed: a required-input workflow is NOT uncallable.
+    expect(err.message).not.toContain('reusable block');
+  });
+
+  test('throws when only SOME required inputs are supplied, naming just the missing one', () => {
+    let thrown: unknown;
+    try {
+      resolveTopLevelInputs(
+        { name: 'block', inputs: { diff: { required: true }, plan: { required: true } } },
+        { diff: 'D' }
+      );
+    } catch (err) {
+      thrown = err;
+    }
+    expect((thrown as WorkflowMissingInputsError).missing).toEqual(['plan']);
+  });
+
+  test('rejects an undeclared key the same way a composing `with:` map is rejected', () => {
+    let thrown: unknown;
+    try {
+      resolveTopLevelInputs({ name: 'block', inputs: { style: {} } }, { stlye: 'terse' });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(WorkflowInputContractError);
+    const err = thrown as WorkflowInputContractError;
+    expect(err.undeclared).toEqual(['stlye']);
+    expect(err.message).toContain('stlye');
+    expect(err.message).toContain('style');
+  });
+
+  test('a workflow declaring no inputs keeps Phase-1 passthrough for supplied values', () => {
+    expect(resolveTopLevelInputs({ name: 'legacy' }, { anything: 'goes' })).toEqual({
+      anything: 'goes',
+    });
   });
 });

--- a/packages/workflows/src/utils/workflow-requirements.ts
+++ b/packages/workflows/src/utils/workflow-requirements.ts
@@ -10,6 +10,7 @@
  * just encodes the policy so all three behave identically.
  */
 import type { WorkflowRequirement, WorkflowInputSpec } from '../schemas/workflow';
+import { resolveDeclaredInputs, WorkflowInputContractError } from '../workflow-inputs';
 
 /** Minimal shape needed to evaluate requirements — avoids a full WorkflowDefinition dep. */
 export interface RequirementBearingWorkflow {
@@ -53,7 +54,7 @@ export function assertWorkflowRequirementsMet(
 }
 
 // ---------------------------------------------------------------------------
-// Declared-input satisfiability (#2470)
+// Declared-input resolution for a TOP-LEVEL invocation (#2470, #2554)
 // ---------------------------------------------------------------------------
 
 /** Minimal shape needed to evaluate declared inputs — avoids a full WorkflowDefinition dep. */
@@ -63,9 +64,14 @@ export interface InputBearingWorkflow {
 }
 
 /**
- * Thrown when a workflow that declares `required` inputs is invoked at the TOP LEVEL,
- * where no caller `with:` can satisfy them. `message` is user-facing and names the
- * missing inputs plus the two ways to supply them (`include:`/`workflow:` with `with:`).
+ * Thrown when a TOP-LEVEL invocation supplies no value for a workflow's `required`
+ * input. `message` is user-facing and names the missing inputs plus the channels that
+ * can carry them.
+ *
+ * Before #2554 this said the workflow "is a reusable block" that could only be called
+ * from another workflow — that was the defect, not a description of the design. A
+ * workflow is a workflow: it runs on its own when its inputs are supplied, and composes
+ * unchanged.
  */
 export class WorkflowMissingInputsError extends Error {
   constructor(
@@ -73,32 +79,62 @@ export class WorkflowMissingInputsError extends Error {
     public readonly missing: readonly string[]
   ) {
     const names = missing.map(n => `'${n}'`).join(', ');
+    const plural = missing.length === 1 ? '' : 's';
     super(
-      `This workflow declares required input${missing.length === 1 ? '' : 's'} ${names} that only a ` +
-        'caller can supply. It is a reusable block: reference it from another workflow with an ' +
-        '`include:` or `workflow:` node and pass the input(s) via `with:` (e.g. `with: { ' +
-        `${missing[0]}: $someNode.output }\`). No worktree was created and no AI cost was incurred.`
+      `This workflow requires input${plural} ${names}, and none was supplied. Supply ` +
+        `${missing.length === 1 ? 'it' : 'them'} with \`--input ${missing[0]}=<value>\` on the ` +
+        'CLI (repeat the flag per input), or fill the run form in the web console. When ' +
+        'composing this workflow from another, pass the same values via `with:` on the ' +
+        '`include:`/`workflow:` node. Chat platforms cannot supply inputs yet (#2555). ' +
+        'No worktree was created and no AI cost was incurred.'
     );
     this.name = 'WorkflowMissingInputsError';
   }
 }
 
 /**
- * Throw {@link WorkflowMissingInputsError} when a TOP-LEVEL invocation cannot satisfy the
- * workflow's declared `required` inputs (#2470). A `required` input never carries a default
- * (the loader drops that contradiction), so a bare run can never satisfy one — the block is
- * meant to be called via `include:`/`workflow:` `with:`. The workflow still LOADS and LISTS
- * normally (discovery/builder need it visible); only top-level invocation fails, before any
- * worktree/clone/AI cost. A workflow with no declared inputs always passes.
+ * Resolve a TOP-LEVEL invocation's declared inputs from the values its channel supplied
+ * (#2554) — `--input name=value` on the CLI, the `inputs` map on the run route, or the
+ * console's run form.
+ *
+ * Validation delegates to {@link resolveDeclaredInputs}, the same implementation
+ * `include:` and `workflow:` use, so a map accepted when composing is accepted here and
+ * vice versa. Callers run this BEFORE any worktree, clone, run row, or AI call, matching
+ * where the `workflow:` child path resolves its own `with:` map.
+ *
+ * Returns ONLY the caller-supplied entries — never the declared defaults that
+ * `resolveDeclaredInputs` folds in. Defaults stay DERIVED at execution time
+ * (`defaultRunInputs` in executor.ts), so they track the workflow's current YAML instead
+ * of freezing a snapshot into the run row, and a bare run persists exactly nothing and so
+ * behaves byte-for-byte as it did before this feature. The `workflow:` child path
+ * persists the resolved map instead; the effective `$INPUTS` is identical either way
+ * because the executor layers defaults *under* whatever the row carries — the difference
+ * is deliberate, not drift.
+ *
+ * @returns the supplied map, or undefined when nothing was supplied.
+ * @throws WorkflowMissingInputsError when a `required` input has no supplied value.
+ * @throws WorkflowInputContractError when a supplied key is not declared.
  */
-export function assertWorkflowInputsSatisfiable(workflow: InputBearingWorkflow): void {
-  const inputs = workflow.inputs;
-  if (!inputs) return;
-  const missing = Object.entries(inputs)
-    .filter(([, spec]) => spec.required === true)
-    .map(([name]) => name)
-    .sort();
-  if (missing.length > 0) {
-    throw new WorkflowMissingInputsError(workflow.name, missing);
+export function resolveTopLevelInputs(
+  workflow: InputBearingWorkflow,
+  supplied: Readonly<Record<string, string>> | undefined
+): Record<string, string> | undefined {
+  const suppliedMap = { ...supplied };
+  try {
+    resolveDeclaredInputs(
+      suppliedMap,
+      workflow.inputs,
+      `Cannot run workflow '${workflow.name ?? 'unknown'}'`,
+      'it'
+    );
+  } catch (err) {
+    // Re-shape only the missing-required case: its shared message ends in "Pass them
+    // through 'with:'", which is the wrong remediation for a direct run. The undeclared-key
+    // message already reads correctly and lists the declared names, so it propagates as-is.
+    if (err instanceof WorkflowInputContractError && err.missingRequired.length > 0) {
+      throw new WorkflowMissingInputsError(workflow.name, err.missingRequired);
+    }
+    throw err;
   }
+  return Object.keys(suppliedMap).length > 0 ? suppliedMap : undefined;
 }

--- a/packages/workflows/src/workflow-inputs.test.ts
+++ b/packages/workflows/src/workflow-inputs.test.ts
@@ -52,6 +52,13 @@ describe('parseInputAssignments (#2554)', () => {
     expect(() => parseInputAssignments(['=api'])).toThrow(/Invalid input name/);
   });
 
+  test('never echoes the value back in a bad-name error', () => {
+    // The message reaches the user's terminal; the name identifies the flag to fix,
+    // while the value after `=` is user content and often a secret.
+    expect(() => parseInputAssignments(['1bad=hunter2'])).toThrow(/'1bad'/);
+    expect(() => parseInputAssignments(['1bad=hunter2'])).not.toThrow(/hunter2/);
+  });
+
   test('rejects a duplicate name rather than silently taking the last', () => {
     expect(() => parseInputAssignments(['scope=api', 'scope=web'])).toThrow(
       /Duplicate input 'scope'/

--- a/packages/workflows/src/workflow-inputs.test.ts
+++ b/packages/workflows/src/workflow-inputs.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Unit tests for the declared-input contract module (#2470, #2554).
+ *
+ * These cover the two pieces every invocation surface shares: the `name=value` grammar
+ * a textual channel speaks, and the structured error data that lets a surface re-shape
+ * a contract violation's remediation without parsing the message string.
+ */
+import { describe, test, expect } from 'bun:test';
+import {
+  parseInputAssignments,
+  resolveDeclaredInputs,
+  defaultRunInputs,
+  WorkflowInputContractError,
+} from './workflow-inputs';
+
+describe('parseInputAssignments (#2554)', () => {
+  test('parses one assignment per entry', () => {
+    expect(parseInputAssignments(['scope=api', 'style=terse'])).toEqual({
+      scope: 'api',
+      style: 'terse',
+    });
+  });
+
+  test('splits on the FIRST = so a value may contain =', () => {
+    expect(parseInputAssignments(['query=a=b=c'])).toEqual({ query: 'a=b=c' });
+  });
+
+  test('accepts an empty value as a deliberate empty string', () => {
+    expect(parseInputAssignments(['scope='])).toEqual({ scope: '' });
+  });
+
+  test('accepts hyphens and underscores in a name, matching the shared grammar', () => {
+    expect(parseInputAssignments(['base-branch=dev', '_internal=1'])).toEqual({
+      'base-branch': 'dev',
+      _internal: '1',
+    });
+  });
+
+  test('returns an empty map for no assignments', () => {
+    expect(parseInputAssignments([])).toEqual({});
+  });
+
+  test('rejects an entry with no =', () => {
+    expect(() => parseInputAssignments(['scope'])).toThrow(WorkflowInputContractError);
+    expect(() => parseInputAssignments(['scope'])).toThrow(/expected 'name=value'/);
+  });
+
+  test('rejects a name that is not a valid input name', () => {
+    // Leading digit and a dot are both outside INPUT_NAME_PATTERN.
+    expect(() => parseInputAssignments(['1scope=api'])).toThrow(/Invalid input name/);
+    expect(() => parseInputAssignments(['my.key=api'])).toThrow(/Invalid input name/);
+    expect(() => parseInputAssignments(['=api'])).toThrow(/Invalid input name/);
+  });
+
+  test('rejects a duplicate name rather than silently taking the last', () => {
+    expect(() => parseInputAssignments(['scope=api', 'scope=web'])).toThrow(
+      /Duplicate input 'scope'/
+    );
+  });
+});
+
+describe('resolveDeclaredInputs structured error data (#2554)', () => {
+  test('carries the undeclared names on the error', () => {
+    let caught: unknown;
+    try {
+      resolveDeclaredInputs({ stlye: 'x' }, { style: {} }, "Node 'n'", 'block');
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(WorkflowInputContractError);
+    const err = caught as WorkflowInputContractError;
+    expect(err.undeclared).toEqual(['stlye']);
+    expect(err.missingRequired).toEqual([]);
+  });
+
+  test('carries the missing required names on the error', () => {
+    let caught: unknown;
+    try {
+      resolveDeclaredInputs({}, { diff: { required: true }, scope: { required: true } }, 'C', 'b');
+    } catch (err) {
+      caught = err;
+    }
+    const err = caught as WorkflowInputContractError;
+    expect(err.missingRequired.slice().sort()).toEqual(['diff', 'scope']);
+    expect(err.undeclared).toEqual([]);
+  });
+
+  test('a grammar error carries neither list', () => {
+    let caught: unknown;
+    try {
+      parseInputAssignments(['nope']);
+    } catch (err) {
+      caught = err;
+    }
+    const err = caught as WorkflowInputContractError;
+    expect(err.undeclared).toEqual([]);
+    expect(err.missingRequired).toEqual([]);
+  });
+});
+
+describe('defaultRunInputs', () => {
+  test('synthesizes declared defaults only, never required inputs', () => {
+    expect(defaultRunInputs({ style: { default: 'strict' }, diff: { required: true } })).toEqual({
+      style: 'strict',
+    });
+  });
+
+  test('is undefined when nothing is declared or nothing is defaulted', () => {
+    expect(defaultRunInputs(undefined)).toBeUndefined();
+    expect(defaultRunInputs({ diff: { required: true } })).toBeUndefined();
+  });
+});

--- a/packages/workflows/src/workflow-inputs.ts
+++ b/packages/workflows/src/workflow-inputs.ts
@@ -154,8 +154,10 @@ export function parseInputAssignments(assignments: readonly string[]): Record<st
     }
     const name = assignment.slice(0, eq);
     if (!INPUT_NAME_PATTERN.test(name)) {
+      // Names the offending NAME, never the whole assignment — the value after `=` is
+      // user content (often a secret) and the name alone identifies which flag to fix.
       throw new WorkflowInputContractError(
-        `Invalid input name '${name}' in '${assignment}': a name must start with a letter or ` +
+        `Invalid input name '${name}': a name must start with a letter or ` +
           'underscore and contain only letters, digits, underscores, and hyphens.'
       );
     }

--- a/packages/workflows/src/workflow-inputs.ts
+++ b/packages/workflows/src/workflow-inputs.ts
@@ -1,32 +1,52 @@
 /**
- * The declared-input contract (#2470), shared by both call surfaces.
+ * The declared-input contract (#2470, #2554), shared by every call surface.
  *
- * A workflow's `inputs:` block is one contract with two callers:
+ * A workflow's `inputs:` block is one contract with three callers:
  *   - `include:` resolves it at LOAD time (include-expander.ts), splicing values into
  *     `$INPUTS.<name>` before the DAG is ever persisted;
  *   - `workflow:` resolves it at RUN time (executor.ts), persisting the resolved map to
- *     the child's `metadata.inputs`.
+ *     the child's `metadata.inputs`;
+ *   - a DIRECT top-level invocation resolves it at the invocation gate (#2554) —
+ *     `resolveTopLevelInputs` in utils/workflow-requirements.ts — from values supplied
+ *     by the CLI's `--input name=value` or the run route's `inputs` map.
  *
- * They must agree — a `with:` map accepted by one and rejected by the other would make
- * the same block behave differently depending on how it was called. This module is the
- * single implementation both go through, so parity is structural rather than a comment
- * asking two files to stay in sync.
+ * They must agree — a map accepted by one and rejected by another would make the same
+ * workflow behave differently depending on how it was called. This module is the single
+ * implementation they all go through, so parity is structural rather than a comment
+ * asking three files to stay in sync.
  *
- * Semantics (identical on both surfaces): a workflow that declares NO `inputs:` keeps
+ * Semantics (identical on every surface): a workflow that declares NO `inputs:` keeps
  * Phase-1 passthrough (the caller's map is forwarded verbatim). One that declares
  * `inputs:` applies each spec's `default` for an omitted name, rejects an unsupplied
  * `required` input, and rejects a caller key the workflow does not declare.
  */
 import type { WorkflowDefinition } from './schemas/workflow';
+import { INPUT_NAME_PATTERN } from './schemas/dag-node';
 
 /** A workflow's declared `inputs:` block, or undefined when it declares none. */
 export type DeclaredInputs = WorkflowDefinition['inputs'];
 
-/** Thrown when a caller's `with:` map violates the callee's declared contract. */
+/**
+ * Thrown when a caller's supplied map violates the callee's declared contract.
+ *
+ * `undeclared` and `missingRequired` carry the offending names as data so a caller can
+ * re-shape the remediation for its own surface — a direct run must say
+ * `--input name=value`, not "pass it through `with:`" — without parsing the message
+ * string. Exactly one is non-empty for a contract violation; both are empty for the
+ * grammar errors raised by {@link parseInputAssignments}.
+ */
 export class WorkflowInputContractError extends Error {
-  constructor(message: string) {
+  readonly undeclared: readonly string[];
+  readonly missingRequired: readonly string[];
+
+  constructor(
+    message: string,
+    details?: { undeclared?: readonly string[]; missingRequired?: readonly string[] }
+  ) {
     super(message);
     this.name = 'WorkflowInputContractError';
+    this.undeclared = details?.undeclared ?? [];
+    this.missingRequired = details?.missingRequired ?? [];
   }
 }
 
@@ -61,7 +81,8 @@ export function resolveDeclaredInputs(
   const undeclared = Object.keys(supplied).filter(k => !Object.hasOwn(declared, k));
   if (undeclared.length > 0) {
     throw new WorkflowInputContractError(
-      `${context}: ${calleeLabel} does not declare input${undeclared.length === 1 ? '' : 's'} ${quoteNames(undeclared)}. Declared inputs: ${Object.keys(declared).sort().join(', ') || '(none)'}.`
+      `${context}: ${calleeLabel} does not declare input${undeclared.length === 1 ? '' : 's'} ${quoteNames(undeclared)}. Declared inputs: ${Object.keys(declared).sort().join(', ') || '(none)'}.`,
+      { undeclared }
     );
   }
 
@@ -80,7 +101,8 @@ export function resolveDeclaredInputs(
   }
   if (missingRequired.length > 0) {
     throw new WorkflowInputContractError(
-      `${context}: ${calleeLabel} requires input${missingRequired.length === 1 ? '' : 's'} ${quoteNames(missingRequired)}. Pass ${missingRequired.length === 1 ? 'it' : 'them'} through 'with:'.`
+      `${context}: ${calleeLabel} requires input${missingRequired.length === 1 ? '' : 's'} ${quoteNames(missingRequired)}. Pass ${missingRequired.length === 1 ? 'it' : 'them'} through 'with:'.`,
+      { missingRequired }
     );
   }
   return resolved;
@@ -102,4 +124,47 @@ export function defaultRunInputs(declared: DeclaredInputs): Record<string, strin
     if (spec.default !== undefined) defaults[name] = spec.default;
   }
   return Object.keys(defaults).length > 0 ? defaults : undefined;
+}
+
+/**
+ * Parse `name=value` assignments into a supplied-input map (#2554) — the grammar the
+ * CLI's repeatable `--input` flag speaks, kept here so every surface that ever accepts
+ * a textual assignment speaks exactly the same one.
+ *
+ * The split is on the FIRST `=` only: the value is the literal remainder, so
+ * `msg=a=b` yields `a=b`. An empty value (`name=`) is a legitimate empty string. A
+ * duplicate name is rejected rather than silently last-wins — a repeated assignment is
+ * far more likely a mistake than an intent, and quietly picking one is the kind of
+ * behaviour the fail-fast rule exists to prevent.
+ *
+ * Names are validated against the shared {@link INPUT_NAME_PATTERN} rather than a local
+ * copy of the grammar; that constant's docblock explains why a second copy drifts
+ * silently in the dangerous direction.
+ *
+ * @throws WorkflowInputContractError on a missing `=`, an invalid name, or a duplicate.
+ */
+export function parseInputAssignments(assignments: readonly string[]): Record<string, string> {
+  const parsed: Record<string, string> = {};
+  for (const assignment of assignments) {
+    const eq = assignment.indexOf('=');
+    if (eq === -1) {
+      throw new WorkflowInputContractError(
+        `Invalid input assignment '${assignment}': expected 'name=value'.`
+      );
+    }
+    const name = assignment.slice(0, eq);
+    if (!INPUT_NAME_PATTERN.test(name)) {
+      throw new WorkflowInputContractError(
+        `Invalid input name '${name}' in '${assignment}': a name must start with a letter or ` +
+          'underscore and contain only letters, digits, underscores, and hyphens.'
+      );
+    }
+    if (Object.hasOwn(parsed, name)) {
+      throw new WorkflowInputContractError(
+        `Duplicate input '${name}': supply each input at most once.`
+      );
+    }
+    parsed[name] = assignment.slice(eq + 1);
+  }
+  return parsed;
 }


### PR DESCRIPTION
## Summary

- **Problem:** Declaring an input a workflow actually needs made it uninvokable. `assertWorkflowInputsSatisfiable` refused *every* top-level run of a workflow with a `required` input, calling it "a reusable block" only `include:`/`workflow:` could call.
- **Why it matters:** A workflow became callable-only at exactly the moment it became worth composing. `review-github-issue.yaml` had to choose between running on its own and composing into ten parents — and a workflow you cannot run alone is hard to develop, test, or debug. This is the invocation half of "a workflow is a workflow" (#1764 is the config half), and it unblocks the #2123 decomposition.
- **What changed:** Values can now be supplied at invocation — `--input name=value` on the CLI (repeatable), an `inputs` map on `POST /api/workflows/:name/run`, and a run form in the console. All three go through the **same** `resolveDeclaredInputs` contract a caller's `with:` map goes through, so rejections match, defaults still apply, and the refusal still lands before any worktree, clone, or AI cost. Supplied values persist to `metadata.inputs`, so a cold resume replays the same invocation.
- **What did NOT change (scope boundary):** No new YAML surface — `inputs:` already exists (#2470); this is an invocation channel for it, so the workflow-language constitution is untouched. `include:`/`workflow:` `with:` is byte-for-byte unchanged. Chat adapters deliberately get **no** channel (they carry only a trigger message) and keep the reworded pre-cost refusal — tracked in #2555. Typed/non-string input values remain #2453's; the canonical-representation rule is held so #2453 can widen this channel without redesigning it.

## UX Journey

### Before

```
  Author                 Archon
  ──────                 ──────
  writes review-block.yaml
    inputs: {diff: {required: true}}
  archon workflow run review-block ────▶  assertWorkflowInputsSatisfiable
                                          ✗ REFUSED, always
  sees "It is a reusable block:      ◀──  "reference it from another
  reference it from another               workflow with an include:
  workflow…"                               or workflow: node"

  (the only way to run it is to write a SECOND workflow that calls it)
```

### After

```
  Author                 Archon
  ──────                 ──────
  archon workflow run review-block \
    --input diff="$(git diff)"     ────▶  *resolveTopLevelInputs*
    --input style=terse                   → resolveDeclaredInputs (shared contract)
                                          ✓ validated pre-cost
                                          *metadata.inputs stamped on the run row*
                                          $INPUTS.diff / $INPUTS_DIFF reach nodes
  run completes                     ◀──

  console: picks review-block       ────▶  *run form renders a field per input*
           fills "diff" *            ◀──   Start disabled until required filled
           Start run                ────▶  POST …/run { inputs: {...} }

  archon workflow run review-block  ────▶  ✗ still refused, pre-cost —
    (nothing supplied)              ◀──   *now naming --input and the console*

  Slack: "run review-block"         ────▶  ✗ refused (no channel yet, #2555)
```

## Architecture Diagram

### Before

```
  include: with: ──┐
                   ├──▶ resolveDeclaredInputs ──▶ (load-time splice / child metadata.inputs)
  workflow: with: ─┘

  CLI  ──┐
  HTTP ──┼──▶ assertWorkflowInputsSatisfiable(workflow)  ──✗ any required input
  chat ──┘         (no parameter for supplied values)

  executor: createWorkflowRun{metadata} ──▶ defaultRunInputs merge ──▶ dag-executor
                                                                        ├─▶ $INPUTS.<name>  (AI/prompt)
                                                                        └─▶ INPUTS_<SNAKE>  (bash/script)
```

### After

```
  include: with: ──┐
                   ├──▶ resolveDeclaredInputs ──▶ (load-time splice / child metadata.inputs)
  workflow: with: ─┘         ▲
                             ‖ (same implementation — parity is structural)
  CLI  --input k=v ──▶ [+] parseInputAssignments ══╗
  HTTP { inputs } ═══▶ [~] HandleMessageContext    ╠══▶ [+] resolveTopLevelInputs
      (via [~] WorkflowDispatchOptions.inputs      ║          ✗ pre-cost refusal
       and [~] WorkflowRoutingContext.inputs)      ║
  chat  ─────────────────(supplies nothing)════════╝

  [~] executor: createWorkflowRun{metadata + inputs} ──▶ defaultRunInputs merge (unchanged)
  [~] orchestrator: pre-created row{metadata + inputs}         │
                                                                ▼
                                                          dag-executor (unchanged)
                                                            ├─▶ $INPUTS.<name>
                                                            └─▶ INPUTS_<SNAKE>

  [+] web console: DraftRunCard form ──▶ [+] lib/workflow-inputs ──▶ [~] startRun
```

**Connection inventory**

| From | To | Status | Notes |
|------|----|--------|-------|
| `cli/cli.ts` (parseArgs) | `commands/workflow.ts` | **modified** | `input: {type:'string', multiple:true}` → `WorkflowRunOptions.inputs` (first repeatable flag in the tree) |
| `commands/workflow.ts` | `workflows/workflow-inputs` | **new** | `parseInputAssignments` — the `name=value` grammar |
| `commands/workflow.ts` | `utils/workflow-requirements` | **modified** | `assertWorkflowInputsSatisfiable` → `resolveTopLevelInputs(workflow, supplied)` |
| `utils/workflow-requirements` | `workflow-inputs` | **new** | gate now delegates to the shared `resolveDeclaredInputs` |
| `server/routes/api.ts` | `core/types` (`HandleMessageContext`) | **modified** | `workflowInputs` — a side channel, never the message text |
| `orchestrator-agent` | `orchestrator` (`WorkflowRoutingContext`) | **modified** | `inputs` threaded to the console's background-dispatch path |
| `orchestrator-agent` / `orchestrator` | `workflows/executor` | **modified** | `ExecuteWorkflowOptions.inputs` |
| `executor.ts` | `workflow_runs.metadata` | **modified** | stamps `SUBRUN_METADATA_KEYS.inputs` on a fresh row only |
| `web/DraftRunCard` | `web/console/lib/workflow-inputs` | **new** | the form's two pure decisions, unit-tested |
| `web/startRun` | `POST /api/workflows/:name/run` | **modified** | `inputs` in JSON; JSON-encoded `inputs` form field in multipart |
| `dag-executor` → node surfaces | — | unchanged | delivery already worked for a top-level row; no engine change |
| `include-expander` / `workflow:` child spawn | — | unchanged | composition untouched |

## Label Snapshot

- Risk: `risk: low`
- Size: `size: L`
- Scope: `workflows`
- Module: `workflows:workflow-inputs`, `cli:workflow`, `server:api`, `core:orchestrator`, `web:console`

## Change Metadata

- Change type: `feature`
- Primary scope: `multi` (workflows, cli, server, core, web, docs)

## Linked Issue

- Closes #2554
- Related #2555 (chat adapters: natural-language → inputs; filed during planning, deliberately unscoped)
- Related #2453 (declared input value shapes), #1764 (composed workflows run as authored), #2123 (the defaults overhaul this unblocks), #2470 (delivered the `inputs:`/`with:`/`$INPUTS` baseline)

## Validation Evidence (required)

```bash
bun run validate     # EXIT=0 — all 10 steps green
```

Focused suites:

- `bun test src/workflow-inputs.test.ts` (workflows) — 13 pass / 0 fail (new file)
- `bun test src/utils/workflow-requirements.test.ts` — 11 pass / 0 fail
- `bun test src/subrun.test.ts` — 64 pass / 0 fail (5 new direct-run cases)
- `bun test src/commands/workflow.test.ts` (cli) — 221 pass / 0 fail (6 new)
- `bun test src/routes/api.workflow-runs.test.ts` (server) — 104 pass / 0 fail (5 new)
- `bun test src/orchestrator/orchestrator-agent.test.ts` (core) — 220 pass / 0 fail (5 new)
- `bun test src/lib/ src/experiments/console/` (web) — 548 pass / 0 fail across 47 files

**Falsification of the core change:** removing the `SUBRUN_METADATA_KEYS.inputs` spread from `executor.ts` turns 4 of the 5 new subrun tests red (60 pass / 4 fail), and the bare-run test correctly stays green. Restored → 64 pass. The tests fail for the intended reason.

## Security Impact (required)

- New permissions/capabilities? **No**
- New external network calls? **No**
- Secrets/tokens handling changed? **No**
- File system access scope changed? **No**

Two notes worth a reviewer's eye, both preserving existing invariants:

- **`$INPUTS` still never reaches shell source.** Text substitution stays in the non-`shellSafe` branch; `bash:`/`script:` nodes read `INPUTS_<UPPER_SNAKE>` env vars, exactly as #2115 hardened. A direct run changes nothing here.
- **Input names are validated** against the shared `INPUT_NAME_PATTERN` (one source, `schemas/dag-node.ts`), and the HTTP route refuses any `inputs` payload that is not a flat object of strings — matching `readSubrunMetadata`'s guard, so nothing unreadable can be persisted. Supplied **values** are never logged (key names only).

## Compatibility / Migration

- Backward compatible? **Yes** — purely additive. A bare run of a defaulted workflow persists nothing and behaves byte-for-byte as before (regression-tested). A previously-unrunnable workflow becomes runnable.
- Config/env changes? **No**
- Database migration needed? **No** — `metadata.inputs` is an existing key with an existing reader; only the set of runs that carry it widens. An older Archon build ignores it on a top-level run exactly as it does today.

## Human Verification (required)

Verified scenarios (live runs against a real fixture repo, not only unit tests):

- **CLI, bare run of a required-input workflow** → refused with `requires input 'scope', and none was supplied … --input scope=<value> … web console … (#2555). No worktree was created and no AI cost was incurred.`
- **CLI, `--input scope=auth --input style=terse`** → completed; the `script:` node printed `script scope=auth style=terse`; row metadata `{"inputs":{"scope":"auth","style":"terse"}}`.
- **CLI, `--input scope=billing`** (style omitted) → node received `style=strict` from the declared default, while the row recorded only `{"inputs":{"scope":"billing"}}` — the default is *not* frozen onto the row.
- **HTTP, `inputs: {scope: 5}`** → `400 {"error":"inputs value for 'scope' must be a string"}`.
- **HTTP, valid map** (console background path) → `200`, run `completed`, metadata `{"inputs":{"scope":"http-path","style":"loose"}}`. This is the path that would have silently done nothing had `dispatchBackgroundWorkflow` not been threaded.
- **HTTP, nothing supplied** on a required-input workflow → run count unchanged (1 → 1): refused before a run row existed.

Edge cases checked: `=` inside a value (`msg=a=b` → `a=b`); empty value (`name=`) as a deliberate empty string; duplicate `--input` rejected rather than last-wins; invalid name rejected; `--input` + `--resume` rejected; repeated `--input` survives the `--detach` argv rebuild (pinned by test); cold resume of a top-level run replays the values (unit-tested against the persisted row alone, no invocation channel in the loop).

What was not verified: the console form was not click-tested in a browser — `@archon/web` has no React DOM test harness, so the card's two real decisions were extracted into `console/lib/workflow-inputs.ts` and unit-tested instead, and the HTTP path underneath the form was verified live end-to-end.

## Side Effects / Blast Radius (required)

- **Affected subsystems:** the workflow invocation gate (CLI + orchestrator), the run route, run-row creation in both `executor.ts` and `dispatchBackgroundWorkflow`, and the console draft-run card. The DAG executor and both composition paths are untouched.
- **Potential unintended effects:** the gate's signature change touches every top-level dispatch, so the riskiest failure mode would be a dispatch branch that forgets to thread `inputs`. Two branches create a fresh row (`executeWorkflow` and the orchestrator's pre-created row) and both are covered; the true-resume branch deliberately does not thread it.
- **Guardrails:** the refusal remains pre-cost on every surface, so a mis-threaded value fails loudly at the gate or at the `$INPUTS.<name>` reference site (`executor-shared.ts` throws with a "Did you mean / Available inputs" hint) rather than running with a wrong value. `workflow.required_inputs_unsatisfiable` logs the missing and supplied **key names**.

## Rollback Plan (required)

- Fast rollback: `git revert a37fcd21` — one commit, no schema change, no data an older build would misread.
- Feature flags: none (a channel with nothing supplied is byte-for-byte prior behavior).
- Observable failure symptoms: a required-input workflow refusing despite `--input` being passed; a run starting with empty `$INPUTS_*`; a console Start button stuck disabled.

## Risks and Mitigations

- **Risk:** the gate now runs on paths that previously could not exist, and a resume supplies nothing — naively re-gating would make every resume of a required-input run impossible.
  - **Mitigation:** the gate is skipped on any resume path (CLI and orchestrator), documented inline; the row's inputs were validated at creation. CLI `--input` + `--resume` is rejected outright rather than silently ignored. Covered by an orchestrator test.
- **Risk:** persisting the *resolved* map (supplied + defaults), mirroring the `workflow:` child path, would start freezing declared defaults onto rows for every existing defaulted workflow — a silent behavior change and a stale snapshot across resume.
  - **Mitigation:** only caller-supplied values are persisted; defaults stay derived at execution. Regression-tested both ways (a bare run writes no `inputs` key). The asymmetry with the child path is deliberate and documented at the call site — effective `$INPUTS` is identical either way.
- **Risk:** `packages/web/src/lib/api.generated.d.ts` was stale (missing `inputs`/`returns` since #2523), so a naive regeneration could have carried unrelated drift.
  - **Mitigation:** regenerated in full from this branch's own server and formatted; the real diff is 9 insertions / 1 deletion — only the two fields and the route description. No unrelated drift.

---

Plan: https://github.com/coleam00/Archon/issues/2554#issuecomment-5314152150


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflows now accept declared inputs through the CLI, web console, or API.
  * CLI users can provide multiple `--input name=value` options.
  * The web console displays input fields, descriptions, defaults, and required indicators.
  * Supplied inputs are preserved across workflow runs and resumes.

* **Bug Fixes**
  * Improved validation and error messages for missing, duplicate, malformed, or undeclared inputs.
  * Prevented unsupported inputs during dry runs and resumed executions.

* **Documentation**
  * Added guidance for configuring and supplying workflow inputs across supported run methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->