### PR TITLE
fix(web): the workflow builder rejected `when:` conditions the engine accepts

### DIFF
--- a/packages/web/src/experiments/console/builder/components/WhenBuilder.tsx
+++ b/packages/web/src/experiments/console/builder/components/WhenBuilder.tsx
@@ -11,7 +11,7 @@
  */
 import { type ChangeEvent, type ReactElement } from 'react';
 import { format, parse } from '../validation';
-import type { AtomNode, WhenAst, WhenOp } from '../types';
+import type { AtomNode, InputAtom, NodeAtom, WhenAst, WhenOp } from '../types';
 
 interface WhenBuilderProps {
   value: string | undefined;
@@ -26,23 +26,22 @@ const SMALL_INPUT =
   'rounded-[7px] border border-border bg-surface px-1.5 py-1 font-mono text-[11.5px] text-text-primary outline-none focus:border-accent-bright/60';
 
 function emptyAtom(firstUpstream: string | undefined): AtomNode {
-  return { nodeId: firstUpstream ?? 'node', op: '==', value: '' };
+  return { kind: 'node', nodeId: firstUpstream ?? 'node', op: '==', value: '' };
 }
 
-function AtomRow({
+/** The node picker + field box, for an atom that reads a node's output. */
+function NodeRefFields({
   atom,
   upstreamIds,
   onChange,
-  onRemove,
 }: {
-  atom: AtomNode;
+  atom: NodeAtom;
   upstreamIds: readonly string[];
   onChange: (next: AtomNode) => void;
-  onRemove: () => void;
 }): ReactElement {
   const known = upstreamIds.includes(atom.nodeId);
   return (
-    <div className="flex items-center gap-1">
+    <>
       <select
         aria-label="Node"
         value={atom.nodeId}
@@ -71,13 +70,71 @@ function AtomRow({
           // (`$node.field`) flag is intentionally not carried over, so the atom
           // re-serializes as the canonical `$node.output.field`. The `bare` RHS
           // spelling (unquoted number/boolean) is preserved as the author wrote it.
-          const next: AtomNode = { nodeId: atom.nodeId, op: atom.op, value: atom.value };
+          const next: NodeAtom = {
+            kind: 'node',
+            nodeId: atom.nodeId,
+            op: atom.op,
+            value: atom.value,
+          };
           if (field.length > 0) next.field = field;
           if (atom.bare === true) next.bare = true;
           onChange(next);
         }}
         className={`${SMALL_INPUT} w-20 min-w-0 flex-1`}
       />
+    </>
+  );
+}
+
+/**
+ * The `$INPUTS.` prefix + name box, for an atom that reads a workflow input.
+ *
+ * An input is not a node, so there is no picker and no upstream-dependency
+ * notion here — the name is whatever the workflow's `inputs:` declares.
+ */
+function InputRefFields({
+  atom,
+  onChange,
+}: {
+  atom: InputAtom;
+  onChange: (next: AtomNode) => void;
+}): ReactElement {
+  return (
+    <>
+      <span className="font-mono text-[11px] text-text-tertiary">$INPUTS.</span>
+      <input
+        aria-label="Input name"
+        type="text"
+        value={atom.name}
+        placeholder="name"
+        spellCheck={false}
+        onChange={(e: ChangeEvent<HTMLInputElement>): void => {
+          onChange({ ...atom, name: e.target.value.trim() });
+        }}
+        className={`${SMALL_INPUT} w-20 min-w-0 flex-1`}
+      />
+    </>
+  );
+}
+
+function AtomRow({
+  atom,
+  upstreamIds,
+  onChange,
+  onRemove,
+}: {
+  atom: AtomNode;
+  upstreamIds: readonly string[];
+  onChange: (next: AtomNode) => void;
+  onRemove: () => void;
+}): ReactElement {
+  return (
+    <div className="flex items-center gap-1">
+      {atom.kind === 'input' ? (
+        <InputRefFields atom={atom} onChange={onChange} />
+      ) : (
+        <NodeRefFields atom={atom} upstreamIds={upstreamIds} onChange={onChange} />
+      )}
       <select
         aria-label="Operator"
         value={atom.op}

--- a/packages/web/src/experiments/console/builder/types/index.ts
+++ b/packages/web/src/experiments/console/builder/types/index.ts
@@ -19,4 +19,4 @@ export type {
   BuilderWorkflow,
 } from './variant';
 export type { Severity, IssueSource, IssuePath, Issue, IssueId } from './issue';
-export type { WhenOp, AtomNode, WhenAst, ParseResult } from './when';
+export type { WhenOp, AtomNode, NodeAtom, InputAtom, WhenAst, ParseResult } from './when';

--- a/packages/web/src/experiments/console/builder/types/when.ts
+++ b/packages/web/src/experiments/console/builder/types/when.ts
@@ -1,28 +1,20 @@
 /**
  * AST types for the `when:` expression grammar.
  *
- * Wire syntax: `$<nodeId>.output[.<field>]` (canonical) or `$<nodeId>.<field>`
- * (shorthand) compared against a single-quoted string or a bare number/boolean,
- * joined by `||` (outer / OR) and `&&` (inner / AND). The AST is in disjunctive
- * normal form: an outer OR of inner AND-groups of atoms.
+ * Wire syntax: `$<nodeId>.output[.<field>]` (canonical), `$<nodeId>.<field>`
+ * (shorthand) or `$INPUTS.<name>` (a declared workflow input), compared against a
+ * single-quoted string or a bare number/boolean, joined by `||` (outer / OR) and
+ * `&&` (inner / AND). The AST is in disjunctive normal form: an outer OR of inner
+ * AND-groups of atoms.
  */
 
 /** The six supported comparison operators. */
 export type WhenOp = '==' | '!=' | '<' | '>' | '<=' | '>=';
 
-/** A single comparison atom: `$nodeId.output[.field] op value`. */
-export interface AtomNode {
-  nodeId: string;
-  /** Field on the output — undefined for a bare `$nodeId.output`. */
-  field?: string;
+/** Fields every atom carries, whatever its left-hand side refers to. */
+interface AtomComparison {
   op: WhenOp;
   value: string;
-  /**
-   * Present (true) when the path was written as the `$nodeId.field` shorthand
-   * rather than the canonical `$nodeId.output.field`. Preserved so `format()`
-   * round-trips the author's spelling. Implies `field` is defined.
-   */
-  shorthand?: boolean;
   /**
    * Present (true) when the RHS was written bare (unquoted number/boolean)
    * rather than single-quoted. Preserved so `format()` round-trips the
@@ -30,6 +22,35 @@ export interface AtomNode {
    */
   bare?: boolean;
 }
+
+/** A comparison against a node's output: `$nodeId.output[.field] op value`. */
+export interface NodeAtom extends AtomComparison {
+  kind: 'node';
+  nodeId: string;
+  /** Field on the output — undefined for a bare `$nodeId.output`. */
+  field?: string;
+  /**
+   * Present (true) when the path was written as the `$nodeId.field` shorthand
+   * rather than the canonical `$nodeId.output.field`. Preserved so `format()`
+   * round-trips the author's spelling. Implies `field` is defined.
+   */
+  shorthand?: boolean;
+}
+
+/**
+ * A comparison against a declared workflow input: `$INPUTS.name op value`.
+ *
+ * `INPUTS` is a reserved scope, not a node — the engine's schema rejects it as a
+ * node id outright — so an input atom carries no `nodeId` and no `field`, and the
+ * builder must not offer it the node picker or the upstream-dependency check.
+ */
+export interface InputAtom extends AtomComparison {
+  kind: 'input';
+  name: string;
+}
+
+/** A single comparison atom. */
+export type AtomNode = NodeAtom | InputAtom;
 
 /** Disjunctive normal form: outer OR of inner AND-groups. */
 export interface WhenAst {

--- a/packages/web/src/experiments/console/builder/validation/when-grammar.test.ts
+++ b/packages/web/src/experiments/console/builder/validation/when-grammar.test.ts
@@ -135,7 +135,7 @@ describe('when-grammar parse', () => {
 });
 
 // `$INPUTS.<name>` is the engine's input scope (#2470), and the builder rejected
-// every one of these conditions until #2588 — a workflow using a declared input in
+// every one of these conditions until #2591 — a workflow using a declared input in
 // a `when:` validated clean at load and red in the builder.
 describe('when-grammar parse — $INPUTS (engine parity)', () => {
   test('parses an input atom', () => {

--- a/packages/web/src/experiments/console/builder/validation/when-grammar.test.ts
+++ b/packages/web/src/experiments/console/builder/validation/when-grammar.test.ts
@@ -6,7 +6,7 @@ describe('when-grammar parse', () => {
     const r = parse("$classify.output == 'BUG'");
     expect(r.ok).toBe(true);
     if (r.ok) {
-      expect(r.ast.or).toEqual([[{ nodeId: 'classify', op: '==', value: 'BUG' }]]);
+      expect(r.ast.or).toEqual([[{ kind: 'node', nodeId: 'classify', op: '==', value: 'BUG' }]]);
     }
   });
 
@@ -15,6 +15,7 @@ describe('when-grammar parse', () => {
     expect(r.ok).toBe(true);
     if (r.ok) {
       expect(r.ast.or[0][0]).toEqual({
+        kind: 'node',
         nodeId: 'classify',
         field: 'type',
         op: '!=',
@@ -33,6 +34,7 @@ describe('when-grammar parse', () => {
     expect(r.ok).toBe(true);
     if (r.ok) {
       expect(r.ast.or[0][0]).toEqual({
+        kind: 'node',
         nodeId: 'classify-testability',
         field: 'testable',
         op: '==',
@@ -75,6 +77,7 @@ describe('when-grammar parse', () => {
       expect(r.ast.or).toEqual([
         [
           {
+            kind: 'node',
             nodeId: 'build',
             field: 'exit_code',
             op: '==',
@@ -92,6 +95,7 @@ describe('when-grammar parse', () => {
     expect(bool.ok).toBe(true);
     if (bool.ok) {
       expect(bool.ast.or[0][0]).toEqual({
+        kind: 'node',
         nodeId: 'check',
         field: 'passed',
         op: '==',
@@ -104,6 +108,7 @@ describe('when-grammar parse', () => {
     expect(num.ok).toBe(true);
     if (num.ok) {
       expect(num.ast.or[0][0]).toEqual({
+        kind: 'node',
         nodeId: 'score',
         field: 'value',
         op: '>=',
@@ -129,6 +134,68 @@ describe('when-grammar parse', () => {
   });
 });
 
+// `$INPUTS.<name>` is the engine's input scope (#2470), and the builder rejected
+// every one of these conditions until #2588 — a workflow using a declared input in
+// a `when:` validated clean at load and red in the builder.
+describe('when-grammar parse — $INPUTS (engine parity)', () => {
+  test('parses an input atom', () => {
+    const r = parse("$INPUTS.mode == 'fast'");
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.ast.or).toEqual([[{ kind: 'input', name: 'mode', op: '==', value: 'fast' }]]);
+    }
+  });
+
+  test('an input name may be hyphenated', () => {
+    // Input names use the engine's `with:` key grammar, which admits hyphens.
+    const r = parse("$INPUTS.my-input == 'x'");
+    expect(r.ok).toBe(true);
+    if (r.ok)
+      expect(r.ast.or[0][0]).toEqual({ kind: 'input', name: 'my-input', op: '==', value: 'x' });
+  });
+
+  test('binds to the input scope even when the name is `output`', () => {
+    // The input branch is tried first, so this is the input named `output`,
+    // not a node called INPUTS.
+    const r = parse("$INPUTS.output == 'x'");
+    expect(r.ok).toBe(true);
+    if (r.ok)
+      expect(r.ast.or[0][0]).toEqual({ kind: 'input', name: 'output', op: '==', value: 'x' });
+  });
+
+  test('takes a bare RHS like any other atom', () => {
+    const r = parse('$INPUTS.retries >= 3');
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.ast.or[0][0]).toEqual({
+        kind: 'input',
+        name: 'retries',
+        op: '>=',
+        value: '3',
+        bare: true,
+      });
+    }
+  });
+
+  test('rejects a sub-field on an input ref', () => {
+    // The regex backtracks into the node branch with nodeId `INPUTS`; the engine's
+    // parseWhenAtom returns null there and so must the builder.
+    const r = parse("$INPUTS.a.b == 'x'");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('cannot carry a sub-field');
+  });
+
+  test('rejects a bare $INPUTS with no name', () => {
+    expect(parse("$INPUTS == 'x'").ok).toBe(false);
+  });
+
+  test('composes with node atoms in one expression', () => {
+    const r = parse("$INPUTS.mode == 'fast' && $classify.output.type == 'BUG'");
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.ast.or[0].length).toBe(2);
+  });
+});
+
 describe('when-grammar format', () => {
   test('round-trips parse → format', () => {
     const inputs = [
@@ -141,6 +208,10 @@ describe('when-grammar format', () => {
       "$score.output.value >= -0.5 && $gate.approved == 'yes'",
       // A quoted numeral stays quoted (it is not rewritten to bare).
       "$n.output == '-1'",
+      // Input refs round-trip in both RHS spellings, alone and mixed with nodes.
+      "$INPUTS.mode == 'fast'",
+      '$INPUTS.retries >= 3',
+      "$INPUTS.mode == 'fast' && $classify.output.type == 'BUG'",
     ];
     for (const input of inputs) {
       const r = parse(input);
@@ -150,9 +221,9 @@ describe('when-grammar format', () => {
   });
 
   test('quotes a non-numeric value even if a hand-built atom claims bare', () => {
-    expect(format({ or: [[{ nodeId: 'a', op: '==', value: 'hello', bare: true }]] })).toBe(
-      "$a.output == 'hello'"
-    );
+    expect(
+      format({ or: [[{ kind: 'node', nodeId: 'a', op: '==', value: 'hello', bare: true }]] })
+    ).toBe("$a.output == 'hello'");
   });
 
   test('an empty AST formats to undefined (no when condition)', () => {
@@ -161,7 +232,9 @@ describe('when-grammar format', () => {
   });
 
   test('empty AND-groups are dropped before formatting', () => {
-    expect(format({ or: [[{ nodeId: 'a', op: '==', value: 'X' }], []] })).toBe("$a.output == 'X'");
+    expect(format({ or: [[{ kind: 'node', nodeId: 'a', op: '==', value: 'X' }], []] })).toBe(
+      "$a.output == 'X'"
+    );
   });
 });
 
@@ -169,11 +242,15 @@ describe('when-grammar toDnf', () => {
   test('drops empty AND-groups and preserves structure', () => {
     // The parser never yields an empty group, so feed toDnf an AST that has one.
     const dnf = toDnf({
-      or: [[{ nodeId: 'a', op: '==', value: 'X' }], [], [{ nodeId: 'b', op: '==', value: 'Y' }]],
+      or: [
+        [{ kind: 'node', nodeId: 'a', op: '==', value: 'X' }],
+        [],
+        [{ kind: 'node', nodeId: 'b', op: '==', value: 'Y' }],
+      ],
     });
     expect(dnf.or).toEqual([
-      [{ nodeId: 'a', op: '==', value: 'X' }],
-      [{ nodeId: 'b', op: '==', value: 'Y' }],
+      [{ kind: 'node', nodeId: 'a', op: '==', value: 'X' }],
+      [{ kind: 'node', nodeId: 'b', op: '==', value: 'Y' }],
     ]);
   });
 });

--- a/packages/web/src/experiments/console/builder/validation/when-grammar.ts
+++ b/packages/web/src/experiments/console/builder/validation/when-grammar.ts
@@ -1,37 +1,75 @@
 /**
  * Pure parser/formatter for the `when:` expression grammar.
  *
- * Wire syntax per atom: `$<nodeId>.output[.<field>] <op> <rhs>` (canonical) or
- * `$<nodeId>.<field> <op> <rhs>` (shorthand), where `<rhs>` is a single-quoted
- * string literal or a bare number/boolean. `||` joins OR-clauses (outer, lower
- * precedence) and `&&` joins atoms within a clause (inner, higher precedence).
- * Six operators: `== != < > <= >=`. No parentheses. This mirrors the engine's
- * condition-evaluator grammar (`atomPattern` plus the shorthand sub-field
- * rejection in `evaluateAtom`, packages/workflows/src/condition-evaluator.ts)
- * so the builder and the runtime agree on what parses.
+ * Wire syntax per atom: `$<nodeId>.output[.<field>] <op> <rhs>` (canonical),
+ * `$<nodeId>.<field> <op> <rhs>` (shorthand) or `$INPUTS.<name> <op> <rhs>` (a
+ * declared workflow input), where `<rhs>` is a single-quoted string literal or a
+ * bare number/boolean. `||` joins OR-clauses (outer, lower precedence) and `&&`
+ * joins atoms within a clause (inner, higher precedence). Six operators:
+ * `== != < > <= >=`. No parentheses. This mirrors the engine's one atom parser
+ * (`WHEN_ATOM_PATTERN` plus the follow-up rules in `parseWhenAtom`,
+ * packages/workflows/src/when-atom.ts) so the builder and the runtime agree on
+ * what parses.
+ *
+ * `@archon/web` must never import `@archon/workflows` (a server package), so the
+ * grammar is copied rather than shared; `scripts/node-ref-parity.test.ts` runs
+ * both parsers against one corpus and compares this pattern's compiled `.source`
+ * against the engine's, so the copy cannot drift silently.
  *
  * No React, no logging — errors surface via the `ParseResult` return value.
  */
 import { NODE_ID_SOURCE } from '@/lib/node-ref';
-import type { AtomNode, ParseResult, WhenAst, WhenOp } from '../types';
+import type { AtomNode, ParseResult, WhenAst, WhenOp } from '../types/when';
 
 /** A path segment (`output`, or a field name) — no hyphen, unlike a node id. */
 const SEGMENT_SOURCE = String.raw`[a-zA-Z_][a-zA-Z0-9_]*`;
 
 /**
- * Single-atom pattern, mirroring the engine's `atomPattern`:
- *   1. nodeId   — `$nodeId`, using the package-wide id grammar (`@/lib/node-ref`)
- *   2. segment1 — first path segment (`output` for canonical refs, else a
- *                 shorthand field name)
- *   3. segment2 — optional second segment (the field name when segment1 is `output`)
- *   4. op       — one of the six operators
- *   5. quoted   — single-quoted RHS literal (may be empty)
- *   6. bare     — unquoted RHS: number (`-?\d+(.\d+)?`) or `true`/`false`
- *
- * Exactly one of groups 5/6 is populated on a successful match.
+ * The reserved scope name for workflow inputs (the engine's `WHEN_INPUTS_SCOPE`).
+ * It can never be a node id — the engine's node schema rejects it outright — so
+ * binding the name to the input scope here cannot shadow a real node.
  */
-const ATOM_PATTERN = new RegExp(
-  String.raw`^\$(${NODE_ID_SOURCE})\.(${SEGMENT_SOURCE})(?:\.(${SEGMENT_SOURCE}))?\s*(==|!=|<=|>=|<|>)\s*(?:'([^']*)'|(-?\d+(?:\.\d+)?|true|false))$`
+const INPUTS_SCOPE = 'INPUTS';
+
+/**
+ * An input name, as the engine's `with:` key validator defines it
+ * (`INPUT_NAME_SOURCE` in packages/workflows/src/schemas/dag-node.ts).
+ *
+ * Identical to `NODE_ID_SOURCE` today, and kept separate anyway: they are
+ * different vocabularies that happen to coincide, and writing the coincidence
+ * into the code would hide a future widening of one from the reader.
+ */
+const INPUT_NAME_SOURCE = String.raw`[a-zA-Z_][a-zA-Z0-9_-]*`;
+
+/**
+ * Single-atom pattern, mirroring the engine's `WHEN_ATOM_PATTERN`:
+ *   1. inputName — `$INPUTS.<name>` (the input branch; tried first)
+ *   2. nodeId    — `$nodeId`, using the package-wide id grammar (`@/lib/node-ref`)
+ *   3. segment1  — first path segment (`output` for canonical refs, else a
+ *                  shorthand field name)
+ *   4. segment2  — optional second segment (the field name when segment1 is `output`)
+ *   5. op        — one of the six operators
+ *   6. quoted    — single-quoted RHS literal (may be empty)
+ *   7. bare      — unquoted RHS: number (`-?\d+(.\d+)?`) or `true`/`false`
+ *
+ * Exactly one of groups 6/7 is populated on a successful match.
+ *
+ * The input branch is first so `$INPUTS.mode` binds to the input scope. `$INPUTS.a.b`
+ * fails that branch (an input name cannot carry a sub-field) and backtracks into the
+ * node branch, where `parseAtom` rejects the reserved id explicitly — exactly as the
+ * engine's `parseWhenAtom` does.
+ *
+ * Exported for the cross-package parity check; the builder's own API is
+ * `parse`/`format`.
+ */
+export const ATOM_PATTERN = new RegExp(
+  '^(?:' +
+    String.raw`\$${INPUTS_SCOPE}\.(${INPUT_NAME_SOURCE})` +
+    '|' +
+    String.raw`\$(${NODE_ID_SOURCE})\.(${SEGMENT_SOURCE})(?:\.(${SEGMENT_SOURCE}))?` +
+    ')' +
+    String.raw`\s*(==|!=|<=|>=|<|>)\s*` +
+    String.raw`(?:'([^']*)'|(-?\d+(?:\.\d+)?|true|false))$`
 );
 
 /** RHS spellings that are valid bare (unquoted) — used by `formatAtom` as a guard. */
@@ -74,12 +112,39 @@ function parseAtom(raw: string): { ok: true; atom: AtomNode } | { ok: false; err
   if (!match) {
     return { ok: false, error: `cannot parse condition: "${trimmed}"` };
   }
-  const [, nodeId, segment1, segment2, op, quoted, bare] = match;
-  if (nodeId === undefined || segment1 === undefined || op === undefined) {
+  const [, inputName, nodeId, segment1, segment2, op, quoted, bare] = match;
+  if (op === undefined) {
     return { ok: false, error: `cannot parse condition: "${trimmed}"` };
   }
 
-  // Canonical-vs-shorthand path resolution, matching the engine's evaluateAtom:
+  const rhs = quoted !== undefined ? quoted : bare;
+  if (rhs === undefined) {
+    return { ok: false, error: `cannot parse condition: "${trimmed}"` };
+  }
+  const spelling = quoted === undefined ? { bare: true as const } : {};
+
+  if (inputName !== undefined) {
+    return {
+      ok: true,
+      atom: { kind: 'input', name: inputName, op: op as WhenOp, value: rhs, ...spelling },
+    };
+  }
+
+  if (nodeId === undefined || segment1 === undefined) {
+    return { ok: false, error: `cannot parse condition: "${trimmed}"` };
+  }
+
+  // Reached only by `$INPUTS.<a>.<b>` backtracking out of the input branch above: no
+  // node can carry the reserved id, so this is a malformed input ref rather than a
+  // node reference. The engine's parseWhenAtom rejects it the same way.
+  if (nodeId === INPUTS_SCOPE) {
+    return {
+      ok: false,
+      error: `cannot parse condition: "${trimmed}" ('$${INPUTS_SCOPE}.<name>' names a workflow input and cannot carry a sub-field)`,
+    };
+  }
+
+  // Canonical-vs-shorthand path resolution, matching the engine's parseWhenAtom:
   //   `$node.output`        → bare output reference (field undefined)
   //   `$node.output.field`  → field access on the output
   //   `$node.field`         → shorthand, equivalent to `$node.output.field`
@@ -99,18 +164,14 @@ function parseAtom(raw: string): { ok: true; atom: AtomNode } | { ok: false; err
     field = segment1;
   }
 
-  const value = quoted !== undefined ? quoted : bare;
-  if (value === undefined) {
-    return { ok: false, error: `cannot parse condition: "${trimmed}"` };
-  }
-
   const atom: AtomNode = {
+    kind: 'node',
     nodeId,
     op: op as WhenOp,
-    value,
+    value: rhs,
     ...(field !== undefined ? { field } : {}),
     ...(shorthand ? { shorthand: true } : {}),
-    ...(quoted === undefined ? { bare: true } : {}),
+    ...spelling,
   };
   return { ok: true, atom };
 }
@@ -142,14 +203,17 @@ export function parse(input: string): ParseResult {
   return { ok: true, ast: { or } };
 }
 
+/** The wire spelling of an atom's left-hand side. */
+function formatRef(atom: AtomNode): string {
+  if (atom.kind === 'input') return `$${INPUTS_SCOPE}.${atom.name}`;
+  if (atom.shorthand && atom.field !== undefined) return `$${atom.nodeId}.${atom.field}`;
+  if (atom.field !== undefined) return `$${atom.nodeId}.output.${atom.field}`;
+  return `$${atom.nodeId}.output`;
+}
+
 /** Format a single atom back to wire syntax, preserving the author's spelling. */
 function formatAtom(atom: AtomNode): string {
-  const path =
-    atom.shorthand && atom.field !== undefined
-      ? `$${atom.nodeId}.${atom.field}`
-      : atom.field !== undefined
-        ? `$${atom.nodeId}.output.${atom.field}`
-        : `$${atom.nodeId}.output`;
+  const path = formatRef(atom);
   // Bare spelling is only valid for number/boolean RHS — quote anything else so a
   // hand-built AST cannot format to an unparseable expression.
   const rhs = atom.bare && BARE_VALUE_PATTERN.test(atom.value) ? atom.value : `'${atom.value}'`;

--- a/packages/workflows/src/when-atom.ts
+++ b/packages/workflows/src/when-atom.ts
@@ -65,8 +65,15 @@ const PATH_SEGMENT_SOURCE = String.raw`[a-zA-Z_][a-zA-Z0-9_]*`;
  * The input branch is first so `$INPUTS.mode` binds to the input scope. `$INPUTS.a.b`
  * fails that branch (an input name cannot carry a sub-field) and backtracks into the
  * node branch, where {@link parseWhenAtom} rejects the reserved id explicitly.
+ *
+ * Exported for `scripts/node-ref-parity.test.ts`, which compares `.source` against the
+ * web builder's hand-maintained copy of this grammar. Comparing the COMPILED pattern is
+ * what makes that check immune to how either side spells its composition — the previous
+ * text-scraping version broke the moment this constant became a `new RegExp(...)`
+ * concatenation. No engine code outside this module reads it — `parseWhenAtom` is the
+ * API, and callers that reach for the pattern instead are re-implementing it.
  */
-const atomPattern = new RegExp(
+export const WHEN_ATOM_PATTERN = new RegExp(
   '^(?:' +
     String.raw`\$${WHEN_INPUTS_SCOPE}\.(${INPUT_NAME_SOURCE})` +
     '|' +
@@ -135,7 +142,7 @@ export function whenAtoms(expr: string): string[] {
  * node; the loader leaves the atom to that runtime behaviour).
  */
 export function parseWhenAtom(expr: string): WhenAtom | null {
-  const match = atomPattern.exec(expr.trim());
+  const match = WHEN_ATOM_PATTERN.exec(expr.trim());
   if (!match) return null;
 
   const [, inputName, nodeId, segment1, segment2, operator, quotedValue, unquotedValue] = match;

--- a/scripts/node-ref-parity.test.ts
+++ b/scripts/node-ref-parity.test.ts
@@ -197,6 +197,12 @@ describe('when-atom parity: the builder parses what the engine parses', () => {
     "$INPUTS.output.x == 'y'",
     "$INPUTS == 'x'",
     "$INPUTS. == 'x'",
+    // A node whose id merely STARTS with the scope name is an ordinary node. Pins the
+    // reserved-id check against the `startsWith('INPUTS')` spelling a hand-written
+    // mirror reaches for, which would reject this one.
+    "$INPUTSX.output.x == 'y'",
+    // The scope name is matched case-sensitively, so this is a node called `inputs`.
+    "$inputs.mode == 'x'",
     // Every operator, in both RHS spellings.
     "$n.output == '5'",
     "$n.output != '5'",

--- a/scripts/node-ref-parity.test.ts
+++ b/scripts/node-ref-parity.test.ts
@@ -20,7 +20,7 @@
  *   - #2567 — the builder's legacy copy used `\w`, which excludes the hyphen, so
  *     it silently validated none of the hyphenated node ids the bundled
  *     workflows use.
- *   - #2588 — #2579 added a `$INPUTS.<name>` branch to the engine atom, and the
+ *   - #2591 — #2579 added a `$INPUTS.<name>` branch to the engine atom, and the
  *     builder's copy did not follow, so `when: "$INPUTS.mode == 'fast'"` was an
  *     error in the builder and a clean load in the engine.
  *
@@ -150,7 +150,7 @@ describe('node-ref parity: @archon/web mirrors the engine', () => {
  *
  *   - `.source` identity pins the GRAMMAR, including the parts no corpus entry
  *     happens to exercise. An alternation branch added to one side only fails
- *     here immediately, which is exactly what #2588 needed and did not have.
+ *     here immediately, which is exactly what #2591 needed and did not have.
  *   - the corpus pins the PARSE SEMANTICS around the grammar — the rules that
  *     live in code after the regex matches. `$INPUTS.a.b` is the standing
  *     example: both patterns match it (it backtracks into the node branch), and
@@ -181,7 +181,7 @@ describe('when-atom parity: the builder parses what the engine parses', () => {
     // #2567: hyphenated ids, which the builder's legacy `\w` copy rejected.
     "$check-reproduction.output == 'done'",
     "$classify-testability.output.testable == 'e2e_testable'",
-    // #2588: the `$INPUTS.<name>` scope #2579 added to the engine.
+    // #2591: the `$INPUTS.<name>` scope #2579 added to the engine.
     "$INPUTS.mode == 'fast'",
     "$INPUTS.my-input == 'x'",
     "$INPUTS.output == 'x'",

--- a/scripts/node-ref-parity.test.ts
+++ b/scripts/node-ref-parity.test.ts
@@ -43,6 +43,7 @@ import { join } from 'node:path';
 import {
   WHEN_ATOM_PATTERN,
   parseWhenAtom,
+  splitOutsideQuotes,
   whenAtoms,
   type WhenAtom,
 } from '../packages/workflows/src/when-atom';
@@ -151,16 +152,27 @@ describe('node-ref parity: @archon/web mirrors the engine', () => {
  *   - `.source` identity pins the GRAMMAR, including the parts no corpus entry
  *     happens to exercise. An alternation branch added to one side only fails
  *     here immediately, which is exactly what #2591 needed and did not have.
- *   - the corpus pins the PARSE SEMANTICS around the grammar — the rules that
- *     live in code after the regex matches. `$INPUTS.a.b` is the standing
- *     example: both patterns match it (it backtracks into the node branch), and
- *     only the follow-up reserved-id rejection makes it an error. Identical
- *     patterns with a missing rejection would pass the first check and fail here.
+ *   - the corpus pins the PARSE SEMANTICS around the grammar — the rules that run
+ *     before the regex sees a substring (the `||`/`&&` splitter) and after it
+ *     matches. `$INPUTS.a.b` is the standing example of the latter: both patterns
+ *     match it (it backtracks into the node branch), and only the follow-up
+ *     reserved-id rejection makes it an error. Identical patterns with a missing
+ *     rejection would pass the first check and fail here.
+ *
+ * Each accepted entry is compared THREE ways — verdict, atom list, and GROUPING.
+ * The third is not redundant: both parsers flatten `||`/`&&` into an ordered list,
+ * and splitting on two disjoint separators in either order yields the same list,
+ * so a one-sided precedence swap is invisible to an atom-list comparison no matter
+ * how many entries it has. It is caught only by comparing the AND/OR shape.
  *
  * Honest limit: the corpus catches a semantic divergence only where it has an
- * entry. A new rule added after the regex, on one side only, in a case no entry
- * covers, still slips through — so a change to either parser's post-match rules
- * should arrive with a corpus entry.
+ * entry. A new rule on one side only, in a case no entry covers, still slips
+ * through — so a change to either parser should arrive with a corpus entry. The
+ * splitter is the weaker half: the atom pattern is pinned exhaustively by
+ * `.source` (every character of the compiled regex), while the splitter — written
+ * out by hand on both sides, and textually different while behaviourally
+ * identical, so no `.toString()` trick applies — is pinned only for the strings
+ * enumerated below, plus their grouping.
  */
 describe('when-atom parity: the builder parses what the engine parses', () => {
   test("the builder's atom pattern is byte-identical to the engine's", () => {
@@ -187,13 +199,13 @@ describe('when-atom parity: the builder parses what the engine parses', () => {
     "$INPUTS.output == 'x'",
     '$INPUTS.retries >= 3',
     "$INPUTS.a.b == 'x'",
-    // The case that DISCRIMINATES the reserved-id rule from the shorthand rule, and
-    // the only corpus entry that does. `$INPUTS.a.b` backtracks into the node branch
-    // and is then caught by the shorthand-cannot-carry-a-sub-field rule anyway, so it
-    // still agrees with a parser that has forgotten `INPUTS` is reserved. This one
-    // does not: `output` is the canonical segment, so a parser missing that rule
-    // accepts it as a field read on a node called `INPUTS`. Found by deleting the
-    // rule and watching the suite stay green.
+    // The only entry that catches the reserved-id rule being DELETED (the two below
+    // catch it being MIS-SPELLED). `$INPUTS.a.b` backtracks into the node branch and is
+    // then caught by the shorthand-cannot-carry-a-sub-field rule anyway, so it still
+    // agrees with a parser that has forgotten `INPUTS` is reserved. This one does not:
+    // `output` is the canonical segment, so a parser missing the rule accepts it as a
+    // field read on a node called `INPUTS`. Found by deleting the rule and watching the
+    // suite stay green.
     "$INPUTS.output.x == 'y'",
     "$INPUTS == 'x'",
     "$INPUTS. == 'x'",
@@ -214,13 +226,26 @@ describe('when-atom parity: the builder parses what the engine parses', () => {
     '$n.output == false',
     '$score.output.value >= -0.5',
     "$n.output == ''",
-    // Compound expressions — these also pin the quote-aware splitter, which is
-    // duplicated on both sides just like the atom pattern is.
+    // Compound expressions — the only entries that reach the quote-aware splitter,
+    // which is hand-duplicated on both sides. Unlike the atom pattern it has no
+    // exhaustive pin, so these carry it by example; the grouping assertion below is
+    // what makes them catch a precedence divergence rather than just an atom-set one.
     "$a.output == 'X' && $b.output == 'Y'",
     "$a.output == 'X' || $b.output == 'Y'",
     "$a.output == 'X' && $b.output == 'Y' || $c.output == 'Z'",
+    // Mixed precedence across four atoms: correct grouping is [1,2,1], and splitting
+    // `&&` outer instead would give [2,2]. The three-atom case above discriminates
+    // too, but this one fails on shape LENGTH as well, not only on distribution.
+    "$a.output == 'X' || $b.output == 'Y' && $c.output == 'Z' || $d.output == 'W'",
     "$a.output == 'x && y || z'",
     "$INPUTS.mode == 'fast' && $classify.output.type == 'BUG'",
+    // Splitter edges: an unterminated quote (which leaves the scanner in-quote to the
+    // end), a separator flush against a closing quote with no whitespace, and doubled
+    // separators that leave an empty atom between them.
+    "$a.output == 'x",
+    "$a.output == 'X'&&$b.output == 'Y'",
+    "$a.output == 'X' &&&& $b.output == 'Y'",
+    "$a.output == 'X' |||| $b.output == 'Y'",
     // Malformed.
     '',
     '   ',
@@ -273,9 +298,37 @@ describe('when-atom parity: the builder parses what the engine parses', () => {
     );
   }
 
+  /**
+   * The AND/OR shape as a list of group sizes — `[2, 1]` for `a && b || c`.
+   *
+   * The engine has no grouped parse to compare against (`whenAtoms` flattens on
+   * purpose, because its callers want every atom, not the boolean structure), so
+   * the expected shape is derived from the engine's OWN exported splitter. That
+   * keeps this a cross-package comparison rather than the web checking itself.
+   *
+   * `null` for a rejected expression, so the two sides stay comparable on the
+   * malformed entries as well.
+   */
+  function engineGroupShape(expr: string): number[] | null {
+    if (engineParse(expr) === null) return null;
+    return splitOutsideQuotes(expr.trim(), '||').map(
+      clause => splitOutsideQuotes(clause, '&&').length
+    );
+  }
+
+  function webGroupShape(expr: string): number[] | null {
+    const result = parse(expr);
+    return result.ok ? result.ast.or.map(group => group.length) : null;
+  }
+
   for (const expr of CORPUS) {
     test(`agrees on ${JSON.stringify(expr)}`, () => {
       expect(webParse(expr)).toEqual(engineParse(expr));
+      // Not implied by the line above: both sides flatten, and `a && b || c` and
+      // `a || b && c` flatten to the SAME ordered atom list. Only the grouping
+      // separates them, and getting it wrong changes the boolean formula the
+      // builder writes back through `format()`.
+      expect(webGroupShape(expr)).toEqual(engineGroupShape(expr));
     });
   }
 });

--- a/scripts/node-ref-parity.test.ts
+++ b/scripts/node-ref-parity.test.ts
@@ -11,33 +11,49 @@
  *
  * They live in `scripts/` rather than beside the web modules because this is a
  * cross-package repository invariant, not a unit of `@archon/web` behavior — the
- * same reason the bundled-defaults and capability-matrix checks live here. Every
- * file is read as TEXT, so no package boundary is crossed. `bun run test` ends
+ * same reason the bundled-defaults and capability-matrix checks live here. This
+ * file importing both packages does not breach the rule above: the rule is about
+ * what ships in the web bundle, and nothing here is bundled. `bun run test` ends
  * with `bun test ./scripts/`, so CI enforces it.
  *
- * The drift this catches actually happened: the builder's legacy copy used
- * `\w`, which excludes the hyphen, so it silently validated none of the
- * hyphenated node ids the bundled workflows use (#2567).
+ * The drift this catches actually happened, twice:
+ *   - #2567 — the builder's legacy copy used `\w`, which excludes the hyphen, so
+ *     it silently validated none of the hyphenated node ids the bundled
+ *     workflows use.
+ *   - #2588 — #2579 added a `$INPUTS.<name>` branch to the engine atom, and the
+ *     builder's copy did not follow, so `when: "$INPUTS.mode == 'fast'"` was an
+ *     error in the builder and a clean load in the engine.
+ *
+ * TWO MECHANISMS, deliberately, because the two grammars are spelled differently:
+ *
+ *   - The `$<nodeId>.output` reference is a plain `String.raw` literal on both
+ *     sides, so it is compared as TEXT (see the decoy analysis on `DECL` below).
+ *   - The `when:` atom is COMPOSED from several constants on both sides, so it is
+ *     compared by EXECUTING both modules. Reading a composition as text is what
+ *     broke here: #2570 scraped `const atomPattern = /…/;` out of
+ *     `condition-evaluator.ts`, #2579 moved it to `when-atom.ts` and rebuilt it as
+ *     a `new RegExp(...)` concatenation, and the scraper could only report that it
+ *     had lost its target. Comparing compiled `.source` cannot be broken that way,
+ *     and — unlike any regex over source text — it cannot be fooled by a
+ *     commented-out copy either, because a comment does not execute.
  */
 import { describe, test, expect } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import {
+  WHEN_ATOM_PATTERN,
+  parseWhenAtom,
+  whenAtoms,
+  type WhenAtom,
+} from '../packages/workflows/src/when-atom';
+import {
+  ATOM_PATTERN,
+  parse,
+} from '../packages/web/src/experiments/console/builder/validation/when-grammar';
 
 const REPO_ROOT = join(import.meta.dir, '..');
 const ENGINE_LOADER = join(REPO_ROOT, 'packages', 'workflows', 'src', 'loader.ts');
-const ENGINE_CONDITIONS = join(REPO_ROOT, 'packages', 'workflows', 'src', 'condition-evaluator.ts');
 const WEB_NODE_REF = join(REPO_ROOT, 'packages', 'web', 'src', 'lib', 'node-ref.ts');
-const WEB_WHEN_GRAMMAR = join(
-  REPO_ROOT,
-  'packages',
-  'web',
-  'src',
-  'experiments',
-  'console',
-  'builder',
-  'validation',
-  'when-grammar.ts'
-);
 
 function missing(name: string, file: string): Error {
   return new Error(
@@ -50,7 +66,8 @@ function missing(name: string, file: string): Error {
  * A regex over raw source cannot tell a DECLARATION from a MENTION of one. That
  * is the whole difficulty here, and every layer below is about narrowing the gap
  * — none of them closes it, so treat this as "cheap steps toward reading code",
- * not as a solved problem.
+ * not as a solved problem. (The `when:` checks further down close it by executing
+ * the modules instead; this layer remains only for the plain-literal grammar.)
  *
  * The failure mode is concrete: a commented-out copy holding the CURRENT value,
  * sitting above a live constant that has genuinely drifted. That is an ordinary
@@ -69,7 +86,7 @@ function missing(name: string, file: string): Error {
  * anchor still rejects a mention embedded mid-line in live code, which stripping
  * leaves untouched.
  *
- * Column 0 is safe rather than brittle: all six constants this file extracts are
+ * Column 0 is safe rather than brittle: all three constants this file extracts are
  * top-level, and an indented one would not be. If a future constant is nested,
  * widen deliberately and re-run the decoy matrix — do not reach for `\s*`.
  *
@@ -83,30 +100,14 @@ function stripComments(source: string): string {
   return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '');
 }
 
-/**
- * Extract a `const <name> = String.raw`…`` literal, failing loudly if it moved.
- * Also accepts the `new RegExp(String.raw`…`)` wrapper, which is how a composed
- * pattern is spelled.
- */
+/** Extract a `const <name> = String.raw`…`` literal, failing loudly if it moved. */
 function rawConstant(file: string, name: string): string {
   const source = stripComments(readFileSync(file, 'utf8'));
-  const match = new RegExp(
-    String.raw`${DECL} ${name} =\s*(?:new RegExp\(\s*)?String\.raw\x60([^\x60]*)\x60`,
-    'm'
-  ).exec(source);
+  const match = new RegExp(String.raw`${DECL} ${name} =\s*String\.raw\x60([^\x60]*)\x60`, 'm').exec(
+    source
+  );
   if (match?.[1] === undefined) throw missing(name, file);
   return match[1];
-}
-
-/** Extract a `const <name> = /…/;` regex literal, joining a wrapped one back up. */
-function regexConstant(file: string, name: string): string {
-  const source = stripComments(readFileSync(file, 'utf8'));
-  const match = new RegExp(String.raw`${DECL} ${name} =\s*\/([\s\S]*?)\/;`, 'm').exec(source);
-  if (match?.[1] === undefined) throw missing(name, file);
-  return match[1]
-    .split('\n')
-    .map(line => line.trim())
-    .join('');
 }
 
 /** Resolve the `${NAME}` interpolations a composed web pattern is built from. */
@@ -140,18 +141,135 @@ describe('node-ref parity: @archon/web mirrors the engine', () => {
     expect(nodeId.test('check-reproduction')).toBe(true);
     expect(nodeId.test('classify-testability')).toBe(true);
   });
+});
 
-  // The builder's `when:` parser makes the same "mirrors the engine" claim about
-  // a second grammar. It was held by a comment alone; a divergence would let a
-  // condition validate clean in the builder and fail to parse at run time.
-  test("the builder's when-atom pattern is byte-identical to the condition evaluator's", () => {
-    // Engine side is a `/…/` literal; the web side composes a `String.raw`.
-    const engine = regexConstant(ENGINE_CONDITIONS, 'atomPattern');
-    const web = resolveInterpolations(rawConstant(WEB_WHEN_GRAMMAR, 'ATOM_PATTERN'), {
-      NODE_ID_SOURCE: rawConstant(WEB_NODE_REF, 'NODE_ID_SOURCE'),
-      SEGMENT_SOURCE: rawConstant(WEB_WHEN_GRAMMAR, 'SEGMENT_SOURCE'),
-    });
-
-    expect(web).toBe(engine);
+/**
+ * The `when:` atom, compared by running both parsers rather than reading them.
+ *
+ * The two checks below are complementary, and neither subsumes the other:
+ *
+ *   - `.source` identity pins the GRAMMAR, including the parts no corpus entry
+ *     happens to exercise. An alternation branch added to one side only fails
+ *     here immediately, which is exactly what #2588 needed and did not have.
+ *   - the corpus pins the PARSE SEMANTICS around the grammar — the rules that
+ *     live in code after the regex matches. `$INPUTS.a.b` is the standing
+ *     example: both patterns match it (it backtracks into the node branch), and
+ *     only the follow-up reserved-id rejection makes it an error. Identical
+ *     patterns with a missing rejection would pass the first check and fail here.
+ *
+ * Honest limit: the corpus catches a semantic divergence only where it has an
+ * entry. A new rule added after the regex, on one side only, in a case no entry
+ * covers, still slips through — so a change to either parser's post-match rules
+ * should arrive with a corpus entry.
+ */
+describe('when-atom parity: the builder parses what the engine parses', () => {
+  test("the builder's atom pattern is byte-identical to the engine's", () => {
+    expect(ATOM_PATTERN.source).toBe(WHEN_ATOM_PATTERN.source);
+    expect(ATOM_PATTERN.flags).toBe(WHEN_ATOM_PATTERN.flags);
   });
+
+  /**
+   * Every grammar feature, plus both historical regressions. Each entry is
+   * compared for the same accept/reject verdict AND the same decomposition.
+   */
+  const CORPUS: readonly string[] = [
+    // Canonical, field access, and the `$node.field` shorthand.
+    "$classify.output == 'BUG'",
+    "$classify.output.type != 'FEATURE'",
+    '$build.exit_code == 0',
+    "$a.field.sub == 'x'",
+    // #2567: hyphenated ids, which the builder's legacy `\w` copy rejected.
+    "$check-reproduction.output == 'done'",
+    "$classify-testability.output.testable == 'e2e_testable'",
+    // #2588: the `$INPUTS.<name>` scope #2579 added to the engine.
+    "$INPUTS.mode == 'fast'",
+    "$INPUTS.my-input == 'x'",
+    "$INPUTS.output == 'x'",
+    '$INPUTS.retries >= 3',
+    "$INPUTS.a.b == 'x'",
+    // The case that DISCRIMINATES the reserved-id rule from the shorthand rule, and
+    // the only corpus entry that does. `$INPUTS.a.b` backtracks into the node branch
+    // and is then caught by the shorthand-cannot-carry-a-sub-field rule anyway, so it
+    // still agrees with a parser that has forgotten `INPUTS` is reserved. This one
+    // does not: `output` is the canonical segment, so a parser missing that rule
+    // accepts it as a field read on a node called `INPUTS`. Found by deleting the
+    // rule and watching the suite stay green.
+    "$INPUTS.output.x == 'y'",
+    "$INPUTS == 'x'",
+    "$INPUTS. == 'x'",
+    // Every operator, in both RHS spellings.
+    "$n.output == '5'",
+    "$n.output != '5'",
+    "$n.output < '5'",
+    "$n.output > '5'",
+    "$n.output <= '5'",
+    "$n.output >= '5'",
+    '$n.output == true',
+    '$n.output == false',
+    '$score.output.value >= -0.5',
+    "$n.output == ''",
+    // Compound expressions — these also pin the quote-aware splitter, which is
+    // duplicated on both sides just like the atom pattern is.
+    "$a.output == 'X' && $b.output == 'Y'",
+    "$a.output == 'X' || $b.output == 'Y'",
+    "$a.output == 'X' && $b.output == 'Y' || $c.output == 'Z'",
+    "$a.output == 'x && y || z'",
+    "$INPUTS.mode == 'fast' && $classify.output.type == 'BUG'",
+    // Malformed.
+    '',
+    '   ',
+    'garbage',
+    '$a.output ~~ 5',
+    '$a.output == unquoted',
+    '$a.output == yes',
+    '$a.output ==',
+    '$1bad.output == 1',
+    "$a.output == 'X' &&",
+  ];
+
+  /**
+   * The canonical spelling of an atom's left-hand side. Normalizing erases the
+   * spellings the two sides legitimately record differently (the web keeps
+   * `shorthand`/`bare` so it can round-trip an author's text; the engine has no
+   * reason to) and leaves the meaning, which is what must agree.
+   */
+  function engineRef(atom: WhenAtom): string {
+    if (atom.ref.kind === 'input') return `$INPUTS.${atom.ref.name}`;
+    return atom.ref.field === undefined
+      ? `$${atom.ref.nodeId}.output`
+      : `$${atom.ref.nodeId}.output.${atom.ref.field}`;
+  }
+
+  /** `null` means "rejected"; an array means "accepted, and here is what it means". */
+  function engineParse(expr: string): string[] | null {
+    const atoms = whenAtoms(expr).map(parseWhenAtom);
+    if (atoms.some(atom => atom === null)) return null;
+    return atoms.map(atom => {
+      // Narrowed by the `some` guard above; `flatMap` would lose that.
+      if (atom === null) throw new Error('unreachable');
+      return `${engineRef(atom)} ${atom.operator} ${JSON.stringify(atom.expected)}`;
+    });
+  }
+
+  function webParse(expr: string): string[] | null {
+    const result = parse(expr);
+    if (!result.ok) return null;
+    return result.ast.or.flatMap(group =>
+      group.map(atom => {
+        const ref =
+          atom.kind === 'input'
+            ? `$INPUTS.${atom.name}`
+            : atom.field === undefined
+              ? `$${atom.nodeId}.output`
+              : `$${atom.nodeId}.output.${atom.field}`;
+        return `${ref} ${atom.op} ${JSON.stringify(atom.value)}`;
+      })
+    );
+  }
+
+  for (const expr of CORPUS) {
+    test(`agrees on ${JSON.stringify(expr)}`, () => {
+      expect(webParse(expr)).toEqual(engineParse(expr));
+    });
+  }
 });

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -5,7 +5,13 @@
     "declaration": false,
     "declarationMap": false,
     "sourceMap": false,
-    "types": ["bun-types"]
+    "types": ["bun-types"],
+    // `node-ref-parity.test.ts` imports the web builder's `when:` grammar to run it
+    // against the engine's. That module resolves its own imports through the web
+    // package's `@/` alias, so this project needs the same mapping to follow it.
+    "paths": {
+      "@/*": ["../packages/web/src/*"]
+    }
   },
   "include": ["*.ts"]
 }


### PR DESCRIPTION
## Problem and outcome

`dev` is red. #2570 landed a drift guard that reads the engine's `when:` atom pattern out of
`condition-evaluator.ts` as text; #2579 then moved that pattern to `when-atom.ts`, rebuilt it as a
composed `new RegExp(...)`, and added a `$INPUTS.<name>` branch to it. Each PR was green alone.
Together the guard can no longer find its target, and every open PR is blocked behind the failure.

The guard was **right**. Re-pointing it at the new file still fails, for a second and more
important reason: the builder's copy of that grammar never got the `$INPUTS` branch, so
`when: "$INPUTS.mode == 'fast'"` is a validation error in the console builder and a clean load in
the engine. That is exactly the builder-vs-engine disagreement #2567/#2570 exist to eliminate,
reintroduced through a different door.

- **Outcome:** `bun test ./scripts/node-ref-parity.test.ts` passes; the builder accepts every
  `$INPUTS` condition the engine accepts and rejects every one it rejects, including
  `$INPUTS.a.b` and `$INPUTS.output.x`.
- **Invariant:** the builder's `when:` parser and the engine's return the same verdict, and the
  same decomposition, for the same expression — and the repository fails if they stop doing so.
- **Scope boundary:** `@archon/web` still does not import `@archon/workflows`. The grammar stays
  copied; only the guard over the copy changed. Load-time *semantic* rejections (#2566's
  whole-output check) are not mirrored into the builder — that needs node-type knowledge the
  grammar layer does not have, and it is a separate piece of work.
- **Root cause:** two independent failures with one trigger. (1) `regexConstant` matches
  `const NAME = /…/;`; the engine's constant is now a multi-line concatenation of interpolated
  constants, which neither extractor can read. (2) the web `ATOM_PATTERN` has no `$INPUTS`
  alternation — the string `INPUTS` did not appear anywhere in that validation directory.

## Review guidance

- **Feedback requested:** correctness of the grammar mirror, and whether the guard's new shape is
  the right trade.
- **Start here:** `packages/web/src/experiments/console/builder/validation/when-grammar.ts:60` —
  the composed `ATOM_PATTERN`. It must stay byte-identical to
  `packages/workflows/src/when-atom.ts:69`, and the test enforces exactly that.
- **Review order:**
  1. `packages/workflows/src/when-atom.ts` — one line of behavior change (a `const` becomes an
     `export`); everything else is the docblock explaining why.
  2. `packages/web/.../validation/when-grammar.ts` — the actual fix.
  3. `packages/web/.../types/when.ts` + `components/WhenBuilder.tsx` — the AST gains a variant, so
     the editor is forced by the compiler to handle it.
  4. `scripts/node-ref-parity.test.ts` — the guard.
- **Lower-attention areas:** `when-grammar.test.ts` — the `kind: 'node'` discriminant is mechanical
  churn across existing assertions; the new `$INPUTS` describe block is the substance.
- **Known risk or uncertainty:** the parity test now imports both packages instead of reading them
  as text. That is a new dependency for a `scripts/` test on both packages resolving (including
  Bun following the web package's `@/` alias). It fails loudly rather than silently if it breaks —
  an unresolvable import throws — and `scripts/tsconfig.json` gained the matching path mapping so
  `type-check` covers it too.

## Solution

**The fix.** The builder's `ATOM_PATTERN` gains the input branch, first in the alternation, exactly
as the engine spells it, and `parseAtom` gains the follow-up rule the engine has: a match whose
node id is the reserved `INPUTS` is a malformed input ref, not a node reference. `AtomNode` becomes
a discriminated union of `NodeAtom | InputAtom` rather than growing an optional field, so an input
atom cannot reach the node picker, the upstream-dependency check, or the `$id.output` formatter by
accident — the compiler routes it. That is what forced the `WhenBuilder` change; it was not
discovered by reading the component.

**The guard.** The `when:` atom is now composed from several constants on *both* sides, so reading
it as text is no longer possible — and the attempt to is what turned a semantic drift into a red
`dev`. It is compared by executing both modules instead:

| | pins | catches what the others miss |
|---|---|---|
| `ATOM_PATTERN.source === WHEN_ATOM_PATTERN.source` | the grammar, including parts no corpus entry exercises | an alternation branch or operator added on one side only |
| a corpus run through both parsers | the rules around the match — the `\|\|`/`&&` splitter before it, the reserved-id and shorthand rules after it | a missing reserved-id rejection, with the patterns still identical |
| the AND/OR shape of each accepted entry | the boolean structure the atom list throws away | a precedence swap, which flattens to a byte-identical atom list |

Comparing compiled `.source` is strictly stronger than the text scrape it replaces: it is immune to
how either side spells its composition, and it cannot be fooled by a commented-out copy, because a
comment does not execute — which retires the decoy problem #2570's docblock documents at length for
this half of the file.

The `$<nodeId>.output` half of the guard is **unchanged**. Its target is a plain `String.raw`
literal on both sides, the extractor reads it correctly, and it passes today. Both mechanisms now
live in the file with a comment saying which tool fits which shape.

**Why not just re-point the text scrape:** it was tried first and still fails. Teaching
`regexConstant` to parse a multi-line concatenation of five interpolated constants is a
re-implementation of the composition inside a test, and would break again on the next spelling
change.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | `when: "$INPUTS.mode == 'fast'"` shows `content.when.parse` error in the builder; the engine loads it fine | The builder parses it, renders a structured row, and round-trips it |
| **Failure behavior** | `$INPUTS.a.b` rejected with a misleading message suggesting `'$INPUTS.output.a.…'`, a form the engine also rejects | Rejected naming the real rule: `$INPUTS.<name>` cannot carry a sub-field |

### Changed seams

| Boundary or contract | Change | Evidence |
|---|---|---|
| `when-atom.ts → scripts/node-ref-parity.test.ts` | `atomPattern` becomes the exported `WHEN_ATOM_PATTERN`; the guard compares the compiled value instead of the source text | `packages/workflows/src/when-atom.ts:69` |
| `when-grammar.ts → WhenBuilder.tsx` | `AtomNode` becomes a discriminated union; consumers must narrow | `packages/web/.../types/when.ts:49`, `components/WhenBuilder.tsx:113` |

## Validation

- `bun run validate` — exit 0 — proves the whole repository gate, including the previously failing
  `bun test ./scripts/`.
- `bun test ./scripts/node-ref-parity.test.ts` — 48 pass, 0 fail — proves `dev` goes green.
- `bun test packages/web/src/experiments/console/builder/validation/when-grammar.test.ts` —
  22 pass — proves the builder's `$INPUTS` accept/reject set, including the hyphenated name, the
  input literally named `output`, the bare RHS, and both malformed forms.
- **Mutation testing** — the guard's teeth, proven rather than argued. Each mutation was applied to
  a **detached copy** of the tree in a temp directory, never to the working checkout, and reverted
  after:

  | mutation | `.source` identity | atom corpus | grouping |
  |---|---|---|---|
  | web input-name grammar drops the hyphen (this PR's bug class) | **fail** | **fail** | pass |
  | web node-id grammar drops the hyphen (the #2567 regression) | **fail** | **fail** | pass |
  | web loses the reserved-id rejection, patterns still identical | pass | **fail** | pass |
  | web writes the reserved-id check as `startsWith('INPUTS')` | pass | **fail** | pass |
  | web writes it case-insensitively | pass | **fail** | pass |
  | engine gains a `=~` operator the web lacks | **fail** | pass | pass |
  | web splits `&&` outer instead of `||` (precedence swap) | pass | pass | **fail** |

  Two rows are worth reading. The third survived the first attempt: `$INPUTS.a.b` alone does
  **not** discriminate, because the shorthand rule rejects it anyway — the suite stayed green with
  the rule deleted. Adding `$INPUTS.output.x`, where `output` is the canonical segment, is what
  makes the deletion visible.

  The last row was found by review, not by me, and it is the reason a third column exists. Both
  parsers flatten `||`/`&&` into an ordered list, and splitting on two disjoint separators in
  either order yields the *same* list — so an atom-list comparison cannot see a precedence swap at
  any corpus size. Demonstrated both ways on a detached copy: the guard as first pushed passes
  **43/0** against a precedence-inverted builder; with the grouping assertion it fails on 6
  entries. The consequence was real, not theoretical — `WhenBuilder` round-trips
  `parse()` → edit → `format()`, so a wrong grouping silently rewrites `(a && b) || c` as
  `a || (b && c)` in the author's saved workflow.

- **Not verified:** the atom pattern is pinned exhaustively — every character of the compiled
  regex — but the `||`/`&&` splitter is not, and cannot be by the same trick: it is written out by
  hand on both sides and is textually different while behaviourally identical, so there is no
  `.source` equivalent to compare. It is pinned by example only (the compound entries, plus their
  grouping shape). An earlier draft of this section claimed the residual was "bounded to code
  after the match"; that was wrong in both directions — `splitOutsideQuotes` runs *before* the
  regex ever sees a substring, and grouping was not pinned at all. Both the section and the test
  file's comment now describe the residual they actually have. #2488 is the durable answer to the
  duplication itself.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Rollout / rollback | Pure fix, no schema or config; revert is a single commit revert | 8 files, no generated artifacts |
| Observability | A future divergence fails `bun run test` in CI rather than reaching an author's builder | `scripts/node-ref-parity.test.ts` |

## Links

- Related #2570 — the guard this re-points; its history of being defeated by decoys is why this one
  was mutation-tested rather than reasoned about.
- Related #2579 — added the `$INPUTS` branch and the composed pattern.
- Related #2567 — the original builder-vs-engine node-id drift.
- Related #2488 — the engine hand-writes this grammar in several places; the underlying reason
  copies like this exist at all.
- Related #2580 — worth knowing while reading this: `$INPUTS.mode == 'fast'` is valid as authored
  and is what a `workflow:` sub-run and a direct `--input` run evaluate, but `include:` expansion
  substitutes the value into the left-hand side and turns it into `fast == 'fast'`, which then
  fail-closes at run time. That is an engine bug in the macro, not a grammar question: the
  builder validates the YAML as authored, pre-expansion, which is exactly what the engine's
  loader accepts too. This PR neither fixes nor worsens it, and matching the engine is still the
  right behavior for the builder.
- Related #2590 — filed from this work: the builder's `$<nodeId>.output` **scan** does not skip
  `$INPUTS.output` the way the engine's loader does. Warning-level, different module, and it needs
  a parity assertion for the skip rule rather than the pattern, so it is deliberately not in this
  urgent fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for using workflow inputs in `when:` conditions with `$INPUTS.<name>` references.
  * Updated the condition builder to edit workflow-input and node references.
  * Improved handling of node fields and shorthand values.

* **Bug Fixes**
  * Added validation for malformed input references, missing names, invalid fields, and incomplete conditions.

* **Tests**
  * Expanded grammar coverage and added parity checks to ensure consistent condition parsing across the web experience and workflow engine.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->