### PR TITLE
fix(web): the chat UI reads the server's message category instead of guessing from an emoji

### DIFF
--- a/packages/server/src/adapters/web.test.ts
+++ b/packages/server/src/adapters/web.test.ts
@@ -125,3 +125,42 @@ describe('WebAdapter.sendStructuredEvent — tool_result output bounding', () =>
     expect(appendToolResultCalls[0]![2]).toBe(largeOutput);
   });
 });
+
+describe('WebAdapter.sendMessage — text event category', () => {
+  test('carries the metadata category on the text event', async () => {
+    const { adapter, emitted } = makeAdapter();
+
+    await adapter.sendMessage('conv-1', '🚀 Dispatching workflow: **plan**', {
+      category: 'workflow_dispatch_status',
+      segment: 'new',
+    });
+
+    expect(emitted.length).toBe(1);
+    const parsed = JSON.parse(emitted[0]!) as { type: string; category?: string };
+    expect(parsed.type).toBe('text');
+    expect(parsed.category).toBe('workflow_dispatch_status');
+  });
+
+  test('omits the category key entirely for agent prose', async () => {
+    const { adapter, emitted } = makeAdapter();
+
+    await adapter.sendMessage('conv-1', 'ordinary assistant text');
+
+    expect(emitted.length).toBe(1);
+    const parsed = JSON.parse(emitted[0]!) as Record<string, unknown>;
+    expect('category' in parsed).toBe(false);
+  });
+
+  test('still suppresses structurally-handled categories rather than emitting them', async () => {
+    const { adapter, emitted } = makeAdapter();
+
+    await adapter.sendMessage('conv-1', 'formatted tool call', {
+      category: 'tool_call_formatted',
+    });
+    await adapter.sendMessage('conv-1', '📍 repo @ `branch`', {
+      category: 'isolation_context',
+    });
+
+    expect(emitted.length).toBe(0);
+  });
+});

--- a/packages/server/src/adapters/web.ts
+++ b/packages/server/src/adapters/web.ts
@@ -74,11 +74,15 @@ export class WebAdapter implements IWebPlatformAdapter {
       return;
     }
 
+    // `category` rides the wire so the client segments messages from the same
+    // typed signal `MessagePersistence.appendText` uses (persistence.ts), rather
+    // than re-deriving it by pattern-matching the message text.
     const event = JSON.stringify({
       type: 'text',
       content: message,
       isComplete: true,
       timestamp: Date.now(),
+      ...(metadata?.category ? { category: metadata.category } : {}),
       ...(metadata?.workflowResult ? { workflowResult: metadata.workflowResult } : {}),
     });
 

--- a/packages/web/src/components/chat/ChatInterface.tsx
+++ b/packages/web/src/components/chat/ChatInterface.tsx
@@ -26,6 +26,7 @@ import type {
   FileAttachment,
   ToolCallDisplay,
   ErrorDisplay,
+  TextEventMeta,
   WorkflowDispatchEvent,
 } from '@/lib/types';
 import { applyOnText } from '@/lib/chat-message-reducer';
@@ -292,15 +293,12 @@ export function ChatInterface({
     return `msg-${String(messageIdCounter.current)}`;
   };
 
-  const onText = useCallback(
-    (content: string, workflowResult?: { workflowName: string; runId: string }): void => {
-      // First AI text received — the thinking placeholder is about to gain content,
-      // so the hydration merge no longer needs the sendInFlight guard.
-      setSendInFlight(false);
-      setMessages(prev => applyOnText(prev, content, undefined, undefined, workflowResult));
-    },
-    []
-  );
+  const onText = useCallback((content: string, meta?: TextEventMeta): void => {
+    // First AI text received — the thinking placeholder is about to gain content,
+    // so the hydration merge no longer needs the sendInFlight guard.
+    setSendInFlight(false);
+    setMessages(prev => applyOnText(prev, content, undefined, undefined, meta));
+  }, []);
 
   const onToolCall = useCallback(
     (name: string, input: Record<string, unknown>, toolCallId?: string): void => {

--- a/packages/web/src/components/workflows/WorkflowLogs.tsx
+++ b/packages/web/src/components/workflows/WorkflowLogs.tsx
@@ -4,9 +4,10 @@ import { MessageList } from '@/components/chat/MessageList';
 import { useSSE } from '@/hooks/useSSE';
 import { getMessages } from '@/lib/api';
 import { ensureUtc, formatDurationMs } from '@/lib/format';
+import { isWorkflowStatusCategory } from '@/lib/chat-message-reducer';
 import type { MessageResponse } from '@/lib/api';
 import { workflowSSEHandlers } from '@/stores/workflow-store';
-import type { ChatMessage, ToolCallDisplay, ErrorDisplay } from '@/lib/types';
+import type { ChatMessage, ToolCallDisplay, ErrorDisplay, TextEventMeta } from '@/lib/types';
 import type { ToolEvent } from './WorkflowExecution';
 
 interface WorkflowLogsProps {
@@ -433,48 +434,37 @@ export function WorkflowLogs({
     return combined;
   }, [queryMessages, sseMessages, isRunning, gracePolling]);
 
-  const onText = useCallback((content: string): void => {
+  const onText = useCallback((content: string, meta?: TextEventMeta): void => {
     setSseMessages(prev => {
       const last = prev[prev.length - 1];
-      // Workflow status messages (🚀 start, ✅ complete) should be their own message,
-      // matching ChatInterface's behavior and persistence segmentation. Without this,
+      // Workflow status messages should be their own message, matching
+      // ChatInterface's behavior and persistence segmentation. Without this,
       // all text concatenates into one giant streaming message, breaking text dedup
       // against DB messages (which are stored as separate segments).
-      const isWorkflowStatus = /^[\u{1F680}\u{2705}]/u.test(content);
+      const category = meta?.category;
+      const isWorkflowStatus = isWorkflowStatusCategory(category);
+      const newMessage = (): ChatMessage => ({
+        id: `msg-${String(Date.now())}`,
+        role: 'assistant' as const,
+        content,
+        timestamp: Date.now(),
+        isStreaming: true,
+        toolCalls: [],
+        ...(category !== undefined ? { category } : {}),
+      });
 
       if (last?.role === 'assistant' && last.isStreaming) {
-        const lastIsWorkflowStatus = /^[\u{1F680}\u{2705}]/u.test(last.content);
+        const lastIsWorkflowStatus = isWorkflowStatusCategory(last.category);
 
         if ((isWorkflowStatus && last.content) || (lastIsWorkflowStatus && !isWorkflowStatus)) {
           // Close the current streaming message and start a new one when:
           // 1. Incoming is a workflow status and current has content
           // 2. Current is a workflow status and incoming is regular text
-          return [
-            ...prev.slice(0, -1),
-            { ...last, isStreaming: false },
-            {
-              id: `msg-${String(Date.now())}`,
-              role: 'assistant' as const,
-              content,
-              timestamp: Date.now(),
-              isStreaming: true,
-              toolCalls: [],
-            },
-          ];
+          return [...prev.slice(0, -1), { ...last, isStreaming: false }, newMessage()];
         }
         return [...prev.slice(0, -1), { ...last, content: last.content + content }];
       }
-      return [
-        ...prev,
-        {
-          id: `msg-${String(Date.now())}`,
-          role: 'assistant' as const,
-          content,
-          timestamp: Date.now(),
-          isStreaming: true,
-          toolCalls: [],
-        },
-      ];
+      return [...prev, newMessage()];
     });
   }, []);
 

--- a/packages/web/src/hooks/useSSE.ts
+++ b/packages/web/src/hooks/useSSE.ts
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import type {
+  MessageCategory,
+  TextEventMeta,
   SSEEvent,
   ErrorDisplay,
   LoopIterationEvent,
@@ -31,7 +33,7 @@ function parseSSEEvent(raw: string): SSEEvent | null {
 }
 
 interface SSEHandlers {
-  onText: (content: string, workflowResult?: { workflowName: string; runId: string }) => void;
+  onText: (content: string, meta?: TextEventMeta) => void;
   onToolCall: (name: string, input: Record<string, unknown>, toolCallId?: string) => void;
   onToolResult: (name: string, output: string, duration: number, toolCallId?: string) => void;
   onError: (error: ErrorDisplay) => void;
@@ -61,18 +63,33 @@ export function useSSE(
   // Text batching: accumulate text for 50ms before dispatching
   const textBufferRef = useRef('');
   const flushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingCategoryRef = useRef<MessageCategory | undefined>(undefined);
   const pendingWorkflowResultRef = useRef<{ workflowName: string; runId: string } | undefined>(
     undefined
   );
 
   const flushText = useCallback((): void => {
     if (textBufferRef.current) {
-      handlersRef.current.onText(textBufferRef.current, pendingWorkflowResultRef.current);
+      handlersRef.current.onText(textBufferRef.current, {
+        category: pendingCategoryRef.current,
+        workflowResult: pendingWorkflowResultRef.current,
+      });
       textBufferRef.current = '';
+      pendingCategoryRef.current = undefined;
       pendingWorkflowResultRef.current = undefined;
     }
     flushTimerRef.current = null;
   }, []);
+
+  /** Cancel the batching window and dispatch immediately, if anything is buffered. */
+  const flushTextNow = useCallback((): void => {
+    if (!textBufferRef.current) return;
+    if (flushTimerRef.current) {
+      clearTimeout(flushTimerRef.current);
+      flushTimerRef.current = null;
+    }
+    flushText();
+  }, [flushText]);
 
   useEffect(() => {
     if (!conversationId) return;
@@ -116,7 +133,16 @@ export function useSSE(
 
         switch (data.type) {
           case 'text':
+            // One batch carries one category, so a category change is a message
+            // boundary: flush what is buffered before mixing in text of a
+            // different kind. Without this, a workflow-status line batched behind
+            // agent prose would inherit — or overwrite — the wrong category and
+            // lose its own bubble.
+            if (data.category !== pendingCategoryRef.current) {
+              flushTextNow();
+            }
             textBufferRef.current += data.content;
+            pendingCategoryRef.current = data.category;
             if (
               'workflowResult' in data &&
               data.workflowResult &&
@@ -134,24 +160,12 @@ export function useSSE(
           case 'tool_call':
             // Flush buffered text before tool events to ensure text
             // attaches to the correct message (not the previous one)
-            if (textBufferRef.current) {
-              if (flushTimerRef.current) {
-                clearTimeout(flushTimerRef.current);
-                flushTimerRef.current = null;
-              }
-              flushText();
-            }
+            flushTextNow();
             h.onToolCall(data.name, data.input, data.toolCallId);
             break;
           case 'tool_result':
             // Flush buffered text before tool result too
-            if (textBufferRef.current) {
-              if (flushTimerRef.current) {
-                clearTimeout(flushTimerRef.current);
-                flushTimerRef.current = null;
-              }
-              flushText();
-            }
+            flushTextNow();
             h.onToolResult(data.name, data.output, data.duration, data.toolCallId);
             break;
           case 'error':
@@ -165,12 +179,8 @@ export function useSSE(
             // Flush any buffered text before processing lock change,
             // otherwise text arriving just before lock release creates
             // a streaming message that never gets cleared.
-            if (!data.locked && textBufferRef.current) {
-              if (flushTimerRef.current) {
-                clearTimeout(flushTimerRef.current);
-                flushTimerRef.current = null;
-              }
-              flushText();
+            if (!data.locked) {
+              flushTextNow();
             }
             h.onLockChange(data.locked, data.queuePosition);
             break;
@@ -197,16 +207,10 @@ export function useSSE(
             h.onLoopIteration?.(data);
             break;
           case 'workflow_dispatch':
-            // Flush buffered text before dispatch events to ensure the dispatch
-            // message (🚀) is committed as an assistant message before
-            // onWorkflowDispatch attaches metadata to the "last assistant message".
-            if (textBufferRef.current) {
-              if (flushTimerRef.current) {
-                clearTimeout(flushTimerRef.current);
-                flushTimerRef.current = null;
-              }
-              flushText();
-            }
+            // Flush buffered text before dispatch events to ensure the
+            // `workflow_dispatch_status` message is committed as an assistant message
+            // before onWorkflowDispatch attaches metadata to the "last assistant message".
+            flushTextNow();
             h.onWorkflowDispatch?.(data);
             break;
           case 'workflow_output_preview':
@@ -231,6 +235,7 @@ export function useSSE(
               flushTimerRef.current = null;
             }
             textBufferRef.current = '';
+            pendingCategoryRef.current = undefined;
             pendingWorkflowResultRef.current = undefined;
             h.onRetract?.();
             break;
@@ -263,7 +268,7 @@ export function useSSE(
         flushText();
       }
     };
-  }, [conversationId, flushText]);
+  }, [conversationId, flushText, flushTextNow]);
 
   return { connected };
 }

--- a/packages/web/src/hooks/useSSE.ts
+++ b/packages/web/src/hooks/useSSE.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
+import { startsNewTextBatch } from '@/lib/chat-message-reducer';
 import type {
-  MessageCategory,
   TextEventMeta,
   SSEEvent,
   ErrorDisplay,
@@ -60,23 +60,18 @@ export function useSSE(
   const handlersRef = useRef(handlers);
   handlersRef.current = handlers;
 
-  // Text batching: accumulate text for 50ms before dispatching
+  // Text batching: accumulate text for 50ms before dispatching. The batch is
+  // dispatched as ONE message, so `pendingMetaRef` holds the single identity
+  // (category + finished run) that the buffered text belongs to.
   const textBufferRef = useRef('');
   const flushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const pendingCategoryRef = useRef<MessageCategory | undefined>(undefined);
-  const pendingWorkflowResultRef = useRef<{ workflowName: string; runId: string } | undefined>(
-    undefined
-  );
+  const pendingMetaRef = useRef<TextEventMeta>({});
 
   const flushText = useCallback((): void => {
     if (textBufferRef.current) {
-      handlersRef.current.onText(textBufferRef.current, {
-        category: pendingCategoryRef.current,
-        workflowResult: pendingWorkflowResultRef.current,
-      });
+      handlersRef.current.onText(textBufferRef.current, pendingMetaRef.current);
       textBufferRef.current = '';
-      pendingCategoryRef.current = undefined;
-      pendingWorkflowResultRef.current = undefined;
+      pendingMetaRef.current = {};
     }
     flushTimerRef.current = null;
   }, []);
@@ -132,31 +127,29 @@ export function useSSE(
         const h = handlersRef.current;
 
         switch (data.type) {
-          case 'text':
-            // One batch carries one category, so a category change is a message
-            // boundary: flush what is buffered before mixing in text of a
-            // different kind. Without this, a workflow-status line batched behind
-            // agent prose would inherit — or overwrite — the wrong category and
-            // lose its own bubble.
-            if (data.category !== pendingCategoryRef.current) {
+          case 'text': {
+            // A batch speaks for one message, so it can carry only one identity:
+            // one category and one finished run. When either changes, flush first.
+            //
+            // Category: without this a workflow-status line batched behind agent
+            // prose would inherit — or overwrite — the wrong category and lose its
+            // own bubble. Run: two `workflow_result` events for different runs can
+            // arrive back-to-back (SSETransport replays its buffer on reconnect),
+            // and merging them would drop one result card and splice the summaries.
+            const incoming: TextEventMeta = {
+              category: data.category,
+              workflowResult: data.workflowResult ?? undefined,
+            };
+            if (startsNewTextBatch(pendingMetaRef.current, incoming)) {
               flushTextNow();
             }
             textBufferRef.current += data.content;
-            pendingCategoryRef.current = data.category;
-            if (
-              'workflowResult' in data &&
-              data.workflowResult &&
-              typeof data.workflowResult === 'object'
-            ) {
-              pendingWorkflowResultRef.current = data.workflowResult as {
-                workflowName: string;
-                runId: string;
-              };
-            }
+            pendingMetaRef.current = incoming;
             if (!flushTimerRef.current) {
               flushTimerRef.current = setTimeout(flushText, 50);
             }
             break;
+          }
           case 'tool_call':
             // Flush buffered text before tool events to ensure text
             // attaches to the correct message (not the previous one)
@@ -235,8 +228,7 @@ export function useSSE(
               flushTimerRef.current = null;
             }
             textBufferRef.current = '';
-            pendingCategoryRef.current = undefined;
-            pendingWorkflowResultRef.current = undefined;
+            pendingMetaRef.current = {};
             h.onRetract?.();
             break;
           case 'heartbeat':

--- a/packages/web/src/lib/chat-message-reducer.test.ts
+++ b/packages/web/src/lib/chat-message-reducer.test.ts
@@ -161,6 +161,38 @@ describe('applyOnText — workflow-status boundary (Rules 2 & 3)', () => {
     expect(result[0].content).toBe('🚀 Starting');
   });
 
+  test('an empty placeholder adopts the category of the first text that lands in it', () => {
+    // ChatInterface pushes `{ content: '', isStreaming: true }` the moment the
+    // user sends, so a dispatch status is the first text to reach it. Without
+    // adopting the category the placeholder would look like prose, and the
+    // following text would merge into a workflow-status bubble.
+    const placeholder: ChatMessage[] = [makeAssistant({ content: '' })];
+    const filled = applyOnText(placeholder, '🚀 Dispatching workflow', makeId, NOW, {
+      category: 'workflow_dispatch_status',
+    });
+
+    expect(filled).toHaveLength(1);
+    expect(filled[0].category).toBe('workflow_dispatch_status');
+
+    const next = applyOnText(filled, 'agent prose', makeId, NOW);
+    expect(next).toHaveLength(2);
+    expect(next[0].isStreaming).toBe(false);
+    expect(next[1].content).toBe('agent prose');
+  });
+
+  test('consecutive workflow-status messages each get their own bubble', () => {
+    const prev: ChatMessage[] = [
+      makeAssistant({ content: '🚀 Starting', category: 'workflow_status' }),
+    ];
+    const result = applyOnText(prev, '🚀 Dispatching', makeId, NOW, {
+      category: 'workflow_dispatch_status',
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[0].isStreaming).toBe(false);
+    expect(result[1].category).toBe('workflow_dispatch_status');
+  });
+
   test('stamps the category on the message it creates so the next event can read it', () => {
     const result = applyOnText([], 'Starting', makeId, NOW, { category: 'workflow_status' });
 

--- a/packages/web/src/lib/chat-message-reducer.test.ts
+++ b/packages/web/src/lib/chat-message-reducer.test.ts
@@ -128,7 +128,9 @@ describe('applyOnText — new message (Rule 6)', () => {
 describe('applyOnText — workflow-status boundary (Rules 2 & 3)', () => {
   test('starts a new segment when incoming is workflow-status and current has content', () => {
     const prev: ChatMessage[] = [makeAssistant({ content: 'some existing text' })];
-    const result = applyOnText(prev, '🚀 Workflow started', makeId, NOW);
+    const result = applyOnText(prev, '🚀 Workflow started', makeId, NOW, {
+      category: 'workflow_dispatch_status',
+    });
 
     expect(result).toHaveLength(2);
     expect(result[0].isStreaming).toBe(false);
@@ -137,7 +139,9 @@ describe('applyOnText — workflow-status boundary (Rules 2 & 3)', () => {
   });
 
   test('starts a new segment when current is workflow-status and incoming is regular text', () => {
-    const prev: ChatMessage[] = [makeAssistant({ content: '✅ Workflow done' })];
+    const prev: ChatMessage[] = [
+      makeAssistant({ content: '✅ Workflow done', category: 'workflow_status' }),
+    ];
     const result = applyOnText(prev, 'Regular text now', makeId, NOW);
 
     expect(result).toHaveLength(2);
@@ -146,13 +150,64 @@ describe('applyOnText — workflow-status boundary (Rules 2 & 3)', () => {
   });
 
   test('does not start new segment when incoming is workflow-status and current is empty', () => {
-    // Empty content: the status emoji goes into the empty placeholder
+    // Empty content: the status text goes into the empty placeholder
     const prev: ChatMessage[] = [makeAssistant({ content: '' })];
-    const result = applyOnText(prev, '🚀 Starting', makeId, NOW);
+    const result = applyOnText(prev, '🚀 Starting', makeId, NOW, {
+      category: 'workflow_status',
+    });
 
     // isWorkflowStatus && last.content evaluates to false because last.content === ''
     expect(result).toHaveLength(1);
     expect(result[0].content).toBe('🚀 Starting');
+  });
+
+  test('stamps the category on the message it creates so the next event can read it', () => {
+    const result = applyOnText([], 'Starting', makeId, NOW, { category: 'workflow_status' });
+
+    expect(result[0].category).toBe('workflow_status');
+    // …and the stamped category drives the trailing boundary on the next event.
+    const next = applyOnText(result, 'agent prose', makeId, NOW);
+    expect(next).toHaveLength(2);
+    expect(next[1].content).toBe('agent prose');
+    expect(next[1].category).toBeUndefined();
+  });
+
+  test('splits on a workflow-status message that does not start with an emoji', () => {
+    // executor.ts prepends PR-review context before the 🚀 line, so a real
+    // `workflow_status` message can begin with prose. The deleted `^`-anchored
+    // emoji regex missed exactly this; the category does not.
+    const prev: ChatMessage[] = [makeAssistant({ content: 'some existing text' })];
+    const result = applyOnText(
+      prev,
+      'Reviewing PR at commit `abc1234`\n\n🚀 Starting',
+      makeId,
+      NOW,
+      {
+        category: 'workflow_status',
+      }
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[0].isStreaming).toBe(false);
+    expect(result[1].category).toBe('workflow_status');
+  });
+
+  test('does not split on emoji-prefixed text that carries no category', () => {
+    // Uncategorized `✅` notices (e.g. container write-back) are agent-adjacent
+    // prose to the server, which never segments them — the client now agrees.
+    const prev: ChatMessage[] = [makeAssistant({ content: 'some existing text' })];
+    const result = applyOnText(prev, '✅ Applied to the live folder', makeId, NOW);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toBe('some existing text✅ Applied to the live folder');
+  });
+
+  test('a non-status category is not a status boundary', () => {
+    const prev: ChatMessage[] = [makeAssistant({ content: 'some existing text' })];
+    const result = applyOnText(prev, ' more', makeId, NOW, { category: 'isolation_context' });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toBe('some existing text more');
   });
 });
 
@@ -164,7 +219,7 @@ describe('applyOnText — workflow-result (Rule 1)', () => {
   const wfResult = { workflowName: 'plan', runId: 'run-1' };
 
   test('creates a non-streaming message for a workflow result', () => {
-    const result = applyOnText([], 'Plan complete', makeId, NOW, wfResult);
+    const result = applyOnText([], 'Plan complete', makeId, NOW, { workflowResult: wfResult });
 
     expect(result).toHaveLength(1);
     expect(result[0].workflowResult).toEqual(wfResult);
@@ -174,7 +229,7 @@ describe('applyOnText — workflow-result (Rule 1)', () => {
 
   test('closes the current streaming message before adding workflow result', () => {
     const prev: ChatMessage[] = [makeAssistant({ content: 'partial' })];
-    const result = applyOnText(prev, 'Done', makeId, NOW, wfResult);
+    const result = applyOnText(prev, 'Done', makeId, NOW, { workflowResult: wfResult });
 
     expect(result).toHaveLength(2);
     expect(result[0].isStreaming).toBe(false);
@@ -185,7 +240,7 @@ describe('applyOnText — workflow-result (Rule 1)', () => {
     const prev: ChatMessage[] = [
       makeAssistant({ content: 'Plan complete', isStreaming: false, workflowResult: wfResult }),
     ];
-    const result = applyOnText(prev, 'Plan complete', makeId, NOW, wfResult);
+    const result = applyOnText(prev, 'Plan complete', makeId, NOW, { workflowResult: wfResult });
 
     // Same runId already in state — no new message added
     expect(result).toHaveLength(1);

--- a/packages/web/src/lib/chat-message-reducer.test.ts
+++ b/packages/web/src/lib/chat-message-reducer.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { applyOnText } from './chat-message-reducer';
+import { applyOnText, startsNewTextBatch } from './chat-message-reducer';
 import type { ChatMessage, ToolCallDisplay } from './types';
 
 // Helpers
@@ -240,6 +240,53 @@ describe('applyOnText — workflow-status boundary (Rules 2 & 3)', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].content).toBe('some existing text more');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useSSE batch boundary — extracted so the 50 ms coalescing window is testable
+// ---------------------------------------------------------------------------
+
+describe('startsNewTextBatch', () => {
+  const runA = { workflowName: 'plan', runId: 'run-a' };
+  const runB = { workflowName: 'plan', runId: 'run-b' };
+
+  test('keeps accumulating while the identity is unchanged', () => {
+    expect(startsNewTextBatch({}, {})).toBe(false);
+    expect(
+      startsNewTextBatch({ category: 'workflow_status' }, { category: 'workflow_status' })
+    ).toBe(false);
+    expect(
+      startsNewTextBatch(
+        { category: 'workflow_result', workflowResult: runA },
+        { category: 'workflow_result', workflowResult: runA }
+      )
+    ).toBe(false);
+  });
+
+  test('breaks when a categorized message follows agent prose', () => {
+    expect(startsNewTextBatch({}, { category: 'workflow_dispatch_status' })).toBe(true);
+  });
+
+  test('breaks when agent prose follows a categorized message', () => {
+    expect(startsNewTextBatch({ category: 'workflow_dispatch_status' }, {})).toBe(true);
+  });
+
+  test('breaks between two results for different runs', () => {
+    // SSETransport replays its buffer on reconnect, so two `workflow_result`
+    // events can land inside one 50 ms window. Merging them would drop a card.
+    expect(
+      startsNewTextBatch(
+        { category: 'workflow_result', workflowResult: runA },
+        { category: 'workflow_result', workflowResult: runB }
+      )
+    ).toBe(true);
+  });
+
+  test('breaks when a result follows text that had none', () => {
+    expect(startsNewTextBatch({}, { category: 'workflow_result', workflowResult: runA })).toBe(
+      true
+    );
   });
 });
 

--- a/packages/web/src/lib/chat-message-reducer.ts
+++ b/packages/web/src/lib/chat-message-reducer.ts
@@ -6,10 +6,19 @@
  * the same output with no side effects.
  */
 
-import type { ChatMessage } from './types';
+import type { ChatMessage, MessageCategory, TextEventMeta } from './types';
 
-/** Regex that identifies workflow-status messages (🚀 / ✅ prefix). */
-const WORKFLOW_STATUS_RE = /^[\u{1F680}\u{2705}]/u;
+/**
+ * Whether a message is workflow-status narration that deserves its own bubble.
+ *
+ * The client-side counterpart to the `isWorkflowStatus` check in the web
+ * adapter's `MessagePersistence.appendText` — both answer the same question
+ * about the same message, so they must name the same categories. The category
+ * arrives on the `text` SSE event; a message without one is agent prose.
+ */
+export function isWorkflowStatusCategory(category: MessageCategory | undefined): boolean {
+  return category === 'workflow_status' || category === 'workflow_dispatch_status';
+}
 
 /**
  * Builds a new streaming assistant message.  The `id` is caller-supplied so
@@ -20,7 +29,7 @@ function makeStreamingMessage(
   content: string,
   timestamp: number,
   isStreaming: boolean,
-  workflowResult?: { workflowName: string; runId: string }
+  meta: TextEventMeta = {}
 ): ChatMessage {
   return {
     id,
@@ -29,7 +38,8 @@ function makeStreamingMessage(
     timestamp,
     isStreaming,
     toolCalls: [],
-    ...(workflowResult !== undefined ? { workflowResult } : {}),
+    ...(meta.category !== undefined ? { category: meta.category } : {}),
+    ...(meta.workflowResult !== undefined ? { workflowResult: meta.workflowResult } : {}),
   };
 }
 
@@ -46,21 +56,26 @@ function makeStreamingMessage(
  * 5. Otherwise → append to the current streaming message.
  * 6. No streaming assistant message → create a new one.
  *
+ * "Workflow-status" is decided by `isWorkflowStatusCategory` on the event's
+ * server-supplied `category`, never by inspecting the text.
+ *
  * @param prev        Current message list (treated as immutable).
  * @param content     Text to apply.
  * @param makeId      Factory for generating a new message ID (injectable for testing).
  * @param now         Timestamp to use for new messages (injectable for testing).
- * @param workflowResult  Optional workflow-result metadata carried by the text event.
+ * @param meta        Server-supplied metadata from the text event (category,
+ *                    workflow-result). Absent `category` means agent prose.
  */
 export function applyOnText(
   prev: ChatMessage[],
   content: string,
   makeId: () => string = () => `msg-${String(Date.now())}`,
   now: number = Date.now(),
-  workflowResult?: { workflowName: string; runId: string }
+  meta: TextEventMeta = {}
 ): ChatMessage[] {
   const last = prev[prev.length - 1];
-  const isWorkflowStatus = WORKFLOW_STATUS_RE.test(content);
+  const isWorkflowStatus = isWorkflowStatusCategory(meta.category);
+  const { workflowResult } = meta;
 
   // Rule 1: workflow-result messages always start as a new non-streaming message.
   // Dedup: SSETransport replays buffered events on reconnect, so skip if already present.
@@ -72,18 +87,18 @@ export function applyOnText(
       last?.role === 'assistant' && last.isStreaming
         ? [...prev.slice(0, -1), { ...last, isStreaming: false }]
         : [...prev];
-    return [...updated, makeStreamingMessage(makeId(), content, now, false, workflowResult)];
+    return [...updated, makeStreamingMessage(makeId(), content, now, false, meta)];
   }
 
   if (last?.role === 'assistant' && last.isStreaming) {
-    const lastIsWorkflowStatus = WORKFLOW_STATUS_RE.test(last.content);
+    const lastIsWorkflowStatus = isWorkflowStatusCategory(last.category);
 
     // Rules 2 & 3: workflow-status boundary.
     if ((isWorkflowStatus && last.content) || (lastIsWorkflowStatus && !isWorkflowStatus)) {
       return [
         ...prev.slice(0, -1),
         { ...last, isStreaming: false },
-        makeStreamingMessage(makeId(), content, now, true),
+        makeStreamingMessage(makeId(), content, now, true, meta),
       ];
     }
 
@@ -93,7 +108,7 @@ export function applyOnText(
       return [
         ...prev.slice(0, -1),
         { ...last, isStreaming: false },
-        makeStreamingMessage(makeId(), content, now, true),
+        makeStreamingMessage(makeId(), content, now, true, meta),
       ];
     }
 
@@ -102,5 +117,5 @@ export function applyOnText(
   }
 
   // Rule 6: no active streaming assistant message → create a new one.
-  return [...prev, makeStreamingMessage(makeId(), content, now, true)];
+  return [...prev, makeStreamingMessage(makeId(), content, now, true, meta)];
 }

--- a/packages/web/src/lib/chat-message-reducer.ts
+++ b/packages/web/src/lib/chat-message-reducer.ts
@@ -21,6 +21,26 @@ export function isWorkflowStatusCategory(category: MessageCategory | undefined):
 }
 
 /**
+ * Whether an incoming `text` event must close the batch `useSSE` is currently
+ * accumulating.
+ *
+ * The hook coalesces text over a 50 ms window and hands the result to
+ * `applyOnText` as ONE segment, so a batch can carry only one identity: one
+ * category and one finished run. When either differs, the buffered text belongs
+ * to a different message and has to go out first.
+ *
+ * Extracted from the hook so the decision is unit-testable — `@archon/web` has
+ * no DOM harness and `EventSource` does not exist under Bun, so nothing inside
+ * `useSSE` itself can be exercised directly.
+ */
+export function startsNewTextBatch(buffered: TextEventMeta, incoming: TextEventMeta): boolean {
+  return (
+    buffered.category !== incoming.category ||
+    buffered.workflowResult?.runId !== incoming.workflowResult?.runId
+  );
+}
+
+/**
  * Builds a new streaming assistant message.  The `id` is caller-supplied so
  * that tests can produce stable, deterministic IDs.
  */

--- a/packages/web/src/lib/chat-message-reducer.ts
+++ b/packages/web/src/lib/chat-message-reducer.ts
@@ -113,7 +113,23 @@ export function applyOnText(
     }
 
     // Rule 5: append to existing streaming message.
-    return [...prev.slice(0, -1), { ...last, content: last.content + content }];
+    //
+    // A message can start life without a category: `ChatInterface` pushes an
+    // empty "thinking" placeholder the moment the user sends, and the guard in
+    // Rules 2 & 3 lets text fall through into it (`last.content` is ''). The
+    // first text to land therefore defines what that message is — adopt its
+    // category, or the *next* event's trailing-boundary check reads `undefined`
+    // and merges prose into what is really a workflow-status bubble.
+    return [
+      ...prev.slice(0, -1),
+      {
+        ...last,
+        content: last.content + content,
+        ...(last.category === undefined && meta.category !== undefined
+          ? { category: meta.category }
+          : {}),
+      },
+    ];
   }
 
   // Rule 6: no active streaming assistant message → create a new one.

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -44,6 +44,8 @@ export interface TextEvent extends BaseSSEEvent {
   isComplete: boolean;
   /** Present only on server-emitted framework messages; absent for agent prose. */
   category?: MessageCategory;
+  /** Present only on `workflow_result` messages — identifies the finished run. */
+  workflowResult?: { workflowName: string; runId: string };
 }
 
 /**
@@ -51,10 +53,7 @@ export interface TextEvent extends BaseSSEEvent {
  * `useSSE` batches text over a 50 ms window, so this describes the flushed
  * segment rather than any single event.
  */
-export interface TextEventMeta {
-  category?: MessageCategory;
-  workflowResult?: { workflowName: string; runId: string };
-}
+export type TextEventMeta = Pick<TextEvent, 'category' | 'workflowResult'>;
 
 // Tool call started
 export interface ToolCallEvent extends BaseSSEEvent {

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -13,6 +13,24 @@ export type WorkflowRunStatus =
 export type WorkflowStepStatus = 'pending' | 'running' | 'completed' | 'failed' | 'skipped';
 export type ArtifactType = 'pr' | 'commit' | 'file_created' | 'file_modified' | 'branch';
 
+/**
+ * Framework category the server attaches to a message it emitted itself (as
+ * opposed to the agent's own prose). Mirrors `MessageMetadata['category']` in
+ * `@archon/core` — `@archon/web` is a client package and cannot import from a
+ * server package, so the union is restated here.
+ *
+ * An unrecognized value is a wider server, not an error: TypeScript does not
+ * narrow at runtime, and every consumer asks a predicate ("is this a workflow
+ * status?") rather than switching exhaustively, so a new category degrades to
+ * ordinary prose.
+ */
+export type MessageCategory =
+  | 'tool_call_formatted'
+  | 'workflow_status'
+  | 'workflow_dispatch_status'
+  | 'isolation_context'
+  | 'workflow_result';
+
 // Base SSE event
 interface BaseSSEEvent {
   type: string;
@@ -24,6 +42,18 @@ export interface TextEvent extends BaseSSEEvent {
   type: 'text';
   content: string;
   isComplete: boolean;
+  /** Present only on server-emitted framework messages; absent for agent prose. */
+  category?: MessageCategory;
+}
+
+/**
+ * The non-text fields of a `text` SSE event, as handed to an `onText` handler.
+ * `useSSE` batches text over a 50 ms window, so this describes the flushed
+ * segment rather than any single event.
+ */
+export interface TextEventMeta {
+  category?: MessageCategory;
+  workflowResult?: { workflowName: string; runId: string };
 }
 
 // Tool call started
@@ -249,6 +279,13 @@ export interface ChatMessage {
   timestamp: number;
   isStreaming?: boolean;
   files?: FileAttachment[];
+  /**
+   * Category of the `text` event that opened this message. Retained so the next
+   * event can test the *previous* segment's category, the same way
+   * `BufferedSegment.category` works server-side in the web adapter's
+   * `MessagePersistence`.
+   */
+  category?: MessageCategory;
   workflowDispatch?: {
     workerConversationId: string;
     workflowName: string;


### PR DESCRIPTION
## Problem and outcome

The server already knows which chat messages are workflow narration — it stamps them with a typed `category` and uses that field for its own segmentation — but the live SSE `text` event dropped it, so the legacy chat client re-derived the same decision by testing whether the message text began with 🚀 or ✅. The two implementations disagreed in both directions, which meant the live view and the same conversation reloaded from the database rendered differently.

- **Outcome:** the `text` SSE event carries `category`, and both client reducers segment on it. Neither copy of the emoji regex exists any more.
- **Invariant:** the client and `MessagePersistence` answer "is this a workflow status?" from the same field with the same list of categories, so live rendering and reloaded rendering agree.
- **Scope boundary:** no rendering, styling, or persistence change; `WorkflowLogs`' local reducer stays local (it deliberately lacks the workflow-result and tool-call rules); the console is untouched — it invalidates on `text` and re-reads persisted rows.

## Review guidance

- **Feedback requested:** correctness of the absent-`category` decision, and whether the batching boundary in `useSSE` is the right place to enforce "one segment, one category".
- **Start here:** `packages/server/src/adapters/web.ts` — the one-line wire change everything else follows from.
- **Review order:** `web.ts` (producer) → `packages/web/src/lib/types.ts` (`MessageCategory`, `TextEvent.category`, `ChatMessage.category`) → `useSSE.ts` (batching boundary) → `chat-message-reducer.ts` (`isWorkflowStatusCategory`, both regex tests replaced, and the Rule 5 placeholder adoption) → `WorkflowLogs.tsx` (second copy). Reviewing by commit also works: the first carries the wire change, the second the placeholder gap it exposed.
- **Lower-attention areas:** the five identical `if (buffered) { clearTimeout; flush() }` blocks in `useSSE` collapsed into `flushTextNow()` — mechanical, and the new category boundary needed the sixth.
- **Known risk or uncertainty:** uncategorized `✅` messages lose their own bubble in the live view. Deliberate — see *Behavior change*.

## Solution

`WebAdapter.sendMessage` adds `category` to the `text` payload when the metadata has one. `useSSE` carries it through the 50 ms text batch and flushes when an incoming event's category differs from the buffered one, so a batch never has to speak for two kinds of message — without that, a status line arriving just behind agent prose would concatenate and inherit the wrong category. `applyOnText` and `WorkflowLogs`' reducer both call one shared `isWorkflowStatusCategory()` predicate, and messages retain the category that opened them so the *trailing* boundary can be tested the same way the server tests `lastSeg.category`.

The emoji regex was the only place a second answer to this question existed. Deleting it is the point of the change, not a side effect: the server has been the source of truth all along, and the client was guessing at it from prose.

The second commit closes a gap that only appears once segmentation depends on a stored field. `ChatInterface` pushes an empty `{ content: '', isStreaming: true }` placeholder the moment the user sends, and the `last.content` guard in the status boundary lets text fall straight into it — but the placeholder is built outside the reducer and carries no category. A dispatch status landing there produced a bubble that *looked* like prose to the next event. The first text to reach an uncategorized message now defines its category, which is also how the server behaves: `BufferedSegment.category` is set once when the segment is pushed and never rewritten.

The third commit began as review tidy-up and turned out to fix **a live bug on `dev`**. `pendingWorkflowResultRef` was set by any text event carrying a result and cleared only on flush, so prose and a result arriving inside the same 50 ms window concatenated and flushed as one `onText` carrying the result's metadata — Rule 1 then made a single message, swallowing the agent's prose into the result card, and with two different runs dropping one card entirely and splicing the summaries. `SSETransport` replays its buffer on reconnect, which is exactly how two results land in one window, and is why `applyOnText` already deduplicates by `runId`. Making the finished run part of the batch key fixes it; declaring `workflowResult` on `TextEvent` is what let the batch key be stated honestly.

### The two divergences this fixes

| | Server (`persistence.ts`) | Client (before) |
|---|---|---|
| `workflow_status` message that opens with PR-review context, not the emoji (`executor.ts` prepends `Reviewing PR at commit …` before the 🚀 line) | own segment | **merged** — the `^`-anchored regex misses it |
| Uncategorized `✅ Applied to the live folder` (`dag-executor.ts`) | merged | **own segment** |

### Absent `category` — the deliberate decision

**A text event with no category is agent prose and is not a workflow status.** No text-based fallback survives.

This is not a new rule. `MessagePersistence.appendText` has always treated an uncategorized message as ordinary prose, and every row the client re-renders after a reload was segmented that way. Falling back to the emoji test on absent `category` would preserve exactly the disagreement this PR exists to remove.

Version skew cannot strand a client either: `@archon/web` is built into and served by the same Archon binary, so "new client, old server" is unreachable, and a browser holding a tab open across an upgrade is running the old bundle, which ignores the new field entirely.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | A message got its own chat bubble if its text started with 🚀/✅ | A message gets its own bubble if the server categorised it `workflow_status` or `workflow_dispatch_status` |
| **Failure behavior** | An unrecognised message shape silently produced the wrong segmentation, differing from the persisted view | An unrecognised or absent category degrades to prose — the same answer the server gives, so the two views stay consistent |
| **Result cards** | Prose arriving within 50 ms of a workflow result was swallowed into the result card; two results in one window lost a card and spliced their summaries | The finished run is part of the batch key, so each result is its own message and prose stays outside it |

The accepted cost: uncategorized `✅` notices (container write-back, `dag-executor.ts:7886`/`:7955`) merge into the preceding message in the live view — exactly as they already do on reload. If that grouping is wanted, the fix is to give those sends a category at the source, which is one edit at the server rather than a heuristic at the far end of the wire.

## Architecture

```mermaid
flowchart LR
  O["orchestrator / executor<br/>sendMessage(msg, {category})"] --> W["WebAdapter.sendMessage"]
  W --> P["MessagePersistence<br/>segments on category"]
  W ==>|"text event + category"| S["useSSE<br/>startsNewTextBatch()"]
  S --> R["applyOnText / WorkflowLogs<br/>isWorkflowStatusCategory()"]
```

### Changed seams

| Boundary or contract | Change | Evidence |
|---|---|---|
| `WebAdapter.sendMessage → text SSE event` | additive `category` field; omitted for agent prose | `packages/server/src/adapters/web.ts`, `web.test.ts` (3 new tests) |
| `useSSE → onText` | `onText(content, workflowResult?)` → `onText(content, meta?: TextEventMeta)`; a change of category *or* finished run forces a batch flush | `packages/web/src/hooks/useSSE.ts`; both consumers updated, enforced by the type-checker |
| `text event → ChatMessage` | `ChatMessage.category` retains the opening category, mirroring `BufferedSegment.category` server-side | `packages/web/src/lib/types.ts`, `chat-message-reducer.ts` |
| `TextEvent` wire type | `workflowResult` is now declared, not reached through an `in` check and an unchecked cast — the adapter has always emitted it | `packages/web/src/lib/types.ts`, `useSSE.ts` |

## Validation

- `bun run validate` — exit code `0`; 140 test suites, `0 fail` in every one — proves type-check, lint (`--max-warnings 0`), format, and the full per-package suite pass.
- `bun test src/lib/chat-message-reducer.test.ts` (in `packages/web`) — 25 pass / 0 fail — covers both new directions of the category decision (a `workflow_status` message with no leading emoji **does** split; emoji-prefixed text with no category **does not**), the category being stamped onto new messages, adopted by an empty placeholder, and driving the trailing boundary — plus every arm of `startsNewTextBatch`, including two results for different runs.
- `bun test src/adapters/web.test.ts` (in `packages/server`) — 6 pass / 0 fail — the field is on the wire when metadata carries it, the key is absent for prose, and `tool_call_formatted` / `isolation_context` are still suppressed rather than emitted.
- The compiler is load-bearing evidence here: changing `onText`'s signature failed the build at every call site until each was updated, so no consumer was left reading the old shape.
- **Not verified:** the ref plumbing *inside* `useSSE` — buffer append, timer arming, flush-on-unmount — is still exercised only by the type-checker. `@archon/web` has no DOM or React harness and Bun has no `EventSource`, so nothing in the hook can be driven directly; the repo's one hook test (`useBuilderKeyboard.test.ts`) tests an extracted pure function for the same reason. The *decisions* are now extracted and tested (`startsNewTextBatch`, `isWorkflowStatusCategory`, `applyOnText`); what remains untested is the wiring between them. Adding a renderer to this package for that wiring, in a UI slated for replacement by the console, was not judged worth the dependency.
- **CI note:** `test (windows-latest)` failed on an earlier push in `scripts/migrate-state-dir.test.ts` at exactly 5016 ms — Bun's 5000 ms default, the bimodal signature described in `AGENTS.md`. Unrelated to this diff (no file it touches), and the same test failed identically at 5016 ms on `chore/dead-code-and-rulecheck-guide` 17 minutes earlier, so it is environmental and pre-existing rather than introduced here.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | Purely additive on the wire; no API response shape changed, so no `generate:types` run is needed. Old clients ignore the field. | `packages/server/src/adapters/web.ts`; `api.generated.d.ts` untouched |
| Rollout / rollback | Three commits, no schema or persisted-state change; revert restores the prior heuristic with no cleanup. | — |

## Links

- Surfaced by the #2564 audit (*Natural Language Is Not a Wire Format*): the client was reconstructing a typed server decision from prose. No separate issue was filed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streamed text events now include message category metadata.
  * Chat messages and workflow logs preserve message types.
  * Streaming content separates automatically when its category or workflow run changes.

* **Bug Fixes**
  * Workflow statuses are identified reliably through metadata instead of text formatting.
  * Tool calls, workflow results, and isolation context messages are handled without misclassification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

