### PR TITLE
fix(orchestrator): a plain message at an approval gate no longer approves it

### DIFF
--- a/.claude/skills/archon/references/workflow-dag.md
+++ b/.claude/skills/archon/references/workflow-dag.md
@@ -664,9 +664,12 @@ archon workflow reject <run-id> --reason "plan needs more test coverage"
 /workflow approve <run-id> <optional comment>
 /workflow reject <run-id> <optional reason>
 
-# Natural language (all platforms except CLI — auto-detects paused workflow)
+# Asking the chat agent (all platforms except CLI)
 User: "Looks good, proceed"
-# → auto-approves. With capture_response: true, the message becomes $review-gate.output
+# → the agent reads the open gate and approves it; the run continues.
+#   Your words travel through as the comment, so with capture_response: true they
+#   become $review-gate.output. A plain message is NOT an automatic approval —
+#   an objection rejects, and an ambiguous message resolves nothing.
 ```
 
 ### What Does NOT Work on Approval Nodes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking
+
+- **A plain message at an approval gate no longer approves it.** While a run was paused at a human gate, any message that did not start with `/` was recorded as an approval — so "no, stop, why is it editing the schema?" resolved the gate as approved, stored the objection itself as the approval comment (and as `$gate.output` under `capture_response: true`), and continued doing the thing the user objected to. There was no interpretation step and no natural-language way to reject. The open gate is now given to the chat agent as context for the turn, and the agent resolves it through the same confirm-gated `approve`/`reject` verbs the slash commands drive: a clear approval approves, a clear objection rejects with the user's own words as the reason, and an ambiguous message resolves nothing and gets a question back. Providers without native tools reach the same verbs over the `archon workflow approve|reject` CLI. Resolving a gate now also continues the run on every chat surface — including `/workflow approve` and `/workflow reject`, which previously told you to "type your response in this conversation to resume" and left the run parked. Deterministic behaviour is still available: use the slash commands. (#2565)
+
 ## [0.9.0] - 2026-08-17
 
 Workflows become properly composable: a workflow can now declare the arguments it takes and the result it returns, ship as one self-contained folder, and be simulated end to end without contacting a provider. Alongside that, a workflow node's capabilities become what its YAML declares rather than whatever happens to be configured on the operator's machine — see Breaking before upgrading.

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -2787,7 +2787,8 @@ export async function workflowApproveCommand(
   const resolvedId = await resolveRunIdArg(runId, cwd);
   const result = await approveWorkflow(resolvedId, comment);
 
-  // CLI auto-resumes after approval (unlike chat, which defers to next user message)
+  // CLI auto-resumes after approval, as chat does since #2565. `--json` (handled
+  // above) is the one surface that records the decision without continuing.
   if (!result.workingPath) {
     throw new Error(
       `Workflow run '${resolvedId}' has no working path recorded.\n` +

--- a/packages/core/src/db/workflows.ts
+++ b/packages/core/src/db/workflows.ts
@@ -428,7 +428,8 @@ export async function getActiveWorkflowRun(conversationId: string): Promise<Work
 
 /**
  * Find a paused workflow run for a conversation (or its parent).
- * Used by the message handler to detect approval gates awaiting a natural-language response.
+ * Used by the message handler to give the chat agent the open approval gate as
+ * context for the turn (#2565).
  * Non-throwing: returns null on DB error so the caller can fall through to normal routing.
  */
 export async function getPausedWorkflowRun(conversationId: string): Promise<WorkflowRun | null> {

--- a/packages/core/src/handlers/command-handler.test.ts
+++ b/packages/core/src/handlers/command-handler.test.ts
@@ -2400,6 +2400,124 @@ describe('CommandHandler', () => {
       });
     });
 
+    // A gate decision that does not continue the run leaves it stranded (#2565).
+    // Before #2565 these commands told the user to "type your response to
+    // resume", which relied on a natural-language branch that no longer exists.
+    describe('/workflow approve|reject — run continuation', () => {
+      const baseConversation: Conversation = {
+        id: 'conv-approve',
+        platform_type: 'telegram',
+        platform_conversation_id: 'chat-approve',
+        ai_assistant_type: 'claude',
+        codebase_id: null,
+        cwd: null,
+        isolation_env_id: null,
+        last_activity_at: null,
+        created_at: new Date(),
+        updated_at: new Date(),
+      };
+
+      function pausedRun(overrides: Record<string, unknown> = {}) {
+        return {
+          id: 'run-gate',
+          workflow_name: 'gated-wf',
+          conversation_id: 'conv-approve',
+          parent_conversation_id: null,
+          codebase_id: null,
+          status: 'paused' as const,
+          user_message: 'original prompt',
+          metadata: { approval: { type: 'approval', nodeId: 'review', message: 'Approve?' } },
+          started_at: new Date(),
+          completed_at: null,
+          last_activity_at: new Date(),
+          working_path: '/repo',
+          ...overrides,
+        };
+      }
+
+      /** The gate op reads the run, then the continuation reads it again. */
+      function stubRunReads(run: ReturnType<typeof pausedRun>): void {
+        mockGetWorkflowRun.mockResolvedValueOnce(run).mockResolvedValueOnce(run);
+      }
+
+      function stubWorkflowDiscovery(): void {
+        spyDiscoverWorkflows?.mockResolvedValue({
+          workflows: [makeTestWorkflowWithSource({ name: 'gated-wf' })],
+          errors: [],
+        });
+      }
+
+      test('approve hands the orchestrator the resume payload for the same run', async () => {
+        const run = pausedRun();
+        stubRunReads(run);
+        stubWorkflowDiscovery();
+
+        const result = await handleCommand(baseConversation, '/workflow approve run-gate LGTM');
+
+        expect(result.success).toBe(true);
+        expect(result.message).toContain('approved');
+        expect(result.message).toContain('Resuming');
+        expect(result.workflow?.resumeRunId).toBe('run-gate');
+        expect(result.workflow?.resumeRun).toBe(run);
+        expect(result.workflow?.definition.name).toBe('gated-wf');
+        // The run's own prompt drives the resume, not the approve comment.
+        expect(result.workflow?.args).toBe('original prompt');
+      });
+
+      test('reject with an on_reject rework hands back the resume payload', async () => {
+        const run = pausedRun({
+          metadata: {
+            approval: {
+              type: 'approval',
+              nodeId: 'review',
+              message: 'Approve?',
+              onRejectPrompt: 'Address $REJECTION_REASON',
+            },
+          },
+        });
+        stubRunReads(run);
+        stubWorkflowDiscovery();
+
+        const result = await handleCommand(
+          baseConversation,
+          '/workflow reject run-gate schema is wrong'
+        );
+
+        expect(result.success).toBe(true);
+        expect(result.message).toContain('Reworking');
+        expect(result.workflow?.resumeRunId).toBe('run-gate');
+      });
+
+      test('reject that cancels the run hands back nothing to resume', async () => {
+        // No on_reject prompt ⇒ the run is cancelled, which IS its terminal
+        // state — a resume payload here would try to restart a dead run.
+        mockGetWorkflowRun.mockResolvedValueOnce(pausedRun());
+
+        const result = await handleCommand(baseConversation, '/workflow reject run-gate no thanks');
+
+        expect(result.success).toBe(true);
+        expect(result.message).toContain('rejected and cancelled');
+        expect(result.workflow).toBeUndefined();
+      });
+
+      test('an unresolvable continuation still reports the decision as recorded', async () => {
+        const run = pausedRun();
+        stubRunReads(run);
+        // The workflow YAML is gone, so the run cannot be continued.
+        spyDiscoverWorkflows?.mockResolvedValue({ workflows: [], errors: [] });
+
+        const result = await handleCommand(baseConversation, '/workflow approve run-gate');
+
+        // success:false would send the user to re-approve a gate that is already
+        // resolved — and the second approve throws.
+        expect(result.success).toBe(true);
+        expect(result.message).toContain('approved');
+        expect(result.message).toContain('could not be continued automatically');
+        expect(result.message).toContain('/workflow resume run-gate');
+        expect(result.workflow).toBeUndefined();
+      });
+    });
+
     describe('/workflow approve — standard approval node with captureResponse', () => {
       const baseConversation: Conversation = {
         id: 'conv-approve',

--- a/packages/core/src/handlers/command-handler.test.ts
+++ b/packages/core/src/handlers/command-handler.test.ts
@@ -2500,6 +2500,23 @@ describe('CommandHandler', () => {
         expect(result.workflow).toBeUndefined();
       });
 
+      test('a container run is resolved but points at the CLI instead of resuming', async () => {
+        // Chat cannot rewire the container, so dispatching a resume would fail
+        // the run to say what this message says for free.
+        const run = pausedRun({ metadata: { ...pausedRun().metadata, isolation: 'container' } });
+        stubRunReads(run);
+        stubWorkflowDiscovery();
+
+        const result = await handleCommand(baseConversation, '/workflow approve run-gate');
+
+        expect(result.success).toBe(true);
+        expect(result.message).toContain('approved');
+        expect(result.message).toContain('isolation container');
+        expect(result.message).toContain('archon workflow resume run-gate');
+        expect(result.message).not.toContain('/workflow resume run-gate');
+        expect(result.workflow).toBeUndefined();
+      });
+
       test('an unresolvable continuation still reports the decision as recorded', async () => {
         const run = pausedRun();
         stubRunReads(run);

--- a/packages/core/src/handlers/command-handler.ts
+++ b/packages/core/src/handlers/command-handler.ts
@@ -264,6 +264,107 @@ function findWorkflowLoadError(
   return loadErrors.find(error => error.filename.replace(/\.ya?ml$/, '') === workflowName);
 }
 
+/**
+ * Resolve everything the orchestrator needs to continue a resumable run: the run
+ * itself plus its workflow definition, packaged as the `workflow` payload of a
+ * `CommandResult`. Returns a user-facing failure message instead when the run is
+ * not resumable or its workflow can no longer be loaded.
+ *
+ * Shared by `/workflow resume`, `/workflow approve` and `/workflow reject`
+ * (#2565): a gate decision that does not continue the run leaves it stranded, so
+ * all three resolve the same continuation the same way.
+ */
+async function resolveRunContinuation(
+  runId: string,
+  workflowCwd: string
+): Promise<
+  | { ok: true; workflow: NonNullable<CommandResult['workflow']>; workflowName: string }
+  | { ok: false; message: string }
+> {
+  const run = await resumeWorkflow(runId);
+  let workflowEntries: readonly WorkflowWithSource[];
+  let loadErrors: readonly WorkflowLoadError[];
+  try {
+    const result = await discoverWorkflowsWithConfig(workflowCwd, loadConfig);
+    workflowEntries = result.workflows;
+    loadErrors = result.errors;
+  } catch (error) {
+    const err = error as Error;
+    getLog().error({ err, cwd: workflowCwd, runId }, 'cmd.workflow_resume_discovery_failed');
+    return {
+      ok: false,
+      message: `Failed to load workflows: ${err.message}\n\nCheck .archon/workflows/ for YAML syntax issues.`,
+    };
+  }
+  const workflow = resolveWorkflowName(
+    run.workflow_name,
+    workflowEntries.map(ws => ws.workflow)
+  );
+  if (!workflow) {
+    const loadError = findWorkflowLoadError(loadErrors, run.workflow_name);
+    if (loadError) {
+      return {
+        ok: false,
+        message: `Workflow \`${run.workflow_name}\` failed to load: ${loadError.error}\n\nFix the YAML file and try again.`,
+      };
+    }
+    return {
+      ok: false,
+      message:
+        `Workflow \`${run.workflow_name}\` for run ${runId} was not found.\n\n` +
+        'Use /workflow list to check available workflows.',
+    };
+  }
+  return {
+    ok: true,
+    workflowName: workflow.name,
+    workflow: {
+      definition: workflow,
+      args: run.user_message,
+      resumeRunId: run.id,
+      resumeRun: run,
+    },
+  };
+}
+
+/**
+ * Attach the run continuation to an already-recorded gate decision.
+ *
+ * The decision is committed by the time this runs, so a continuation that cannot
+ * be resolved is reported as a follow-up step, never as a failed command — saying
+ * "failed" about a gate that IS resolved would send the user to re-approve a run
+ * that refuses a second decision.
+ */
+async function withRunContinuation(
+  runId: string,
+  workflowCwd: string,
+  headline: string,
+  action: 'approve' | 'reject'
+): Promise<CommandResult> {
+  let continuation: Awaited<ReturnType<typeof resolveRunContinuation>>;
+  try {
+    continuation = await resolveRunContinuation(runId, workflowCwd);
+  } catch (error) {
+    const err = error as Error;
+    getLog().warn(
+      { err, errorType: err.constructor.name, runId, action },
+      'cmd.workflow_gate_continuation_unresolved'
+    );
+    continuation = { ok: false, message: err.message };
+  }
+  if (!continuation.ok) {
+    return {
+      success: true,
+      message: `${headline}\nThe run could not be continued automatically: ${continuation.message}\nResume it with \`/workflow resume ${runId}\` once that is fixed.`,
+    };
+  }
+  return {
+    success: true,
+    message: `${headline}\nResuming \`${continuation.workflowName}\`...`,
+    workflow: continuation.workflow,
+  };
+}
+
 async function handleWorktreeCommand(
   conversation: Conversation,
   args: string[]
@@ -751,47 +852,14 @@ async function handleWorkflowCommand(
         };
       }
       try {
-        const run = await resumeWorkflow(runId);
-        let workflowEntries: readonly WorkflowWithSource[];
-        let loadErrors: readonly WorkflowLoadError[];
-        try {
-          const result = await discoverWorkflowsWithConfig(workflowCwd, loadConfig);
-          workflowEntries = result.workflows;
-          loadErrors = result.errors;
-        } catch (error) {
-          const err = error as Error;
-          getLog().error({ err, cwd: workflowCwd, runId }, 'cmd.workflow_resume_discovery_failed');
-          return {
-            success: false,
-            message: `Failed to load workflows: ${err.message}\n\nCheck .archon/workflows/ for YAML syntax issues.`,
-          };
-        }
-        const workflows = workflowEntries.map(ws => ws.workflow);
-        const workflow = resolveWorkflowName(run.workflow_name, workflows);
-        if (!workflow) {
-          const loadError = findWorkflowLoadError(loadErrors, run.workflow_name);
-          if (loadError) {
-            return {
-              success: false,
-              message: `Workflow \`${run.workflow_name}\` failed to load: ${loadError.error}\n\nFix the YAML file and try again.`,
-            };
-          }
-          return {
-            success: false,
-            message:
-              `Workflow \`${run.workflow_name}\` for run ${runId} was not found.\n\n` +
-              'Use /workflow list to check available workflows.',
-          };
+        const continuation = await resolveRunContinuation(runId, workflowCwd);
+        if (!continuation.ok) {
+          return { success: false, message: continuation.message };
         }
         return {
           success: true,
-          message: `Resuming workflow: \`${workflow.name}\``,
-          workflow: {
-            definition: workflow,
-            args: run.user_message,
-            resumeRunId: run.id,
-            resumeRun: run,
-          },
+          message: `Resuming workflow: \`${continuation.workflowName}\``,
+          workflow: continuation.workflow,
         };
       } catch (error) {
         const err = error as Error;
@@ -874,11 +942,14 @@ async function handleWorkflowCommand(
       try {
         const result = await approveWorkflow(runId, comment);
         const pathInfo = result.workingPath ? `\nPath: \`${result.workingPath}\`` : '';
-        const msg =
+        const headline =
           result.type === 'interactive_loop'
-            ? `Workflow \`${result.workflowName}\` loop input received.${pathInfo}\nType your next message in this conversation to resume the workflow.`
-            : `Workflow \`${result.workflowName}\` approved.${pathInfo}\nType your response in this conversation to resume the workflow.`;
-        return { success: true, message: msg };
+            ? `Workflow \`${result.workflowName}\` loop input received.${pathInfo}`
+            : `Workflow \`${result.workflowName}\` approved.${pathInfo}`;
+        // Resolving is only half the action — continue the run too (#2565).
+        // Before #2565 this told the user to "type your response to resume",
+        // which relied on a natural-language branch that no longer exists.
+        return await withRunContinuation(runId, workflowCwd, headline, 'approve');
       } catch (error) {
         const err = error as Error;
         getLog().error({ err, runId }, 'cmd.workflow_approve_failed');
@@ -904,12 +975,14 @@ async function handleWorkflowCommand(
             message: `Workflow \`${result.workflowName}\` rejected and cancelled${suffix}.`,
           };
         }
-        return {
-          success: true,
-          message:
-            `Workflow \`${result.workflowName}\` rejected. Reworking with your feedback...\n` +
-            'Type your next message in this conversation to resume the workflow.',
-        };
+        // Not cancelled means an on_reject rework is staged — continue the run so
+        // the rework actually happens (#2565).
+        return await withRunContinuation(
+          runId,
+          workflowCwd,
+          `Workflow \`${result.workflowName}\` rejected. Reworking with your feedback...`,
+          'reject'
+        );
       } catch (error) {
         const err = error as Error;
         getLog().error({ err, runId }, 'cmd.workflow_reject_failed');

--- a/packages/core/src/handlers/command-handler.ts
+++ b/packages/core/src/handlers/command-handler.ts
@@ -25,6 +25,7 @@ import type {
   WorkflowLoadError,
   WorkflowDefinition,
 } from '@archon/workflows/schemas/workflow';
+import { isContainerRun } from '@archon/workflows/schemas/workflow-run';
 import * as workflowDb from '../db/workflows';
 import {
   approveWorkflow,
@@ -279,9 +280,21 @@ async function resolveRunContinuation(
   workflowCwd: string
 ): Promise<
   | { ok: true; workflow: NonNullable<CommandResult['workflow']>; workflowName: string }
-  | { ok: false; message: string }
+  // `resumeHint` replaces the caller's default "retry with /workflow resume"
+  // line when that is the wrong next step.
+  | { ok: false; message: string; resumeHint?: string }
 > {
   const run = await resumeWorkflow(runId);
+  // A container run can only be resumed where the container can be rewired, so
+  // handing this one back for a chat dispatch would fail the run to say what we
+  // can say here for free (#2565).
+  if (isContainerRun(run)) {
+    return {
+      ok: false,
+      message: 'it executed inside an isolation container, which chat cannot rewire.',
+      resumeHint: `Finish it with \`archon workflow resume ${runId}\` from the CLI in the same project.`,
+    };
+  }
   let workflowEntries: readonly WorkflowWithSource[];
   let loadErrors: readonly WorkflowLoadError[];
   try {
@@ -353,9 +366,11 @@ async function withRunContinuation(
     continuation = { ok: false, message: err.message };
   }
   if (!continuation.ok) {
+    const hint =
+      continuation.resumeHint ?? `Resume it with \`/workflow resume ${runId}\` once that is fixed.`;
     return {
       success: true,
-      message: `${headline}\nThe run could not be continued automatically: ${continuation.message}\nResume it with \`/workflow resume ${runId}\` once that is fixed.`,
+      message: `${headline}\nThe run could not be continued automatically: ${continuation.message}\n${hint}`,
     };
   }
   return {

--- a/packages/core/src/orchestrator/manage-run-tool.test.ts
+++ b/packages/core/src/orchestrator/manage-run-tool.test.ts
@@ -505,6 +505,28 @@ describe('manage_run — gate continuation', () => {
     expect(mockApprove).not.toHaveBeenCalled();
   });
 
+  test('a container run is never handed to the continuation — it points at the CLI', async () => {
+    // executeWorkflow fails a resume it cannot rewire, so scheduling one would
+    // fail the run to say what the reply says for free.
+    mockFindByPrefix.mockResolvedValue([
+      makeRun({ status: 'paused', metadata: { isolation: 'container' } }),
+    ]);
+    mockApprove.mockResolvedValue({ workflowName: 'wf', type: 'approval_gate' });
+    const { resolved, ctx } = makeCtx();
+
+    const out = await buildManageRunTool(ctx).handler({
+      action: 'approve',
+      runId: 'r1abcdef',
+      confirm: true,
+    });
+
+    expect(mockApprove).toHaveBeenCalled(); // the decision is still recorded
+    expect(resolved).toHaveLength(0);
+    expect(out).toContain('isolation container');
+    expect(out).toContain('archon workflow resume r1abcdef-1234');
+    expect(out).not.toContain('continues from here');
+  });
+
   test('a declined continuation is reported as a manual resume, not as silence', async () => {
     // The orchestrator continues ONE run per turn. A gate it declines must reach
     // the agent as words, or the run is resolved and stranded with no signal.

--- a/packages/core/src/orchestrator/manage-run-tool.test.ts
+++ b/packages/core/src/orchestrator/manage-run-tool.test.ts
@@ -426,6 +426,118 @@ describe('manage_run — destructive confirmation gate', () => {
   });
 });
 
+// Resolving a gate and continuing the run are two halves of one action (#2565).
+// A tool that only resolved would leave every gate the agent decides stranded.
+describe('manage_run — gate continuation', () => {
+  /** `accepts: false` models an orchestrator that already has a run queued. */
+  function makeCtx(accepts = true) {
+    const resolved: { run: WorkflowRun; action: 'approve' | 'reject' }[] = [];
+    return {
+      resolved,
+      ctx: {
+        codebaseId: CODEBASE_ID,
+        onGateResolved: (run: WorkflowRun, action: 'approve' | 'reject') => {
+          resolved.push({ run, action });
+          return accepts;
+        },
+      },
+    };
+  }
+
+  test('approve hands the run to the continuation and says the run moves on', async () => {
+    const run = makeRun({ status: 'paused' });
+    mockFindByPrefix.mockResolvedValue([run]);
+    mockApprove.mockResolvedValue({ workflowName: 'wf', type: 'approval_gate' });
+    const { resolved, ctx } = makeCtx();
+
+    const out = await buildManageRunTool(ctx).handler({
+      action: 'approve',
+      runId: 'r1abcdef',
+      confirm: true,
+    });
+
+    expect(resolved).toEqual([{ run, action: 'approve' }]);
+    expect(out).toContain('continues from here');
+  });
+
+  test('a reject that stages a rework continues; one that cancels does not', async () => {
+    const run = makeRun({ status: 'paused' });
+    mockFindByPrefix.mockResolvedValue([run]);
+    const { resolved, ctx } = makeCtx();
+
+    mockReject.mockResolvedValue({
+      workflowName: 'wf',
+      cancelled: false,
+      maxAttemptsReached: false,
+    });
+    const rework = await buildManageRunTool(ctx).handler({
+      action: 'reject',
+      runId: 'r1abcdef',
+      confirm: true,
+      message: 'redo',
+    });
+    expect(resolved).toEqual([{ run, action: 'reject' }]);
+    expect(rework).toContain('continues from here');
+
+    // A cancelled run is already in its terminal state — nothing to continue.
+    mockReject.mockResolvedValue({
+      workflowName: 'wf',
+      cancelled: true,
+      maxAttemptsReached: false,
+    });
+    const cancelled = await buildManageRunTool(ctx).handler({
+      action: 'reject',
+      runId: 'r1abcdef',
+      confirm: true,
+      message: 'drop it',
+    });
+    expect(resolved).toHaveLength(1);
+    expect(cancelled).toContain('Nothing further runs');
+  });
+
+  test('a preview call resolves nothing, so it never schedules a continuation', async () => {
+    mockFindByPrefix.mockResolvedValue([makeRun({ status: 'paused' })]);
+    const { resolved, ctx } = makeCtx();
+
+    await buildManageRunTool(ctx).handler({ action: 'approve', runId: 'r1abcdef' });
+
+    expect(resolved).toHaveLength(0);
+    expect(mockApprove).not.toHaveBeenCalled();
+  });
+
+  test('a declined continuation is reported as a manual resume, not as silence', async () => {
+    // The orchestrator continues ONE run per turn. A gate it declines must reach
+    // the agent as words, or the run is resolved and stranded with no signal.
+    mockFindByPrefix.mockResolvedValue([makeRun({ status: 'paused' })]);
+    mockApprove.mockResolvedValue({ workflowName: 'wf', type: 'approval_gate' });
+    const { ctx } = makeCtx(false);
+
+    const out = await buildManageRunTool(ctx).handler({
+      action: 'approve',
+      runId: 'r1abcdef',
+      confirm: true,
+    });
+
+    expect(out).toContain('stays paused');
+    expect(out).toContain('/workflow resume r1abcdef-1234');
+  });
+
+  test('without a continuation the tool names the manual resume instead of implying one', async () => {
+    // Silence here would read as "handled" and strand the run invisibly.
+    mockFindByPrefix.mockResolvedValue([makeRun({ status: 'paused' })]);
+    mockApprove.mockResolvedValue({ workflowName: 'wf', type: 'approval_gate' });
+
+    const out = await buildManageRunTool({ codebaseId: CODEBASE_ID }).handler({
+      action: 'approve',
+      runId: 'r1abcdef',
+      confirm: true,
+    });
+
+    expect(out).toContain('stays paused');
+    expect(out).toContain('/workflow resume r1abcdef-1234');
+  });
+});
+
 describe('manage_run — resume (recoverable, no confirm)', () => {
   test('resume validates eligibility without confirm and does not restart the run', async () => {
     mockFindByPrefix.mockResolvedValue([makeRun({ status: 'failed' })]);

--- a/packages/core/src/orchestrator/manage-run-tool.ts
+++ b/packages/core/src/orchestrator/manage-run-tool.ts
@@ -21,6 +21,26 @@ export interface ManageRunContext {
    * context isn't available — `start` is then rejected.
    */
   startWorkflow?: (workflowName: string, message: string) => Promise<string>;
+  /**
+   * Continuation seam for a gate the agent just resolved. Called with the run
+   * (as read BEFORE the resolution) once `approve`/`reject` leaves it resumable
+   * — never for a reject that cancelled the run, which is already terminal.
+   *
+   * Resolving a gate and continuing the run are two halves of one user action:
+   * a tool that only did the first would leave every gate the agent resolves
+   * stranded (#2565). The orchestrator registers this and drives the resume
+   * AFTER the agent's turn ends, so the tool call returns promptly instead of
+   * blocking the agent loop on a whole workflow.
+   *
+   * Returns whether it accepted the run — a turn continues ONE run, so a second
+   * gate resolved in the same turn is declined and told to resume manually. Any
+   * false answer must reach the agent as words, or the run is stranded silently.
+   *
+   * Synchronous and non-throwing by contract — it records intent, it does not
+   * perform the resume. Omitted when the caller has no way to continue a run;
+   * the tool then says so rather than implying the run moves on by itself.
+   */
+  onGateResolved?: (run: WorkflowRun, action: 'approve' | 'reject') => boolean;
 }
 
 /**
@@ -129,9 +149,9 @@ const HELP_BY_ACTION: Record<Exclude<Action, 'help'>, string> = {
   abandon:
     'abandon — discard a paused/failed (non-terminal) run. Required: runId, confirm=true. Irreversible: the run becomes cancelled.',
   approve:
-    'approve — approve a paused human gate so the run can continue. Required: runId, confirm=true. Optional: accept, message. On an interactive loop whose gate shows completionSignaled=true: NO message (or accept=true) FINALIZES the node from the already-computed output without re-running; message=<feedback> runs another iteration with it. On other gates, message is just a comment recorded with the approval. Only paused runs with an approval gate.',
+    'approve — approve a paused human gate; the run then continues on its own (no separate resume). Required: runId, confirm=true. Optional: accept, message. On an interactive loop whose gate shows completionSignaled=true: NO message (or accept=true) FINALIZES the node from the already-computed output without re-running; message=<feedback> runs another iteration with it. On other gates, message is just a comment recorded with the approval — pass the user’s own words, since a gate with capture_response reads it as the node’s output. Only paused runs with an approval gate.',
   reject:
-    'reject — reject a paused human gate. Required: runId, confirm=true. Recommended: message (the reason). If the gate has an on-reject prompt the run reworks; otherwise it is cancelled.',
+    'reject — reject a paused human gate. Required: runId, confirm=true. Recommended: message (the reason, in the user’s own words). If the gate has an on-reject prompt the run reworks and continues on its own; otherwise it is cancelled and nothing further runs.',
 };
 
 /**
@@ -357,25 +377,47 @@ async function handleWrite(
       // so a signal-bearing loop completes from its persisted output on resume.
       const feedback = willFinalize ? undefined : message;
       const result = await approveWorkflow(id, feedback);
+      const continues = signalGateResolved(ctx, run, 'approve');
       if (result.type !== 'interactive_loop') {
-        return `Approved ${result.workflowName} (${id.slice(0, 8)}). The run is now set to resume.`;
+        return `Approved ${result.workflowName} (${id.slice(0, 8)}).${continues}`;
       }
       return feedback === undefined
-        ? `Approved ${result.workflowName} (${id.slice(0, 8)}) with no feedback. If the gate paused on a completion signal, the node finalizes from its computed output on resume (no re-run); otherwise the loop runs another iteration.`
-        : `Feedback recorded for ${result.workflowName} (${id.slice(0, 8)}); the loop will run another iteration with it on resume.`;
+        ? `Approved ${result.workflowName} (${id.slice(0, 8)}) with no feedback. If the gate paused on a completion signal, the node finalizes from its computed output (no re-run); otherwise the loop runs another iteration.${continues}`
+        : `Feedback recorded for ${result.workflowName} (${id.slice(0, 8)}); the loop runs another iteration with it.${continues}`;
     }
     case 'reject': {
       const result = await rejectWorkflow(id, message.length > 0 ? message : undefined);
       if (result.cancelled) {
         const suffix = result.maxAttemptsReached ? ' (max attempts reached)' : '';
-        return `Rejected and cancelled ${result.workflowName} (${id.slice(0, 8)})${suffix}.`;
+        return `Rejected and cancelled ${result.workflowName} (${id.slice(0, 8)})${suffix}. Nothing further runs.`;
       }
-      return `Rejected ${result.workflowName} (${id.slice(0, 8)}). It will rework with your feedback when it resumes.`;
+      const continues = signalGateResolved(ctx, run, 'reject');
+      return `Rejected ${result.workflowName} (${id.slice(0, 8)}). It reworks with your feedback.${continues}`;
     }
   }
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Hand a just-resolved gate to the caller's continuation and describe the
+ * outcome for the agent. Returns the sentence to append to the action's reply:
+ * a promise the run continues when a continuation is wired, and the explicit
+ * manual step when it is not — never silence, which reads as "it's handled".
+ */
+function signalGateResolved(
+  ctx: ManageRunContext,
+  run: WorkflowRun,
+  action: 'approve' | 'reject'
+): string {
+  const scheduled = ctx.onGateResolved?.(run, action) ?? false;
+  if (!scheduled) {
+    log.info({ runId: run.id, action }, 'manage_run.gate_continuation_unavailable');
+    return ` The run stays paused — it must be resumed separately (\`/workflow resume ${run.id}\`).`;
+  }
+  log.info({ runId: run.id, action }, 'manage_run.gate_continuation_scheduled');
+  return ' The run continues from here — no separate resume needed.';
+}
 
 /**
  * Resolve a run id — the short prefix shown in listings OR a full id — to a run

--- a/packages/core/src/orchestrator/manage-run-tool.ts
+++ b/packages/core/src/orchestrator/manage-run-tool.ts
@@ -1,6 +1,6 @@
 import type { NativeTool } from '@archon/providers/types';
 import { createLogger } from '@archon/paths';
-import { isApprovalContext } from '@archon/workflows/schemas/workflow-run';
+import { isApprovalContext, isContainerRun } from '@archon/workflows/schemas/workflow-run';
 import type { WorkflowRun } from '@archon/workflows/schemas/workflow-run';
 import { listDashboardRuns, findWorkflowRunsByIdPrefix } from '../db/workflows';
 import {
@@ -404,12 +404,24 @@ async function handleWrite(
  * outcome for the agent. Returns the sentence to append to the action's reply:
  * a promise the run continues when a continuation is wired, and the explicit
  * manual step when it is not — never silence, which reads as "it's handled".
+ *
+ * A container run is never handed over: `executeWorkflow` refuses a resume it
+ * cannot rewire, so scheduling one would fail the run to say what we can say
+ * here for free (#2565).
  */
 function signalGateResolved(
   ctx: ManageRunContext,
   run: WorkflowRun,
   action: 'approve' | 'reject'
 ): string {
+  if (isContainerRun(run)) {
+    log.info({ runId: run.id, action }, 'manage_run.gate_continuation_container_only_cli');
+    return (
+      ' This run executed inside an isolation container, so it cannot continue from chat — ' +
+      `tell the user to finish it with \`archon workflow resume ${run.id}\` from the CLI in ` +
+      'the same project.'
+    );
+  }
   const scheduled = ctx.onGateResolved?.(run, action) ?? false;
   if (!scheduled) {
     log.info({ runId: run.id, action }, 'manage_run.gate_continuation_unavailable');

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -2658,6 +2658,65 @@ describe('paused approval gate routing', () => {
     expect(toolReplies[0]).toContain('Nothing further runs');
   });
 
+  test('a provider crash after the gate is resolved still continues the run', async () => {
+    // The resolution commits to the DB the moment the tool call returns. If the
+    // rest of the turn throws — a provider subprocess crash, a dropped stream —
+    // skipping the continuation would leave the run resolved and parked with
+    // only a generic error to show for it.
+    arrangeGatedChat();
+    const toolReplies: string[] = [];
+    mockSendQuery.mockImplementationOnce(async function* () {
+      const tool = inFlightManageRunTool();
+      if (tool) {
+        toolReplies.push(await tool.handler({ action: 'approve', runId: 'run-1', confirm: true }));
+      }
+      yield { type: 'assistant', content: 'Approved.' };
+      throw new Error('provider subprocess exited unexpectedly');
+    });
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', 'ship it');
+
+    expect(mockResolveApprovalGate).toHaveBeenCalled();
+    expect(mockExecuteWorkflow).toHaveBeenCalled();
+    expect(platform.sendMessage).toHaveBeenCalledWith(
+      'conv-1',
+      expect.stringContaining('Resuming')
+    );
+  });
+
+  test('a container run is resolved but not resumed from chat', async () => {
+    // Chat cannot rewire the container, so the executor would refuse the resume.
+    arrangeGatedChat({
+      metadata: { approval: { nodeId: 'gate-1', message: 'Apply?' }, isolation: 'container' },
+    });
+    const toolReplies: string[] = [];
+    agentCallsManageRun({ action: 'approve', runId: 'run-1', confirm: true }, toolReplies);
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', 'apply the changes');
+
+    expect(mockResolveApprovalGate).toHaveBeenCalled();
+    expect(mockExecuteWorkflow).not.toHaveBeenCalled();
+    expect(toolReplies[0]).toContain('archon workflow resume');
+    // The prompt must have warned the agent before it acted.
+    expect(lastPrompt()).toContain('isolation container');
+  });
+
+  test('an unscoped conversation gets the gate but no instruction to resolve it', async () => {
+    mockGetOrCreateConversation.mockReturnValueOnce(
+      Promise.resolve(makeConversation({ codebase_id: null }))
+    );
+    mockGetPausedWorkflowRun.mockImplementation(() => Promise.resolve(makePausedRun()));
+
+    await handleMessage(makePlatform(), 'conv-1', 'looks good');
+
+    const prompt = lastPrompt();
+    expect(prompt).toContain('## Paused Approval Gate');
+    expect(prompt).toContain('no project is attached');
+    expect(prompt).not.toContain('resolve the gate as APPROVED');
+  });
+
   test('manage_run without confirm previews the gate action and resolves nothing', async () => {
     arrangeGatedChat();
     const toolReplies: string[] = [];

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -12,7 +12,7 @@
  * Mock setup MUST occur before any import of the module under test.
  */
 
-import { mock, describe, test, expect, beforeEach } from 'bun:test';
+import { mock, describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { createMockLogger } from '../test/mocks/logger';
 import { makeTestWorkflow, makeTestWorkflowWithSource } from '@archon/workflows/test-utils';
 import type { Codebase, Conversation, IPlatformAdapter } from '../types';
@@ -197,12 +197,20 @@ const mockResolveApprovalGate = mock(() => Promise.resolve({ resolved: true }));
 // approveWorkflow (operations/workflow-operations, called by the NL approval
 // path) re-reads the run via getWorkflowRun before recording the resolution.
 const mockGetWorkflowRunDb = mock(() => Promise.resolve(null as unknown));
+// rejectWorkflow's terminal path (no on_reject staged) resolves + cancels in one CAS.
+const mockResolveAndCancelApprovalGate = mock(() => Promise.resolve({ resolved: true }));
+// manage_run resolves every by-id action through this project-scoped prefix lookup.
+const mockFindWorkflowRunsByIdPrefix = mock(() => Promise.resolve([] as unknown[]));
+const mockListDashboardRuns = mock(() => Promise.resolve({ runs: [] as unknown[], total: 0 }));
 mock.module('../db/workflows', () => ({
   getPausedWorkflowRun: mockGetPausedWorkflowRun,
   getWorkflowRun: mockGetWorkflowRunDb,
   findResumableRunByParentConversation: mockFindResumableRunByParentConversation,
   updateWorkflowRun: mockUpdateWorkflowRun,
   resolveApprovalGate: mockResolveApprovalGate,
+  resolveAndCancelApprovalGate: mockResolveAndCancelApprovalGate,
+  findWorkflowRunsByIdPrefix: mockFindWorkflowRunsByIdPrefix,
+  listDashboardRuns: mockListDashboardRuns,
 }));
 
 const mockCreateWorkflowEvent = mock(() => Promise.resolve());
@@ -2309,8 +2317,10 @@ describe('workflow dispatch routing — interactive flag', () => {
 
 // ─── Natural-language approval routing ──────────────────────────────────────
 
-describe('natural-language approval routing', () => {
+describe('paused approval gate routing', () => {
   const approvalWorkflow = makeTestWorkflow({ name: 'prd', interactive: true });
+
+  type ManageRunHandler = (input: Record<string, unknown>) => Promise<string>;
 
   function makePausedRun(overrides: Record<string, unknown> = {}) {
     return {
@@ -2321,7 +2331,7 @@ describe('natural-language approval routing', () => {
       codebase_id: 'codebase-1',
       status: 'paused',
       user_message: 'original prompt',
-      metadata: { approval: { nodeId: 'gate-1', message: 'Please review' } },
+      metadata: { approval: { nodeId: 'gate-1', message: 'Please review the plan' } },
       working_path: '/repos/test-repo',
       started_at: new Date(),
       completed_at: null,
@@ -2343,19 +2353,74 @@ describe('natural-language approval routing', () => {
     };
   }
 
-  beforeEach(() => {
+  /** The prompt handed to the provider on the most recent turn. */
+  function lastPrompt(): string {
+    const call = mockSendQuery.mock.calls.at(-1) as unknown[] | undefined;
+    return (call?.[0] as string | undefined) ?? '';
+  }
+
+  /**
+   * The `manage_run` tool the orchestrator injected for the turn currently in
+   * flight. Read from `mock.calls` rather than the generator's own parameters so
+   * the once-implementation keeps the zero-arg shape the rest of this file uses.
+   */
+  function inFlightManageRunTool(): { name: string; handler: ManageRunHandler } | undefined {
+    const call = mockSendQuery.mock.calls.at(-1) as unknown[] | undefined;
+    const options = call?.[3] as
+      | { nativeTools?: { name: string; handler: ManageRunHandler }[] }
+      | undefined;
+    return options?.nativeTools?.find(t => t.name === 'manage_run');
+  }
+
+  /** Have the agent call `manage_run` once with `input`, then finish its turn. */
+  function agentCallsManageRun(input: Record<string, unknown>, sink: string[]): void {
+    mockSendQuery.mockImplementationOnce(async function* () {
+      const tool = inFlightManageRunTool();
+      if (tool) sink.push(await tool.handler(input));
+      yield { type: 'assistant', content: 'done' };
+      yield { type: 'result', sessionId: 'session-1' };
+    });
+  }
+
+  /**
+   * Wire a project-scoped, native-tool chat sitting on an unresolved gate.
+   * Returns the paused run so a test can assert against the same object the
+   * continuation receives.
+   */
+  function arrangeGatedChat(runOverrides: Record<string, unknown> = {}) {
+    const codebase = makeApprovalCodebase();
+    const run = makePausedRun(runOverrides);
+    mockGetOrCreateConversation.mockReturnValueOnce(
+      Promise.resolve(makeConversation({ codebase_id: 'codebase-1', cwd: '/repos/test-repo' }))
+    );
+    mockGetCodebase.mockImplementation(() => Promise.resolve(codebase));
+    mockListCodebases.mockImplementation(() => Promise.resolve([codebase]));
+    mockGetPausedWorkflowRun.mockImplementation(() => Promise.resolve(run));
+    mockGetWorkflowRunDb.mockImplementation(() => Promise.resolve(run));
+    mockFindWorkflowRunsByIdPrefix.mockImplementation(() => Promise.resolve([run]));
+    mockDiscoverWorkflowsWithConfig.mockImplementation(() =>
+      Promise.resolve({ workflows: [{ workflow: approvalWorkflow }], errors: [] })
+    );
+    return run;
+  }
+
+  let capsMock: ReturnType<typeof mock>;
+
+  beforeEach(async () => {
     mockGetPausedWorkflowRun.mockReset();
     mockGetPausedWorkflowRun.mockImplementation(() => Promise.resolve(null));
-    // approveWorkflow re-reads the run; default to the paused fixture so NL
-    // approval tests exercise the shared operation end-to-end.
     mockGetWorkflowRunDb.mockReset();
     mockGetWorkflowRunDb.mockImplementation(() => Promise.resolve(makePausedRun()));
+    mockFindWorkflowRunsByIdPrefix.mockReset();
+    mockFindWorkflowRunsByIdPrefix.mockImplementation(() => Promise.resolve([]));
     mockCreateWorkflowEvent.mockReset();
     mockCreateWorkflowEvent.mockImplementation(() => Promise.resolve());
     mockGetOrCreateConversation.mockReset();
     mockGetOrCreateConversation.mockImplementation(() => Promise.resolve(null));
     mockGetCodebase.mockReset();
     mockGetCodebase.mockImplementation(() => Promise.resolve(null));
+    mockListCodebases.mockReset();
+    mockListCodebases.mockImplementation(() => Promise.resolve([]));
     mockExecuteWorkflow.mockClear();
     mockFindResumableRunByParentConversation.mockReset();
     mockFindResumableRunByParentConversation.mockImplementation(() => Promise.resolve(null));
@@ -2364,192 +2429,264 @@ describe('natural-language approval routing', () => {
     mockUpdateWorkflowRun.mockImplementation(() => Promise.resolve());
     mockResolveApprovalGate.mockClear();
     mockResolveApprovalGate.mockImplementation(() => Promise.resolve({ resolved: true }));
+    mockResolveAndCancelApprovalGate.mockClear();
+    mockResolveAndCancelApprovalGate.mockImplementation(() => Promise.resolve({ resolved: true }));
+    mockCaptureApprovalResolved.mockClear();
+    mockSendQuery.mockClear();
     mockDiscoverWorkflowsWithConfig.mockReset();
     mockDiscoverWorkflowsWithConfig.mockImplementation(() =>
       Promise.resolve({ workflows: [], errors: [] })
     );
+    // These turns reach the AI, so the provider must report native-tool support
+    // for `manage_run` to be injected. Restored in afterEach.
+    const providers = await import('@archon/providers');
+    capsMock = providers.getProviderCapabilities as ReturnType<typeof mock>;
+    capsMock.mockReturnValue({ envInjection: true, nativeTools: true });
+    // `fs.existsSync` is a file-wide mock other suites mutate (#2551 turns it
+    // into a shared predicate reset in only one describe). Force the value these
+    // tests need rather than inheriting whatever ran last — a false here would
+    // short-circuit the turn before the gate context is ever built.
+    const fs = await import('fs');
+    (fs.existsSync as unknown as ReturnType<typeof mock>).mockImplementation(() => true);
   });
 
-  test('natural language message with paused workflow intercepts and dispatches resume', async () => {
-    const conversation = makeConversation({ codebase_id: 'codebase-1', cwd: '/repos/test-repo' });
-    const codebase = makeApprovalCodebase();
-    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
-    mockGetPausedWorkflowRun.mockReturnValueOnce(Promise.resolve(makePausedRun()));
-    // discoverAllWorkflows calls getCodebase once internally, then the NL path calls it again
-    mockGetCodebase.mockImplementation(() => Promise.resolve(codebase));
-    mockDiscoverWorkflowsWithConfig.mockImplementation(() =>
-      Promise.resolve({ workflows: [{ workflow: approvalWorkflow }], errors: [] })
-    );
-    mockFindResumableRunByParentConversation.mockReturnValueOnce(
-      Promise.resolve(
-        makePausedRun({
-          id: 'run-1',
-          status: 'failed',
-          working_path: '/repos/test-repo',
-          parent_conversation_id: 'conv-1',
-        })
-      )
-    );
+  afterEach(() => {
+    capsMock.mockReturnValue({ envInjection: true });
+  });
+
+  // ── The removed behaviour: prose no longer decides the gate ────────────────
+
+  test('an approving-sounding message no longer resolves the gate by itself', async () => {
+    arrangeGatedChat();
 
     const platform = makePlatform();
     await handleMessage(platform, 'conv-1', 'looks good, proceed with implementation');
 
-    // Approval events ride the CAS transaction now (#2146), not a direct write:
-    // node_completed + approval_received.
-    expect(mockCreateWorkflowEvent).not.toHaveBeenCalled();
-    const casEvents = (mockResolveApprovalGate.mock.calls[0] as unknown[])[2] as Array<
-      Record<string, unknown>
-    >;
-    expect(casEvents).toHaveLength(2);
-    expect(casEvents[0].event_type).toBe('node_completed');
-    expect(casEvents[1].event_type).toBe('approval_received');
-    // Resuming message sent
-    expect(platform.sendMessage).toHaveBeenCalledWith(
+    // Nothing was resolved and nothing resumed — the message went to the agent.
+    expect(mockResolveApprovalGate).not.toHaveBeenCalled();
+    expect(mockResolveAndCancelApprovalGate).not.toHaveBeenCalled();
+    expect(mockCaptureApprovalResolved).not.toHaveBeenCalled();
+    expect(mockExecuteWorkflow).not.toHaveBeenCalled();
+    expect(platform.sendMessage).not.toHaveBeenCalledWith(
       'conv-1',
       expect.stringContaining('Resuming')
     );
-    // Run stays 'paused' — resolution recorded atomically via the CAS on the
-    // approval context (#2075/#2113), with the audit events in the same
-    // transaction (#2146)
+    expect(mockSendQuery).toHaveBeenCalled();
+  });
+
+  test('a rejecting message is never recorded as an approval', async () => {
+    arrangeGatedChat();
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', 'no, stop — why is it editing the schema?');
+
+    // The regression this issue exists for: an objection used to resolve the
+    // gate as APPROVED and store the objection itself as the approval comment.
+    expect(mockResolveApprovalGate).not.toHaveBeenCalled();
+    expect(mockResolveAndCancelApprovalGate).not.toHaveBeenCalled();
+    expect(mockExecuteWorkflow).not.toHaveBeenCalled();
+    expect(mockSendQuery).toHaveBeenCalled();
+  });
+
+  test('an ambiguous message resolves nothing and leaves the gate open', async () => {
+    arrangeGatedChat();
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', 'what would that change?');
+
+    expect(mockResolveApprovalGate).not.toHaveBeenCalled();
+    expect(mockResolveAndCancelApprovalGate).not.toHaveBeenCalled();
+    expect(mockExecuteWorkflow).not.toHaveBeenCalled();
+    expect(platform.sendMessage).not.toHaveBeenCalledWith(
+      'conv-1',
+      expect.stringContaining('Resuming')
+    );
+  });
+
+  // ── The gate reaches the agent as context ──────────────────────────────────
+
+  test('an open gate is handed to the agent as prompt context', async () => {
+    arrangeGatedChat();
+
+    await handleMessage(makePlatform(), 'conv-1', 'what would that change?');
+
+    const prompt = lastPrompt();
+    expect(prompt).toContain('## Paused Approval Gate');
+    expect(prompt).toContain('run-1');
+    expect(prompt).toContain('Please review the plan');
+    expect(prompt).toContain('gate-1');
+    // The gate must sit immediately before the message it is most likely about.
+    expect(prompt.indexOf('## Paused Approval Gate')).toBeLessThan(
+      prompt.indexOf('## User Message')
+    );
+  });
+
+  test('no paused run means no gate section', async () => {
+    mockGetOrCreateConversation.mockReturnValueOnce(
+      Promise.resolve(makeConversation({ codebase_id: null }))
+    );
+    mockGetPausedWorkflowRun.mockImplementation(() => Promise.resolve(null));
+
+    await handleMessage(makePlatform(), 'conv-1', 'hello world');
+
+    expect(lastPrompt()).not.toContain('## Paused Approval Gate');
+  });
+
+  test('a gate already resolved and awaiting resume produces no gate section', async () => {
+    arrangeGatedChat({
+      metadata: {
+        approval: { nodeId: 'gate-1', message: 'Please review the plan', resolved: 'approved' },
+      },
+    });
+
+    await handleMessage(makePlatform(), 'conv-1', 'sounds good');
+
+    // Nothing for a human to decide — the run is only waiting to be resumed.
+    expect(lastPrompt()).not.toContain('## Paused Approval Gate');
+    expect(mockResolveApprovalGate).not.toHaveBeenCalled();
+  });
+
+  test('a paused run with a malformed approval context points the agent at the explicit commands', async () => {
+    arrangeGatedChat({ metadata: {} });
+
+    await handleMessage(makePlatform(), 'conv-1', 'looks good');
+
+    const prompt = lastPrompt();
+    expect(prompt).toContain('## Paused Approval Gate');
+    expect(prompt).toContain('missing or malformed');
+    expect(prompt).toContain('/workflow approve run-1');
+  });
+
+  test('a slash command never reaches the gate lookup', async () => {
+    mockGetOrCreateConversation.mockReturnValueOnce(
+      Promise.resolve(makeConversation({ codebase_id: 'codebase-1' }))
+    );
+    mockHandleCommand.mockReturnValueOnce(
+      Promise.resolve({ success: true, message: 'status ok', workflow: undefined })
+    );
+
+    await handleMessage(makePlatform(), 'conv-1', '/status');
+
+    expect(mockGetPausedWorkflowRun).not.toHaveBeenCalled();
+  });
+
+  // ── Resolution through manage_run also continues the run ───────────────────
+
+  test('the agent approving through manage_run resolves the gate AND resumes the run', async () => {
+    const run = arrangeGatedChat();
+    const toolReplies: string[] = [];
+    agentCallsManageRun(
+      { action: 'approve', runId: 'run-1', confirm: true, message: 'looks good, ship it' },
+      toolReplies
+    );
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', 'looks good, ship it');
+
     expect(mockResolveApprovalGate).toHaveBeenCalledWith(
       'run-1',
       {
-        approval: { nodeId: 'gate-1', message: 'Please review', resolved: 'approved' },
+        approval: {
+          nodeId: 'gate-1',
+          message: 'Please review the plan',
+          resolved: 'approved',
+        },
         approval_response: 'approved',
         rejection_reason: '',
         rejection_count: 0,
       },
       expect.any(Array)
     );
-    expect(mockHydrateResumableRun).toHaveBeenCalled();
-    expect(mockExecuteWorkflow).toHaveBeenCalled();
-    // NL approval path captures the binary resolution
     expect(mockCaptureApprovalResolved).toHaveBeenCalledWith({ resolution: 'approved' });
-    expect(platform.sendMessage).not.toHaveBeenCalledWith(
+    // Continuation: resolution without it would leave the run stranded (#2565).
+    expect(platform.sendMessage).toHaveBeenCalledWith(
       'conv-1',
-      expect.stringContaining('Found a prior failed run')
+      expect.stringContaining('Resuming')
     );
+    expect(mockHydrateResumableRun).toHaveBeenCalled();
+    const hydrated = mockHydrateResumableRun.mock.calls[0] as unknown[];
+    expect((hydrated[1] as { id: string }).id).toBe(run.id);
+    expect(mockExecuteWorkflow).toHaveBeenCalled();
+    // The tool must tell the agent the run moves on, not that it stays parked.
+    expect(toolReplies[0]).toContain('continues from here');
   });
 
-  test('slash command bypasses approval interception — getPausedWorkflowRun not called', async () => {
-    const conversation = makeConversation({ codebase_id: 'codebase-1' });
-    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
-    mockHandleCommand.mockReturnValueOnce(
-      Promise.resolve({ success: true, message: 'status ok', workflow: undefined })
-    );
-
-    const platform = makePlatform();
-    await handleMessage(platform, 'conv-1', '/status');
-
-    expect(mockGetPausedWorkflowRun).not.toHaveBeenCalled();
-    expect(mockCreateWorkflowEvent).not.toHaveBeenCalled();
-  });
-
-  test('message with no paused workflow routes normally', async () => {
-    const conversation = makeConversation({ codebase_id: null });
-    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
-    mockGetPausedWorkflowRun.mockReturnValueOnce(Promise.resolve(null));
-
-    const platform = makePlatform();
-    await handleMessage(platform, 'conv-1', 'hello world');
-
-    expect(mockCreateWorkflowEvent).not.toHaveBeenCalled();
-    // Normal routing proceeds (no early return)
-  });
-
-  test('paused run with an already-resolved gate is skipped — message routes normally', async () => {
-    const conversation = makeConversation({ codebase_id: null });
-    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
-    // Gate already approved and awaiting auto-resume (#2075): the run is still
-    // 'paused' but the message must NOT be treated as another approval.
-    mockGetPausedWorkflowRun.mockReturnValueOnce(
-      Promise.resolve(
-        makePausedRun({
-          metadata: {
-            approval: { nodeId: 'gate-1', message: 'Please review', resolved: 'approved' },
-          },
-        })
-      )
+  test('the agent rejecting a gate with on_reject rework resumes the run', async () => {
+    arrangeGatedChat({
+      metadata: {
+        approval: {
+          nodeId: 'gate-1',
+          message: 'Please review the plan',
+          onRejectPrompt: 'Address $REJECTION_REASON',
+        },
+      },
+    });
+    const toolReplies: string[] = [];
+    agentCallsManageRun(
+      { action: 'reject', runId: 'run-1', confirm: true, message: 'the schema change is wrong' },
+      toolReplies
     );
 
     const platform = makePlatform();
-    await handleMessage(platform, 'conv-1', 'sounds good');
+    await handleMessage(platform, 'conv-1', 'no, the schema change is wrong');
 
-    // No approval events / no resume dispatch — normal routing proceeds
-    expect(mockCreateWorkflowEvent).not.toHaveBeenCalled();
+    expect(mockCaptureApprovalResolved).toHaveBeenCalledWith({ resolution: 'rejected' });
+    expect(mockResolveAndCancelApprovalGate).not.toHaveBeenCalled();
+    expect(mockExecuteWorkflow).toHaveBeenCalled();
+    expect(toolReplies[0]).toContain('continues from here');
+  });
+
+  test('a reject that cancels the run does not try to resume it', async () => {
+    arrangeGatedChat();
+    const toolReplies: string[] = [];
+    agentCallsManageRun(
+      { action: 'reject', runId: 'run-1', confirm: true, message: 'abandon this' },
+      toolReplies
+    );
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', 'no, drop it');
+
+    // No on_reject prompt on the gate → the run is cancelled, which IS its
+    // terminal state. Nothing to continue.
+    expect(mockResolveAndCancelApprovalGate).toHaveBeenCalled();
     expect(mockExecuteWorkflow).not.toHaveBeenCalled();
     expect(platform.sendMessage).not.toHaveBeenCalledWith(
       'conv-1',
       expect.stringContaining('Resuming')
     );
+    expect(toolReplies[0]).toContain('Nothing further runs');
   });
 
-  test('paused run with missing approval context sends explicit guidance', async () => {
-    const conversation = makeConversation({ codebase_id: 'codebase-1' });
-    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
-    mockGetPausedWorkflowRun.mockReturnValueOnce(Promise.resolve(makePausedRun({ metadata: {} })));
+  test('manage_run without confirm previews the gate action and resolves nothing', async () => {
+    arrangeGatedChat();
+    const toolReplies: string[] = [];
+    agentCallsManageRun({ action: 'approve', runId: 'run-1' }, toolReplies);
 
-    const platform = makePlatform();
-    await handleMessage(platform, 'conv-1', 'looks good');
+    await handleMessage(makePlatform(), 'conv-1', 'maybe approve it?');
 
-    expect(mockCreateWorkflowEvent).not.toHaveBeenCalled();
-    expect(platform.sendMessage).toHaveBeenCalledWith(
-      'conv-1',
-      expect.stringContaining('approval context is missing')
-    );
+    expect(mockResolveApprovalGate).not.toHaveBeenCalled();
+    expect(mockExecuteWorkflow).not.toHaveBeenCalled();
+    expect(toolReplies[0]).toContain('confirm');
   });
 
-  test('workflow not found after approval sends error and does not dispatch', async () => {
-    const conversation = makeConversation({ codebase_id: 'codebase-1', cwd: '/repos/test-repo' });
-    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
-    mockGetPausedWorkflowRun.mockReturnValueOnce(Promise.resolve(makePausedRun()));
-    // discoverWorkflowsWithConfig returns no workflows
+  test('a resolved gate whose workflow is gone reports the decision and stops', async () => {
+    arrangeGatedChat();
+    // Discovery finds nothing, so the continuation cannot locate the definition.
     mockDiscoverWorkflowsWithConfig.mockImplementation(() =>
       Promise.resolve({ workflows: [], errors: [] })
     );
+    const toolReplies: string[] = [];
+    agentCallsManageRun({ action: 'approve', runId: 'run-1', confirm: true }, toolReplies);
 
     const platform = makePlatform();
-    await handleMessage(platform, 'conv-1', 'approve it');
+    await handleMessage(platform, 'conv-1', 'ship it');
 
-    expect(platform.sendMessage).toHaveBeenCalledWith(
-      'conv-1',
-      expect.stringContaining('not found')
-    );
+    expect(mockResolveApprovalGate).toHaveBeenCalled();
     expect(mockExecuteWorkflow).not.toHaveBeenCalled();
-  });
-
-  test('no codebase after approval sends error and does not dispatch', async () => {
-    const conversation = makeConversation({ codebase_id: null, cwd: '/repos/test-repo' });
-    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
-    mockGetPausedWorkflowRun.mockReturnValueOnce(Promise.resolve(makePausedRun()));
-    mockDiscoverWorkflowsWithConfig.mockImplementation(() =>
-      Promise.resolve({ workflows: [{ workflow: approvalWorkflow }], errors: [] })
-    );
-
-    const platform = makePlatform();
-    await handleMessage(platform, 'conv-1', 'approved');
-
     expect(platform.sendMessage).toHaveBeenCalledWith(
       'conv-1',
-      expect.stringContaining('no project is attached')
-    );
-    expect(mockExecuteWorkflow).not.toHaveBeenCalled();
-  });
-
-  test('DB failure during approval sends error message to user', async () => {
-    const conversation = makeConversation({ codebase_id: 'codebase-1', cwd: '/repos/test-repo' });
-    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
-    mockGetPausedWorkflowRun.mockReturnValueOnce(Promise.resolve(makePausedRun()));
-    // Simulate a DB error resolving the gate — the resolution + audit events now
-    // commit atomically inside this CAS (#2146), so a failure here is the write path.
-    mockResolveApprovalGate.mockRejectedValueOnce(new Error('connection lost'));
-
-    const platform = makePlatform();
-    await handleMessage(platform, 'conv-1', 'go ahead');
-
-    expect(platform.sendMessage).toHaveBeenCalledWith(
-      'conv-1',
-      expect.stringContaining('Approval failed')
+      expect.stringContaining('was not found')
     );
   });
 });

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -71,6 +71,7 @@ import { IsolationBlockedError } from '@archon/isolation';
 import {
   buildOrchestratorSystemAppend,
   buildRunManagementSection,
+  formatPausedGateSection,
   formatWorkflowContextSection,
 } from './prompt-builder';
 import type { WorkflowResultContext } from './prompt-builder';
@@ -78,9 +79,6 @@ import { reportUnpushedWorkInSource } from './post-message-reminder';
 import * as messageDb from '../db/messages';
 import * as workflowDb from '../db/workflows';
 import { getCodebaseEnvVars } from '../db/env-vars';
-import { approveWorkflow } from '../operations/workflow-operations';
-import { isApprovalContext, isGateResolved } from '@archon/workflows/schemas/workflow-run';
-import type { ApprovalContext } from '@archon/workflows/schemas/workflow-run';
 import {
   buildAiProfile,
   isLiteralSpec,
@@ -1112,6 +1110,110 @@ async function dispatchOrchestratorWorkflow(
   }
 }
 
+/** A human gate the chat agent resolved during a turn, awaiting continuation. */
+interface ResolvedGate {
+  run: WorkflowRun;
+  action: 'approve' | 'reject';
+}
+
+/**
+ * Continue a run whose human gate the chat agent just resolved (#2565).
+ *
+ * A resolution leaves the run `paused` on purpose — `approveWorkflow` and
+ * `rejectWorkflow` record the decision and let the caller decide when to move
+ * (`workflow-operations.ts`). This is chat's "when": the same resume dispatch the
+ * removed natural-language branch performed, now triggered by the agent's
+ * explicit approve/reject verb instead of by "the message did not start with /".
+ * Resolution without continuation would strand the run on every chat surface.
+ *
+ * Never throws — the gate decision is already committed, so a failure here costs
+ * the user a manual `/workflow resume`, not the decision.
+ */
+async function continueResolvedGateRun(
+  platform: IPlatformAdapter,
+  conversationId: string,
+  conversation: Conversation,
+  codebase: Codebase | null,
+  workflowsWithSource: readonly WorkflowWithSource[],
+  run: WorkflowRun,
+  action: 'approve' | 'reject',
+  isolationHints?: HandleMessageContext['isolationHints'],
+  userId?: string
+): Promise<void> {
+  const decision = action === 'approve' ? 'Approved' : 'Rejected';
+  const workflow = findWorkflow(
+    run.workflow_name,
+    workflowsWithSource.map(w => w.workflow)
+  );
+  if (!workflow) {
+    getLog().warn(
+      { conversationId, workflowRunId: run.id, workflowName: run.workflow_name },
+      'orchestrator.gate_continuation_workflow_not_found'
+    );
+    await platform.sendMessage(
+      conversationId,
+      `${decision}, but workflow \`${run.workflow_name}\` was not found, so the run could not ` +
+        'continue. The decision is recorded — use `/workflow list` to check available workflows.'
+    );
+    return;
+  }
+  if (!codebase) {
+    getLog().warn(
+      { conversationId, workflowRunId: run.id },
+      'orchestrator.gate_continuation_no_codebase'
+    );
+    await platform.sendMessage(
+      conversationId,
+      `${decision}, but no project is attached to this conversation, so the run could not ` +
+        `continue. The decision is recorded — use \`/workflow resume ${run.id}\` from the project.`
+    );
+    return;
+  }
+
+  const source = workflowsWithSource.find(w => w.workflow === workflow)?.source;
+  getLog().info(
+    { conversationId, workflowRunId: run.id, workflowName: workflow.name, action },
+    'orchestrator.gate_continuation_started'
+  );
+  try {
+    await platform.sendMessage(conversationId, `▶️ Resuming **${workflow.name}**...`);
+    await dispatchOrchestratorWorkflow(
+      platform,
+      conversationId,
+      conversation,
+      codebase,
+      workflow,
+      run.user_message,
+      isolationHints,
+      userId,
+      source,
+      { resumeRunId: run.id, resumeRun: run }
+    );
+    getLog().info(
+      { conversationId, workflowRunId: run.id, workflowName: workflow.name, action },
+      'orchestrator.gate_continuation_completed'
+    );
+  } catch (error) {
+    const err = toError(error);
+    getLog().error(
+      { err, errorType: err.constructor.name, conversationId, workflowRunId: run.id, action },
+      'orchestrator.gate_continuation_failed'
+    );
+    await platform
+      .sendMessage(
+        conversationId,
+        `${decision}, but resuming **${workflow.name}** failed: ${err.message}. ` +
+          `The decision is recorded — retry with \`/workflow resume ${run.id}\`.`
+      )
+      .catch((sendErr: unknown) => {
+        getLog().warn(
+          { err: toError(sendErr), conversationId },
+          'orchestrator.gate_continuation_notice_failed'
+        );
+      });
+  }
+}
+
 // ─── Session Helpers ────────────────────────────────────────────────────────
 
 async function tryPersistSessionId(
@@ -1264,7 +1366,8 @@ function buildFullPrompt(
   issueContext: string | undefined,
   threadContext: string | undefined,
   attachedFiles?: AttachedFile[],
-  workflowContext?: string
+  workflowContext?: string,
+  pausedGateContext?: string
 ): string {
   const contextSuffix = issueContext ? '\n\n---\n\n## Additional Context\n\n' + issueContext : '';
 
@@ -1277,12 +1380,16 @@ function buildFullPrompt(
       : '';
 
   const workflowContextSuffix = workflowContext ? '\n\n---\n\n' + workflowContext : '';
+  // Placed LAST of the context blocks, immediately before the user's message —
+  // the gate is the thing the message is most likely answering (#2565).
+  const gateSuffix = pausedGateContext ? '\n\n---\n\n' + pausedGateContext : '';
 
   if (threadContext) {
     return (
       '## Thread Context (previous messages)\n\n' +
       threadContext +
       workflowContextSuffix +
+      gateSuffix +
       '\n\n---\n\n## Current Request\n\n' +
       message +
       contextSuffix +
@@ -1291,7 +1398,12 @@ function buildFullPrompt(
   }
 
   return (
-    workflowContextSuffix + '\n\n---\n\n## User Message\n\n' + message + contextSuffix + fileSuffix
+    workflowContextSuffix +
+    gateSuffix +
+    '\n\n---\n\n## User Message\n\n' +
+    message +
+    contextSuffix +
+    fileSuffix
   );
 }
 
@@ -1339,113 +1451,6 @@ export async function handleMessage(
       parentConversationId,
       conversationId
     );
-
-    // Natural-language approval routing — if a workflow is paused in this
-    // conversation awaiting a human gate, treat any non-slash message as the
-    // approval response. A paused run whose gate is already resolved
-    // (metadata.approval.resolved set — approved/rejected and awaiting
-    // auto-resume, #2075) is skipped so the message falls through to normal
-    // routing, matching the pre-#2075 behavior where a staged run no longer
-    // matched the 'paused' query.
-    if (!message.startsWith('/')) {
-      const pausedRun = await workflowDb.getPausedWorkflowRun(conversation.id);
-      const pausedApprovalRaw = pausedRun?.metadata.approval;
-      const gateAlreadyResolved =
-        pausedApprovalRaw !== undefined &&
-        isApprovalContext(pausedApprovalRaw) &&
-        isGateResolved(pausedApprovalRaw);
-      if (pausedRun && !gateAlreadyResolved) {
-        const approvalRaw = pausedRun.metadata.approval;
-        const hasValidApproval =
-          approvalRaw != null &&
-          typeof approvalRaw === 'object' &&
-          'nodeId' in approvalRaw &&
-          typeof (approvalRaw as Record<string, unknown>).nodeId === 'string';
-
-        if (!hasValidApproval) {
-          // Paused run exists but approval context is missing or corrupt —
-          // tell the user so they can use explicit commands instead.
-          await platform.sendMessage(
-            conversationId,
-            'A workflow is paused but its approval context is missing. ' +
-              `Use \`/workflow approve ${pausedRun.id}\` or \`/workflow reject ${pausedRun.id}\`.`
-          );
-          return;
-        }
-
-        const approval = approvalRaw as ApprovalContext;
-        getLog().info(
-          {
-            conversationId,
-            workflowRunId: pausedRun.id,
-            nodeId: approval.nodeId,
-            workflowName: pausedRun.workflow_name,
-          },
-          'orchestrator.natural_language_approval_started'
-        );
-
-        try {
-          // Shared gate logic (events, telemetry, metadata staging) — the run
-          // stays 'paused' with metadata.approval.resolved = 'approved'.
-          await approveWorkflow(pausedRun.id, message);
-
-          // Discover workflow and resume
-          const { workflows: discoveredWorkflows } = await discoverAllWorkflows(conversation);
-          const allWorkflows: WorkflowDefinition[] = discoveredWorkflows.map(w => w.workflow);
-          const workflow = findWorkflow(pausedRun.workflow_name, allWorkflows);
-          const workflowSource = workflow
-            ? discoveredWorkflows.find(w => w.workflow === workflow)?.source
-            : undefined;
-          if (!workflow) {
-            await platform.sendMessage(
-              conversationId,
-              `Approved, but workflow \`${pausedRun.workflow_name}\` not found. ` +
-                'The approval was recorded — use `/workflow list` to check available workflows.'
-            );
-            return;
-          }
-          const codebase = conversation.codebase_id
-            ? await codebaseDb.getCodebase(conversation.codebase_id)
-            : null;
-          if (!codebase) {
-            await platform.sendMessage(
-              conversationId,
-              'Approved, but no project is attached to this conversation. ' +
-                'The approval was recorded — re-run the workflow to resume.'
-            );
-            return;
-          }
-          await platform.sendMessage(conversationId, `▶️ Resuming **${workflow.name}**...`);
-          await dispatchOrchestratorWorkflow(
-            platform,
-            conversationId,
-            conversation,
-            codebase,
-            workflow,
-            pausedRun.user_message,
-            isolationHints,
-            userId,
-            workflowSource,
-            { resumeRunId: pausedRun.id, resumeRun: pausedRun }
-          );
-          getLog().info(
-            { conversationId, workflowRunId: pausedRun.id, workflowName: pausedRun.workflow_name },
-            'orchestrator.natural_language_approval_completed'
-          );
-        } catch (error) {
-          getLog().error(
-            { err: error as Error, workflowRunId: pausedRun.id, conversationId },
-            'orchestrator.natural_language_approval_failed'
-          );
-          await platform.sendMessage(
-            conversationId,
-            `Approval failed: ${(error as Error).message}. ` +
-              `Try again or use \`/workflow approve ${pausedRun.id}\` explicitly.`
-          );
-        }
-        return;
-      }
-    }
 
     // 2. Check for deterministic commands
     if (message.startsWith('/')) {
@@ -1623,12 +1628,39 @@ export async function handleMessage(
       // Non-critical — continue without context
     }
 
+    // A human gate paused in this conversation is CONTEXT for the agent, not a
+    // branch in the router (#2565). Before #2565 any non-slash message here was
+    // recorded as an approval — including an objection — so an interpretation
+    // step never existed. Now the agent reads the gate alongside the message and
+    // resolves it (or doesn't) through the explicit approve/reject verbs it
+    // already has. Best-effort: getPausedWorkflowRun swallows DB errors and
+    // returns null, and a missing section only means the agent isn't told.
+    const pausedGateRun = await workflowDb.getPausedWorkflowRun(conversation.id);
+    const pausedGateContext = pausedGateRun
+      ? formatPausedGateSection({
+          runId: pausedGateRun.id,
+          workflowName: pausedGateRun.workflow_name,
+          approval: pausedGateRun.metadata.approval,
+        }) || undefined
+      : undefined;
+    if (pausedGateContext !== undefined) {
+      getLog().info(
+        {
+          conversationId,
+          workflowRunId: pausedGateRun?.id,
+          workflowName: pausedGateRun?.workflow_name,
+        },
+        'orchestrator.paused_gate_context_injected'
+      );
+    }
+
     const fullPrompt = buildFullPrompt(
       message,
       issueContext,
       threadContext,
       attachedFiles,
-      workflowContext
+      workflowContext,
+      pausedGateContext
     );
     const scopedCodebase =
       conversation.codebase_id !== null
@@ -1845,6 +1877,14 @@ export async function handleMessage(
       'sending_to_ai'
     );
 
+    // Written by the `manage_run` tool when the agent resolves a human gate
+    // during this turn, and acted on once the turn ends (#2565). Resolving a
+    // gate and continuing the run are two halves of one action — the tool
+    // records the intent so its call returns immediately, and the resume runs
+    // here rather than blocking the agent loop on a whole workflow. Held in an
+    // object because a `let` assigned only from a callback narrows to `null`.
+    const gateResolution: { resolved: ResolvedGate | null } = { resolved: null };
+
     // Project-scoped chats get the `manage_run` tool so the agent can see and
     // launch this project's workflow runs. Only when a codebase is scoped and
     // the provider supports in-process native tools (Claude, Pi). The explicit
@@ -1855,6 +1895,14 @@ export async function handleMessage(
       requestOptions.nativeTools = [
         buildManageRunTool({
           codebaseId: scopedCodebaseId,
+          // One continuation per turn: the resume runs in this conversation and
+          // to completion, so a second gate resolved in the same turn is
+          // declined rather than silently dropped (the tool tells the agent).
+          onGateResolved: (run, action) => {
+            if (gateResolution.resolved !== null) return false;
+            gateResolution.resolved = { run, action };
+            return true;
+          },
           startWorkflow: async (workflowName, msg): Promise<string> => {
             let wf: WorkflowDefinition | undefined;
             try {
@@ -1927,6 +1975,21 @@ export async function handleMessage(
         conversation,
         issueContext,
         requestOptions,
+        userId
+      );
+    }
+
+    // The agent resolved a human gate during the turn — now continue the run.
+    if (gateResolution.resolved !== null) {
+      await continueResolvedGateRun(
+        platform,
+        conversationId,
+        conversation,
+        discoveredCodebase ?? null,
+        workflowsWithSource,
+        gateResolution.resolved.run,
+        gateResolution.resolved.action,
+        isolationHints,
         userId
       );
     }

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -79,6 +79,7 @@ import { reportUnpushedWorkInSource } from './post-message-reminder';
 import * as messageDb from '../db/messages';
 import * as workflowDb from '../db/workflows';
 import { getCodebaseEnvVars } from '../db/env-vars';
+import { isContainerRun } from '@archon/workflows/schemas/workflow-run';
 import {
   buildAiProfile,
   isLiteralSpec,
@@ -1127,7 +1128,9 @@ interface ResolvedGate {
  * Resolution without continuation would strand the run on every chat surface.
  *
  * Never throws — the gate decision is already committed, so a failure here costs
- * the user a manual `/workflow resume`, not the decision.
+ * the user a manual `/workflow resume`, not the decision. The whole body is
+ * guarded so that guarantee holds for the `finally` this runs from, where a
+ * throw would replace the error the user actually needs to see.
  */
 async function continueResolvedGateRun(
   platform: IPlatformAdapter,
@@ -1141,76 +1144,83 @@ async function continueResolvedGateRun(
   userId?: string
 ): Promise<void> {
   const decision = action === 'approve' ? 'Approved' : 'Rejected';
-  const workflow = findWorkflow(
-    run.workflow_name,
-    workflowsWithSource.map(w => w.workflow)
-  );
-  if (!workflow) {
-    getLog().warn(
-      { conversationId, workflowRunId: run.id, workflowName: run.workflow_name },
-      'orchestrator.gate_continuation_workflow_not_found'
-    );
-    await platform.sendMessage(
-      conversationId,
-      `${decision}, but workflow \`${run.workflow_name}\` was not found, so the run could not ` +
-        'continue. The decision is recorded — use `/workflow list` to check available workflows.'
-    );
-    return;
-  }
-  if (!codebase) {
-    getLog().warn(
-      { conversationId, workflowRunId: run.id },
-      'orchestrator.gate_continuation_no_codebase'
-    );
-    await platform.sendMessage(
-      conversationId,
-      `${decision}, but no project is attached to this conversation, so the run could not ` +
-        `continue. The decision is recorded — use \`/workflow resume ${run.id}\` from the project.`
-    );
-    return;
-  }
+  const notify = async (text: string): Promise<void> => {
+    await platform.sendMessage(conversationId, text).catch((sendErr: unknown) => {
+      getLog().warn(
+        { err: toError(sendErr), conversationId, workflowRunId: run.id },
+        'orchestrator.gate_continuation_notice_failed'
+      );
+    });
+  };
 
-  const source = workflowsWithSource.find(w => w.workflow === workflow)?.source;
-  getLog().info(
-    { conversationId, workflowRunId: run.id, workflowName: workflow.name, action },
-    'orchestrator.gate_continuation_started'
-  );
   try {
-    await platform.sendMessage(conversationId, `▶️ Resuming **${workflow.name}**...`);
-    await dispatchOrchestratorWorkflow(
-      platform,
-      conversationId,
-      conversation,
-      codebase,
-      workflow,
-      run.user_message,
-      isolationHints,
-      userId,
-      source,
-      { resumeRunId: run.id, resumeRun: run }
+    const workflow = findWorkflow(
+      run.workflow_name,
+      workflowsWithSource.map(w => w.workflow)
     );
+    if (!workflow) {
+      getLog().warn(
+        { conversationId, workflowRunId: run.id, workflowName: run.workflow_name },
+        'orchestrator.gate_continuation_workflow_not_found'
+      );
+      await notify(
+        `${decision}, but workflow \`${run.workflow_name}\` was not found, so the run could not ` +
+          'continue. The decision is recorded — use `/workflow list` to check available workflows.'
+      );
+      return;
+    }
+    if (!codebase) {
+      getLog().warn(
+        { conversationId, workflowRunId: run.id },
+        'orchestrator.gate_continuation_no_codebase'
+      );
+      await notify(
+        `${decision}, but no project is attached to this conversation, so the run could not ` +
+          `continue. The decision is recorded — use \`/workflow resume ${run.id}\` from the project.`
+      );
+      return;
+    }
+
+    const source = workflowsWithSource.find(w => w.workflow === workflow)?.source;
     getLog().info(
       { conversationId, workflowRunId: run.id, workflowName: workflow.name, action },
-      'orchestrator.gate_continuation_completed'
+      'orchestrator.gate_continuation_started'
     );
-  } catch (error) {
-    const err = toError(error);
-    getLog().error(
-      { err, errorType: err.constructor.name, conversationId, workflowRunId: run.id, action },
-      'orchestrator.gate_continuation_failed'
-    );
-    await platform
-      .sendMessage(
+    try {
+      await notify(`▶️ Resuming **${workflow.name}**...`);
+      await dispatchOrchestratorWorkflow(
+        platform,
         conversationId,
+        conversation,
+        codebase,
+        workflow,
+        run.user_message,
+        isolationHints,
+        userId,
+        source,
+        { resumeRunId: run.id, resumeRun: run }
+      );
+      getLog().info(
+        { conversationId, workflowRunId: run.id, workflowName: workflow.name, action },
+        'orchestrator.gate_continuation_completed'
+      );
+    } catch (error) {
+      const err = toError(error);
+      getLog().error(
+        { err, errorType: err.constructor.name, conversationId, workflowRunId: run.id, action },
+        'orchestrator.gate_continuation_failed'
+      );
+      await notify(
         `${decision}, but resuming **${workflow.name}** failed: ${err.message}. ` +
           `The decision is recorded — retry with \`/workflow resume ${run.id}\`.`
-      )
-      .catch((sendErr: unknown) => {
-        getLog().warn(
-          { err: toError(sendErr), conversationId },
-          'orchestrator.gate_continuation_notice_failed'
-        );
-      });
+      );
+    }
+  } catch (error) {
+    // Belt and braces for the "never throws" contract the finally relies on.
+    getLog().error(
+      { err: toError(error), conversationId, workflowRunId: run.id, action },
+      'orchestrator.gate_continuation_failed'
+    );
   }
 }
 
@@ -1641,6 +1651,12 @@ export async function handleMessage(
           runId: pausedGateRun.id,
           workflowName: pausedGateRun.workflow_name,
           approval: pausedGateRun.metadata.approval,
+          // Chat cannot rewire a container, so it cannot continue such a run.
+          containerRun: isContainerRun(pausedGateRun),
+          // Both resolution routes — the `manage_run` tool and the CLI-pointer
+          // section — are gated on a scoped project; without one the section
+          // must not instruct the agent to use verbs it does not have.
+          agentCanResolve: conversation.codebase_id !== null,
         }) || undefined
       : undefined;
     if (pausedGateContext !== undefined) {
@@ -1943,55 +1959,63 @@ export async function handleMessage(
     }
 
     const mode = platform.getStreamingMode();
-    if (mode === 'stream') {
-      await handleStreamMode(
-        platform,
-        conversationId,
-        message,
-        codebases,
-        workflowsWithSource,
-        aiClient,
-        fullPrompt,
-        cwd,
-        session,
-        isolationHints,
-        conversation,
-        issueContext,
-        requestOptions,
-        userId
-      );
-    } else {
-      await handleBatchMode(
-        platform,
-        conversationId,
-        message,
-        codebases,
-        workflowsWithSource,
-        aiClient,
-        fullPrompt,
-        cwd,
-        session,
-        isolationHints,
-        conversation,
-        issueContext,
-        requestOptions,
-        userId
-      );
-    }
-
-    // The agent resolved a human gate during the turn — now continue the run.
-    if (gateResolution.resolved !== null) {
-      await continueResolvedGateRun(
-        platform,
-        conversationId,
-        conversation,
-        discoveredCodebase ?? null,
-        workflowsWithSource,
-        gateResolution.resolved.run,
-        gateResolution.resolved.action,
-        isolationHints,
-        userId
-      );
+    // `finally`, not straight-line code: the gate resolution is committed to the
+    // DB the moment the tool call returns, so once the agent has resolved a gate
+    // the continuation must run even if the rest of the turn throws — a provider
+    // subprocess crash after a successful tool call would otherwise leave the run
+    // resolved and parked with only a generic error to show for it. The outer
+    // catch cannot cover this: it does not know about the resolution.
+    // continueResolvedGateRun never throws, so this cannot mask the real error.
+    try {
+      if (mode === 'stream') {
+        await handleStreamMode(
+          platform,
+          conversationId,
+          message,
+          codebases,
+          workflowsWithSource,
+          aiClient,
+          fullPrompt,
+          cwd,
+          session,
+          isolationHints,
+          conversation,
+          issueContext,
+          requestOptions,
+          userId
+        );
+      } else {
+        await handleBatchMode(
+          platform,
+          conversationId,
+          message,
+          codebases,
+          workflowsWithSource,
+          aiClient,
+          fullPrompt,
+          cwd,
+          session,
+          isolationHints,
+          conversation,
+          issueContext,
+          requestOptions,
+          userId
+        );
+      }
+    } finally {
+      if (gateResolution.resolved !== null) {
+        await continueResolvedGateRun(
+          platform,
+          conversationId,
+          conversation,
+          discoveredCodebase ?? null,
+          workflowsWithSource,
+          gateResolution.resolved.run,
+          gateResolution.resolved.action,
+          isolationHints,
+          userId
+        );
+      }
     }
 
     // Direct-chat turns may have written to source/. If there is local-only state

--- a/packages/core/src/orchestrator/prompt-builder.test.ts
+++ b/packages/core/src/orchestrator/prompt-builder.test.ts
@@ -168,6 +168,17 @@ describe('buildRunManagementSection', () => {
     expect(section).toContain('--detach');
   });
 
+  test('tells the CLI-path providers to pass the user’s own words', () => {
+    // Codex/OpenCode/Copilot reach the verbs only through this section — without
+    // the clause they get less instruction density than Claude/Pi, which also see
+    // the manage_run tool help.
+    const section = buildRunManagementSection();
+
+    expect(section).toContain("user's own words");
+    expect(section).toContain('never a summary');
+    expect(section).toContain('on_reject');
+  });
+
   test('warns that a --json gate decision does not continue the run', () => {
     // The CLI-pointer path is how tool-less providers resolve a gate (#2565).
     // `approve --json` records the decision WITHOUT resuming, so an agent that
@@ -202,6 +213,26 @@ describe('formatPausedGateSection', () => {
     expect(section).toContain('REJECTED');
     // The outcome the old auto-approve branch could not produce at all.
     expect(section).toContain('resolve NOTHING');
+  });
+
+  test('demonstrates verbatim-ness with a rejection, not only a rule', () => {
+    // Stating the rule is weaker than showing it, and the rejection reason is the
+    // case where a paraphrase does the most damage — it is what on_reject reworks.
+    const section = formatPausedGateSection(openGate);
+
+    expect(section).toContain('why is it editing the schema?');
+    expect(section).toContain('NOT "the user objected to the schema change"');
+    expect(section).toContain('add error handling for the edge cases');
+  });
+
+  test('names no tool, so the section stays usable by every provider', () => {
+    // Claude/Pi reach the verbs through `manage_run`; Codex/OpenCode/Copilot reach
+    // them through the CLI section. Naming either here advertises the wrong route
+    // to half the providers.
+    const section = formatPausedGateSection(openGate);
+
+    expect(section).not.toContain('manage_run');
+    expect(section).not.toContain('archon workflow');
   });
 
   test('tells the agent to pass the user’s own words through', () => {

--- a/packages/core/src/orchestrator/prompt-builder.test.ts
+++ b/packages/core/src/orchestrator/prompt-builder.test.ts
@@ -4,6 +4,7 @@ import {
   formatWorkflowContextSection,
   buildOrchestratorSystemAppend,
   buildRunManagementSection,
+  formatPausedGateSection,
 } from './prompt-builder';
 
 describe('buildRoutingRulesWithProject', () => {
@@ -165,5 +166,104 @@ describe('buildRunManagementSection', () => {
     }
     expect(section).toContain('--json');
     expect(section).toContain('--detach');
+  });
+
+  test('warns that a --json gate decision does not continue the run', () => {
+    // The CLI-pointer path is how tool-less providers resolve a gate (#2565).
+    // `approve --json` records the decision WITHOUT resuming, so an agent that
+    // reflexively adds --json would resolve the gate and strand the run.
+    const section = buildRunManagementSection();
+    expect(section).toContain('stranded');
+    expect(section).toContain('archon workflow resume');
+  });
+});
+
+describe('formatPausedGateSection', () => {
+  const openGate = {
+    runId: 'run-abc',
+    workflowName: 'prd',
+    approval: { type: 'approval', nodeId: 'review', message: 'Approve the plan above.' },
+  };
+
+  test('states the gate facts the agent needs to act on', () => {
+    const section = formatPausedGateSection(openGate);
+
+    expect(section).toContain('## Paused Approval Gate');
+    expect(section).toContain('run-abc');
+    expect(section).toContain('prd');
+    expect(section).toContain('review');
+    expect(section).toContain('Approve the plan above.');
+  });
+
+  test('spells out all three outcomes, including resolving nothing', () => {
+    const section = formatPausedGateSection(openGate);
+
+    expect(section).toContain('APPROVED');
+    expect(section).toContain('REJECTED');
+    // The outcome the old auto-approve branch could not produce at all.
+    expect(section).toContain('resolve NOTHING');
+  });
+
+  test('tells the agent to pass the user’s own words through', () => {
+    // A gate with capture_response reads the comment as the node's output, so a
+    // paraphrase silently rewrites workflow input.
+    expect(formatPausedGateSection(openGate)).toContain('verbatim');
+  });
+
+  test('promises continuation so the agent does not hunt for a resume step', () => {
+    expect(formatPausedGateSection(openGate)).toContain('no separate resume step');
+  });
+
+  test('quotes a multi-line gate message as a single block', () => {
+    const section = formatPausedGateSection({
+      ...openGate,
+      approval: { type: 'approval', nodeId: 'review', message: 'Line one\nLine two' },
+    });
+
+    expect(section).toContain('> Line one\n> Line two');
+  });
+
+  test('names the loop iteration on an interactive-loop gate', () => {
+    const section = formatPausedGateSection({
+      ...openGate,
+      approval: {
+        type: 'interactive_loop',
+        nodeId: 'refine',
+        iteration: 3,
+        message: 'Review the output',
+      },
+    });
+
+    expect(section).toContain('Loop iteration: 3');
+  });
+
+  test('returns nothing for a gate already resolved and awaiting resume', () => {
+    // Resolved gates are waiting on the machine, not on a human — offering them
+    // to the agent invites a second decision the operations reject.
+    expect(
+      formatPausedGateSection({
+        ...openGate,
+        approval: { ...openGate.approval, resolved: 'approved' },
+      })
+    ).toBe('');
+  });
+
+  test('points at the child run when the pause belongs to a sub-run', () => {
+    const section = formatPausedGateSection({
+      ...openGate,
+      approval: { type: 'child_workflow', nodeId: 'child', message: 'blocked', childRunId: 'kid' },
+    });
+
+    expect(section).toContain('kid');
+    expect(section).toContain('no gate you can resolve');
+  });
+
+  test('falls back to the explicit commands when the approval context is unusable', () => {
+    for (const approval of [undefined, null, {}, { nodeId: 'x' }, 'garbage']) {
+      const section = formatPausedGateSection({ ...openGate, approval });
+      expect(section).toContain('missing or malformed');
+      expect(section).toContain('/workflow approve run-abc');
+      expect(section).toContain('/workflow reject run-abc');
+    }
   });
 });

--- a/packages/core/src/orchestrator/prompt-builder.test.ts
+++ b/packages/core/src/orchestrator/prompt-builder.test.ts
@@ -258,6 +258,29 @@ describe('formatPausedGateSection', () => {
     expect(section).toContain('no gate you can resolve');
   });
 
+  test('does not promise continuation for a container run', () => {
+    // executeWorkflow refuses a resume it cannot rewire, so "the run continues"
+    // is false here — the agent must send the user to the CLI instead.
+    const section = formatPausedGateSection({ ...openGate, containerRun: true });
+
+    expect(section).not.toContain('no separate resume step');
+    expect(section).toContain('isolation container');
+    expect(section).toContain('archon workflow resume run-abc');
+  });
+
+  test('does not tell the agent to resolve the gate when it has no route to the verbs', () => {
+    // No project scope means neither manage_run nor the CLI section is present.
+    const section = formatPausedGateSection({ ...openGate, agentCanResolve: false });
+
+    expect(section).toContain('## Paused Approval Gate');
+    expect(section).toContain('Approve the plan above.');
+    expect(section).toContain('no project is attached');
+    expect(section).toContain('/workflow approve run-abc');
+    // It must not hand out the decision policy for verbs it cannot reach.
+    expect(section).not.toContain('resolve the gate as APPROVED');
+    expect(section).not.toContain('no separate resume step');
+  });
+
   test('falls back to the explicit commands when the approval context is unusable', () => {
     for (const approval of [undefined, null, {}, { nodeId: 'x' }, 'garbage']) {
       const section = formatPausedGateSection({ ...openGate, approval });

--- a/packages/core/src/orchestrator/prompt-builder.ts
+++ b/packages/core/src/orchestrator/prompt-builder.ts
@@ -72,6 +72,21 @@ export interface PausedGateContext {
   workflowName: string;
   /** The run's raw `metadata.approval` — may be absent or malformed. */
   approval: unknown;
+  /**
+   * The run executed inside an isolation container, so chat cannot continue it
+   * (`isContainerRun`). The section promises continuation, and that promise is
+   * false here — the executor refuses a resume it cannot rewire.
+   */
+  containerRun?: boolean;
+  /**
+   * This turn actually has a route to the approve/reject verbs — i.e. the
+   * conversation is project-scoped, which is what gates both the `manage_run`
+   * tool and the CLI-pointer section. Default `true`. When false the section
+   * must not tell the agent to resolve the gate itself; the routes it would name
+   * are not wired, and handing out instructions for an absent tool is the same
+   * dishonesty this issue removed.
+   */
+  agentCanResolve?: boolean;
 }
 
 /**
@@ -123,13 +138,39 @@ export function formatPausedGateSection(gate: PausedGateContext): string {
     facts.push(`- Loop iteration: ${String(approval.iteration)}`);
   }
 
-  return (
+  const explicitCommands = `\`/workflow approve ${gate.runId} [comment]\` or \`/workflow reject ${gate.runId} <reason>\``;
+
+  const preamble =
     header +
     'A workflow run in this conversation is PAUSED waiting for a human decision. It does not ' +
     'continue until the gate is resolved.\n\n' +
     facts.join('\n') +
     '\n\nWhat the run is asking:\n\n' +
-    `> ${approval.message.replace(/\n/g, '\n> ')}\n\n` +
+    `> ${approval.message.replace(/\n/g, '\n> ')}\n\n`;
+
+  // No project is attached, so neither the `manage_run` tool nor the CLI-pointer
+  // section is present this turn. Relay the gate rather than instructing the
+  // agent to use verbs it does not have.
+  if (gate.agentCanResolve === false) {
+    return (
+      preamble +
+      'You have no way to resolve this gate yourself in this conversation — no project is ' +
+      'attached, so the run-management verbs are not available. If the user is answering the ' +
+      `gate, tell them to decide it explicitly with ${explicitCommands}. Do not claim you ` +
+      'resolved anything.'
+    );
+  }
+
+  // A container run can only be resumed where the container can be rewired.
+  const continuation = gate.containerRun
+    ? 'This run executed inside an isolation container, so resolving the gate records the ' +
+      'decision but CANNOT continue the run from here — only the CLI can rewire the ' +
+      `container. Tell the user to finish it with \`archon workflow resume ${gate.runId}\` ` +
+      'from the CLI in the same project.'
+    : 'Resolving the gate also continues the run — there is no separate resume step.';
+
+  return (
+    preamble +
     "Read the user's message and judge what it means for THIS gate:\n\n" +
     '- It clearly approves → resolve the gate as APPROVED, passing their own words verbatim as ' +
     'the comment (a workflow may read that comment as the gate node’s output).\n' +
@@ -141,9 +182,8 @@ export function formatPausedGateSection(gate: PausedGateContext): string {
     'resolve it in the same turn rather than making them repeat themselves. When you are not ' +
     'sure what they meant, ask: leaving the gate open costs nothing, and resolving it against ' +
     'their intent cannot be undone.\n\n' +
-    'Resolving the gate also continues the run — there is no separate resume step. The user ' +
-    `can always decide it themselves with \`/workflow approve ${gate.runId} [comment]\` or ` +
-    `\`/workflow reject ${gate.runId} <reason>\`.`
+    continuation +
+    ` The user can always decide it themselves with ${explicitCommands}.`
   );
 }
 

--- a/packages/core/src/orchestrator/prompt-builder.ts
+++ b/packages/core/src/orchestrator/prompt-builder.ts
@@ -5,6 +5,7 @@
  */
 import type { Codebase, Conversation } from '../types';
 import type { WorkflowDefinition } from '@archon/workflows/schemas/workflow';
+import { isApprovalContext, isGateResolved } from '@archon/workflows/schemas/workflow-run';
 
 /**
  * Format a single project for the orchestrator prompt.
@@ -63,6 +64,87 @@ export function formatWorkflowContextSection(results: readonly WorkflowResultCon
   }
 
   return section.trimEnd();
+}
+
+/** The paused run a conversation's approval gate belongs to. */
+export interface PausedGateContext {
+  runId: string;
+  workflowName: string;
+  /** The run's raw `metadata.approval` — may be absent or malformed. */
+  approval: unknown;
+}
+
+/**
+ * Format the "there is a human gate waiting in this conversation" section.
+ *
+ * This is the ONLY thing that tells the chat agent a gate is open. It states the
+ * facts of the gate and the decision policy; it does NOT name a tool, because the
+ * verbs reach different providers by different routes (the `manage_run` native
+ * tool on Claude/Pi, the `archon workflow approve|reject` CLI section on the
+ * others). Both routes are described elsewhere in the same prompt.
+ *
+ * Returns '' when there is nothing for the agent to decide — an already-resolved
+ * gate is awaiting resume, not a human.
+ */
+export function formatPausedGateSection(gate: PausedGateContext): string {
+  const header = '## Paused Approval Gate\n\n';
+  const approval = gate.approval;
+
+  if (!isApprovalContext(approval)) {
+    // Paused, but the gate cannot be described. Preserve the explicit-command
+    // guidance the old natural-language branch sent directly to the user.
+    return (
+      header +
+      `Run \`${gate.runId}\` (**${gate.workflowName}**) is paused, but its approval context is ` +
+      'missing or malformed, so the gate cannot be described. Tell the user to resolve it ' +
+      `explicitly with \`/workflow approve ${gate.runId}\` or \`/workflow reject ${gate.runId} <reason>\`.`
+    );
+  }
+
+  if (isGateResolved(approval)) return '';
+
+  if (approval.type === 'child_workflow') {
+    const childRunId = approval.childRunId ?? '<unknown>';
+    return (
+      header +
+      `Run \`${gate.runId}\` (**${gate.workflowName}**) is paused waiting on its sub-run ` +
+      `\`${childRunId}\`, which has a gate of its own. This run has no gate you can resolve — ` +
+      'the decision belongs to the child run, and this one continues on its own once the child ' +
+      'finishes.'
+    );
+  }
+
+  const facts = [
+    `- Run id: \`${gate.runId}\``,
+    `- Workflow: **${gate.workflowName}**`,
+    `- Gate node: \`${approval.nodeId}\``,
+  ];
+  if (approval.type === 'interactive_loop' && typeof approval.iteration === 'number') {
+    facts.push(`- Loop iteration: ${String(approval.iteration)}`);
+  }
+
+  return (
+    header +
+    'A workflow run in this conversation is PAUSED waiting for a human decision. It does not ' +
+    'continue until the gate is resolved.\n\n' +
+    facts.join('\n') +
+    '\n\nWhat the run is asking:\n\n' +
+    `> ${approval.message.replace(/\n/g, '\n> ')}\n\n` +
+    "Read the user's message and judge what it means for THIS gate:\n\n" +
+    '- It clearly approves → resolve the gate as APPROVED, passing their own words verbatim as ' +
+    'the comment (a workflow may read that comment as the gate node’s output).\n' +
+    '- It clearly objects, refuses, or asks to stop → resolve the gate as REJECTED, passing ' +
+    'their own words verbatim as the reason.\n' +
+    '- Anything else — a question, a request for detail, an unrelated message → resolve ' +
+    'NOTHING. Answer them and leave the gate open.\n\n' +
+    'An unambiguous decision from the user IS the human confirmation a gate action needs — ' +
+    'resolve it in the same turn rather than making them repeat themselves. When you are not ' +
+    'sure what they meant, ask: leaving the gate open costs nothing, and resolving it against ' +
+    'their intent cannot be undone.\n\n' +
+    'Resolving the gate also continues the run — there is no separate resume step. The user ' +
+    `can always decide it themselves with \`/workflow approve ${gate.runId} [comment]\` or ` +
+    `\`/workflow reject ${gate.runId} <reason>\`.`
+  );
 }
 
 /**
@@ -236,7 +318,7 @@ Run these from within the project's git repo (any subdirectory works — they re
 - \`archon workflow get <run-id> [--json]\` — one run's status/error (add \`--verbose\` for per-node detail)
 - \`archon workflow status [--json]\` — active runs only (running/paused)
 - \`archon workflow run <workflow> "<message>" --detach\` — start a run in the background (returns immediately)
-- \`archon workflow approve <run-id> [--json]\` / \`archon workflow reject <run-id> [reason] [--json]\` — resolve a paused approval gate
+- \`archon workflow approve <run-id> [comment]\` / \`archon workflow reject <run-id> [reason]\` — resolve a paused approval gate AND continue the run in one step. Add \`--json\` only when you need a machine-readable ack: \`--json\` records the decision WITHOUT continuing, and you must then drive \`archon workflow resume <run-id>\` yourself or the run stays stranded.
 - \`archon workflow resume <run-id>\` — re-run a failed/paused run, skipping completed nodes (run as a background task; \`--json\` validates only)
 - \`archon workflow abandon <run-id> [--json]\` — cancel a non-terminal run
 

--- a/packages/core/src/orchestrator/prompt-builder.ts
+++ b/packages/core/src/orchestrator/prompt-builder.ts
@@ -178,6 +178,16 @@ export function formatPausedGateSection(gate: PausedGateContext): string {
     'their own words verbatim as the reason.\n' +
     '- Anything else — a question, a request for detail, an unrelated message → resolve ' +
     'NOTHING. Answer them and leave the gate open.\n\n' +
+    // Demonstration, not just the rule: the reason a rejection carries is what an
+    // on_reject prompt reworks the code from, so a paraphrase there is a different
+    // artifact from what the user asked for.
+    'The words that travel are the user’s, not your summary:\n\n' +
+    '  User: "no, stop — why is it editing the schema?"\n' +
+    '  → REJECT, reason: "no, stop — why is it editing the schema?"\n' +
+    '    (NOT "the user objected to the schema change" — the reason is what an on_reject\n' +
+    '     prompt reworks from, so a summary reworks the wrong thing.)\n\n' +
+    '  User: "looks good, but add error handling for the edge cases"\n' +
+    '  → APPROVE, comment: "looks good, but add error handling for the edge cases"\n\n' +
     'An unambiguous decision from the user IS the human confirmation a gate action needs — ' +
     'resolve it in the same turn rather than making them repeat themselves. When you are not ' +
     'sure what they meant, ask: leaving the gate open costs nothing, and resolving it against ' +
@@ -358,7 +368,7 @@ Run these from within the project's git repo (any subdirectory works — they re
 - \`archon workflow get <run-id> [--json]\` — one run's status/error (add \`--verbose\` for per-node detail)
 - \`archon workflow status [--json]\` — active runs only (running/paused)
 - \`archon workflow run <workflow> "<message>" --detach\` — start a run in the background (returns immediately)
-- \`archon workflow approve <run-id> [comment]\` / \`archon workflow reject <run-id> [reason]\` — resolve a paused approval gate AND continue the run in one step. Add \`--json\` only when you need a machine-readable ack: \`--json\` records the decision WITHOUT continuing, and you must then drive \`archon workflow resume <run-id>\` yourself or the run stays stranded.
+- \`archon workflow approve <run-id> [comment]\` / \`archon workflow reject <run-id> [reason]\` — resolve a paused approval gate AND continue the run in one step. Pass the user's own words as the comment or reason, never a summary: a workflow may read the comment as the gate node's output, and the reason is what an \`on_reject\` prompt reworks from. Add \`--json\` only when you need a machine-readable ack: \`--json\` records the decision WITHOUT continuing, and you must then drive \`archon workflow resume <run-id>\` yourself or the run stays stranded.
 - \`archon workflow resume <run-id>\` — re-run a failed/paused run, skipping completed nodes (run as a background task; \`--json\` validates only)
 - \`archon workflow abandon <run-id> [--json]\` — cancel a non-terminal run
 

--- a/packages/docs-web/src/content/docs/guides/approval-nodes.md
+++ b/packages/docs-web/src/content/docs/guides/approval-nodes.md
@@ -54,11 +54,11 @@ to the user on whatever platform they're using (CLI, Slack, GitHub, etc.). On th
 3. **Wait**: The workflow stays paused until the user takes action. Paused runs
    block the worktree path guard (no other workflow can start on the same path).
 4. **Approve**: The user approves, which writes a `node_completed` event for
-   the approval node and transitions the run to resumable. Natural-language
-   messages, the CLI, the Web UI approve button, and the in-thread **Approve**
-   button posted by the Slack adapter all auto-resume the workflow from the
-   paused gate. (The explicit `/workflow approve <run-id>` slash command also
-   auto-resumes when issued in the originating conversation.)
+   the approval node and transitions the run to resumable. Every approve surface
+   also continues the run: the `/workflow approve <run-id>` slash command, the
+   CLI, the Web UI approve button, the in-thread **Approve** button posted by the
+   Slack adapter, and a chat agent resolving the gate on your behalf after you
+   tell it to.
 5. **Reject**: The user rejects.
    - **Without `on_reject`**: The workflow is cancelled immediately.
    - **With `on_reject`**: The executor runs the `on_reject.prompt` via AI (with
@@ -107,20 +107,49 @@ not `retry`.
 
 ## Approving and Rejecting
 
-### Natural Language (recommended)
-
-Just type your answer in the same conversation. The system detects the paused
-workflow and treats your message as the approval response:
+### Explicit Commands (all platforms)
 
 ```
-User: "Looks good, but add error handling for the edge cases"
-→ System auto-approves, resumes workflow with your message as $gate.output
-  (only if capture_response: true is set)
+/workflow approve <run-id> looks good
+/workflow reject <run-id> needs changes
 ```
 
-This works on all platforms (Web, Slack, Telegram, Discord, GitHub).
+Both resolve the gate **and** continue the run — approving no longer needs a
+follow-up message.
 
-To reject instead, use `/workflow reject <run-id>`.
+### Asking the chat agent
+
+You can also just say what you want in the conversation. The agent reads the open
+gate along with your message and decides:
+
+```
+User: "looks good, ship it"
+→ agent approves the gate; the run continues
+
+User: "no, stop — why is it editing the schema?"
+→ agent rejects the gate with your words as the reason
+
+User: "what would that change?"
+→ agent answers you; the gate stays open and nothing is resolved
+```
+
+The agent passes your own words through as the approval comment or the rejection
+reason, so a gate with `capture_response: true` still receives what you typed.
+
+:::caution[Behaviour change]
+Archon used to record **any** message that did not start with `/` as an approval —
+including an objection, which was stored as the approval comment while the run
+carried on doing the thing you objected to. Typing at a gate no longer approves by
+itself. If your message is ambiguous the agent asks instead of guessing, and
+nothing is resolved until you are explicit.
+
+Two consequences worth knowing:
+
+- Providers without native tool support (Codex, OpenCode, Copilot) resolve the
+  gate by running `archon workflow approve|reject <run-id>` for you instead.
+- If you want a decision recorded with no interpretation at all, use the slash
+  commands above — they are deterministic.
+:::
 
 ### CLI
 
@@ -138,13 +167,6 @@ bun run cli workflow reject <run-id>
 bun run cli workflow reject <run-id> --reason "Plan needs more test coverage"
 ```
 
-### Explicit Commands (all platforms)
-
-```
-/workflow approve <run-id> looks good
-/workflow reject <run-id> needs changes
-```
-
 ### Interactive-loop gates: bare approve finalizes
 
 Interactive **loop** gates (`loop:`/`loop_group:` with `interactive: true`) share these
@@ -154,8 +176,9 @@ by `workflow get --json` and `manage_run` — leads with "✅ Completion signal 
 in chat the same line follows the `⏸ Input required` prefix),
 approving **without a comment** finalizes the loop node from the already-computed output —
 no extra iteration runs. Approving **with** a comment runs another iteration with your
-comment as `$LOOP_USER_INPUT`. Natural-language approval always counts as a comment
-(iterates); use the slash command, CLI, web button, or `manage_run` to finalize. See
+comment as `$LOOP_USER_INPUT`. Asking the agent to approve without passing anything on
+finalizes too; if you want the finalize to be unambiguous, use `/workflow approve <id>`
+with no comment, the CLI, or the web button. See
 [Loop Nodes → `interactive` and `gate_message`](/guides/loop-nodes/#interactive-and-gate_message)
 for the full semantics, `signal_completes`, and the AI-approver steering pattern.
 

--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -670,7 +670,7 @@ When a `nodes:` (DAG) workflow fails, the prior run stays in the database as a c
 **How to resume:**
 
 - **CLI**: `archon workflow run <name> --resume` resumes the most recent failed run for `(workflow_name, cwd)`. Or `archon workflow resume <run-id>` to target a specific run.
-- **Chat**: Approving or rejecting a _paused_ workflow auto-resumes from where it left off (the platform already knows the run id). For a prior **failed** (or stale `running`) run, `/workflow run <name>` does **not** silently resume — it shows a prompt offering three choices: resume it, abandon it and run fresh, or start fresh anyway. Pass `--force` to skip the prompt: `/workflow run <name> --force <args>` always starts a fresh run.
+- **Chat**: Approving or rejecting a _paused_ workflow continues it from where it left off (the platform already knows the run id). For a prior **failed** (or stale `running`) run, `/workflow run <name>` does **not** silently resume — it shows a prompt offering three choices: resume it, abandon it and run fresh, or start fresh anyway. Pass `--force` to skip the prompt: `/workflow run <name> --force <args>` always starts a fresh run.
 - **Web UI**: Resume button on the workflow card.
 
 **What happens on resume:**
@@ -2289,13 +2289,13 @@ nodes:
 
 When the workflow reaches `review-gate`, it pauses and notifies you. Approve or reject via:
 
-- **Natural language** (recommended): Just type your response in the conversation — the system detects the paused workflow and auto-resumes
-- **CLI**: `bun run cli workflow approve <run-id>` or `bun run cli workflow reject <run-id>` — auto-resumes
-- **Explicit command**: `/workflow approve <run-id>` or `/workflow reject <run-id>` — auto-resumes when issued in the originating conversation
+- **Explicit command**: `/workflow approve <run-id>` or `/workflow reject <run-id>` — deterministic; resolves and continues the run
+- **CLI**: `bun run cli workflow approve <run-id>` or `bun run cli workflow reject <run-id>` — resolves and continues (`--json` records the decision only)
+- **Chat**: tell the agent what you want ("looks good, ship it" / "no, stop") — it resolves the gate and the run continues. An ambiguous message resolves nothing and the agent asks; a plain message is **not** an automatic approval
 - **Web UI**: Click the Approve/Reject buttons on the dashboard card — auto-resumes for Web-UI-dispatched runs; the Reject dialog includes an optional reason field that flows to `$REJECTION_REASON`
 - **API**: `POST /api/workflows/runs/<run-id>/approve` or `/reject`
 
-All four paths auto-resume the workflow from the next node. The user's approval comment is available as `$review-gate.output` in downstream nodes only when `capture_response: true` is set on the approval node. Cross-platform caveat: Web-UI approvals on Slack / Telegram / GitHub-dispatched runs record the decision but do not auto-resume — re-run from the originating platform to continue.
+Every path continues the workflow from the next node. The user's approval comment is available as `$review-gate.output` in downstream nodes only when `capture_response: true` is set on the approval node. Cross-platform caveat: Web-UI approvals on Slack / Telegram / GitHub-dispatched runs record the decision but do not auto-resume — re-run from the originating platform to continue.
 
 Without `on_reject`: rejecting cancels the workflow.
 With `on_reject`: rejecting triggers an AI rework prompt and re-pauses for re-review.

--- a/packages/docs-web/src/content/docs/guides/loop-nodes.md
+++ b/packages/docs-web/src/content/docs/guides/loop-nodes.md
@@ -367,10 +367,12 @@ The same rule applies on every approve surface: chat `/workflow approve`, the CL
 endpoint (omit `comment`), the web console ("Accept & complete" with an empty comment
 field), and the `manage_run` chat tool (no `message`, or `accept: true`).
 
-> **Known limitation:** approving via a plain natural-language chat message (not the
-> slash command) always counts as feedback and iterates. To finalize, use
-> `/workflow approve <id>` with no comment, the CLI/web/`manage_run` surfaces above,
-> or `signal_completes`.
+A plain chat message at a loop gate is not itself an approve — the same rule now holds
+at [approval gates](/guides/approval-nodes/#asking-the-chat-agent). Say what you want and
+the agent resolves the gate for you, passing your words through as the feedback; ask a
+question and nothing is resolved. Because your words travel as the approve comment, that
+route iterates. To finalize, use `/workflow approve <id>` with no comment, the CLI/web
+surfaces above, `manage_run` with `accept: true`, or `signal_completes`.
 
 ### `signal_completes` — autonomous completion
 

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -3614,7 +3614,7 @@ export function registerApiRoutes(
         success: true,
         message: autoResumed
           ? `Workflow approved: ${run.workflow_name}. Resuming workflow.`
-          : `Workflow approved: ${run.workflow_name}. Run \`archon workflow resume ${runId}\` from the CLI to continue, or send a new message in the originating conversation.`,
+          : `Workflow approved: ${run.workflow_name}. Run \`archon workflow resume ${runId}\` from the CLI to continue, or resume it from the originating conversation.`,
       });
     } catch (error) {
       getLog().error({ err: error, runId }, 'api.workflow_run_approve_failed');

--- a/packages/workflows/src/schemas/workflow-run.ts
+++ b/packages/workflows/src/schemas/workflow-run.ts
@@ -332,8 +332,9 @@ export interface LoopGateRunMetadata {
 /**
  * True when the run's current approval gate has already been resolved
  * (approved, or rejected with a staged on_reject rework) and the run is
- * paused only while awaiting resume. Guards double-approve/reject and the
- * natural-language approval routing.
+ * paused only while awaiting resume. Guards double-approve/reject, and keeps a
+ * resolved gate out of the chat agent's prompt context (#2565) — it is waiting
+ * on the machine, not on a human.
  */
 export function isGateResolved(approval: ApprovalContext): boolean {
   return approval.resolved === 'approved' || approval.resolved === 'rejected';

--- a/packages/workflows/src/schemas/workflow-run.ts
+++ b/packages/workflows/src/schemas/workflow-run.ts
@@ -377,6 +377,20 @@ export function isRunBlockedOnChild(
   );
 }
 
+/**
+ * True when `run` executed inside an isolation container.
+ *
+ * Such a run can only be resumed where the docker backend is reachable and the
+ * container can be rewired — the CLI. `executeWorkflow` enforces this: a resume
+ * without a container context fails the run with a CLI pointer rather than
+ * silently running host-side and dropping the write-back. Callers that offer to
+ * continue a run consult this FIRST so they never promise a continuation the
+ * executor will refuse (#2565). Reads defensively from possibly-absent metadata.
+ */
+export function isContainerRun(run: { metadata?: Record<string, unknown> }): boolean {
+  return run.metadata?.isolation === 'container';
+}
+
 // ---------------------------------------------------------------------------
 // ArtifactType
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem and outcome

While a workflow run was paused at a human approval gate, **any** message that did not start with `/` was recorded as an approval. Typing *"no, stop — why is it editing the schema?"* resolved the gate as **approved**, stored the objection itself as the approval comment (and as `$gate.output` under `capture_response: true`), printed `▶️ Resuming …`, and carried on doing the thing the user objected to. There was no interpretation step and no natural-language way to reject.

- **Outcome:** a plain message at a gate no longer approves it. The open gate is given to the chat agent as context for the turn; a clear approval approves, a clear objection rejects with the user's own words as the reason, and an ambiguous message resolves nothing and gets a question back.
- **Invariant:** **whatever resolves a gate also continues the run.** Resolution without continuation is a stranded run, not a neutral refactor — the branch being deleted was the only chat path that did both, so the continuation had to be replaced, not just removed.
- **Scope boundary:** the resolution primitives are unchanged. `approveWorkflow`/`rejectWorkflow` still record and return without resuming, `manage_run`'s `confirm: true` gate on approve/reject is untouched, `resume` stays validate-only, and the web/CLI/Slack surfaces keep the resume paths they already had. This is not #2008's resume-in-place.
- **Root cause:** `orchestrator-agent.ts` branched on `!message.startsWith('/')` as the first thing after conversation setup and called `approveWorkflow(pausedRun.id, message)` unconditionally inside it. `rejectWorkflow` was never reachable from that file. The feature was deliberate (#915) and documented as "Natural Language (recommended)" — it decided an intent without ever interpreting it, which is the inverted form of the violation in `AGENTS.md` → *Natural Language Is Not a Wire Format*, bullet 3.

## Review guidance

- **Feedback requested:** the continuation mechanism, and whether the UX trade is the one you want (a typed approval now goes through the agent's judgement instead of a hard-coded branch). This is a user-visible breaking change — please sign off on the product decision, not just the code.
- **Start here:** `packages/core/src/orchestrator/orchestrator-agent.ts` — `continueResolvedGateRun` plus the `onGateResolved` callback wired into `buildManageRunTool`. That pair is the load-bearing half: it is the same `dispatchOrchestratorWorkflow(..., { resumeRunId, resumeRun })` the deleted branch performed, now triggered by the agent's explicit verb rather than by "the message did not start with `/`".
- **Review order:**
  1. `orchestrator-agent.ts` — the deleted branch, the gate-context fetch before the prompt build, the continuation after the turn.
  2. `manage-run-tool.ts` — the `onGateResolved` seam and `signalGateResolved`.
  3. `prompt-builder.ts` — `formatPausedGateSection`, the only thing that tells the agent a gate is open.
  4. `command-handler.ts` — `/workflow approve|reject` now continue the run (see *Scope note* below).
  5. Docs + `CHANGELOG.md`.
- **Lower-attention areas:** the `resolveRunContinuation` extraction in `command-handler.ts` is a straight lift of the existing `/workflow resume` body — the diff looks large but the logic is unchanged, and the existing resume tests still pass untouched.
- **Known risk or uncertainty:** the agent can now misjudge a borderline message. That risk is bounded by `confirm: true` on gate actions and by the section instructing it to ask rather than guess — but it is a judgement call replacing a deterministic (and wrong) branch. The slash commands remain fully deterministic for anyone who wants that.

### Scope note: why `/workflow approve|reject` are in this diff

Those commands told the user *"Type your response in this conversation to resume the workflow"* — that sentence pointed at the branch this PR deletes, so leaving it would ship a false instruction. It was already stale since #2075 (a resolved gate makes the branch skip), so the commands recorded a decision and parked the run. They now return the same `{ definition, args, resumeRunId, resumeRun }` payload `/workflow resume` already returns, which `handleMessage` already knows how to dispatch. No new mechanism.

## Solution

Three pieces, each reusing an existing primitive:

1. **The gate becomes context, not a branch.** `formatPausedGateSection` renders the open gate — run id, workflow, node, the gate's own message — plus the decision policy, and `buildFullPrompt` places it immediately before the user's message. It deliberately does not name a tool: the verbs reach Claude/Pi through the `manage_run` native tool and Codex/OpenCode/Copilot through the `archon workflow approve|reject` CLI section, both already in the same prompt. A gate that is already resolved renders nothing (it is waiting on the machine, not a human); a malformed approval context renders the explicit-command guidance the old branch used to send directly.

2. **`manage_run` gained a continuation seam, not a continuation.** `onGateResolved(run, action) => boolean` mirrors the existing `startWorkflow` seam. The tool records intent and returns immediately — it never blocks the agent loop on a whole workflow — and the orchestrator drives the resume after the turn ends. The boolean matters: a turn continues **one** run, so a second gate resolved in the same turn is declined and the tool says so in words. A tool reply that promised continuation it did not get would recreate the exact bug this PR fixes.

3. **The continuation is the old code path.** `continueResolvedGateRun` calls `dispatchOrchestratorWorkflow` with `{ resumeRunId, resumeRun }` — byte-identical in effect to what the deleted branch did after `approveWorkflow`. It reuses the workflow list and codebase already fetched for the turn (no extra discovery), and never throws: the decision is committed by then, so a failure costs a manual `/workflow resume`, not the decision.

A reject that **cancels** the run continues nothing — cancelled is its terminal state, and `rejectWorkflow` already reports which outcome happened via `cancelled`.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Any non-slash message at a paused gate → gate approved, message stored as the approval comment, run resumed | The agent reads the gate and the message: clear approval → approved + run continues; clear objection → rejected with the user's words as the reason; ambiguous → nothing resolved, the agent asks |
| **Failure behavior** | An objection resolved the gate as *approved* and the run continued past it — silent inversion of user intent | A gate is only resolved by an explicit verb. If the continuation fails, the decision is still recorded and the user is told to run `/workflow resume <id>` |
| **`/workflow approve\|reject` in chat** | Decision recorded; *"Type your response in this conversation to resume"* — which no longer resumed anything since #2075 | Decision recorded **and** the run continues; a reject that cancels says so and stops |
| **Interactive-loop gates** | A typed message always counted as feedback (iterate) — the opposite position to approval gates on the identical user action | Both gate types agree: a typed message is interpreted, not auto-applied. At a loop gate the user's words still travel as the approve comment, so that route still iterates; finalize with `/workflow approve <id>` (no comment), the CLI/web surfaces, `manage_run` `accept: true`, or `signal_completes` |

### User flow

```mermaid
flowchart LR
  subgraph Before
    B1["User: 'no, stop'"] --> B2["!startsWith('/')"] --> B3[approveWorkflow] --> B4[run continues past the objection]
  end

  subgraph After
    A1["User: 'no, stop'"] --> A2[gate passed as context] --> A3[agent judges intent]
    A3 -->|clear objection| A4[manage_run reject] --> A5[run reworks or stops]
    A3 -->|clear approval| A6[manage_run approve] --> A7[run continues]
    A3 -->|ambiguous| A8[answers; gate stays open]
  end
```

### Changed seams

| Boundary or contract | Change | Evidence |
|---|---|---|
| `manage_run → orchestrator` | New `onGateResolved(run, action) => boolean` on `ManageRunContext`. Fires only when the resolution leaves the run resumable; the boolean says whether a continuation was accepted, and the tool words its reply from it | `manage-run-tool.ts` `signalGateResolved`; tests *"approve hands the run to the continuation…"*, *"a declined continuation is reported as a manual resume, not as silence"*, *"without a continuation the tool names the manual resume instead of implying one"* |
| `orchestrator → provider prompt` | New paused-gate section, injected only when an unresolved gate exists in the conversation | `prompt-builder.ts` `formatPausedGateSection`; 9 unit tests, plus *"an open gate is handed to the agent as prompt context"* |
| `command-handler → orchestrator` | `/workflow approve` and `/workflow reject` now return the `workflow` resume payload that `/workflow resume` already returned | `command-handler.ts` `resolveRunContinuation` / `withRunContinuation`; 4 tests under *"/workflow approve\|reject — run continuation"* |
| `handleMessage` routing | The `!message.startsWith('/')` gate branch is gone; `getPausedWorkflowRun` now runs on AI-bound turns only | Test *"a slash command never reaches the gate lookup"* |

## Validation

- `bun run validate` — **exit 0**, 140 test blocks, zero failures — proves type-check, lint (`--max-warnings 0`), format, generated-file freshness, and every package suite pass together.
- `bun test src/orchestrator/orchestrator-agent.test.ts` — **234 pass / 0 fail** — the rewritten suite. The old suite had 7 cases and **zero** negative-message coverage; its happy path used `'looks good, proceed with implementation'`, text that merely *sounds* like approval. The new one covers: an approving-sounding message resolving nothing on its own, a **rejecting** message (`"no, stop — why is it editing the schema?"`) never being recorded as an approval, an **ambiguous** message (`"what would that change?"`) resolving nothing, the gate reaching the prompt (and sitting before the user's message), resolved and malformed gates, slash-command bypass, and — driving the real injected `manage_run` tool through a stubbed agent turn — approve resolving **and** resuming, reject-with-rework resuming, reject-that-cancels not resuming, and an unconfirmed preview resolving nothing. The review round added three more: a provider crash *after* the tool call still continuing the run, a container run resolved but not resumed, and an unscoped conversation getting the gate without instructions to resolve it.
- `bun test src/orchestrator/manage-run-tool.test.ts` — **36 pass / 0 fail**; `src/orchestrator/prompt-builder.test.ts` — **26 pass / 0 fail**; `src/handlers/command-handler.test.ts` — **131 pass / 0 fail**.
- **Not verified:** no live end-to-end run against a real provider. The agent's *judgement* on borderline phrasings is not unit-testable — the tests prove the wiring (a resolution reaches the gate op, and a resolution always either schedules the continuation or says in words why it cannot), and the section prompt is what steers the judgement. A maintainer smoke test on one chat surface before release would be worth doing.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | User-visible breaking change: a typed approval at a gate now goes through the agent. No data or schema change; runs paused before the upgrade resolve normally after it. Anyone wanting deterministic behavior uses the slash commands | `CHANGELOG.md` `[Unreleased] → Breaking` |
| Security / permissions / data | Tightens a governance boundary. An objection could previously resolve a human gate as approved; a gate is now only resolved by an explicit, confirm-gated verb. No new permissions or network calls | `DESTRUCTIVE_ACTIONS` / `GATE_ACTIONS` unchanged in `manage-run-tool.ts` |
| Rollout / rollback | Self-contained in `@archon/core` plus docs; one commit, revertible without data migration | — |
| Observability | `orchestrator.paused_gate_context_injected`, `orchestrator.gate_continuation_started/_completed/_failed`, `manage_run.gate_continuation_scheduled/_unavailable` | Log sites in the diff |
| Documentation / communication | `guides/approval-nodes.md` rewritten (the "Natural Language (recommended)" section marketed exactly the removed behavior, with a worked example that auto-approved feedback-shaped text); `guides/loop-nodes.md` and `guides/authoring-workflows.md` reconciled; the `archon` skill reference and three stale code comments corrected | Docs diff |

### How the two gate types now relate

They were contradictory on the identical user action: `loop-nodes.md` said a plain message *"always counts as feedback and iterates"* while `approval-nodes.md` said the same message auto-approves — and called that the recommended path. **Both now say the same thing: a typed message is interpreted by the agent, never auto-applied.** The remaining difference is a consequence, not a policy: the user's words travel through as the approve *comment*, and at an interactive loop a comment means "run another iteration". So asking the agent to approve a loop gate iterates unless nothing is passed on. Finalizing deterministically is still `/workflow approve <id>` with no comment, the CLI/web surfaces, `manage_run` with `accept: true`, or `signal_completes`.

### Follow-up: PR #2529

#2529 (still open at the time of writing) adds a Slack-side re-dispatch of `/workflow resume <id>` after a Block Kit gate approval — the third surface-specific re-dispatch alongside web's `tryAutoResumeAfterGate` and the CLI approve path. This PR lands the general continuation for the chat path, so **if #2529 merges, its Slack dispatch should be deleted rather than layered over.** It is untouched here because it has not merged. #2008 remains the right end state: resume-in-place, independent of surface — deliberately out of scope for this change.

## Links

- Closes #2565
- Related #2008, #2529, #2564, #915



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Approval and rejection commands now automatically continue eligible workflows.
  - Chat agents can resolve approval gates through explicit decisions.
  - Rejections may trigger rework or terminal cancellation, with status updates.
  - Container-isolated workflows receive clear CLI instructions.
  - JSON decisions record outcomes without automatically continuing execution.
  - Ambiguous chat messages leave approval gates unresolved.

- **Documentation**
  - Clarified approval, resumption, interactive-loop, and ambiguous-message behavior across the documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->