### PR TITLE
fix(isolation): overlay walk scripts mis-decoded adversarial filenames, and forked per entry

### DIFF
--- a/packages/isolation/src/container/overlay-scripts.test.ts
+++ b/packages/isolation/src/container/overlay-scripts.test.ts
@@ -248,6 +248,34 @@ describe('apply script — guards pinned on the apply copy', () => {
     rmSync(root, { recursive: true, force: true });
   });
 
+  // The apply-side mirror of the summary's TAB-target guard. Deleting that guard left
+  // the whole suite green, which is this PR's own lesson reproduced inside its own
+  // fix: a guard added to both copies but tested on one. The consequence is an M1
+  // violation rather than an escape — `symlink_escapes` still catches real traversal
+  // on the raw target — but it is the sharp kind. Measured with the guard removed, for
+  // a target `foo<TAB>bar` that contains no `..`:
+  //   summary → S x unsafe-record-target   (approver is told it was skipped)
+  //   apply   → K x, symlink lands in the live root
+  // i.e. the summary lies to the approver about what apply will do.
+  test.skipIf(isWin)('a TAB in a symlink target is refused by the APPLY script too', () => {
+    const { root, upper, dest, ws } = makeDirs();
+    symlinkSync('foo\tbar', join(upper, 'x'));
+
+    const { records } = runScript(buildApplyScript(), upper, dest, ws);
+
+    expect(records).toEqual([{ tag: 'S', fields: ['x', 'unsafe-record-target'] }]);
+    // Nothing reproduced into the destination under any spelling of the name.
+    expect(existsSync(join(dest, 'x'))).toBe(false);
+    let landed = true;
+    try {
+      lstatSync(join(dest, 'x'));
+    } catch {
+      landed = false;
+    }
+    expect(landed).toBe(false);
+    rmSync(root, { recursive: true, force: true });
+  });
+
   // R4: the newline fix had two halves and only the whiteout half was pinned. The
   // other half is safe_parent — `$(dirname)` stripped the trailing newline, so it
   // confined `$DEST/d` while the write went through `$DEST/d\n`. With a dest symlink
@@ -420,6 +448,27 @@ describe('summary script — faithful representation (M1)', () => {
     // (Asserting merely that no `L … '0'` record exists passed before the guard too,
     // because the forged flag was a path rather than '0'.)
     expect(records).toEqual([{ tag: 'S', fields: ['a?b', 'unsafe-record-name'] }]);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  // C1's mirror on the consent surface. The apply script's valid_name refusal is
+  // pinned by two tests; the summary's call site was pinned by none — bypassing it
+  // left the whole suite green. The failure is the inverse of an over-apply: apply
+  // correctly refuses, while the summary tells the approver that `subdir` itself is
+  // about to be deleted. A human asked to approve a deletion that will not happen is
+  // being misinformed just as surely as one shown a deletion that will.
+  test('the summary refuses an unsafe whiteout name rather than reporting a deletion', () => {
+    const { root, upper, dest, ws } = makeDirs();
+    mkdirSync(join(upper, 'subdir'), { recursive: true });
+    writeFileSync(join(upper, 'subdir', '.wh.'), ''); // decodes to the empty name
+    mkdirSync(join(dest, 'subdir'), { recursive: true });
+    writeFileSync(join(dest, 'subdir', 'keepme.txt'), 'precious');
+
+    const { records } = runScript(buildSummaryScript(), upper, dest, ws);
+
+    expect(records.some(r => r.tag === 'S' && r.fields[1] === 'unsafe-whiteout-name')).toBe(true);
+    // Nothing may be presented as a pending deletion — least of all the parent dir.
+    expect(records.some(r => r.tag === 'D')).toBe(false);
     rmSync(root, { recursive: true, force: true });
   });
 

--- a/packages/isolation/src/container/overlay-scripts.test.ts
+++ b/packages/isolation/src/container/overlay-scripts.test.ts
@@ -134,6 +134,53 @@ describe('apply script — C1 whiteout-name traversal', () => {
   });
 });
 
+// The rel/base/dir split uses shell parameter expansion rather than forking
+// sed/basename/dirname per entry (#2558). Those are NOT drop-in equivalents, and
+// the divergences all live in the path-splitting the traversal guards consume:
+// `${rel%/*}` returns rel unchanged when there is no slash where `dirname` returns
+// '.', and `${base#.wh.}` strips one prefix occurrence where `cut -c5-` strips
+// four characters. Every pre-existing apply test that SUCCEEDS operates at the top
+// level, so a wrong `dir` at depth would not have failed any of them. These do.
+// Deliberately no skipIf — Windows is where the fork cost was, so this is exactly
+// where the replacement has to be proven.
+describe('apply script — rel/base/dir splitting', () => {
+  test('a legit whiteout inside a subdirectory deletes exactly that nested file', () => {
+    const { root, upper, dest, ws } = makeDirs();
+    mkdirSync(join(upper, 'sub'), { recursive: true });
+    writeFileSync(join(upper, 'sub', '.wh.gone.txt'), '');
+    mkdirSync(join(dest, 'sub'), { recursive: true });
+    writeFileSync(join(dest, 'sub', 'gone.txt'), 'bye');
+    writeFileSync(join(dest, 'sub', 'stay.txt'), 'keep');
+    writeFileSync(join(dest, 'gone.txt'), 'different file, same basename');
+
+    const { records } = runScript(buildApplyScript(), upper, dest, ws);
+
+    expect(existsSync(join(dest, 'sub', 'gone.txt'))).toBe(false);
+    expect(existsSync(join(dest, 'sub', 'stay.txt'))).toBe(true);
+    // The decisive assertion: a `dir` that came back empty would resolve the
+    // target to top-level 'gone.txt' and delete the wrong file entirely.
+    expect(existsSync(join(dest, 'gone.txt'))).toBe(true);
+    expect(records.some(r => r.tag === 'D' && r.fields[0] === 'sub/gone.txt')).toBe(true);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test('`.wh..wh.x` decodes to `.wh.x` — one prefix stripped, not four characters', () => {
+    // cut -c5- and ${base#.wh.} agree here, and this pins that they keep agreeing:
+    // stripping greedily (##) would decode to 'x' and delete the wrong entry.
+    const { root, upper, dest, ws } = makeDirs();
+    writeFileSync(join(upper, '.wh..wh.x'), '');
+    writeFileSync(join(dest, '.wh.x'), 'the real target');
+    writeFileSync(join(dest, 'x'), 'must survive');
+
+    const { records } = runScript(buildApplyScript(), upper, dest, ws);
+
+    expect(existsSync(join(dest, '.wh.x'))).toBe(false);
+    expect(existsSync(join(dest, 'x'))).toBe(true);
+    expect(records.some(r => r.tag === 'D' && r.fields[0] === '.wh.x')).toBe(true);
+    rmSync(root, { recursive: true, force: true });
+  });
+});
+
 describe('apply script — C2 special files + setuid', () => {
   test('setuid/setgid/sticky bits are stripped from applied files', () => {
     const { root, upper, dest, ws } = makeDirs();

--- a/packages/isolation/src/container/overlay-scripts.test.ts
+++ b/packages/isolation/src/container/overlay-scripts.test.ts
@@ -164,9 +164,53 @@ describe('apply script — rel/base/dir splitting', () => {
     rmSync(root, { recursive: true, force: true });
   });
 
+  // The expansions are not merely cheaper than the forks they replaced — they are
+  // correct where the forks were not, and these two cases were live holes. Nothing
+  // in the suite caught either, because the whole pre-PR implementation passes it.
+  test.skipIf(isWin)('a whiteout name ending in a newline deletes THAT file, not its stem', () => {
+    // `$(basename …)` strips trailing newlines, so `.wh.evil\n` used to decode to
+    // `evil` and delete a different, innocent file — while `safe_parent` also
+    // confined the wrong path. Skipped on win32: creating such a name is not
+    // portable there, and these scripts only ever run in the Linux runner image.
+    const { root, upper, dest, ws } = makeDirs();
+    writeFileSync(join(upper, '.wh.evil\n'), '');
+    writeFileSync(join(dest, 'evil\n'), 'the real target');
+    writeFileSync(join(dest, 'evil'), 'innocent bystander');
+
+    const { records } = runScript(buildApplyScript(), upper, dest, ws);
+
+    expect(existsSync(join(dest, 'evil\n'))).toBe(false);
+    expect(existsSync(join(dest, 'evil'))).toBe(true);
+    expect(records.some(r => r.tag === 'D' && r.fields[0] === 'evil\n')).toBe(true);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test('a whiteout under a `-`-prefixed directory still decodes instead of being copied', () => {
+    // `basename "-d/.wh.foo"` exits 1 with "illegal option -- d", so `base` came
+    // back empty, the `.wh.*` arm never matched, and the marker was applied as an
+    // ordinary FILE — planting a `.wh.foo` file in the live root instead of
+    // deleting `foo`.
+    const { root, upper, dest, ws } = makeDirs();
+    mkdirSync(join(upper, '-d'), { recursive: true });
+    writeFileSync(join(upper, '-d', '.wh.foo'), '');
+    mkdirSync(join(dest, '-d'), { recursive: true });
+    writeFileSync(join(dest, '-d', 'foo'), 'should be deleted');
+
+    const { records } = runScript(buildApplyScript(), upper, dest, ws);
+
+    expect(existsSync(join(dest, '-d', 'foo'))).toBe(false);
+    // The marker itself must never land in the destination.
+    expect(existsSync(join(dest, '-d', '.wh.foo'))).toBe(false);
+    expect(records.some(r => r.tag === 'D' && r.fields[0] === '-d/foo')).toBe(true);
+    rmSync(root, { recursive: true, force: true });
+  });
+
   test('`.wh..wh.x` decodes to `.wh.x` — one prefix stripped, not four characters', () => {
-    // cut -c5- and ${base#.wh.} agree here, and this pins that they keep agreeing:
-    // stripping greedily (##) would decode to 'x' and delete the wrong entry.
+    // cut -c5- and ${base#.wh.} agree here, and this pins that they keep agreeing.
+    // The mutation it catches is `${base##*.wh.}`, which decodes to 'x' and deletes
+    // the wrong entry. Note plain `##` is NOT the hazard: with a literal pattern
+    // `${base##.wh.}` is byte-identical to `${base#.wh.}` — only adding the `*`
+    // makes it greedy.
     const { root, upper, dest, ws } = makeDirs();
     writeFileSync(join(upper, '.wh..wh.x'), '');
     writeFileSync(join(dest, '.wh.x'), 'the real target');
@@ -282,6 +326,28 @@ describe('summary script — faithful representation (M1)', () => {
     expect(okLink?.fields[2]).toBe('0'); // in-project
     expect(records.some(r => r.tag === 'A' && r.fields[0] === 'added.txt')).toBe(true);
     expect(records.some(r => r.tag === 'M' && r.fields[0] === 'mod.txt')).toBe(true);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  // The summary script carries its OWN copy of the rel/base/dir splitting, and
+  // until this test nothing executed it: the case above is skipped on win32, sits
+  // entirely at the top level, and contains no whiteout. Drift between the two
+  // copies would therefore be invisible — and it is the summary that renders the
+  // delete list a human approves, so a wrong `dir` there misinforms consent rather
+  // than merely misapplying. No symlinks, so this runs everywhere.
+  test('a nested whiteout is reported at its full path, not its stem', () => {
+    const { root, upper, dest, ws } = makeDirs();
+    mkdirSync(join(upper, 'sub'), { recursive: true });
+    writeFileSync(join(upper, 'sub', '.wh.gone.txt'), '');
+    mkdirSync(join(dest, 'sub'), { recursive: true });
+    writeFileSync(join(dest, 'sub', 'gone.txt'), 'bye');
+
+    const { records } = runScript(buildSummaryScript(), upper, dest, ws);
+
+    expect(records.some(r => r.tag === 'D' && r.fields[0] === 'sub/gone.txt')).toBe(true);
+    // An empty `dir` would report the top-level name and invite the approver to
+    // sign off on deleting a different file.
+    expect(records.some(r => r.tag === 'D' && r.fields[0] === 'gone.txt')).toBe(false);
     rmSync(root, { recursive: true, force: true });
   });
 });

--- a/packages/isolation/src/container/overlay-scripts.test.ts
+++ b/packages/isolation/src/container/overlay-scripts.test.ts
@@ -335,6 +335,27 @@ describe('summary script — faithful representation (M1)', () => {
   // copies would therefore be invisible — and it is the summary that renders the
   // delete list a human approves, so a wrong `dir` there misinforms consent rather
   // than merely misapplying. No symlinks, so this runs everywhere.
+  // Records are TAB-separated and decoded positionally, so a TAB in a filename used
+  // to shift every later field: an escaping symlink was rendered to the approver
+  // with its TARGET in the name slot and a path where the `escapes` flag belongs —
+  // reaching the gate looking safe. Apply still refused it, so the exposure was
+  // misinformed consent rather than over-apply, which is why it survived unnoticed.
+  test.skipIf(isWin)('a TAB in a filename cannot forge the fields of a later record', () => {
+    const { root, upper, dest, ws } = makeDirs();
+    symlinkSync('/etc/shadow', join(upper, 'a\tb'));
+
+    const { records } = runScript(buildSummaryScript(), upper, dest, ws);
+
+    // Refused outright, with the TAB rendered so the refusal itself decodes.
+    const refusal = records.find(r => r.tag === 'S' && r.fields[1] === 'unsafe-record-name');
+    expect(refusal?.fields[0]).toBe('a?b');
+    // The decisive property: no record claims this entry is a non-escaping symlink.
+    expect(records.some(r => r.tag === 'L' && r.fields[2] === '0')).toBe(false);
+    // And every emitted record decodes to its declared arity.
+    for (const r of records) expect(r.fields[0]).not.toContain('\t');
+    rmSync(root, { recursive: true, force: true });
+  });
+
   test('a nested whiteout is reported at its full path, not its stem', () => {
     const { root, upper, dest, ws } = makeDirs();
     mkdirSync(join(upper, 'sub'), { recursive: true });

--- a/packages/isolation/src/container/overlay-scripts.test.ts
+++ b/packages/isolation/src/container/overlay-scripts.test.ts
@@ -16,6 +16,7 @@ import {
   mkdtempSync,
   mkdirSync,
   writeFileSync,
+  readFileSync,
   symlinkSync,
   existsSync,
   lstatSync,
@@ -141,8 +142,9 @@ describe('apply script — C1 whiteout-name traversal', () => {
 // '.', and `${base#.wh.}` strips one prefix occurrence where `cut -c5-` strips
 // four characters. Every pre-existing apply test that SUCCEEDS operates at the top
 // level, so a wrong `dir` at depth would not have failed any of them. These do.
-// Deliberately no skipIf — Windows is where the fork cost was, so this is exactly
-// where the replacement has to be proven.
+// These run on Windows wherever the fixture is portable there — that is where the
+// fork cost was, so it is where the replacement most needs proving. Only the cases
+// whose filenames cannot portably exist on win32 carry a skipIf, individually.
 describe('apply script — rel/base/dir splitting', () => {
   test('a legit whiteout inside a subdirectory deletes exactly that nested file', () => {
     const { root, upper, dest, ws } = makeDirs();
@@ -170,8 +172,8 @@ describe('apply script — rel/base/dir splitting', () => {
   test.skipIf(isWin)('a whiteout name ending in a newline deletes THAT file, not its stem', () => {
     // `$(basename …)` strips trailing newlines, so `.wh.evil\n` used to decode to
     // `evil` and delete a different, innocent file — while `safe_parent` also
-    // confined the wrong path. Skipped on win32: creating such a name is not
-    // portable there, and these scripts only ever run in the Linux runner image.
+    // confined the wrong path. Skipped on win32 only because a trailing-newline
+    // filename is not portably creatable there.
     const { root, upper, dest, ws } = makeDirs();
     writeFileSync(join(upper, '.wh.evil\n'), '');
     writeFileSync(join(dest, 'evil\n'), 'the real target');
@@ -186,8 +188,9 @@ describe('apply script — rel/base/dir splitting', () => {
   });
 
   test('a whiteout under a `-`-prefixed directory still decodes instead of being copied', () => {
-    // `basename "-d/.wh.foo"` exits 1 with "illegal option -- d", so `base` came
-    // back empty, the `.wh.*` arm never matched, and the marker was applied as an
+    // `basename "-d/.wh.foo"` treats the path as an option and exits 1 (BSD:
+    // "illegal option -- d"; GNU: "invalid option -- 'd'"), so `base` came back
+    // empty, the `.wh.*` arm never matched, and the marker was applied as an
     // ordinary FILE — planting a `.wh.foo` file in the live root instead of
     // deleting `foo`.
     const { root, upper, dest, ws } = makeDirs();
@@ -223,6 +226,72 @@ describe('apply script — rel/base/dir splitting', () => {
     expect(records.some(r => r.tag === 'D' && r.fields[0] === '.wh.x')).toBe(true);
     rmSync(root, { recursive: true, force: true });
   });
+});
+
+// The reviewer's through-line for this PR: every guard here exists in two
+// hand-duplicated copies, and each fix landed with a test on exactly one of them, so
+// the mirror copy stayed provably unpinned. These three close the remaining mutations
+// that passed the whole suite green.
+describe('apply script — guards pinned on the apply copy', () => {
+  // R9: commit 3 tested the TAB guard only through the SUMMARY script, so deleting the
+  // apply-side guard outright passed everything. Apply is the copy that writes.
+  test.skipIf(isWin)('a TAB-bearing entry is refused by the APPLY script, not applied', () => {
+    const { root, upper, dest, ws } = makeDirs();
+    writeFileSync(join(upper, 'a\tb'), 'payload');
+
+    const { records } = runScript(buildApplyScript(), upper, dest, ws);
+
+    expect(records).toEqual([{ tag: 'S', fields: ['a?b', 'unsafe-record-name'] }]);
+    // Nothing was written under either the real or the mangled name.
+    expect(existsSync(join(dest, 'a\tb'))).toBe(false);
+    expect(existsSync(join(dest, 'a?b'))).toBe(false);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  // R4: the newline fix had two halves and only the whiteout half was pinned. The
+  // other half is safe_parent — `$(dirname)` stripped the trailing newline, so it
+  // confined `$DEST/d` while the write went through `$DEST/d\n`. With a dest symlink
+  // there, that write leaves the live root entirely AND is reported as applied.
+  test.skipIf(isWin)(
+    'a write cannot escape via a dest symlink whose name ends in a newline',
+    () => {
+      const { root, upper, dest, ws } = makeDirs();
+      const outside = join(root, 'outside');
+      mkdirSync(outside, { recursive: true });
+      mkdirSync(join(upper, 'd\n'), { recursive: true });
+      writeFileSync(join(upper, 'd\n', 'f.txt'), 'exfil');
+      symlinkSync(outside, join(dest, 'd\n'));
+
+      const { records } = runScript(buildApplyScript(), upper, dest, ws);
+
+      // The decisive assertion: nothing reached the directory outside the root.
+      expect(existsSync(join(outside, 'f.txt'))).toBe(false);
+      // And it was refused rather than reported applied.
+      expect(records.some(r => r.tag === 'W' && r.fields[0] === 'd\n/f.txt')).toBe(false);
+      rmSync(root, { recursive: true, force: true });
+    }
+  );
+
+  // R7: safe_parent's no-slash branch is observed by nothing. Dropping it makes
+  // `_parent` equal the filename for a top-level entry, so the loop tests the entry
+  // itself for symlink-ness and refuses a perfectly ordinary overwrite.
+  test.skipIf(isWin)(
+    'a top-level file whose dest counterpart is a symlink is still applied',
+    () => {
+      const { root, upper, dest, ws } = makeDirs();
+      writeFileSync(join(upper, 'f.txt'), 'new content');
+      writeFileSync(join(root, 'elsewhere.txt'), 'old');
+      symlinkSync(join(root, 'elsewhere.txt'), join(dest, 'f.txt'));
+
+      const { records } = runScript(buildApplyScript(), upper, dest, ws);
+
+      expect(records.some(r => r.tag === 'W' && r.fields[0] === 'f.txt')).toBe(true);
+      // Replaced as a real file, and the symlink's old target left untouched.
+      expect(lstatSync(join(dest, 'f.txt')).isSymbolicLink()).toBe(false);
+      expect(readFileSync(join(root, 'elsewhere.txt'), 'utf8')).toBe('old');
+      rmSync(root, { recursive: true, force: true });
+    }
+  );
 });
 
 describe('apply script — C2 special files + setuid', () => {
@@ -346,13 +415,65 @@ describe('summary script — faithful representation (M1)', () => {
 
     const { records } = runScript(buildSummaryScript(), upper, dest, ws);
 
-    // Refused outright, with the TAB rendered so the refusal itself decodes.
-    const refusal = records.find(r => r.tag === 'S' && r.fields[1] === 'unsafe-record-name');
-    expect(refusal?.fields[0]).toBe('a?b');
-    // The decisive property: no record claims this entry is a non-escaping symlink.
-    expect(records.some(r => r.tag === 'L' && r.fields[2] === '0')).toBe(false);
-    // And every emitted record decodes to its declared arity.
-    for (const r of records) expect(r.fields[0]).not.toContain('\t');
+    // The decisive property, and the only assertion here that fails pre-guard: the
+    // entry is REFUSED by name, with the TAB rendered so the refusal itself decodes.
+    // (Asserting merely that no `L … '0'` record exists passed before the guard too,
+    // because the forged flag was a path rather than '0'.)
+    expect(records).toEqual([{ tag: 'S', fields: ['a?b', 'unsafe-record-name'] }]);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  // R6, second half: a TAB in the symlink TARGET forges the fields after it, so the
+  // consumer reads a benign target and a PATH where the escape flag belongs. Measured
+  // before the fix: ["L","utils-link.ts","src/utils.ts","../../../../etc/shadow","1"]
+  // — the gate renders "-> src/utils.ts", no warning, while the real target escapes.
+  // The name-only guard did not catch this; both variable-width fields need checking.
+  test.skipIf(isWin)('a TAB in a symlink TARGET cannot forge the escape flag', () => {
+    const { root, upper, dest, ws } = makeDirs();
+    symlinkSync('src/utils.ts\t../../../../etc/shadow', join(upper, 'utils-link.ts'));
+
+    const { records } = runScript(buildSummaryScript(), upper, dest, ws);
+
+    expect(records).toEqual([{ tag: 'S', fields: ['utils-link.ts', 'unsafe-record-target'] }]);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  // R8: the previous summary fixture pinned only `dir`. These pin the `base`/`whname`
+  // decodes on the consent surface too — reverting the summary copy's split to forks,
+  // or making its whiteout decode greedy, passed the whole suite before this.
+  test('the summary decodes a nested whiteout name, not just its directory', () => {
+    const { root, upper, dest, ws } = makeDirs();
+    mkdirSync(join(upper, 'sub'), { recursive: true });
+    writeFileSync(join(upper, 'sub', '.wh..wh.x'), '');
+    mkdirSync(join(dest, 'sub'), { recursive: true });
+    writeFileSync(join(dest, 'sub', '.wh.x'), 'the real target');
+
+    const { records } = runScript(buildSummaryScript(), upper, dest, ws);
+
+    // Greedy decode would report 'sub/x'; a forked basename on a '-'-prefixed
+    // component would report nothing at all.
+    expect(records.some(r => r.tag === 'D' && r.fields[0] === 'sub/.wh.x')).toBe(true);
+    expect(records.some(r => r.tag === 'D' && r.fields[0] === 'sub/x')).toBe(false);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  // Reverting the summary copy's rel/base to forks passed even the test above,
+  // because `sub/.wh..wh.x` is an input where forks and expansions AGREE. Only a
+  // divergent input discriminates: `basename "-d/.wh.foo"` treats the path as an
+  // option and fails, so `base` comes back empty, the whiteout arm never matches, and
+  // the summary shows the approver an ADDED marker file instead of a deletion.
+  test('the summary decodes a whiteout under a `-`-prefixed directory', () => {
+    const { root, upper, dest, ws } = makeDirs();
+    mkdirSync(join(upper, '-d'), { recursive: true });
+    writeFileSync(join(upper, '-d', '.wh.foo'), '');
+    mkdirSync(join(dest, '-d'), { recursive: true });
+    writeFileSync(join(dest, '-d', 'foo'), 'would be deleted');
+
+    const { records } = runScript(buildSummaryScript(), upper, dest, ws);
+
+    expect(records.some(r => r.tag === 'D' && r.fields[0] === '-d/foo')).toBe(true);
+    // A failed decode surfaces the marker itself as an addition — the wrong story.
+    expect(records.some(r => r.tag === 'A' && r.fields[0] === '-d/.wh.foo')).toBe(false);
     rmSync(root, { recursive: true, force: true });
   });
 

--- a/packages/isolation/src/container/overlay.ts
+++ b/packages/isolation/src/container/overlay.ts
@@ -280,11 +280,14 @@ safe_parent() {
   IFS="$_oldifs"; return 0
 }
 
-# Records are TAB-separated and decoded POSITIONALLY (parseRecords), so a TAB in a
-# filename shifts every later field: a symlink named 'a<TAB>b' decodes as
-# ["L","a","b",target,esc], handing the consumer the target from the name slot and a
-# path where the escape flag belongs — an escaping symlink reaches the approval gate
-# looking safe. Refuse such an entry instead of emitting an undecodable record, and
+# Records are TAB-separated and decoded POSITIONALLY (parseRecords), so a TAB in ANY
+# variable-width field shifts every later one. Both such fields are attacker
+# controlled and both must be checked:
+#   name:   'a<TAB>b'                  -> ["L","a","b",target,esc]
+#   target: 'ok.ts<TAB>../../etc/pw'   -> ["L",name,"ok.ts","../../etc/pw",esc]
+# In the second the consumer reads a benign target and a PATH where the escape flag
+# belongs, so an escaping symlink reaches the approval gate rendered as safe — the
+# name-only check missed it. Refuse rather than emit an undecodable record, and
 # render the TAB as '?' so the refusal itself decodes. Builtins only, no fork.
 has_tab() {
   case "$1" in *"$TAB_CHAR"*) return 0 ;; *) return 1 ;; esac
@@ -355,6 +358,10 @@ find . -mindepth 1 -print0 2>/dev/null | while IFS= read -r -d '' p; do
   # --- symlink (check BEFORE -d/-f so a symlink-to-dir is not misclassified) ---
   if [ -L "$UP/$rel" ]; then
     ltarget="$(readlink "$UP/$rel")"
+    if has_tab "$ltarget"; then
+      printf 'S\\t%s\\tunsafe-record-target\\0' "\${rel//"$TAB_CHAR"/?}"
+      continue
+    fi
     if symlink_escapes "$ltarget"; then esc=1; else esc=0; fi
     printf 'L\\t%s\\t%s\\t%s\\0' "$rel" "$ltarget" "$esc"
     continue
@@ -411,6 +418,10 @@ find . -mindepth 1 -print0 2>/dev/null | while IFS= read -r -d '' p; do
   # --- symlink (check BEFORE -d/-f: a symlink-to-dir must not be treated as a dir) ---
   if [ -L "$UP/$rel" ]; then
     ltarget="$(readlink "$UP/$rel")"
+    if has_tab "$ltarget"; then
+      printf 'S\\t%s\\tunsafe-record-target\\0' "\${rel//"$TAB_CHAR"/?}"
+      continue
+    fi
     if symlink_escapes "$ltarget"; then printf 'S\\t%s\\tescaping-symlink\\0' "$rel"; continue; fi
     if ! safe_parent "$rel" "$DEST"; then printf 'S\\t%s\\tescaping-symlink-path\\0' "$rel"; continue; fi
     mkdir -p "$DEST/$dir" 2>/dev/null || true

--- a/packages/isolation/src/container/overlay.ts
+++ b/packages/isolation/src/container/overlay.ts
@@ -232,8 +232,15 @@ function pushCapped(list: string[], path: string): void {
 // Shell scripts. Parameterized ($1=upperdir, $2=lower|dest, $3=project root) and
 // portable (no `stat -c` / `realpath -m`) so they run in the runner image AND under
 // bash in the unit tests. NUL-delimited, TAB-separated records. `set -f` disables
-// globbing so adversarial filenames can't expand. NO `${…}` brace expansion (it
-// would be read as a JS template interpolation) — basename/dirname/cut/ls are used.
+// globbing so adversarial filenames can't expand.
+//
+// Path splitting uses `${…}` parameter expansion, escaped as `\${…}` so TypeScript
+// does not read it as a template interpolation. It replaced per-entry
+// basename/dirname/cut forks (#2558) — and note the expansions are the SAFER form,
+// not merely the cheaper one: `$(…)` strips trailing newlines, so a filename ending
+// in one used to decode to a different name and act on the wrong file. Do not
+// reintroduce command substitution here. The escaping is parser-enforced: an
+// unescaped `${…}` in these template literals is a TypeScript syntax error.
 // ---------------------------------------------------------------------------
 
 /**

--- a/packages/isolation/src/container/overlay.ts
+++ b/packages/isolation/src/container/overlay.ts
@@ -250,6 +250,7 @@ function pushCapped(list: string[], path: string): void {
 const SHELL_HELPERS = `
 set -uf
 UP="$1"; OTHER="$2"; WS="$3"
+TAB_CHAR="	"
 
 # Reject a decoded whiteout name that could escape or wipe: empty, '.'/'..', or
 # containing a slash (defensive — a real basename can't, but never trust it).
@@ -277,6 +278,16 @@ safe_parent() {
     _cur="$_cur/$_seg"
   done
   IFS="$_oldifs"; return 0
+}
+
+# Records are TAB-separated and decoded POSITIONALLY (parseRecords), so a TAB in a
+# filename shifts every later field: a symlink named 'a<TAB>b' decodes as
+# ["L","a","b",target,esc], handing the consumer the target from the name slot and a
+# path where the escape flag belongs — an escaping symlink reaches the approval gate
+# looking safe. Refuse such an entry instead of emitting an undecodable record, and
+# render the TAB as '?' so the refusal itself decodes. Builtins only, no fork.
+has_tab() {
+  case "$1" in *"$TAB_CHAR"*) return 0 ;; *) return 1 ;; esac
 }
 
 # A char device is an overlay WHITEOUT iff its major,minor is 0,0. Parsed from
@@ -311,17 +322,19 @@ export function buildSummaryScript(): string {
 [ -d "$UP" ] || exit 0
 cd "$UP"
 find . -mindepth 1 -print0 2>/dev/null | while IFS= read -r -d '' p; do
-  # Builtins, not sed/basename/dirname. These three ran once per entry, and on
-  # Windows resolveBashPath() gives Git-Bash, whose MSYS fork emulation makes a
-  # process creation dear enough that they dominated the runtime (#2558). Note
-  # \${rel%/*} is NOT dirname: with no slash it returns rel unchanged, where
-  # dirname returns '.', so the no-slash case is branched explicitly.
+  # Builtins, not sed/basename/dirname — see the note above SHELL_HELPERS in
+  # overlay.ts for why (#2558). \${rel%/*} is NOT dirname: with no slash it
+  # returns rel unchanged, so the no-slash case is branched explicitly.
   rel="\${p#./}"
   base="\${rel##*/}"
   case "$rel" in
     */*) dir="\${rel%/*}" ;;
     *) dir="" ;;
   esac
+  if has_tab "$rel"; then
+    printf 'S\\t%s\\tunsafe-record-name\\0' "\${rel//"$TAB_CHAR"/?}"
+    continue
+  fi
 
   # --- whiteout markers → deletion ---
   is_wh=0; whname=""
@@ -363,17 +376,19 @@ DEST="$OTHER"
 [ -d "$UP" ] || exit 0
 cd "$UP"
 find . -mindepth 1 -print0 2>/dev/null | while IFS= read -r -d '' p; do
-  # Builtins, not sed/basename/dirname. These three ran once per entry, and on
-  # Windows resolveBashPath() gives Git-Bash, whose MSYS fork emulation makes a
-  # process creation dear enough that they dominated the runtime (#2558). Note
-  # \${rel%/*} is NOT dirname: with no slash it returns rel unchanged, where
-  # dirname returns '.', so the no-slash case is branched explicitly.
+  # Builtins, not sed/basename/dirname — see the note above SHELL_HELPERS in
+  # overlay.ts for why (#2558). \${rel%/*} is NOT dirname: with no slash it
+  # returns rel unchanged, so the no-slash case is branched explicitly.
   rel="\${p#./}"
   base="\${rel##*/}"
   case "$rel" in
     */*) dir="\${rel%/*}" ;;
     *) dir="" ;;
   esac
+  if has_tab "$rel"; then
+    printf 'S\\t%s\\tunsafe-record-name\\0' "\${rel//"$TAB_CHAR"/?}"
+    continue
+  fi
 
   # --- whiteout markers → deletion ---
   is_wh=0; whname=""

--- a/packages/isolation/src/container/overlay.ts
+++ b/packages/isolation/src/container/overlay.ts
@@ -259,8 +259,10 @@ valid_name() {
 # or 1 (refuse). Portable (test -L), no realpath.
 safe_parent() {
   _rel="$1"; _cur="$2"; _oldifs="$IFS"; IFS='/'
-  _parent="$(dirname "$_rel")"
-  [ "$_parent" = "." ] && _parent=""
+  case "$_rel" in
+    */*) _parent="\${_rel%/*}" ;;
+    *) _parent="" ;;
+  esac
   for _seg in $_parent; do
     [ -z "$_seg" ] && continue
     case "$_seg" in .|..) IFS="$_oldifs"; return 1 ;; esac
@@ -302,16 +304,23 @@ export function buildSummaryScript(): string {
 [ -d "$UP" ] || exit 0
 cd "$UP"
 find . -mindepth 1 -print0 2>/dev/null | while IFS= read -r -d '' p; do
-  rel="$(printf '%s' "$p" | sed 's#^[.]/##')"
-  base="$(basename "$rel")"
-  dir="$(dirname "$rel")"
-  [ "$dir" = "." ] && dir=""
+  # Builtins, not sed/basename/dirname. These three ran once per entry, and on
+  # Windows resolveBashPath() gives Git-Bash, whose MSYS fork emulation makes a
+  # process creation dear enough that they dominated the runtime (#2558). Note
+  # \${rel%/*} is NOT dirname: with no slash it returns rel unchanged, where
+  # dirname returns '.', so the no-slash case is branched explicitly.
+  rel="\${p#./}"
+  base="\${rel##*/}"
+  case "$rel" in
+    */*) dir="\${rel%/*}" ;;
+    *) dir="" ;;
+  esac
 
   # --- whiteout markers → deletion ---
   is_wh=0; whname=""
   case "$base" in
     .wh..wh..opq) printf 'S\\t%s\\topaque-dir-marker\\0' "$rel"; continue ;;
-    .wh.*) is_wh=1; whname="$(printf '%s' "$base" | cut -c5-)" ;;
+    .wh.*) is_wh=1; whname="\${base#.wh.}" ;;
   esac
   if [ "$is_wh" = "0" ] && [ -c "$UP/$rel" ]; then
     if is_whiteout_char "$UP/$rel"; then is_wh=1; whname="$base"; else printf 'S\\t%s\\tspecial-char-device\\0' "$rel"; continue; fi
@@ -347,16 +356,23 @@ DEST="$OTHER"
 [ -d "$UP" ] || exit 0
 cd "$UP"
 find . -mindepth 1 -print0 2>/dev/null | while IFS= read -r -d '' p; do
-  rel="$(printf '%s' "$p" | sed 's#^[.]/##')"
-  base="$(basename "$rel")"
-  dir="$(dirname "$rel")"
-  [ "$dir" = "." ] && dir=""
+  # Builtins, not sed/basename/dirname. These three ran once per entry, and on
+  # Windows resolveBashPath() gives Git-Bash, whose MSYS fork emulation makes a
+  # process creation dear enough that they dominated the runtime (#2558). Note
+  # \${rel%/*} is NOT dirname: with no slash it returns rel unchanged, where
+  # dirname returns '.', so the no-slash case is branched explicitly.
+  rel="\${p#./}"
+  base="\${rel##*/}"
+  case "$rel" in
+    */*) dir="\${rel%/*}" ;;
+    *) dir="" ;;
+  esac
 
   # --- whiteout markers → deletion ---
   is_wh=0; whname=""
   case "$base" in
     .wh..wh..opq) printf 'S\\t%s\\topaque-dir-marker\\0' "$rel"; continue ;;
-    .wh.*) is_wh=1; whname="$(printf '%s' "$base" | cut -c5-)" ;;
+    .wh.*) is_wh=1; whname="\${base#.wh.}" ;;
   esac
   if [ "$is_wh" = "0" ] && [ -c "$UP/$rel" ]; then
     if is_whiteout_char "$UP/$rel"; then is_wh=1; whname="$base"; else printf 'S\\t%s\\tspecial-char-device\\0' "$rel"; continue; fi


### PR DESCRIPTION
## Problem and outcome

This began as a performance change and is not one. `overlay-scripts.test.ts` was the site in #2306's flake cluster that is a *gradient* rather than a bounded stall — 1000–2391 ms against a 5000 ms budget, per-test durations from 15 green `test (windows-latest)` logs — because both overlay walk scripts forked `sed`, `basename` and `dirname` once per upperdir entry (and `safe_parent` forked `dirname` again). Replacing those with shell parameter expansion also **fixed three reachable defects on the one path that writes the live root** — the module header calls it the ONE place the live root is written — and none of them was caught by any test:

1. **A whiteout marker under a `-`-prefixed directory was applied as a file instead of deleting its target.** `basename "-d/.wh.foo"` treats the path as an option and exits 1, so `base` came back empty, the `.wh.*` arm never matched, and the script planted a literal `.wh.foo` file in the live root while `foo` survived. Plain filename, no adversary required — a project with a `-`-prefixed directory hit this in ordinary use.
2. **A whiteout whose name ends in a newline deleted a different, innocent file.** `$(basename …)` strips trailing newlines, so `.wh.evil␊` decoded to `evil`. The same stripping made `safe_parent` confine `$DEST/d` while the write went through `$DEST/d␊`, so with a dest symlink there the write **left the live root and was reported as applied**.
3. **A TAB in a filename or symlink target forged the fields after it,** because records are decoded positionally — presenting an escaping symlink to the approval gate as safe, with no warning.

- **Outcome:** fork count per regular-file entry drops 8 → 4 and per whiteout entry 6 → 1 (109 ms → 70 ms for the three C1 tests on macOS, where forks are cheapest) — **and** those three defects are closed, each pinned by a test that fails against the commit before it. The performance work is now the *smaller* half of this PR; read the title as `fix`, not `perf`.
- **Invariant:** what the scripts *decide* about safety is a strict superset of before — `safe_parent` refuses everything it refused plus cases it previously let through, and no entry that was correctly applied stops being applied. What is **not** unchanged is behaviour on adversarial filenames: see Behavior change.
- **Scope boundary:** `mkdir`/`rm`/`cp`/`chmod` stay — they are the work, not path computation. No change to the container lifecycle, the approval flow, or `parseRecords`.
- **Root cause:** `$(…)` command substitution strips trailing newlines, and `basename`/`dirname` parse a leading `-` as an option — so the strings feeding `valid_name` and `safe_parent` did not always describe the file on disk. Separately, records are TAB-separated and decoded **positionally** (`parseRecords`, `overlay.ts:86`), so a TAB in either variable-width field shifts every field after it.

## Review guidance

- **Feedback requested:** correctness of the substitutions and of the new TAB refusal, on a security-audited surface.
- **Start here:** `packages/isolation/src/container/overlay.ts` — the banner above `SHELL_HELPERS`, then `has_tab`, then the shared split prologue in both `buildApplyScript()` and `buildSummaryScript()`.
- **Review order:** `77625c61` the substitution → `690997ff` tests for the two decode holes + the summary copy → `10387507` the TAB guard → `811623bb` the TAB guard's second half plus both-copy coverage.
- **Known risk or uncertainty:** the guards in this file exist in **two hand-duplicated copies**, and this PR's own history is the argument for the coverage it now has: each fix initially landed with a test on one copy only, and five separate mutations passed the full suite green. All five now fail. If you extend this file, assume a fixture that exercises one copy proves nothing about the other, and prefer inputs where forks and expansions actually diverge — an earlier fixture used `sub/.wh..wh.x`, where they agree, and caught nothing.

## Solution

Four replacements, all POSIX parameter expansion under the existing `set -uf`:

| Was | Now |
|---|---|
| `rel="$(printf '%s' "$p" \| sed 's#^[.]/##')"` | `rel="${p#./}"` |
| `base="$(basename "$rel")"` | `base="${rel##*/}"` |
| `dir="$(dirname "$rel")"` + `.`-normalisation | explicit `case "$rel" in */*) dir="${rel%/*}" ;; *) dir="" ;; esac` |
| `whname="$(printf '%s' "$base" \| cut -c5-)"` | `whname="${base#.wh.}"` |

plus the same `case` for `safe_parent`'s `_parent`, and a `has_tab` refusal covering both the entry name and the symlink target. `${rel%/*}` is deliberately **not** `dirname` — with no slash it returns the input unchanged where `dirname` returns `.` — so that case branches explicitly. The prologue stays duplicated rather than extracted: a shell function returning three globals is harder to audit than four visible expansions, the copies are `cmp`-identical, and a test now executes each.

## Behavior change

| | Before | After |
|---|---|---|
| Whiteout `.wh.evil␊` | deleted `evil` — a **different, innocent file** | deletes `evil␊` |
| Whiteout under `-d/` | marker **applied as a file** into the live root; `foo` never deleted | deletes `-d/foo` |
| Write under a dest symlink named `d␊` | escaped the live root **and was reported applied** | refused |
| Symlink target containing a TAB | gate rendered a benign target and a non-escaping flag while the real target escaped | refused (`unsafe-record-target`) |
| Entry name containing a TAB | emitted an undecodable record | refused (`unsafe-record-name`) |
| **Legitimately** TAB-named entry | applied | **now skipped**, announced as an `S` record |

The last row is the only regression in capability, and it is deliberate: a name that cannot be represented in the record format cannot be shown to an approver, and a human must not be asked to approve a line that does not decode.

## Validation

- `bun run validate` — exit 0 at `811623bb`.
- `bun test packages/isolation/src/container/overlay-scripts.test.ts` — **23 pass / 0 fail** (was 11 before this PR).
- Every defect pinned against the commit that preceded its fix: the two decode holes fail against `origin/dev`; the TAB-name forgery fails against `690997ff`; the TAB-target forgery and all four both-copy mutations fail against `10387507`.
- **Five mutations that previously passed the whole suite green now each fail**, and no test is redundant — every one is the sole detector of at least one: `safe_parent` → `$(dirname)`; summary whiteout decode greedy; summary split → forks; apply-side TAB guard deleted; `safe_parent` no-slash branch dropped.
- Asserted against the **emitted shell**, not the TypeScript source (the `${…}` needs escaping, so "it compiled" proves nothing): all expansions present literally, zero `sed`/`basename`/`dirname`/`cut` on non-comment lines, `TAB_CHAR` is a real `0x09`, `bash -n` clean, both prologues `cmp`-identical.
- A third candidate test was written, found to catch none of the mutations, and dropped rather than kept as coverage.
- **Not verified:** that Windows CI durations actually compress — that needs ~15–20 post-merge runs, recorded as the open acceptance criterion on #2558. If they do not, fork count is falsified as the driver.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Security / permissions / data | Fixes three reachable defects on the container overlay write-back path — the module header's "ONE place the live root is written". Two produced wrong-file mutation, one produced misinformed consent at the approval gate. No new capability or permission. | Behavior change table; tests fail against the pre-fix commits |
| Compatibility / migration | Only adversarial filenames change outcome, plus TAB-named entries now skipped-and-announced. No data migration, no config, no API. | Behavior change table |
| Rollout / rollback | Four independent commits. **Do not read this as perf-only when deciding to revert** — reverting restores the three defects. | This section |
| Observability | Every refusal emits an `S` record with a reason (`unsafe-record-name`, `unsafe-record-target`), surfaced in the change summary rather than silently dropped. | `overlay.ts` guards |

## Links

- Closes #2558
- Related #2306 — the parent flake cluster; PR #2557 handles a different site in it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved overlay handling for nested whiteouts, similarly named whiteout files, and paths containing newlines or leading hyphens.
  * Prevented malformed path and symlink records containing TAB characters from corrupting overlay processing.
  * Improved symlink safety, including confinement for nested paths and correct replacement of top-level symlinks.
  * Preserved correct handling of deleted files, directories, symlinks, regular files, and special files.

* **Tests**
  * Added comprehensive regression coverage for path parsing, whiteouts, symlink behavior, and malformed records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
