### PR TITLE
test: include independent package tests in strict type-check

### DIFF
--- a/packages/git/src/git.test.ts
+++ b/packages/git/src/git.test.ts
@@ -68,12 +68,16 @@ mock.module('@archon/paths', () => ({
 // ---------------------------------------------------------------------------
 import * as git from './index';
 
+const repo = git.toRepoPath;
+const branch = git.toBranchName;
+const worktree = git.toWorktreePath;
+
 // ============================================================================
 // Tests
 // ============================================================================
 
 describe('git utilities', () => {
-  const testDir = join(tmpdir(), 'git-utils-test-' + Date.now());
+  const testDir = repo(join(tmpdir(), 'git-utils-test-' + Date.now()));
 
   beforeEach(async () => {
     await realMkdir(testDir, { recursive: true });
@@ -154,7 +158,7 @@ describe('git utilities', () => {
     test('extracts main repo path from worktree', async () => {
       await writeFile(join(testDir, '.git'), 'gitdir: /workspace/my-repo/.git/worktrees/issue-42');
       const result = await git.getCanonicalRepoPath(testDir);
-      expect(result).toBe('/workspace/my-repo');
+      expect(result).toBe(repo('/workspace/my-repo'));
     });
 
     test('handles worktree path with nested directories', async () => {
@@ -163,7 +167,7 @@ describe('git utilities', () => {
         'gitdir: /home/user/projects/my-app/.git/worktrees/feature-branch'
       );
       const result = await git.getCanonicalRepoPath(testDir);
-      expect(result).toBe('/home/user/projects/my-app');
+      expect(result).toBe(repo('/home/user/projects/my-app'));
     });
   });
 
@@ -211,7 +215,7 @@ describe('git utilities', () => {
       delete process.env.WORKSPACE_PATH;
       delete process.env.ARCHON_HOME;
       delete process.env.ARCHON_DOCKER;
-      const result = git.getWorktreeBase('/workspace/my-repo');
+      const result = git.getWorktreeBase(repo('/workspace/my-repo'));
       expect(result).toEqual({
         base: join(homedir(), '.archon', 'workspaces', '_local', 'my-repo', 'worktrees'),
         layout: 'workspace-scoped',
@@ -223,7 +227,7 @@ describe('git utilities', () => {
       delete process.env.WORKTREE_BASE;
       delete process.env.ARCHON_DOCKER;
       process.env.ARCHON_HOME = '/custom/archon';
-      const result = git.getWorktreeBase('/workspace/my-repo');
+      const result = git.getWorktreeBase(repo('/workspace/my-repo'));
       expect(result).toEqual({
         base: join('/custom/archon', 'workspaces', '_local', 'my-repo', 'worktrees'),
         layout: 'workspace-scoped',
@@ -233,7 +237,7 @@ describe('git utilities', () => {
     test('uses the Docker archon home for the workspace-scoped base', () => {
       delete process.env.ARCHON_HOME;
       process.env.ARCHON_DOCKER = 'true';
-      const result = git.getWorktreeBase('/workspace/my-repo');
+      const result = git.getWorktreeBase(repo('/workspace/my-repo'));
       expect(result).toEqual({
         base: join('/', '.archon', 'workspaces', '_local', 'my-repo', 'worktrees'),
         layout: 'workspace-scoped',
@@ -246,7 +250,7 @@ describe('git utilities', () => {
       delete process.env.ARCHON_HOME;
       const workspacesPath = join(homedir(), '.archon', 'workspaces');
       const repoPath = join(workspacesPath, 'acme', 'widget', 'source');
-      const result = git.getWorktreeBase(repoPath);
+      const result = git.getWorktreeBase(repo(repoPath));
       expect(result).toEqual({
         base: join(workspacesPath, 'acme', 'widget', 'worktrees'),
         layout: 'workspace-scoped',
@@ -258,7 +262,7 @@ describe('git utilities', () => {
       delete process.env.ARCHON_DOCKER;
       process.env.ARCHON_HOME = join('/', 'custom', 'archon');
       const repoPath = join('/', 'custom', 'archon', 'workspaces', 'acme', 'widget', 'source');
-      const result = git.getWorktreeBase(repoPath);
+      const result = git.getWorktreeBase(repo(repoPath));
       expect(result).toEqual({
         base: join('/', 'custom', 'archon', 'workspaces', 'acme', 'widget', 'worktrees'),
         layout: 'workspace-scoped',
@@ -270,7 +274,7 @@ describe('git utilities', () => {
       delete process.env.ARCHON_DOCKER;
       delete process.env.ARCHON_HOME;
       const localRepoPath = '/Users/rasmus/Projects/sasha-demo';
-      const result = git.getWorktreeBase(localRepoPath, 'Widinglabs/sasha-demo');
+      const result = git.getWorktreeBase(repo(localRepoPath), 'Widinglabs/sasha-demo');
       expect(result).toEqual({
         base: join(homedir(), '.archon', 'workspaces', 'Widinglabs', 'sasha-demo', 'worktrees'),
         layout: 'workspace-scoped',
@@ -283,7 +287,7 @@ describe('git utilities', () => {
       delete process.env.ARCHON_HOME;
       const workspacesPath = join(homedir(), '.archon', 'workspaces');
       const repoPath = join(workspacesPath, 'old-owner', 'old-repo', 'source');
-      const result = git.getWorktreeBase(repoPath, 'new-owner/new-repo');
+      const result = git.getWorktreeBase(repo(repoPath), 'new-owner/new-repo');
       expect(result).toEqual({
         base: join(workspacesPath, 'new-owner', 'new-repo', 'worktrees'),
         layout: 'workspace-scoped',
@@ -296,7 +300,7 @@ describe('git utilities', () => {
       delete process.env.WORKSPACE_PATH;
       delete process.env.ARCHON_DOCKER;
       delete process.env.ARCHON_HOME;
-      const result = git.getWorktreeBase('/local/repo', 'invalid-no-slash');
+      const result = git.getWorktreeBase(repo('/local/repo'), 'invalid-no-slash');
       expect(result).toEqual({
         base: join(homedir(), '.archon', 'workspaces', '_local', 'repo', 'worktrees'),
         layout: 'workspace-scoped',
@@ -313,7 +317,7 @@ describe('git utilities', () => {
       delete process.env.ARCHON_HOME;
       mockLogger.warn.mockClear();
       const result = git.getWorktreeBase(
-        '/srv/projects/widget-app',
+        repo('/srv/projects/widget-app'),
         'git@git.example.net:acme/widget-app'
       );
       expect(result).toEqual({
@@ -339,7 +343,7 @@ describe('git utilities', () => {
       delete process.env.WORKSPACE_PATH;
       delete process.env.ARCHON_DOCKER;
       delete process.env.ARCHON_HOME;
-      const result = git.getWorktreeBase('/workspace');
+      const result = git.getWorktreeBase(repo('/workspace'));
       expect(result).toEqual({
         base: join(homedir(), '.archon', 'workspaces', '_local', 'workspace', 'worktrees'),
         layout: 'workspace-scoped',
@@ -350,7 +354,7 @@ describe('git utilities', () => {
       delete process.env.WORKSPACE_PATH;
       delete process.env.ARCHON_DOCKER;
       delete process.env.ARCHON_HOME;
-      expect(() => git.getWorktreeBase('/')).toThrow('Cannot derive a project identity');
+      expect(() => git.getWorktreeBase(repo('/'))).toThrow('Cannot derive a project identity');
     });
 
     test('repoLocal override wins over workspace-scoped default', () => {
@@ -358,7 +362,7 @@ describe('git utilities', () => {
       delete process.env.ARCHON_DOCKER;
       delete process.env.ARCHON_HOME;
       const repoPath = '/Users/rasmus/Projects/myapp';
-      const result = git.getWorktreeBase(repoPath, undefined, { repoLocal: '.worktrees' });
+      const result = git.getWorktreeBase(repo(repoPath), undefined, { repoLocal: '.worktrees' });
       expect(result).toEqual({
         base: join(repoPath, '.worktrees'),
         layout: 'repo-local',
@@ -371,7 +375,7 @@ describe('git utilities', () => {
       delete process.env.ARCHON_HOME;
       const workspacesPath = join(homedir(), '.archon', 'workspaces');
       const repoPath = join(workspacesPath, 'acme', 'widget', 'source');
-      const result = git.getWorktreeBase(repoPath, 'acme/widget', { repoLocal: '.wt' });
+      const result = git.getWorktreeBase(repo(repoPath), 'acme/widget', { repoLocal: '.wt' });
       expect(result).toEqual({
         base: join(repoPath, '.wt'),
         layout: 'repo-local',
@@ -408,7 +412,7 @@ describe('git utilities', () => {
       delete process.env.ARCHON_HOME;
       const workspacesPath = join(homedir(), '.archon', 'workspaces');
       expect(
-        git.isProjectScopedWorktreeBase(join(workspacesPath, 'acme', 'widget', 'source'))
+        git.isProjectScopedWorktreeBase(repo(join(workspacesPath, 'acme', 'widget', 'source')))
       ).toBe(true);
     });
 
@@ -419,16 +423,16 @@ describe('git utilities', () => {
       delete process.env.WORKSPACE_PATH;
       delete process.env.ARCHON_DOCKER;
       delete process.env.ARCHON_HOME;
-      expect(git.isProjectScopedWorktreeBase('/workspace/my-repo')).toBe(true);
+      expect(git.isProjectScopedWorktreeBase(repo('/workspace/my-repo'))).toBe(true);
     });
 
     test('returns true when codebaseName is provided (local repo)', () => {
       delete process.env.WORKSPACE_PATH;
       delete process.env.ARCHON_DOCKER;
       delete process.env.ARCHON_HOME;
-      expect(git.isProjectScopedWorktreeBase('/Users/rasmus/Projects/repo', 'owner/repo')).toBe(
-        true
-      );
+      expect(
+        git.isProjectScopedWorktreeBase(repo('/Users/rasmus/Projects/repo'), 'owner/repo')
+      ).toBe(true);
     });
 
     test('returns true when codebaseName is invalid (falls back to path-derived)', () => {
@@ -437,7 +441,7 @@ describe('git utilities', () => {
       delete process.env.WORKSPACE_PATH;
       delete process.env.ARCHON_DOCKER;
       delete process.env.ARCHON_HOME;
-      expect(git.isProjectScopedWorktreeBase('/local/repo', 'invalid')).toBe(true);
+      expect(git.isProjectScopedWorktreeBase(repo('/local/repo'), 'invalid')).toBe(true);
     });
   });
 
@@ -446,12 +450,12 @@ describe('git utilities', () => {
       await realMkdir(join(testDir, 'worktree-test'), { recursive: true });
       await writeFile(join(testDir, 'worktree-test', '.git'), 'gitdir: /some/path');
 
-      const result = await git.worktreeExists(join(testDir, 'worktree-test'));
+      const result = await git.worktreeExists(worktree(join(testDir, 'worktree-test')));
       expect(result).toBe(true);
     });
 
     test('returns false when path does not exist', async () => {
-      const result = await git.worktreeExists(join(testDir, 'nonexistent'));
+      const result = await git.worktreeExists(worktree(join(testDir, 'nonexistent')));
       expect(result).toBe(false);
     });
 
@@ -459,7 +463,7 @@ describe('git utilities', () => {
       await realMkdir(join(testDir, 'no-git'), { recursive: true });
       mockLogger.warn.mockClear();
 
-      const result = await git.worktreeExists(join(testDir, 'no-git'));
+      const result = await git.worktreeExists(worktree(join(testDir, 'no-git')));
       expect(result).toBe(false);
       expect(mockLogger.warn).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -481,7 +485,7 @@ describe('git utilities', () => {
       accessSpy.mockRejectedValue(eaccesError);
 
       try {
-        await expect(git.worktreeExists(testPath)).rejects.toThrow(
+        await expect(git.worktreeExists(worktree(testPath))).rejects.toThrow(
           `Failed to check worktree at ${testPath}: Permission denied`
         );
         expect(mockLogger.error).toHaveBeenCalledWith(
@@ -520,17 +524,20 @@ branch refs/heads/feature/auth
 `;
       execSpy.mockResolvedValue({ stdout: mockOutput, stderr: '' });
 
-      const result = await git.listWorktrees('/path/to/main');
+      const result = await git.listWorktrees(repo('/path/to/main'));
 
       expect(result).toHaveLength(2);
-      expect(result[0]).toEqual({ path: '/path/to/main', branch: 'main' });
-      expect(result[1]).toEqual({ path: '/path/to/feature', branch: 'feature/auth' });
+      expect(result[0]).toEqual({ path: worktree('/path/to/main'), branch: branch('main') });
+      expect(result[1]).toEqual({
+        path: worktree('/path/to/feature'),
+        branch: branch('feature/auth'),
+      });
     });
 
     test('returns empty array for "not a git repository" error', async () => {
       execSpy.mockRejectedValue(new Error('fatal: not a git repository'));
 
-      const result = await git.listWorktrees('/path/to/repo');
+      const result = await git.listWorktrees(repo('/path/to/repo'));
       expect(result).toEqual([]);
     });
 
@@ -538,7 +545,7 @@ branch refs/heads/feature/auth
       execSpy.mockRejectedValue(new Error('No such file or directory'));
       mockLogger.warn.mockClear();
 
-      const result = await git.listWorktrees('/path/to/repo');
+      const result = await git.listWorktrees(repo('/path/to/repo'));
       expect(result).toEqual([]);
       expect(mockLogger.warn).toHaveBeenCalledWith(
         expect.objectContaining({ repoPath: '/path/to/repo' }),
@@ -549,7 +556,7 @@ branch refs/heads/feature/auth
     test('throws for unexpected errors', async () => {
       execSpy.mockRejectedValue(new Error('git not found'));
 
-      await expect(git.listWorktrees('/path/to/repo')).rejects.toThrow(
+      await expect(git.listWorktrees(repo('/path/to/repo'))).rejects.toThrow(
         'Failed to list worktrees for /path/to/repo: git not found'
       );
     });
@@ -559,7 +566,7 @@ branch refs/heads/feature/auth
       error.stderr = 'fatal: not a git repository (or any parent up to mount point /)';
       execSpy.mockRejectedValue(error);
 
-      const result = await git.listWorktrees('/path/to/repo');
+      const result = await git.listWorktrees(repo('/path/to/repo'));
       expect(result).toEqual([]);
     });
 
@@ -569,7 +576,7 @@ branch refs/heads/feature/auth
       execSpy.mockRejectedValue(error);
       mockLogger.warn.mockClear();
 
-      const result = await git.listWorktrees('/path/to/repo');
+      const result = await git.listWorktrees(repo('/path/to/repo'));
       expect(result).toEqual([]);
       expect(mockLogger.warn).toHaveBeenCalledWith(
         expect.objectContaining({ repoPath: '/path/to/repo' }),
@@ -583,7 +590,9 @@ branch refs/heads/feature/auth
       execSpy.mockRejectedValue(mockError);
       mockLogger.error.mockClear();
 
-      await expect(git.listWorktrees('/path/to/repo')).rejects.toThrow('Failed to list worktrees');
+      await expect(git.listWorktrees(repo('/path/to/repo'))).rejects.toThrow(
+        'Failed to list worktrees'
+      );
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.objectContaining({
           repoPath: '/path/to/repo',
@@ -616,17 +625,23 @@ branch refs/heads/feature/auth
     });
 
     test('finds exact branch match', async () => {
-      const result = await git.findWorktreeByBranch('/workspace/main', 'feature/auth');
-      expect(result).toBe('/workspace/worktrees/feature-auth');
+      const result = await git.findWorktreeByBranch(
+        repo('/workspace/main'),
+        branch('feature/auth')
+      );
+      expect(result).toBe(worktree('/workspace/worktrees/feature-auth'));
     });
 
     test('finds slugified branch match', async () => {
-      const result = await git.findWorktreeByBranch('/workspace/main', 'feature-auth');
-      expect(result).toBe('/workspace/worktrees/feature-auth');
+      const result = await git.findWorktreeByBranch(
+        repo('/workspace/main'),
+        branch('feature-auth')
+      );
+      expect(result).toBe(worktree('/workspace/worktrees/feature-auth'));
     });
 
     test('returns null when no match', async () => {
-      const result = await git.findWorktreeByBranch('/workspace/main', 'nonexistent');
+      const result = await git.findWorktreeByBranch(repo('/workspace/main'), branch('nonexistent'));
       expect(result).toBeNull();
     });
   });
@@ -649,7 +664,7 @@ branch refs/heads/feature/auth
     test('checks out existing branch successfully', async () => {
       execSpy.mockResolvedValue({ stdout: '', stderr: '' });
 
-      await git.checkout('/workspace/repo', 'feature-branch');
+      await git.checkout(repo('/workspace/repo'), branch('feature-branch'));
 
       expect(execSpy).toHaveBeenCalledWith(
         'git',
@@ -668,7 +683,7 @@ branch refs/heads/feature/auth
       );
       execSpy.mockResolvedValueOnce({ stdout: '', stderr: '' });
 
-      await git.checkout('/workspace/repo', 'new-branch');
+      await git.checkout(repo('/workspace/repo'), branch('new-branch'));
 
       expect(execSpy).toHaveBeenCalledTimes(2);
       expect(execSpy).toHaveBeenLastCalledWith(
@@ -688,7 +703,7 @@ branch refs/heads/feature/auth
       );
       execSpy.mockResolvedValueOnce({ stdout: '', stderr: '' });
 
-      await git.checkout('/workspace/repo', 'new-branch');
+      await git.checkout(repo('/workspace/repo'), branch('new-branch'));
 
       expect(execSpy).toHaveBeenCalledTimes(2);
       expect(execSpy).toHaveBeenLastCalledWith(
@@ -706,7 +721,7 @@ branch refs/heads/feature/auth
         Object.assign(new Error('Permission denied'), { stderr: 'fatal: Permission denied' })
       );
 
-      await expect(git.checkout('/workspace/repo', 'some-branch')).rejects.toThrow(
+      await expect(git.checkout(repo('/workspace/repo'), branch('some-branch'))).rejects.toThrow(
         'Failed to checkout branch some-branch: Permission denied'
       );
 
@@ -734,7 +749,7 @@ branch refs/heads/feature/auth
     test('returns true when there are uncommitted changes', async () => {
       execSpy.mockResolvedValue({ stdout: ' M file.ts\n?? newfile.ts\n', stderr: '' });
 
-      const result = await git.hasUncommittedChanges('/workspace/repo');
+      const result = await git.hasUncommittedChanges(repo('/workspace/repo'));
 
       expect(result).toBe(true);
       expect(execSpy).toHaveBeenCalledWith('git', [
@@ -748,7 +763,7 @@ branch refs/heads/feature/auth
     test('returns false when working tree is clean', async () => {
       execSpy.mockResolvedValue({ stdout: '', stderr: '' });
 
-      const result = await git.hasUncommittedChanges('/workspace/repo');
+      const result = await git.hasUncommittedChanges(repo('/workspace/repo'));
 
       expect(result).toBe(false);
     });
@@ -756,7 +771,7 @@ branch refs/heads/feature/auth
     test('returns false when output is only whitespace', async () => {
       execSpy.mockResolvedValue({ stdout: '   \n\n', stderr: '' });
 
-      const result = await git.hasUncommittedChanges('/workspace/repo');
+      const result = await git.hasUncommittedChanges(repo('/workspace/repo'));
 
       expect(result).toBe(false);
     });
@@ -766,7 +781,7 @@ branch refs/heads/feature/auth
       error.code = 'ENOENT';
       execSpy.mockRejectedValue(error);
 
-      const result = await git.hasUncommittedChanges('/nonexistent');
+      const result = await git.hasUncommittedChanges(repo('/nonexistent'));
 
       expect(result).toBe(false);
     });
@@ -774,7 +789,7 @@ branch refs/heads/feature/auth
     test('returns true (fail-safe) when git fails with unexpected error', async () => {
       execSpy.mockRejectedValue(new Error('fatal: not a git repository'));
 
-      const result = await git.hasUncommittedChanges('/workspace/corrupted');
+      const result = await git.hasUncommittedChanges(repo('/workspace/corrupted'));
 
       expect(result).toBe(true);
     });
@@ -782,7 +797,7 @@ branch refs/heads/feature/auth
     test('returns true (fail-safe) when git lock file exists', async () => {
       execSpy.mockRejectedValue(new Error('Another git process seems to be running'));
 
-      const result = await git.hasUncommittedChanges('/workspace/locked');
+      const result = await git.hasUncommittedChanges(repo('/workspace/locked'));
 
       expect(result).toBe(true);
     });
@@ -802,9 +817,9 @@ branch refs/heads/feature/auth
     test('returns branch from symbolic-ref (origin/main)', async () => {
       execSpy.mockResolvedValue({ stdout: 'origin/main\n', stderr: '' });
 
-      const result = await git.getDefaultBranch('/workspace/repo');
+      const result = await git.getDefaultBranch(repo('/workspace/repo'));
 
-      expect(result).toBe('main');
+      expect(result).toBe(branch('main'));
       expect(execSpy).toHaveBeenCalledWith(
         'git',
         ['-C', '/workspace/repo', 'symbolic-ref', 'refs/remotes/origin/HEAD', '--short'],
@@ -815,17 +830,17 @@ branch refs/heads/feature/auth
     test('returns branch from symbolic-ref (origin/master)', async () => {
       execSpy.mockResolvedValue({ stdout: 'origin/master\n', stderr: '' });
 
-      const result = await git.getDefaultBranch('/workspace/repo');
+      const result = await git.getDefaultBranch(repo('/workspace/repo'));
 
-      expect(result).toBe('master');
+      expect(result).toBe(branch('master'));
     });
 
     test('uses custom remote for symbolic-ref lookup and prefix stripping', async () => {
       execSpy.mockResolvedValue({ stdout: 'upstream/main\n', stderr: '' });
 
-      const result = await git.getDefaultBranch('/workspace/repo', 'upstream');
+      const result = await git.getDefaultBranch(repo('/workspace/repo'), 'upstream');
 
-      expect(result).toBe('main');
+      expect(result).toBe(branch('main'));
       expect(execSpy).toHaveBeenCalledWith(
         'git',
         ['-C', '/workspace/repo', 'symbolic-ref', 'refs/remotes/upstream/HEAD', '--short'],
@@ -847,7 +862,7 @@ branch refs/heads/feature/auth
         return { stdout: 'abc123\n', stderr: '' };
       });
 
-      await expect(git.getDefaultBranch('/workspace/repo')).rejects.toThrow(
+      await expect(git.getDefaultBranch(repo('/workspace/repo'))).rejects.toThrow(
         'Cannot detect default branch for /workspace/repo: origin/HEAD is not set'
       );
       // The error must name all three configuration surfaces so the reader
@@ -864,23 +879,23 @@ branch refs/heads/feature/auth
       // Error must surface all three configuration surfaces.
       const expectedMessage =
         'Pass --base, set worktree.baseBranch in .archon/config.yaml, or set the codebase default_branch field.';
-      await expect(git.getDefaultBranch('/workspace/repo')).rejects.toThrow(expectedMessage);
+      await expect(git.getDefaultBranch(repo('/workspace/repo'))).rejects.toThrow(expectedMessage);
     });
 
     test('returns non-standard branch from symbolic-ref (origin/develop)', async () => {
       execSpy.mockResolvedValue({ stdout: 'origin/develop\n', stderr: '' });
 
-      const result = await git.getDefaultBranch('/workspace/repo');
+      const result = await git.getDefaultBranch(repo('/workspace/repo'));
 
-      expect(result).toBe('develop');
+      expect(result).toBe(branch('develop'));
     });
 
     test('returns non-standard branch from symbolic-ref (origin/trunk)', async () => {
       execSpy.mockResolvedValue({ stdout: 'origin/trunk\n', stderr: '' });
 
-      const result = await git.getDefaultBranch('/workspace/repo');
+      const result = await git.getDefaultBranch(repo('/workspace/repo'));
 
-      expect(result).toBe('trunk');
+      expect(result).toBe(branch('trunk'));
     });
 
     test('throws when symbolic-ref fails and names the remote in the error', async () => {
@@ -891,7 +906,7 @@ branch refs/heads/feature/auth
         throw new Error('fatal: Needed a single revision');
       });
 
-      await expect(git.getDefaultBranch('/workspace/repo', 'mar')).rejects.toThrow(
+      await expect(git.getDefaultBranch(repo('/workspace/repo'), 'mar')).rejects.toThrow(
         'mar/HEAD is not set'
       );
       // Verify NO rev-parse fallback is attempted — the <remote>/main guess is
@@ -906,7 +921,7 @@ branch refs/heads/feature/auth
       mockLogger.error.mockClear();
       execSpy.mockRejectedValue(new Error('fatal: permission denied'));
 
-      await expect(git.getDefaultBranch('/workspace/repo')).rejects.toThrow(
+      await expect(git.getDefaultBranch(repo('/workspace/repo'))).rejects.toThrow(
         'Failed to get default branch for /workspace/repo: fatal: permission denied'
       );
       expect(mockLogger.error).toHaveBeenCalledWith(
@@ -924,7 +939,7 @@ branch refs/heads/feature/auth
         new Error("fatal: cannot change to '/workspace/missing': No such file or directory")
       );
 
-      await expect(git.getDefaultBranch('/workspace/missing')).rejects.toThrow(
+      await expect(git.getDefaultBranch(repo('/workspace/missing'))).rejects.toThrow(
         "Failed to get default branch for /workspace/missing: fatal: cannot change to '/workspace/missing': No such file or directory"
       );
       expect(mockLogger.warn).not.toHaveBeenCalled();
@@ -947,9 +962,11 @@ branch refs/heads/feature/auth
         return { stdout: '', stderr: '' };
       });
 
-      await expect(git.getDefaultBranch('/workspace/repo')).rejects.toThrow('--base');
-      await expect(git.getDefaultBranch('/workspace/repo')).rejects.toThrow('worktree.baseBranch');
-      await expect(git.getDefaultBranch('/workspace/repo')).rejects.toThrow('default_branch');
+      await expect(git.getDefaultBranch(repo('/workspace/repo'))).rejects.toThrow('--base');
+      await expect(git.getDefaultBranch(repo('/workspace/repo'))).rejects.toThrow(
+        'worktree.baseBranch'
+      );
+      await expect(git.getDefaultBranch(repo('/workspace/repo'))).rejects.toThrow('default_branch');
     });
   });
 
@@ -973,7 +990,10 @@ branch refs/heads/feature/auth
         })
         .mockResolvedValueOnce({ stdout: '', stderr: '' });
 
-      const result = await git.getUniqueCommitCount('/workspace/repo', 'feature/auth');
+      const result = await git.getUniqueCommitCount(
+        repo('/workspace/repo'),
+        branch('feature/auth')
+      );
 
       expect(result).toBe(0);
       expect(execSpy).toHaveBeenNthCalledWith(
@@ -1012,7 +1032,10 @@ branch refs/heads/feature/auth
         .mockResolvedValueOnce({ stdout: 'refs/heads/feature/auth\nrefs/heads/dev\n', stderr: '' })
         .mockResolvedValueOnce({ stdout: 'abc123\ndef456\n\n', stderr: '' });
 
-      const result = await git.getUniqueCommitCount('/workspace/repo', 'feature/auth');
+      const result = await git.getUniqueCommitCount(
+        repo('/workspace/repo'),
+        branch('feature/auth')
+      );
 
       expect(result).toBe(2);
     });
@@ -1026,7 +1049,7 @@ branch refs/heads/feature/auth
         })
         .mockResolvedValueOnce({ stdout: 'abc123\n', stderr: '' });
 
-      await git.getUniqueCommitCount('/workspace/repo', 'feature/auth', 'upstream');
+      await git.getUniqueCommitCount(repo('/workspace/repo'), branch('feature/auth'), 'upstream');
 
       expect(execSpy).toHaveBeenNthCalledWith(
         2,
@@ -1052,7 +1075,10 @@ branch refs/heads/feature/auth
         })
         .mockResolvedValueOnce({ stdout: 'abc123\ndef456\n', stderr: '' });
 
-      const result = await git.getUniqueCommitCount('/workspace/repo', 'feature/auth');
+      const result = await git.getUniqueCommitCount(
+        repo('/workspace/repo'),
+        branch('feature/auth')
+      );
 
       expect(result).toBe(2);
       expect(execSpy).toHaveBeenNthCalledWith(
@@ -1066,7 +1092,9 @@ branch refs/heads/feature/auth
     test('rejects when Git cannot enumerate refs', async () => {
       execSpy.mockRejectedValueOnce(new Error('fatal: not a git repository'));
 
-      await expect(git.getUniqueCommitCount('/workspace/repo', 'feature/auth')).rejects.toThrow(
+      await expect(
+        git.getUniqueCommitCount(repo('/workspace/repo'), branch('feature/auth'))
+      ).rejects.toThrow(
         'Failed to count unique commits for feature/auth: fatal: not a git repository'
       );
     });
@@ -1091,7 +1119,7 @@ branch refs/heads/feature/auth
         return { stdout: '', stderr: '' };
       });
 
-      const result = await git.commitAllChanges('/workspace/repo', 'test commit');
+      const result = await git.commitAllChanges(repo('/workspace/repo'), 'test commit');
 
       expect(result).toBe(true);
       expect(execSpy).toHaveBeenCalledWith('git', ['-C', '/workspace/repo', 'add', '-A'], {
@@ -1107,7 +1135,7 @@ branch refs/heads/feature/auth
     test('returns false when no changes to commit', async () => {
       execSpy.mockResolvedValue({ stdout: '', stderr: '' });
 
-      const result = await git.commitAllChanges('/workspace/repo', 'test commit');
+      const result = await git.commitAllChanges(repo('/workspace/repo'), 'test commit');
 
       expect(result).toBe(false);
       expect(execSpy).toHaveBeenCalledTimes(1); // only hasUncommittedChanges
@@ -1133,7 +1161,7 @@ branch refs/heads/feature/auth
         return { stdout: '', stderr: '' };
       });
 
-      const result = await git.commitAllChanges('/workspace/repo', 'test commit');
+      const result = await git.commitAllChanges(repo('/workspace/repo'), 'test commit');
 
       expect(result).toBe(false);
       expect(execSpy).toHaveBeenCalledTimes(3); // status + add + commit
@@ -1150,7 +1178,7 @@ branch refs/heads/feature/auth
         return { stdout: '', stderr: '' };
       });
 
-      await expect(git.commitAllChanges('/workspace/repo', 'test commit')).rejects.toThrow(
+      await expect(git.commitAllChanges(repo('/workspace/repo'), 'test commit')).rejects.toThrow(
         'git add failed'
       );
     });
@@ -1169,7 +1197,7 @@ branch refs/heads/feature/auth
         return { stdout: '', stderr: '' };
       });
 
-      await expect(git.commitAllChanges('/workspace/repo', 'test commit')).rejects.toThrow(
+      await expect(git.commitAllChanges(repo('/workspace/repo'), 'test commit')).rejects.toThrow(
         'pre-commit hook failed'
       );
     });
@@ -1192,7 +1220,11 @@ branch refs/heads/feature/auth
         stderr: '',
       });
 
-      const result = await git.isBranchMerged('/workspace/repo', 'feature-branch', 'main');
+      const result = await git.isBranchMerged(
+        repo('/workspace/repo'),
+        branch('feature-branch'),
+        branch('main')
+      );
       expect(result).toBe(true);
     });
 
@@ -1202,7 +1234,11 @@ branch refs/heads/feature/auth
         stderr: '',
       });
 
-      const result = await git.isBranchMerged('/workspace/repo', 'feature-branch', 'main');
+      const result = await git.isBranchMerged(
+        repo('/workspace/repo'),
+        branch('feature-branch'),
+        branch('main')
+      );
       expect(result).toBe(false);
     });
 
@@ -1212,14 +1248,22 @@ branch refs/heads/feature/auth
         stderr: '',
       });
 
-      const result = await git.isBranchMerged('/workspace/repo', 'feature/auth', 'main');
+      const result = await git.isBranchMerged(
+        repo('/workspace/repo'),
+        branch('feature/auth'),
+        branch('main')
+      );
       expect(result).toBe(true);
     });
 
     test('returns false on expected errors (not a git repo)', async () => {
       execSpy.mockRejectedValue(new Error('fatal: not a git repository'));
 
-      const result = await git.isBranchMerged('/workspace/repo', 'feature', 'main');
+      const result = await git.isBranchMerged(
+        repo('/workspace/repo'),
+        branch('feature'),
+        branch('main')
+      );
       expect(result).toBe(false);
     });
 
@@ -1227,9 +1271,9 @@ branch refs/heads/feature/auth
       mockLogger.error.mockClear();
       execSpy.mockRejectedValue(new Error('fatal: permission denied'));
 
-      await expect(git.isBranchMerged('/workspace/repo', 'feature', 'main')).rejects.toThrow(
-        'Failed to check if feature is merged into main'
-      );
+      await expect(
+        git.isBranchMerged(repo('/workspace/repo'), branch('feature'), branch('main'))
+      ).rejects.toThrow('Failed to check if feature is merged into main');
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.objectContaining({
           repoPath: '/workspace/repo',
@@ -1243,7 +1287,11 @@ branch refs/heads/feature/auth
     test('uses provided mainBranch parameter', async () => {
       execSpy.mockResolvedValue({ stdout: '* develop\n  feature\n', stderr: '' });
 
-      const result = await git.isBranchMerged('/workspace/repo', 'feature', 'develop');
+      const result = await git.isBranchMerged(
+        repo('/workspace/repo'),
+        branch('feature'),
+        branch('develop')
+      );
 
       expect(execSpy).toHaveBeenCalledWith('git', [
         '-C',
@@ -1261,7 +1309,11 @@ branch refs/heads/feature/auth
         stderr: '',
       });
 
-      const result = await git.isBranchMerged('/workspace/repo', 'main', 'main');
+      const result = await git.isBranchMerged(
+        repo('/workspace/repo'),
+        branch('main'),
+        branch('main')
+      );
       expect(result).toBe(true);
     });
   });
@@ -1279,34 +1331,50 @@ branch refs/heads/feature/auth
 
     test('returns true when all cherry lines start with -', async () => {
       execSpy.mockResolvedValue({ stdout: '- abc123\n- def456\n', stderr: '' });
-      const result = await git.isPatchEquivalent('/workspace/repo', 'feature', 'main');
+      const result = await git.isPatchEquivalent(
+        repo('/workspace/repo'),
+        branch('feature'),
+        branch('main')
+      );
       expect(result).toBe(true);
     });
 
     test('returns false when any cherry line starts with +', async () => {
       execSpy.mockResolvedValue({ stdout: '- abc123\n+ def456\n', stderr: '' });
-      const result = await git.isPatchEquivalent('/workspace/repo', 'feature', 'main');
+      const result = await git.isPatchEquivalent(
+        repo('/workspace/repo'),
+        branch('feature'),
+        branch('main')
+      );
       expect(result).toBe(false);
     });
 
     test('returns true for empty cherry output', async () => {
       execSpy.mockResolvedValue({ stdout: '', stderr: '' });
-      const result = await git.isPatchEquivalent('/workspace/repo', 'feature', 'main');
+      const result = await git.isPatchEquivalent(
+        repo('/workspace/repo'),
+        branch('feature'),
+        branch('main')
+      );
       expect(result).toBe(true);
     });
 
     test('returns false on expected errors (not a git repo)', async () => {
       execSpy.mockRejectedValue(new Error('fatal: not a git repository'));
-      const result = await git.isPatchEquivalent('/workspace/repo', 'feature', 'main');
+      const result = await git.isPatchEquivalent(
+        repo('/workspace/repo'),
+        branch('feature'),
+        branch('main')
+      );
       expect(result).toBe(false);
     });
 
     test('throws on unexpected errors', async () => {
       mockLogger.error.mockClear();
       execSpy.mockRejectedValue(new Error('fatal: permission denied'));
-      await expect(git.isPatchEquivalent('/workspace/repo', 'feature', 'main')).rejects.toThrow(
-        'Failed to check if feature is patch-equivalent to main'
-      );
+      await expect(
+        git.isPatchEquivalent(repo('/workspace/repo'), branch('feature'), branch('main'))
+      ).rejects.toThrow('Failed to check if feature is patch-equivalent to main');
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.objectContaining({ branchName: 'feature', baseBranch: 'main' }),
         'branch.patch_equivalent_check_failed'
@@ -1328,7 +1396,7 @@ branch refs/heads/feature/auth
     test('returns valid date from git log output', async () => {
       execSpy.mockResolvedValue({ stdout: '2024-01-15 10:30:00 +0000\n', stderr: '' });
 
-      const result = await git.getLastCommitDate('/workspace/repo');
+      const result = await git.getLastCommitDate(repo('/workspace/repo'));
       expect(result).toBeInstanceOf(Date);
       expect(result!.getFullYear()).toBe(2024);
     });
@@ -1336,14 +1404,14 @@ branch refs/heads/feature/auth
     test('returns null on expected errors (not a git repo)', async () => {
       execSpy.mockRejectedValue(new Error('fatal: not a git repository'));
 
-      const result = await git.getLastCommitDate('/workspace/repo');
+      const result = await git.getLastCommitDate(repo('/workspace/repo'));
       expect(result).toBeNull();
     });
 
     test('returns null on expected errors (no commits)', async () => {
       execSpy.mockRejectedValue(new Error('fatal: does not have any commits yet'));
 
-      const result = await git.getLastCommitDate('/workspace/repo');
+      const result = await git.getLastCommitDate(repo('/workspace/repo'));
       expect(result).toBeNull();
     });
 
@@ -1352,7 +1420,7 @@ branch refs/heads/feature/auth
       error.code = 'ENOENT';
       execSpy.mockRejectedValue(error);
 
-      const result = await git.getLastCommitDate('/nonexistent');
+      const result = await git.getLastCommitDate(repo('/nonexistent'));
       expect(result).toBeNull();
     });
 
@@ -1360,7 +1428,7 @@ branch refs/heads/feature/auth
       mockLogger.error.mockClear();
       execSpy.mockRejectedValue(new Error('fatal: permission denied'));
 
-      await expect(git.getLastCommitDate('/workspace/repo')).rejects.toThrow(
+      await expect(git.getLastCommitDate(repo('/workspace/repo'))).rejects.toThrow(
         'Failed to get last commit date for /workspace/repo'
       );
       expect(mockLogger.error).toHaveBeenCalledWith(
@@ -1372,7 +1440,7 @@ branch refs/heads/feature/auth
     test('returns null for empty git log output', async () => {
       execSpy.mockResolvedValue({ stdout: '', stderr: '' });
 
-      const result = await git.getLastCommitDate('/workspace/repo');
+      const result = await git.getLastCommitDate(repo('/workspace/repo'));
       expect(result).toBeNull();
     });
 
@@ -1380,7 +1448,7 @@ branch refs/heads/feature/auth
       mockLogger.warn.mockClear();
       execSpy.mockResolvedValue({ stdout: 'not-a-date\n', stderr: '' });
 
-      const result = await git.getLastCommitDate('/workspace/repo');
+      const result = await git.getLastCommitDate(repo('/workspace/repo'));
       expect(result).toBeNull();
       expect(mockLogger.warn).toHaveBeenCalledWith(
         expect.objectContaining({ workingPath: '/workspace/repo', rawDate: 'not-a-date' }),
@@ -1405,7 +1473,7 @@ branch refs/heads/feature/auth
 
       const result = await git.getCurrentBranch('/workspace/repo' as git.RepoPath);
 
-      expect(result).toBe('main');
+      expect(result).toBe(branch('main'));
       expect(execSpy).toHaveBeenCalledWith(
         'git',
         ['-C', '/workspace/repo', 'symbolic-ref', '--short', 'HEAD'],
@@ -1601,7 +1669,7 @@ branch refs/heads/feature/auth
     beforeEach(() => {
       execSpy = spyOn(git, 'execFileAsync');
       getDefaultBranchSpy = spyOn(git, 'getDefaultBranch');
-      getDefaultBranchSpy.mockResolvedValue('main');
+      getDefaultBranchSpy.mockResolvedValue(branch('main'));
     });
 
     afterEach(() => {
@@ -1624,10 +1692,10 @@ branch refs/heads/feature/auth
         return { stdout: '', stderr: '' };
       });
 
-      const result = await git.syncWorkspace('/workspace/repo', 'main');
+      const result = await git.syncWorkspace(repo('/workspace/repo'), branch('main'));
 
       expect(result).toEqual({
-        branch: 'main',
+        branch: branch('main'),
         synced: true,
         mode: 'fast-forward',
         state: 'in_sync',
@@ -1646,7 +1714,7 @@ branch refs/heads/feature/auth
     test('does not reset by default', async () => {
       execSpy.mockResolvedValue({ stdout: '', stderr: '' });
 
-      await git.syncWorkspace('/workspace/repo', 'main');
+      await git.syncWorkspace(repo('/workspace/repo'), branch('main'));
 
       const resetCalls = execSpy.mock.calls.filter((call: unknown[]) => {
         const args = call[1] as string[];
@@ -1659,7 +1727,7 @@ branch refs/heads/feature/auth
     test('hard-resets working tree to origin in reset mode', async () => {
       execSpy.mockResolvedValue({ stdout: '', stderr: '' });
 
-      await git.syncWorkspace('/workspace/repo', 'main', { mode: 'reset' });
+      await git.syncWorkspace(repo('/workspace/repo'), branch('main'), { mode: 'reset' });
 
       const resetCalls = execSpy.mock.calls.filter((call: unknown[]) => {
         const args = call[1] as string[];
@@ -1678,9 +1746,9 @@ branch refs/heads/feature/auth
         return { stdout: '', stderr: '' };
       });
 
-      await expect(git.syncWorkspace('/workspace/repo', 'main', { mode: 'reset' })).rejects.toThrow(
-        'Reset to origin/main failed'
-      );
+      await expect(
+        git.syncWorkspace(repo('/workspace/repo'), branch('main'), { mode: 'reset' })
+      ).rejects.toThrow('Reset to origin/main failed');
     });
 
     test('throws error if fetch fails', async () => {
@@ -1691,7 +1759,7 @@ branch refs/heads/feature/auth
         return { stdout: '', stderr: '' };
       });
 
-      await expect(git.syncWorkspace('/workspace/repo', 'main')).rejects.toThrow(
+      await expect(git.syncWorkspace(repo('/workspace/repo'), branch('main'))).rejects.toThrow(
         'unable to access repository'
       );
     });
@@ -1711,7 +1779,7 @@ branch refs/heads/feature/auth
         return { stdout: '', stderr: '' };
       });
 
-      const result = await git.syncWorkspace('/workspace/repo', 'main');
+      const result = await git.syncWorkspace(repo('/workspace/repo'), branch('main'));
 
       expect(result.previousHead).toBe('');
       expect(result.newHead).toBe('');
@@ -1724,7 +1792,7 @@ branch refs/heads/feature/auth
     test('passes correct timeout value to fetch command', async () => {
       execSpy.mockResolvedValue({ stdout: '', stderr: '' });
 
-      await git.syncWorkspace('/workspace/repo', 'main');
+      await git.syncWorkspace(repo('/workspace/repo'), branch('main'));
 
       const fetchCall = execSpy.mock.calls.find((call: unknown[]) => {
         const args = call[1] as string[];
@@ -1741,7 +1809,7 @@ branch refs/heads/feature/auth
         return { stdout: '', stderr: '' };
       });
 
-      await expect(git.syncWorkspace('/workspace/repo', 'main')).rejects.toThrow(
+      await expect(git.syncWorkspace(repo('/workspace/repo'), branch('main'))).rejects.toThrow(
         'Sync fetch from origin/main failed'
       );
     });
@@ -1760,12 +1828,12 @@ branch refs/heads/feature/auth
         }
         return { stdout: '', stderr: '' };
       });
-      getDefaultBranchSpy.mockResolvedValue('develop');
+      getDefaultBranchSpy.mockResolvedValue(branch('develop'));
 
-      const result = await git.syncWorkspace('/workspace/repo');
+      const result = await git.syncWorkspace(repo('/workspace/repo'));
 
       expect(result).toEqual({
-        branch: 'develop',
+        branch: branch('develop'),
         synced: true,
         mode: 'fast-forward',
         state: 'in_sync',
@@ -1784,12 +1852,12 @@ branch refs/heads/feature/auth
         return { stdout: '', stderr: '' };
       });
 
-      await expect(git.syncWorkspace('/workspace/repo', 'does-not-exist')).rejects.toThrow(
-        "Configured base branch 'does-not-exist' not found on remote"
-      );
-      await expect(git.syncWorkspace('/workspace/repo', 'does-not-exist')).rejects.toThrow(
-        'update worktree.baseBranch'
-      );
+      await expect(
+        git.syncWorkspace(repo('/workspace/repo'), branch('does-not-exist'))
+      ).rejects.toThrow("Configured base branch 'does-not-exist' not found on remote");
+      await expect(
+        git.syncWorkspace(repo('/workspace/repo'), branch('does-not-exist'))
+      ).rejects.toThrow('update worktree.baseBranch');
     });
 
     test('throws generic error when auto-detected branch not found (not actionable)', async () => {
@@ -1799,12 +1867,14 @@ branch refs/heads/feature/auth
         }
         return { stdout: '', stderr: '' };
       });
-      getDefaultBranchSpy.mockResolvedValue('main');
+      getDefaultBranchSpy.mockResolvedValue(branch('main'));
 
-      await expect(git.syncWorkspace('/workspace/repo')).rejects.toThrow(
+      await expect(git.syncWorkspace(repo('/workspace/repo'))).rejects.toThrow(
         'Sync fetch from origin/main failed'
       );
-      await expect(git.syncWorkspace('/workspace/repo')).rejects.not.toThrow('worktree.baseBranch');
+      await expect(git.syncWorkspace(repo('/workspace/repo'))).rejects.not.toThrow(
+        'worktree.baseBranch'
+      );
     });
 
     test('fetch-only mode fetches and does not reset or merge', async () => {
@@ -1825,7 +1895,7 @@ branch refs/heads/feature/auth
         return { stdout: '', stderr: '' };
       });
 
-      const result = await git.syncWorkspace('/workspace/repo', 'main', {
+      const result = await git.syncWorkspace(repo('/workspace/repo'), branch('main'), {
         mode: 'fetch-only',
       });
 
@@ -1862,7 +1932,7 @@ branch refs/heads/feature/auth
         return { stdout: '', stderr: '' };
       });
 
-      const result = await git.syncWorkspace('/workspace/repo', 'main');
+      const result = await git.syncWorkspace(repo('/workspace/repo'), branch('main'));
 
       expect(result.state).toBe('dirty');
       expect(
@@ -1891,7 +1961,7 @@ branch refs/heads/feature/auth
         return { stdout: '', stderr: '' };
       });
 
-      const result = await git.syncWorkspace('/workspace/repo', 'main');
+      const result = await git.syncWorkspace(repo('/workspace/repo'), branch('main'));
 
       expect(result.state).toBe('in_sync');
     });
@@ -1923,7 +1993,7 @@ branch refs/heads/feature/auth
         return { stdout: '', stderr: '' };
       });
 
-      const result = await git.syncWorkspace('/workspace/repo', 'main');
+      const result = await git.syncWorkspace(repo('/workspace/repo'), branch('main'));
 
       expect(result.state).toBe('in_sync');
       expect(result.updated).toBe(true);
@@ -1956,7 +2026,7 @@ branch refs/heads/feature/auth
         return { stdout: '', stderr: '' };
       });
 
-      const result = await git.syncWorkspace('/workspace/repo', 'main');
+      const result = await git.syncWorkspace(repo('/workspace/repo'), branch('main'));
 
       expect(result.state).toBe('behind');
       expect(result.updated).toBe(false);
@@ -1986,7 +2056,7 @@ branch refs/heads/feature/auth
         return { stdout: '', stderr: '' };
       });
 
-      const aheadResult = await git.syncWorkspace('/workspace/repo', 'main');
+      const aheadResult = await git.syncWorkspace(repo('/workspace/repo'), branch('main'));
       expect(aheadResult.state).toBe('ahead');
       expect(
         execSpy.mock.calls.some((call: unknown[]) => (call[1] as string[]).includes('merge'))
@@ -2001,7 +2071,7 @@ branch refs/heads/feature/auth
         return { stdout: '', stderr: '' };
       });
 
-      const divergedResult = await git.syncWorkspace('/workspace/repo', 'main');
+      const divergedResult = await git.syncWorkspace(repo('/workspace/repo'), branch('main'));
       expect(divergedResult.state).toBe('diverged');
       expect(
         execSpy.mock.calls.some((call: unknown[]) => (call[1] as string[]).includes('merge'))
@@ -2026,7 +2096,7 @@ branch refs/heads/feature/auth
         return { stdout: '', stderr: '' };
       });
 
-      await expect(git.syncWorkspace('/workspace/repo', 'main')).rejects.toThrow(
+      await expect(git.syncWorkspace(repo('/workspace/repo'), branch('main'))).rejects.toThrow(
         'Failed to compare git ancestry'
       );
       expect(mockLogger.error).toHaveBeenCalledWith(
@@ -2038,7 +2108,10 @@ branch refs/heads/feature/auth
     test('fetches and resets from custom remote when provided in options', async () => {
       execSpy.mockResolvedValue({ stdout: '', stderr: '' });
 
-      await git.syncWorkspace('/workspace/repo', 'main', { mode: 'reset', remote: 'mar' });
+      await git.syncWorkspace(repo('/workspace/repo'), branch('main'), {
+        mode: 'reset',
+        remote: 'mar',
+      });
 
       expect(execSpy).toHaveBeenCalledWith(
         'git',
@@ -2069,7 +2142,9 @@ branch refs/heads/feature/auth
         return { stdout: '', stderr: '' };
       });
 
-      const result = await git.syncWorkspace('/workspace/repo', 'main', { remote: 'upstream' });
+      const result = await git.syncWorkspace(repo('/workspace/repo'), branch('main'), {
+        remote: 'upstream',
+      });
 
       expect(result.state).toBe('in_sync');
       // The state classification must rev-parse upstream/main, not origin/main
@@ -2082,9 +2157,9 @@ branch refs/heads/feature/auth
 
     test('passes custom remote to getDefaultBranch when baseBranch not provided', async () => {
       execSpy.mockResolvedValue({ stdout: '', stderr: '' });
-      getDefaultBranchSpy.mockResolvedValue('develop');
+      getDefaultBranchSpy.mockResolvedValue(branch('develop'));
 
-      await git.syncWorkspace('/workspace/repo', undefined, { remote: 'upstream' });
+      await git.syncWorkspace(repo('/workspace/repo'), undefined, { remote: 'upstream' });
 
       expect(getDefaultBranchSpy).toHaveBeenCalledWith('/workspace/repo', 'upstream');
     });
@@ -2097,9 +2172,9 @@ branch refs/heads/feature/auth
         return { stdout: '', stderr: '' };
       });
 
-      await expect(git.syncWorkspace('/workspace/repo', 'main', { remote: 'mar' })).rejects.toThrow(
-        'Sync fetch from mar/main failed'
-      );
+      await expect(
+        git.syncWorkspace(repo('/workspace/repo'), branch('main'), { remote: 'mar' })
+      ).rejects.toThrow('Sync fetch from mar/main failed');
     });
 
     test('names the custom remote in the configured-branch-missing error', async () => {
@@ -2111,7 +2186,7 @@ branch refs/heads/feature/auth
       });
 
       await expect(
-        git.syncWorkspace('/workspace/repo', 'does-not-exist', { remote: 'mar' })
+        git.syncWorkspace(repo('/workspace/repo'), branch('does-not-exist'), { remote: 'mar' })
       ).rejects.toThrow("Configured base branch 'does-not-exist' not found on remote 'mar'");
     });
   });
@@ -2130,41 +2205,43 @@ branch refs/heads/feature/auth
     test('returns origin when it exists among multiple remotes', async () => {
       execSpy.mockResolvedValue({ stdout: 'upstream\norigin\n', stderr: '' });
 
-      const result = await git.getDefaultRemote('/workspace/repo');
+      const result = await git.getDefaultRemote(repo('/workspace/repo'));
       expect(result).toBe('origin');
     });
 
     test('returns sole remote when only one is configured', async () => {
       execSpy.mockResolvedValue({ stdout: 'mar\n', stderr: '' });
 
-      const result = await git.getDefaultRemote('/workspace/repo');
+      const result = await git.getDefaultRemote(repo('/workspace/repo'));
       expect(result).toBe('mar');
     });
 
     test('returns null when multiple non-origin remotes exist', async () => {
       execSpy.mockResolvedValue({ stdout: 'jan\nfeb\nmar\n', stderr: '' });
 
-      const result = await git.getDefaultRemote('/workspace/repo');
+      const result = await git.getDefaultRemote(repo('/workspace/repo'));
       expect(result).toBeNull();
     });
 
     test('returns null when no remotes are configured', async () => {
       execSpy.mockResolvedValue({ stdout: '', stderr: '' });
 
-      const result = await git.getDefaultRemote('/workspace/repo');
+      const result = await git.getDefaultRemote(repo('/workspace/repo'));
       expect(result).toBeNull();
     });
 
     test('propagates git errors instead of swallowing them', async () => {
       execSpy.mockRejectedValue(new Error('not a git repository'));
 
-      await expect(git.getDefaultRemote('/workspace/repo')).rejects.toThrow('not a git repository');
+      await expect(git.getDefaultRemote(repo('/workspace/repo'))).rejects.toThrow(
+        'not a git repository'
+      );
     });
 
     test('handles CRLF line endings from git output', async () => {
       execSpy.mockResolvedValue({ stdout: 'origin\r\nupstream\r\n', stderr: '' });
 
-      const result = await git.getDefaultRemote('/workspace/repo');
+      const result = await git.getDefaultRemote(repo('/workspace/repo'));
       expect(result).toBe('origin');
     });
   });
@@ -2183,7 +2260,10 @@ branch refs/heads/feature/auth
     test('clones successfully without token', async () => {
       execSpy.mockResolvedValue({ stdout: '', stderr: '' });
 
-      const result = await git.cloneRepository('https://github.com/owner/repo.git', '/tmp/target');
+      const result = await git.cloneRepository(
+        'https://github.com/owner/repo.git',
+        repo('/tmp/target')
+      );
 
       expect(result).toEqual({ ok: true, value: undefined });
       expect(execSpy).toHaveBeenCalledWith(
@@ -2199,7 +2279,7 @@ branch refs/heads/feature/auth
     test('passes GIT_TERMINAL_PROMPT=0 to the git clone subprocess', async () => {
       execSpy.mockResolvedValue({ stdout: '', stderr: '' });
 
-      await git.cloneRepository('https://github.com/owner/repo.git', '/tmp/target');
+      await git.cloneRepository('https://github.com/owner/repo.git', repo('/tmp/target'));
 
       const env = execSpy.mock.calls[0]![2]?.env ?? {};
       expect(env.GIT_TERMINAL_PROMPT).toBe('0');
@@ -2214,9 +2294,13 @@ branch refs/heads/feature/auth
     test('constructs authenticated URL with token', async () => {
       execSpy.mockResolvedValue({ stdout: '', stderr: '' });
 
-      const result = await git.cloneRepository('https://github.com/owner/repo.git', '/tmp/target', {
-        token: 'ghp_abc123',
-      });
+      const result = await git.cloneRepository(
+        'https://github.com/owner/repo.git',
+        repo('/tmp/target'),
+        {
+          token: 'ghp_abc123',
+        }
+      );
 
       expect(result).toEqual({ ok: true, value: undefined });
       // Verify the token is in the URL
@@ -2230,7 +2314,7 @@ branch refs/heads/feature/auth
 
       const result = await git.cloneRepository(
         'https://github.com/owner/missing.git',
-        '/tmp/target'
+        repo('/tmp/target')
       );
 
       expect(result.ok).toBe(false);
@@ -2244,7 +2328,7 @@ branch refs/heads/feature/auth
 
       const result = await git.cloneRepository(
         'https://github.com/owner/private.git',
-        '/tmp/target'
+        repo('/tmp/target')
       );
 
       expect(result.ok).toBe(false);
@@ -2256,7 +2340,10 @@ branch refs/heads/feature/auth
     test('returns no_space error when disk full', async () => {
       execSpy.mockRejectedValue(new Error('error: no space left on device'));
 
-      const result = await git.cloneRepository('https://github.com/owner/repo.git', '/tmp/target');
+      const result = await git.cloneRepository(
+        'https://github.com/owner/repo.git',
+        repo('/tmp/target')
+      );
 
       expect(result.ok).toBe(false);
       if (!result.ok) {
@@ -2267,7 +2354,10 @@ branch refs/heads/feature/auth
     test('returns unknown error for unexpected failures', async () => {
       execSpy.mockRejectedValue(new Error('segfault'));
 
-      const result = await git.cloneRepository('https://github.com/owner/repo.git', '/tmp/target');
+      const result = await git.cloneRepository(
+        'https://github.com/owner/repo.git',
+        repo('/tmp/target')
+      );
 
       expect(result.ok).toBe(false);
       if (!result.ok) {
@@ -2290,7 +2380,7 @@ branch refs/heads/feature/auth
     test('fetches and resets successfully', async () => {
       execSpy.mockResolvedValue({ stdout: '', stderr: '' });
 
-      const result = await git.syncRepository('/workspace/repo', 'main');
+      const result = await git.syncRepository(repo('/workspace/repo'), branch('main'));
 
       expect(result).toEqual({ ok: true, value: undefined });
       expect(execSpy).toHaveBeenCalledWith('git', ['fetch', 'origin'], {
@@ -2306,7 +2396,7 @@ branch refs/heads/feature/auth
     test('fetches and resets using a custom remote', async () => {
       execSpy.mockResolvedValue({ stdout: '', stderr: '' });
 
-      const result = await git.syncRepository('/workspace/repo', 'main', 'upstream');
+      const result = await git.syncRepository(repo('/workspace/repo'), branch('main'), 'upstream');
 
       expect(result).toEqual({ ok: true, value: undefined });
       expect(execSpy).toHaveBeenCalledWith('git', ['fetch', 'upstream'], {
@@ -2322,7 +2412,7 @@ branch refs/heads/feature/auth
     test('skips reset if fetch fails', async () => {
       execSpy.mockRejectedValue(new Error('fatal: unable to access'));
 
-      const result = await git.syncRepository('/workspace/repo', 'main');
+      const result = await git.syncRepository(repo('/workspace/repo'), branch('main'));
 
       expect(result.ok).toBe(false);
       if (!result.ok) {
@@ -2341,7 +2431,7 @@ branch refs/heads/feature/auth
       error.stderr = 'fatal: not a git repository (or any parent up to mount point /)';
       execSpy.mockRejectedValue(error);
 
-      const result = await git.syncRepository('/workspace/repo', 'main');
+      const result = await git.syncRepository(repo('/workspace/repo'), branch('main'));
 
       expect(result.ok).toBe(false);
       if (!result.ok) {
@@ -2355,7 +2445,7 @@ branch refs/heads/feature/auth
     test('returns permission_denied error when fetch fails with "authentication failed"', async () => {
       execSpy.mockRejectedValue(new Error('fatal: Authentication failed for repository'));
 
-      const result = await git.syncRepository('/workspace/repo', 'main');
+      const result = await git.syncRepository(repo('/workspace/repo'), branch('main'));
 
       expect(result.ok).toBe(false);
       if (!result.ok) {
@@ -2366,7 +2456,7 @@ branch refs/heads/feature/auth
     test('returns no_space error when fetch fails with "no space"', async () => {
       execSpy.mockRejectedValue(new Error('error: no space left on device'));
 
-      const result = await git.syncRepository('/workspace/repo', 'main');
+      const result = await git.syncRepository(repo('/workspace/repo'), branch('main'));
 
       expect(result.ok).toBe(false);
       if (!result.ok) {
@@ -2385,7 +2475,7 @@ branch refs/heads/feature/auth
         return { stdout: '', stderr: '' };
       });
 
-      const result = await git.syncRepository('/workspace/repo', 'nonexistent');
+      const result = await git.syncRepository(repo('/workspace/repo'), branch('nonexistent'));
 
       expect(result.ok).toBe(false);
       if (!result.ok) {
@@ -2404,7 +2494,7 @@ branch refs/heads/feature/auth
         return { stdout: '', stderr: '' };
       });
 
-      const result = await git.syncRepository('/workspace/repo', 'main');
+      const result = await git.syncRepository(repo('/workspace/repo'), branch('main'));
 
       expect(result.ok).toBe(false);
       if (!result.ok) {
@@ -2427,7 +2517,7 @@ branch refs/heads/feature/auth
     test('calls git config with correct arguments', async () => {
       execSpy.mockResolvedValue({ stdout: '', stderr: '' });
 
-      await git.addSafeDirectory('/workspace/repo');
+      await git.addSafeDirectory(repo('/workspace/repo'));
 
       expect(execSpy).toHaveBeenCalledWith(
         'git',
@@ -2439,7 +2529,7 @@ branch refs/heads/feature/auth
     test('uses execFileAsync (not shell exec)', async () => {
       execSpy.mockResolvedValue({ stdout: '', stderr: '' });
 
-      await git.addSafeDirectory('/workspace/path with spaces');
+      await git.addSafeDirectory(repo('/workspace/path with spaces'));
 
       // If this were shell exec, spaces in the path would cause issues.
       // execFileAsync passes args as array, so path with spaces is safe.
@@ -2466,7 +2556,7 @@ branch refs/heads/feature/auth
       execSpy.mockResolvedValue({ stdout: '/workspace/repo\n', stderr: '' });
 
       const result = await git.findRepoRoot('/workspace/repo/src');
-      expect(result).toBe('/workspace/repo');
+      expect(result).toBe(repo('/workspace/repo'));
     });
 
     test('returns null for non-git directory', async () => {
@@ -2546,7 +2636,7 @@ branch refs/heads/feature/auth
         stderr: '',
       });
 
-      const result = await git.getRemoteUrl('/workspace/repo');
+      const result = await git.getRemoteUrl(repo('/workspace/repo'));
       expect(result).toBe('https://github.com/owner/repo.git');
     });
 
@@ -2556,7 +2646,7 @@ branch refs/heads/feature/auth
         stderr: '',
       });
 
-      await git.getRemoteUrl('/workspace/repo', 'upstream');
+      await git.getRemoteUrl(repo('/workspace/repo'), 'upstream');
 
       expect(execSpy).toHaveBeenCalledWith(
         'git',
@@ -2568,14 +2658,16 @@ branch refs/heads/feature/auth
     test('returns null when no remote configured', async () => {
       execSpy.mockRejectedValue(new Error('fatal: No such remote'));
 
-      const result = await git.getRemoteUrl('/workspace/repo');
+      const result = await git.getRemoteUrl(repo('/workspace/repo'));
       expect(result).toBeNull();
     });
 
     test('throws for unexpected errors', async () => {
       execSpy.mockRejectedValue(new Error('fatal: permission denied'));
 
-      await expect(git.getRemoteUrl('/workspace/repo')).rejects.toThrow('Failed to get remote URL');
+      await expect(git.getRemoteUrl(repo('/workspace/repo'))).rejects.toThrow(
+        'Failed to get remote URL'
+      );
     });
   });
 
@@ -2586,17 +2678,17 @@ branch refs/heads/feature/auth
   describe('branded types', () => {
     test('toRepoPath returns the same string value', () => {
       const path = git.toRepoPath('/workspace/repo');
-      expect(path).toBe('/workspace/repo');
+      expect(path).toBe(repo('/workspace/repo'));
     });
 
     test('toBranchName returns the same string value', () => {
       const name = git.toBranchName('feature/auth');
-      expect(name).toBe('feature/auth');
+      expect(name).toBe(branch('feature/auth'));
     });
 
     test('toWorktreePath returns the same string value', () => {
       const path = git.toWorktreePath('/workspace/worktrees/feature');
-      expect(path).toBe('/workspace/worktrees/feature');
+      expect(path).toBe(worktree('/workspace/worktrees/feature'));
     });
 
     test('toRepoPath rejects empty string', () => {
@@ -2630,7 +2722,7 @@ branch refs/heads/feature/auth
     test('calls git worktree remove with correct arguments', async () => {
       execSpy.mockResolvedValue({ stdout: '', stderr: '' });
 
-      await git.removeWorktree('/workspace/repo', '/workspace/worktrees/issue-42');
+      await git.removeWorktree(repo('/workspace/repo'), worktree('/workspace/worktrees/issue-42'));
 
       expect(execSpy).toHaveBeenCalledWith(
         'git',
@@ -2643,7 +2735,7 @@ branch refs/heads/feature/auth
       execSpy.mockRejectedValue(new Error('fatal: cannot remove: has changes'));
 
       await expect(
-        git.removeWorktree('/workspace/repo', '/workspace/worktrees/dirty')
+        git.removeWorktree(repo('/workspace/repo'), worktree('/workspace/worktrees/dirty'))
       ).rejects.toThrow('has changes');
     });
   });
@@ -2663,7 +2755,7 @@ branch refs/heads/feature/auth
       mockLogger.error.mockClear();
       execSpy.mockRejectedValue(new Error('fatal: could not lock config file'));
 
-      await expect(git.addSafeDirectory('/workspace/repo')).rejects.toThrow(
+      await expect(git.addSafeDirectory(repo('/workspace/repo'))).rejects.toThrow(
         "Failed to add safe directory '/workspace/repo': fatal: could not lock config file"
       );
       expect(mockLogger.error).toHaveBeenCalledWith(

--- a/packages/git/tsconfig.json
+++ b/packages/git/tsconfig.json
@@ -4,5 +4,5 @@
     "noEmit": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/isolation/src/pr-state.test.ts
+++ b/packages/isolation/src/pr-state.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { describe, test, expect, mock } from 'bun:test';
 
 const mockLogger = {
   fatal: mock(() => undefined),
@@ -29,9 +29,10 @@ mock.module('@archon/git', () => ({
 }));
 
 import { getPrState, type PrState } from './pr-state';
+import { toBranchName, toRepoPath } from '@archon/git';
 
-const REPO = '/workspace/repo';
-const BRANCH = 'feature-branch';
+const REPO = toRepoPath('/workspace/repo');
+const BRANCH = toBranchName('feature-branch');
 
 function setupGhResponse(remoteUrl: string, ghStdout: string | Error): void {
   mockExecFileAsync.mockReset();

--- a/packages/isolation/src/providers/worktree.test.ts
+++ b/packages/isolation/src/providers/worktree.test.ts
@@ -69,9 +69,11 @@ let getDefaultRemoteSpy: Mock<typeof git.getDefaultRemote>;
 let syncWorkspaceSpy: Mock<typeof git.syncWorkspace>;
 
 // Mock fs.promises.access for destroy() existence check
-const mockAccess = mock(() => Promise.resolve());
-const mockReadFile = mock(() => Promise.reject(new Error('ENOENT')));
-const mockRm = mock(() => Promise.resolve());
+const mockAccess = mock((_path?: unknown) => Promise.resolve());
+const mockReadFile = mock(
+  (_path?: unknown): Promise<string> => Promise.reject(new Error('ENOENT'))
+);
+const mockRm = mock((_path?: unknown) => Promise.resolve());
 mock.module('node:fs/promises', () => ({
   access: mockAccess,
   readFile: mockReadFile,
@@ -91,7 +93,7 @@ describe('WorktreeProvider', () => {
   let getCanonicalRepoPathSpy: Mock<typeof git.getCanonicalRepoPath>;
 
   beforeEach(() => {
-    mockConfigLoader = async () => ({ baseBranch: 'main' });
+    mockConfigLoader = async () => ({ baseBranch: git.toBranchName('main') });
     provider = new WorktreeProvider(mockConfigLoader);
     execSpy = spyOn(git, 'execFileAsync');
     mkdirSpy = spyOn(git, 'mkdirAsync');
@@ -109,7 +111,7 @@ describe('WorktreeProvider', () => {
     worktreeExistsSpy.mockResolvedValue(false);
     listWorktreesSpy.mockResolvedValue([]);
     findWorktreeByBranchSpy.mockResolvedValue(null);
-    getCanonicalRepoPathSpy.mockImplementation(async path => path);
+    getCanonicalRepoPathSpy.mockImplementation(async path => git.toRepoPath(path));
     // Most paths exist by default (directoryExists checks for destroy etc.),
     // but .gitmodules is absent by default — most repos don't use submodules,
     // and default-on submodule init must skip cleanly in that case.
@@ -125,10 +127,10 @@ describe('WorktreeProvider', () => {
     mockRm.mockResolvedValue(undefined);
 
     // Default mocks for workspace sync
-    getDefaultBranchSpy.mockResolvedValue('main');
+    getDefaultBranchSpy.mockResolvedValue(git.toBranchName('main'));
     getDefaultRemoteSpy.mockResolvedValue('origin');
     syncWorkspaceSpy.mockResolvedValue({
-      branch: 'main',
+      branch: git.toBranchName('main'),
       synced: true,
       mode: 'fast-forward',
       state: 'in_sync',
@@ -157,7 +159,7 @@ describe('WorktreeProvider', () => {
     test('generates issue-N for issue workflows', () => {
       const request: IsolationRequest = {
         codebaseId: 'cb-123',
-        canonicalRepoPath: '/workspace/repo',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
         workflowType: 'issue',
         identifier: '42',
       };
@@ -167,10 +169,10 @@ describe('WorktreeProvider', () => {
     test('generates actual branch name for same-repo PR workflows', () => {
       const request: PRIsolationRequest = {
         codebaseId: 'cb-123',
-        canonicalRepoPath: '/workspace/repo',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
         workflowType: 'pr',
         identifier: '123',
-        prBranch: 'feature/auth',
+        prBranch: git.toBranchName('feature/auth'),
         isForkPR: false,
       };
       expect(provider.generateBranchName(request)).toBe('feature/auth');
@@ -179,10 +181,10 @@ describe('WorktreeProvider', () => {
     test('generates pr-N-review for fork PR workflows', () => {
       const request: PRIsolationRequest = {
         codebaseId: 'cb-123',
-        canonicalRepoPath: '/workspace/repo',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
         workflowType: 'pr',
         identifier: '123',
-        prBranch: 'feature/auth',
+        prBranch: git.toBranchName('feature/auth'),
         isForkPR: true,
       };
       expect(provider.generateBranchName(request)).toBe('archon/pr-123-review');
@@ -191,7 +193,7 @@ describe('WorktreeProvider', () => {
     test('generates review-N for review workflows', () => {
       const request: IsolationRequest = {
         codebaseId: 'cb-123',
-        canonicalRepoPath: '/workspace/repo',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
         workflowType: 'review',
         identifier: '456',
       };
@@ -201,7 +203,7 @@ describe('WorktreeProvider', () => {
     test('generates thread-{hash} for thread workflows', () => {
       const request: IsolationRequest = {
         codebaseId: 'cb-123',
-        canonicalRepoPath: '/workspace/repo',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
         workflowType: 'thread',
         identifier: 'C123:1234567890.123456',
       };
@@ -212,7 +214,7 @@ describe('WorktreeProvider', () => {
     test('generates consistent hash for same identifier', () => {
       const request: IsolationRequest = {
         codebaseId: 'cb-123',
-        canonicalRepoPath: '/workspace/repo',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
         workflowType: 'thread',
         identifier: 'same-thread-id',
       };
@@ -224,13 +226,13 @@ describe('WorktreeProvider', () => {
     test('generates different hashes for different identifiers', () => {
       const request1: IsolationRequest = {
         codebaseId: 'cb-123',
-        canonicalRepoPath: '/workspace/repo',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
         workflowType: 'thread',
         identifier: 'thread-1',
       };
       const request2: IsolationRequest = {
         codebaseId: 'cb-123',
-        canonicalRepoPath: '/workspace/repo',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
         workflowType: 'thread',
         identifier: 'thread-2',
       };
@@ -240,7 +242,7 @@ describe('WorktreeProvider', () => {
     test('generates task-{slug} for task workflows', () => {
       const request: IsolationRequest = {
         codebaseId: 'cb-123',
-        canonicalRepoPath: '/workspace/repo',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
         workflowType: 'task',
         identifier: 'add-dark-mode',
       };
@@ -250,7 +252,7 @@ describe('WorktreeProvider', () => {
     test('slugifies task identifiers properly', () => {
       const request: IsolationRequest = {
         codebaseId: 'cb-123',
-        canonicalRepoPath: '/workspace/repo',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
         workflowType: 'task',
         identifier: 'Add Dark Mode!!!',
       };
@@ -261,7 +263,7 @@ describe('WorktreeProvider', () => {
   describe('create', () => {
     const baseRequest: IsolationRequest = {
       codebaseId: 'cb-123',
-      canonicalRepoPath: '/workspace/repo',
+      canonicalRepoPath: git.toRepoPath('/workspace/repo'),
       workflowType: 'issue',
       identifier: '42',
     };
@@ -270,7 +272,7 @@ describe('WorktreeProvider', () => {
       const env = await provider.create(baseRequest);
 
       expect(env.provider).toBe('worktree');
-      expect(env.branchName).toBe('archon/issue-42');
+      expect(env.branchName).toBe(git.toBranchName('archon/issue-42'));
       expect(env.workingPath).toContain('issue-42');
       expect(env.status).toBe('active');
 
@@ -314,7 +316,7 @@ describe('WorktreeProvider', () => {
         ...baseRequest,
         workflowType: 'task',
         identifier: 'test-adapters',
-        fromBranch: 'feature/extract-adapters',
+        fromBranch: git.toBranchName('feature/extract-adapters'),
       };
 
       await provider.create(request);
@@ -350,7 +352,7 @@ describe('WorktreeProvider', () => {
         ...baseRequest,
         workflowType: 'task',
         identifier: 'test-adapters',
-        fromBranch: 'feature/extract-adapters',
+        fromBranch: git.toBranchName('feature/extract-adapters'),
       };
 
       await expect(provider.create(request)).rejects.toThrow(
@@ -405,7 +407,7 @@ describe('WorktreeProvider', () => {
         ...baseRequest,
         workflowType: 'pr',
         identifier: '42',
-        prBranch: 'feature/auth',
+        prBranch: git.toBranchName('feature/auth'),
         isForkPR: false,
       };
 
@@ -453,7 +455,7 @@ describe('WorktreeProvider', () => {
         ...baseRequest,
         workflowType: 'pr',
         identifier: '42',
-        prBranch: 'feature/auth',
+        prBranch: git.toBranchName('feature/auth'),
         prSha: 'abc123def456',
         isForkPR: true,
       };
@@ -501,7 +503,7 @@ describe('WorktreeProvider', () => {
         ...baseRequest,
         workflowType: 'pr',
         identifier: '42',
-        prBranch: 'feature/auth',
+        prBranch: git.toBranchName('feature/auth'),
         isForkPR: true,
       };
 
@@ -538,10 +540,10 @@ describe('WorktreeProvider', () => {
     test('creates worktree for fork PR (uses synthetic review branch)', async () => {
       const request: PRIsolationRequest = {
         codebaseId: 'cb-123',
-        canonicalRepoPath: '/workspace/repo',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
         workflowType: 'pr',
         identifier: '42',
-        prBranch: 'feature/external',
+        prBranch: git.toBranchName('feature/external'),
         isForkPR: true,
       };
 
@@ -618,7 +620,9 @@ describe('WorktreeProvider', () => {
     test('adopts across path normalization differences (trailing slash)', async () => {
       const request: IsolationRequest = {
         ...baseRequest,
-        canonicalRepoPath: '/workspace/repo/' as IsolationRequest['canonicalRepoPath'],
+        canonicalRepoPath: git.toRepoPath(
+          '/workspace/repo/'
+        ) as IsolationRequest['canonicalRepoPath'],
       };
       worktreeExistsSpy.mockResolvedValue(true);
       // .git file has no trailing slash — resolve() should normalize
@@ -632,17 +636,19 @@ describe('WorktreeProvider', () => {
     test('adopts worktree by PR branch name (skill symbiosis)', async () => {
       const request: PRIsolationRequest = {
         codebaseId: 'cb-123',
-        canonicalRepoPath: '/workspace/repo',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
         workflowType: 'pr',
         identifier: '42',
-        prBranch: 'feature/auth',
+        prBranch: git.toBranchName('feature/auth'),
         isForkPR: false,
       };
 
       // First check (expected path) returns false
       worktreeExistsSpy.mockResolvedValueOnce(false);
       // findWorktreeByBranch finds existing worktree
-      findWorktreeByBranchSpy.mockResolvedValue('/workspace/worktrees/repo/feature-auth');
+      findWorktreeByBranchSpy.mockResolvedValue(
+        git.toWorktreePath('/workspace/worktrees/repo/feature-auth')
+      );
       // Same-clone ownership match so adoption proceeds
       mockReadFile.mockResolvedValue('gitdir: /workspace/repo/.git/worktrees/feature-auth\n');
 
@@ -663,16 +669,18 @@ describe('WorktreeProvider', () => {
     test('throws when PR-branch-adopted worktree belongs to a different clone', async () => {
       const request: PRIsolationRequest = {
         codebaseId: 'cb-123',
-        canonicalRepoPath: '/workspace/repo',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
         workflowType: 'pr',
         identifier: '42',
-        prBranch: 'feature/auth',
+        prBranch: git.toBranchName('feature/auth'),
         isForkPR: false,
       };
 
       // Primary path misses, secondary findWorktreeByBranch hits
       worktreeExistsSpy.mockResolvedValueOnce(false);
-      findWorktreeByBranchSpy.mockResolvedValue('/workspace/worktrees/repo/feature-auth');
+      findWorktreeByBranchSpy.mockResolvedValue(
+        git.toWorktreePath('/workspace/worktrees/repo/feature-auth')
+      );
       // .git points to a different clone
       mockReadFile.mockResolvedValue('gitdir: /other/clone/.git/worktrees/feature-auth\n');
 
@@ -790,7 +798,7 @@ describe('WorktreeProvider', () => {
         ...baseRequest,
         workflowType: 'pr',
         identifier: '42',
-        prBranch: 'feature/auth',
+        prBranch: git.toBranchName('feature/auth'),
         isForkPR: false,
       };
 
@@ -811,7 +819,7 @@ describe('WorktreeProvider', () => {
         ...baseRequest,
         workflowType: 'pr',
         identifier: '42',
-        prBranch: 'feature/auth',
+        prBranch: git.toBranchName('feature/auth'),
         isForkPR: true,
       };
 
@@ -832,7 +840,7 @@ describe('WorktreeProvider', () => {
         ...baseRequest,
         workflowType: 'pr',
         identifier: '42',
-        prBranch: 'feature/auth',
+        prBranch: git.toBranchName('feature/auth'),
         isForkPR: false,
       };
 
@@ -872,7 +880,7 @@ describe('WorktreeProvider', () => {
         ...baseRequest,
         workflowType: 'pr',
         identifier: '42',
-        prBranch: 'feature/auth',
+        prBranch: git.toBranchName('feature/auth'),
         prSha: 'abc123',
         isForkPR: true,
       };
@@ -911,7 +919,7 @@ describe('WorktreeProvider', () => {
         ...baseRequest,
         workflowType: 'pr',
         identifier: '42',
-        prBranch: 'feature/auth',
+        prBranch: git.toBranchName('feature/auth'),
         isForkPR: true,
       };
 
@@ -948,7 +956,7 @@ describe('WorktreeProvider', () => {
         ...baseRequest,
         workflowType: 'pr',
         identifier: '42',
-        prBranch: 'feature/auth',
+        prBranch: git.toBranchName('feature/auth'),
         isForkPR: true,
       };
 
@@ -972,7 +980,7 @@ describe('WorktreeProvider', () => {
     test('propagates permission error when workspace sync fails during creation', async () => {
       const request: IsolationRequest = {
         codebaseId: 'cb-123',
-        canonicalRepoPath: '/workspace/repo',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
         workflowType: 'issue',
         identifier: '99',
       };
@@ -989,7 +997,7 @@ describe('WorktreeProvider', () => {
       const request: IsolationRequest = {
         codebaseId: 'cb-local',
         codebaseName: 'Widinglabs/sasha-demo',
-        canonicalRepoPath: '/Users/rasmus/Projects/sasha-demo', // not under workspaces
+        canonicalRepoPath: git.toRepoPath('/Users/rasmus/Projects/sasha-demo'), // not under workspaces
         workflowType: 'task',
         identifier: 'fix-issue-42',
       };
@@ -1055,7 +1063,7 @@ describe('WorktreeProvider', () => {
 
     test('initializes submodules when explicitly opted in and .gitmodules exists', async () => {
       const configLoader: RepoConfigLoader = async () => ({
-        baseBranch: 'main',
+        baseBranch: git.toBranchName('main'),
         initSubmodules: true,
       });
       const submoduleProvider = new WorktreeProvider(configLoader);
@@ -1071,7 +1079,7 @@ describe('WorktreeProvider', () => {
 
     test('skips submodule init when initSubmodules is false', async () => {
       const configLoader: RepoConfigLoader = async () => ({
-        baseBranch: 'main',
+        baseBranch: git.toBranchName('main'),
         initSubmodules: false,
       });
       const noSubmoduleProvider = new WorktreeProvider(configLoader);
@@ -1092,7 +1100,7 @@ describe('WorktreeProvider', () => {
 
     test('throws classifiable error when submodule init fails (fail-fast)', async () => {
       const configLoader: RepoConfigLoader = async () => ({
-        baseBranch: 'main',
+        baseBranch: git.toBranchName('main'),
         initSubmodules: true,
       });
       const submoduleProvider = new WorktreeProvider(configLoader);
@@ -1117,7 +1125,7 @@ describe('WorktreeProvider', () => {
 
     test('throws when .gitmodules read fails with EACCES (fail-fast, no silent skip)', async () => {
       const configLoader: RepoConfigLoader = async () => ({
-        baseBranch: 'main',
+        baseBranch: git.toBranchName('main'),
         initSubmodules: true,
       });
       const submoduleProvider = new WorktreeProvider(configLoader);
@@ -1143,7 +1151,7 @@ describe('WorktreeProvider', () => {
 
     test('throws classifiable error when submodule init times out', async () => {
       const configLoader: RepoConfigLoader = async () => ({
-        baseBranch: 'main',
+        baseBranch: git.toBranchName('main'),
         initSubmodules: true,
       });
       const submoduleProvider = new WorktreeProvider(configLoader);
@@ -1171,10 +1179,10 @@ describe('WorktreeProvider', () => {
 
   describe('destroy', () => {
     test('removes worktree', async () => {
-      const worktreePath = '/workspace/worktrees/repo/issue-42';
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/issue-42');
 
       // Mock getCanonicalRepoPath to return the repo path
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
 
       await provider.destroy(worktreePath);
 
@@ -1186,10 +1194,10 @@ describe('WorktreeProvider', () => {
     });
 
     test('uses force flag when specified', async () => {
-      const worktreePath = '/workspace/worktrees/repo/issue-42';
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/issue-42');
 
       // Mock getCanonicalRepoPath to return the repo path
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
 
       await provider.destroy(worktreePath, { force: true });
 
@@ -1208,7 +1216,7 @@ describe('WorktreeProvider', () => {
     });
 
     test('returns gracefully when path does not exist (ENOENT) without canonicalRepoPath', async () => {
-      const worktreePath = '/workspace/worktrees/repo/nonexistent';
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/nonexistent');
 
       // access() throws ENOENT
       const enoentError = new Error('ENOENT: no such file or directory') as NodeJS.ErrnoException;
@@ -1216,15 +1224,15 @@ describe('WorktreeProvider', () => {
       mockAccess.mockRejectedValueOnce(enoentError);
 
       // Should not throw - but can't clean up branch without canonicalRepoPath
-      await provider.destroy(worktreePath, { branchName: 'test-branch' });
+      await provider.destroy(worktreePath, { branchName: git.toBranchName('test-branch') });
 
       // Should NOT call git commands (no canonicalRepoPath to run them in)
       expect(execSpy).not.toHaveBeenCalled();
     });
 
     test('cleans up branch when path does not exist but canonicalRepoPath provided', async () => {
-      const worktreePath = '/workspace/worktrees/repo/nonexistent';
-      const branchName = 'pr-42-review';
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/nonexistent');
+      const branchName = git.toBranchName('pr-42-review');
 
       // access() throws ENOENT
       const enoentError = new Error('ENOENT: no such file or directory') as NodeJS.ErrnoException;
@@ -1234,7 +1242,7 @@ describe('WorktreeProvider', () => {
       // Should not throw - and should still clean up branch
       await provider.destroy(worktreePath, {
         branchName,
-        canonicalRepoPath: '/workspace/repo',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
       });
 
       // Should NOT call git worktree remove (path doesn't exist)
@@ -1253,7 +1261,7 @@ describe('WorktreeProvider', () => {
     });
 
     test('re-throws non-ENOENT errors from access check', async () => {
-      const worktreePath = '/workspace/worktrees/repo/nopermission';
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/nopermission');
 
       // access() throws EACCES (permission denied)
       const eaccesError = new Error('EACCES: permission denied') as NodeJS.ErrnoException;
@@ -1268,9 +1276,9 @@ describe('WorktreeProvider', () => {
     });
 
     test('returns gracefully when git worktree remove fails with "No such file or directory"', async () => {
-      const worktreePath = '/workspace/worktrees/repo/issue-42';
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/issue-42');
 
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
       // git worktree remove fails
       execSpy.mockRejectedValueOnce(
         new Error(
@@ -1283,9 +1291,9 @@ describe('WorktreeProvider', () => {
     });
 
     test('returns gracefully when git worktree remove fails with "is not a working tree"', async () => {
-      const worktreePath = '/workspace/worktrees/repo/issue-42';
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/issue-42');
 
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
       // git worktree remove fails because it's not a working tree
       const error = new Error('fatal: some error') as Error & { stderr?: string };
       error.stderr = "fatal: '/workspace/worktrees/repo/issue-42' is not a working tree";
@@ -1296,9 +1304,9 @@ describe('WorktreeProvider', () => {
     });
 
     test('re-throws non-directory errors from git worktree remove', async () => {
-      const worktreePath = '/workspace/worktrees/repo/issue-42';
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/issue-42');
 
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
       // git worktree remove fails with uncommitted changes error
       execSpy.mockRejectedValueOnce(
         new Error('fatal: cannot remove: You have local modifications')
@@ -1309,10 +1317,10 @@ describe('WorktreeProvider', () => {
     });
 
     test('deletes branch when branchName provided', async () => {
-      const worktreePath = '/workspace/worktrees/repo/pr-42-review';
-      const branchName = 'pr-42-review';
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/pr-42-review');
+      const branchName = git.toBranchName('pr-42-review');
 
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
 
       await provider.destroy(worktreePath, { branchName });
 
@@ -1332,10 +1340,10 @@ describe('WorktreeProvider', () => {
     });
 
     test('continues if branch deletion fails', async () => {
-      const worktreePath = '/workspace/worktrees/repo/pr-42-review';
-      const branchName = 'pr-42-review';
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/pr-42-review');
+      const branchName = git.toBranchName('pr-42-review');
 
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
 
       execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
         // Branch deletion fails
@@ -1357,9 +1365,9 @@ describe('WorktreeProvider', () => {
     });
 
     test('does not attempt branch deletion when branchName not provided', async () => {
-      const worktreePath = '/workspace/worktrees/repo/pr-42-review';
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/pr-42-review');
 
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
 
       await provider.destroy(worktreePath);
 
@@ -1379,10 +1387,10 @@ describe('WorktreeProvider', () => {
     });
 
     test('still deletes branch even when worktree path does not exist', async () => {
-      const worktreePath = '/workspace/worktrees/repo/pr-42-review';
-      const branchName = 'pr-42-review';
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/pr-42-review');
+      const branchName = git.toBranchName('pr-42-review');
 
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
       // git worktree remove fails because path doesn't exist
       execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
         if (args.includes('worktree')) {
@@ -1405,10 +1413,12 @@ describe('WorktreeProvider', () => {
     });
 
     test('returns DestroyResult with all fields true on full success', async () => {
-      const worktreePath = '/workspace/worktrees/repo/issue-42';
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/issue-42');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
 
-      const result = await provider.destroy(worktreePath, { branchName: 'issue-42' });
+      const result = await provider.destroy(worktreePath, {
+        branchName: git.toBranchName('issue-42'),
+      });
 
       expect(result.worktreeRemoved).toBe(true);
       expect(result.directoryClean).toBe(true);
@@ -1418,12 +1428,14 @@ describe('WorktreeProvider', () => {
     });
 
     test('returns warning when branch cleanup skipped (no canonicalRepoPath)', async () => {
-      const worktreePath = '/workspace/worktrees/repo/nonexistent';
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/nonexistent');
       const enoentError = new Error('ENOENT') as NodeJS.ErrnoException;
       enoentError.code = 'ENOENT';
       mockAccess.mockRejectedValueOnce(enoentError);
 
-      const result = await provider.destroy(worktreePath, { branchName: 'test-branch' });
+      const result = await provider.destroy(worktreePath, {
+        branchName: git.toBranchName('test-branch'),
+      });
 
       expect(result.worktreeRemoved).toBe(true);
       expect(result.branchDeleted).toBeNull(); // Could not attempt (no repo path)
@@ -1432,8 +1444,8 @@ describe('WorktreeProvider', () => {
     });
 
     test('returns branchDeleted=null when no branch requested', async () => {
-      const worktreePath = '/workspace/worktrees/repo/issue-42';
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/issue-42');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
 
       const result = await provider.destroy(worktreePath);
 
@@ -1444,8 +1456,8 @@ describe('WorktreeProvider', () => {
     });
 
     test('returns branchDeleted=false with warning when branch is checked out elsewhere', async () => {
-      const worktreePath = '/workspace/worktrees/repo/issue-42';
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/issue-42');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
 
       execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
         if (args.includes('branch') && args.includes('-D')) {
@@ -1456,7 +1468,9 @@ describe('WorktreeProvider', () => {
         return { stdout: '', stderr: '' };
       });
 
-      const result = await provider.destroy(worktreePath, { branchName: 'issue-42' });
+      const result = await provider.destroy(worktreePath, {
+        branchName: git.toBranchName('issue-42'),
+      });
 
       expect(result.worktreeRemoved).toBe(true);
       expect(result.branchDeleted).toBe(false);
@@ -1465,11 +1479,11 @@ describe('WorktreeProvider', () => {
     });
 
     test('deletes remote branch when deleteRemoteBranch is true', async () => {
-      const worktreePath = '/workspace/worktrees/repo/pr-99';
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/pr-99');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
 
       const result = await provider.destroy(worktreePath, {
-        branchName: 'feature-branch',
+        branchName: git.toBranchName('feature-branch'),
         deleteRemoteBranch: true,
       });
 
@@ -1482,8 +1496,8 @@ describe('WorktreeProvider', () => {
     });
 
     test('returns remoteBranchDeleted=true when remote ref does not exist', async () => {
-      const worktreePath = '/workspace/worktrees/repo/pr-99';
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/pr-99');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
 
       execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
         if (args.includes('push') && args.includes('--delete')) {
@@ -1495,7 +1509,7 @@ describe('WorktreeProvider', () => {
       });
 
       const result = await provider.destroy(worktreePath, {
-        branchName: 'feature-branch',
+        branchName: git.toBranchName('feature-branch'),
         deleteRemoteBranch: true,
       });
 
@@ -1504,8 +1518,8 @@ describe('WorktreeProvider', () => {
     });
 
     test('returns remoteBranchDeleted=false with warning on network error', async () => {
-      const worktreePath = '/workspace/worktrees/repo/pr-99';
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/pr-99');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
 
       execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
         if (args.includes('push') && args.includes('--delete')) {
@@ -1515,7 +1529,7 @@ describe('WorktreeProvider', () => {
       });
 
       const result = await provider.destroy(worktreePath, {
-        branchName: 'feature-branch',
+        branchName: git.toBranchName('feature-branch'),
         deleteRemoteBranch: true,
       });
 
@@ -1525,11 +1539,11 @@ describe('WorktreeProvider', () => {
     });
 
     test('does not attempt remote branch deletion when deleteRemoteBranch is not set', async () => {
-      const worktreePath = '/workspace/worktrees/repo/pr-99';
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/pr-99');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
 
       const result = await provider.destroy(worktreePath, {
-        branchName: 'feature-branch',
+        branchName: git.toBranchName('feature-branch'),
       });
 
       expect(execSpy).not.toHaveBeenCalledWith(
@@ -1541,10 +1555,10 @@ describe('WorktreeProvider', () => {
     });
 
     test('partial cleanup: worktree removed but branch deletion fails with unexpected error', async () => {
-      const worktreePath = '/workspace/worktrees/repo/pr-42-review';
-      const branchName = 'pr-42-review';
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/pr-42-review');
+      const branchName = git.toBranchName('pr-42-review');
 
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
 
       execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
         if (args.includes('branch') && args.includes('-D')) {
@@ -1572,17 +1586,20 @@ describe('WorktreeProvider', () => {
 
     test('returns environment for existing worktree', async () => {
       worktreeExistsSpy.mockResolvedValue(true);
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
       listWorktreesSpy.mockResolvedValue([
-        { path: '/workspace/repo', branch: 'main' },
-        { path: '/workspace/worktrees/repo/issue-42', branch: 'issue-42' },
+        { path: git.toWorktreePath('/workspace/repo'), branch: git.toBranchName('main') },
+        {
+          path: git.toWorktreePath('/workspace/worktrees/repo/issue-42'),
+          branch: git.toBranchName('issue-42'),
+        },
       ]);
 
       const result = await provider.get('/workspace/worktrees/repo/issue-42');
 
       expect(result).not.toBeNull();
       expect(result?.provider).toBe('worktree');
-      expect(result?.branchName).toBe('issue-42');
+      expect(result?.branchName).toBe(git.toBranchName('issue-42'));
     });
 
     test('re-throws errors from getCanonicalRepoPath with logging', async () => {
@@ -1596,7 +1613,7 @@ describe('WorktreeProvider', () => {
 
     test('re-throws errors from listWorktrees with logging', async () => {
       worktreeExistsSpy.mockResolvedValue(true);
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
       listWorktreesSpy.mockRejectedValue(new Error('git timeout'));
 
       await expect(provider.get('/workspace/worktrees/repo/issue-42')).rejects.toThrow(
@@ -1606,11 +1623,14 @@ describe('WorktreeProvider', () => {
 
     test('returns null when worktree exists on disk but not in git list (corrupted state)', async () => {
       worktreeExistsSpy.mockResolvedValue(true);
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
       // Worktree list does NOT include the queried path
       listWorktreesSpy.mockResolvedValue([
-        { path: '/workspace/repo', branch: 'main' },
-        { path: '/workspace/worktrees/repo/other-branch', branch: 'other-branch' },
+        { path: git.toWorktreePath('/workspace/repo'), branch: git.toBranchName('main') },
+        {
+          path: git.toWorktreePath('/workspace/worktrees/repo/other-branch'),
+          branch: git.toBranchName('other-branch'),
+        },
       ]);
 
       const result = await provider.get('/workspace/worktrees/repo/issue-42');
@@ -1621,20 +1641,28 @@ describe('WorktreeProvider', () => {
   describe('list', () => {
     test('returns all worktrees for codebase (excluding main)', async () => {
       listWorktreesSpy.mockResolvedValue([
-        { path: '/workspace/repo', branch: 'main' },
-        { path: '/workspace/worktrees/repo/issue-42', branch: 'issue-42' },
-        { path: '/workspace/worktrees/repo/pr-123', branch: 'pr-123' },
+        { path: git.toWorktreePath('/workspace/repo'), branch: git.toBranchName('main') },
+        {
+          path: git.toWorktreePath('/workspace/worktrees/repo/issue-42'),
+          branch: git.toBranchName('issue-42'),
+        },
+        {
+          path: git.toWorktreePath('/workspace/worktrees/repo/pr-123'),
+          branch: git.toBranchName('pr-123'),
+        },
       ]);
 
       const result = await provider.list('/workspace/repo');
 
       expect(result).toHaveLength(2);
-      expect(result[0].branchName).toBe('issue-42');
-      expect(result[1].branchName).toBe('pr-123');
+      expect(result[0].branchName).toBe(git.toBranchName('issue-42'));
+      expect(result[1].branchName).toBe(git.toBranchName('pr-123'));
     });
 
     test('returns empty array when no worktrees', async () => {
-      listWorktreesSpy.mockResolvedValue([{ path: '/workspace/repo', branch: 'main' }]);
+      listWorktreesSpy.mockResolvedValue([
+        { path: git.toWorktreePath('/workspace/repo'), branch: git.toBranchName('main') },
+      ]);
 
       const result = await provider.list('/workspace/repo');
       expect(result).toHaveLength(0);
@@ -1658,17 +1686,20 @@ describe('WorktreeProvider', () => {
   describe('adopt', () => {
     test('adopts existing worktree', async () => {
       worktreeExistsSpy.mockResolvedValue(true);
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
       listWorktreesSpy.mockResolvedValue([
-        { path: '/workspace/repo', branch: 'main' },
-        { path: '/workspace/worktrees/repo/feature-auth', branch: 'feature/auth' },
+        { path: git.toWorktreePath('/workspace/repo'), branch: git.toBranchName('main') },
+        {
+          path: git.toWorktreePath('/workspace/worktrees/repo/feature-auth'),
+          branch: git.toBranchName('feature/auth'),
+        },
       ]);
 
       const result = await provider.adopt('/workspace/worktrees/repo/feature-auth');
 
       expect(result).not.toBeNull();
       expect(result?.provider).toBe('worktree');
-      expect(result?.branchName).toBe('feature/auth');
+      expect(result?.branchName).toBe(git.toBranchName('feature/auth'));
       expect(result?.metadata).toHaveProperty('adopted', true);
     });
 
@@ -1697,7 +1728,7 @@ describe('WorktreeProvider', () => {
 
     test('throws when listWorktrees fails with unexpected error', async () => {
       worktreeExistsSpy.mockResolvedValue(true);
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
       listWorktreesSpy.mockRejectedValue(new Error('git timeout'));
 
       await expect(provider.adopt('/workspace/worktrees/repo/feature-auth')).rejects.toThrow(
@@ -1707,11 +1738,14 @@ describe('WorktreeProvider', () => {
 
     test('returns null when worktree exists on disk but not in git list (corrupted state)', async () => {
       worktreeExistsSpy.mockResolvedValue(true);
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
       // Worktree list does NOT include the queried path
       listWorktreesSpy.mockResolvedValue([
-        { path: '/workspace/repo', branch: 'main' },
-        { path: '/workspace/worktrees/repo/other-branch', branch: 'other-branch' },
+        { path: git.toWorktreePath('/workspace/repo'), branch: git.toBranchName('main') },
+        {
+          path: git.toWorktreePath('/workspace/worktrees/repo/other-branch'),
+          branch: git.toBranchName('other-branch'),
+        },
       ]);
 
       const result = await provider.adopt('/workspace/worktrees/repo/feature-auth');
@@ -1724,7 +1758,7 @@ describe('WorktreeProvider', () => {
 
     const baseRequest: IsolationRequest = {
       codebaseId: 'cb-123',
-      canonicalRepoPath: '/.archon/workspaces/owner/repo',
+      canonicalRepoPath: git.toRepoPath('/.archon/workspaces/owner/repo'),
       workflowType: 'issue',
       identifier: '42',
     };
@@ -1742,7 +1776,7 @@ describe('WorktreeProvider', () => {
 
     test('copies configured files after worktree creation', async () => {
       const configLoader: RepoConfigLoader = async () => ({
-        baseBranch: 'main',
+        baseBranch: git.toBranchName('main'),
         copyFiles: ['.env.example -> .env', '.vscode/settings.json'],
       });
       provider = new WorktreeProvider(configLoader);
@@ -1778,7 +1812,7 @@ describe('WorktreeProvider', () => {
 
     test('calls copyWorktreeFiles with default .archon when copyFiles is empty', async () => {
       const configLoader: RepoConfigLoader = async () => ({
-        baseBranch: 'main',
+        baseBranch: git.toBranchName('main'),
         copyFiles: [],
       });
       provider = new WorktreeProvider(configLoader);
@@ -1811,7 +1845,7 @@ describe('WorktreeProvider', () => {
 
     test('does not fail worktree creation if file copying fails', async () => {
       const configLoader: RepoConfigLoader = async () => ({
-        baseBranch: 'main',
+        baseBranch: git.toBranchName('main'),
         copyFiles: ['.env'],
       });
       provider = new WorktreeProvider(configLoader);
@@ -1859,7 +1893,7 @@ describe('WorktreeProvider', () => {
     test('should merge .archon default with user copyFiles config', async () => {
       // Mock: User config with additional files
       const configLoader: RepoConfigLoader = async () => ({
-        baseBranch: 'main',
+        baseBranch: git.toBranchName('main'),
         copyFiles: ['.env', '.vscode'],
       });
       provider = new WorktreeProvider(configLoader);
@@ -1885,7 +1919,7 @@ describe('WorktreeProvider', () => {
     test('should deduplicate .archon if user explicitly includes it', async () => {
       // Mock: User config explicitly includes .archon
       const configLoader: RepoConfigLoader = async () => ({
-        baseBranch: 'main',
+        baseBranch: git.toBranchName('main'),
         copyFiles: ['.archon', '.env'],
       });
       provider = new WorktreeProvider(configLoader);
@@ -1945,7 +1979,7 @@ describe('WorktreeProvider', () => {
     test('cleans orphan directory before creating worktree', async () => {
       const request: IsolationRequest = {
         codebaseId: 'cb-123',
-        canonicalRepoPath: '/workspace/repo',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
         workflowType: 'issue',
         identifier: '999',
       };
@@ -1969,7 +2003,7 @@ describe('WorktreeProvider', () => {
     test('does not remove directory if it is a valid worktree', async () => {
       const request: IsolationRequest = {
         codebaseId: 'cb-123',
-        canonicalRepoPath: '/workspace/repo',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
         workflowType: 'issue',
         identifier: '999',
       };
@@ -1988,10 +2022,10 @@ describe('WorktreeProvider', () => {
     test('cleans orphan directory before creating PR worktree', async () => {
       const request: IsolationRequest = {
         codebaseId: 'cb-123',
-        canonicalRepoPath: '/workspace/repo',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
         workflowType: 'pr',
         identifier: '42',
-        prBranch: 'feature/auth',
+        prBranch: git.toBranchName('feature/auth'),
         isForkPR: true, // Fork PR uses pr-N-review naming
       };
 
@@ -2012,10 +2046,10 @@ describe('WorktreeProvider', () => {
     });
 
     test('removes remaining directory after git worktree remove', async () => {
-      const worktreePath = '/workspace/worktrees/repo/issue-999';
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/issue-999');
 
       // Mock getCanonicalRepoPath
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
 
       // Simulate directory still exists after git worktree remove
       accessSpy.mockResolvedValue(undefined);
@@ -2034,10 +2068,10 @@ describe('WorktreeProvider', () => {
     });
 
     test('does not try to remove directory if already gone after git worktree remove', async () => {
-      const worktreePath = '/workspace/worktrees/repo/issue-999';
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/issue-999');
 
       // Mock getCanonicalRepoPath
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
 
       // Simulate directory does not exist after git worktree remove
       // Need to create NodeJS.ErrnoException with proper code property
@@ -2063,7 +2097,7 @@ describe('WorktreeProvider', () => {
     test('propagates rm errors during orphan cleanup in create()', async () => {
       const request: IsolationRequest = {
         codebaseId: 'cb-123',
-        canonicalRepoPath: '/workspace/repo',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
         workflowType: 'issue',
         identifier: '999',
       };
@@ -2080,9 +2114,9 @@ describe('WorktreeProvider', () => {
     });
 
     test('logs but does not throw when rm fails during post-removal cleanup in destroy()', async () => {
-      const worktreePath = '/workspace/worktrees/repo/issue-999';
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/issue-999');
 
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
       // First access check: path exists
       accessSpy.mockResolvedValueOnce(undefined);
       // git worktree remove succeeds
@@ -2105,10 +2139,10 @@ describe('WorktreeProvider', () => {
     test('cleans orphan directory before creating same-repo PR worktree', async () => {
       const request: IsolationRequest = {
         codebaseId: 'cb-123',
-        canonicalRepoPath: '/workspace/repo',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
         workflowType: 'pr',
         identifier: '42',
-        prBranch: 'feature/auth',
+        prBranch: git.toBranchName('feature/auth'),
         isForkPR: false, // Same-repo PR uses actual branch name
       };
 
@@ -2132,9 +2166,9 @@ describe('WorktreeProvider', () => {
     });
 
     test('cleans directory when git worktree remove fails with "not a working tree"', async () => {
-      const worktreePath = '/workspace/worktrees/repo/issue-999';
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/issue-999');
 
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
       // First access check: path exists
       accessSpy.mockResolvedValueOnce(undefined);
       // git worktree remove fails with "is not a working tree" (matches isWorktreeMissingError)
@@ -2155,7 +2189,7 @@ describe('WorktreeProvider', () => {
     test('throws when directoryExists encounters non-ENOENT error', async () => {
       const request: IsolationRequest = {
         codebaseId: 'cb-123',
-        canonicalRepoPath: '/workspace/repo',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
         workflowType: 'issue',
         identifier: '999',
       };
@@ -2174,10 +2208,10 @@ describe('WorktreeProvider', () => {
 
       const request: IsolationRequest = {
         codebaseId: 'cb-123',
-        canonicalRepoPath: '/workspace/repo',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
         workflowType: 'pr',
         identifier: '42',
-        prBranch: 'feature/auth',
+        prBranch: git.toBranchName('feature/auth'),
         isForkPR: true,
         prSha: 'abc123',
       };
@@ -2223,10 +2257,10 @@ describe('WorktreeProvider', () => {
 
       const request: IsolationRequest = {
         codebaseId: 'cb-123',
-        canonicalRepoPath: '/workspace/repo',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
         workflowType: 'pr',
         identifier: '42',
-        prBranch: 'feature/auth',
+        prBranch: git.toBranchName('feature/auth'),
         isForkPR: true,
         prSha: 'abc123',
       };
@@ -2265,7 +2299,7 @@ describe('WorktreeProvider', () => {
     const baseRequest: IsolationRequest = {
       codebaseId: 'cb-123',
       // Uses full owner/repo path format to test path parsing in createWorktree
-      canonicalRepoPath: '/workspace/owner/repo',
+      canonicalRepoPath: git.toRepoPath('/workspace/owner/repo'),
       workflowType: 'issue',
       identifier: '42',
     };
@@ -2287,7 +2321,7 @@ describe('WorktreeProvider', () => {
     test('uses resolved base branch as worktree start-point', async () => {
       worktreeExistsSpy.mockResolvedValue(false);
       syncWorkspaceSpy.mockResolvedValue({
-        branch: 'develop',
+        branch: git.toBranchName('develop'),
         synced: true,
         mode: 'fast-forward',
         state: 'in_sync',
@@ -2296,7 +2330,9 @@ describe('WorktreeProvider', () => {
         updated: false,
       });
 
-      const configLoader: RepoConfigLoader = async () => ({ baseBranch: 'develop' });
+      const configLoader: RepoConfigLoader = async () => ({
+        baseBranch: git.toBranchName('develop'),
+      });
       provider = new WorktreeProvider(configLoader);
 
       await provider.create(baseRequest);
@@ -2333,7 +2369,7 @@ describe('WorktreeProvider', () => {
     test('uses request baseBranch when no config baseBranch is set', async () => {
       worktreeExistsSpy.mockResolvedValue(false);
       syncWorkspaceSpy.mockResolvedValue({
-        branch: 'develop',
+        branch: git.toBranchName('develop'),
         synced: true,
         mode: 'fast-forward',
         state: 'in_sync',
@@ -2370,7 +2406,7 @@ describe('WorktreeProvider', () => {
 
     test('uses configured baseBranch over request baseBranch when both are set', async () => {
       worktreeExistsSpy.mockResolvedValue(false);
-      const configLoader: RepoConfigLoader = async () => ({ baseBranch: 'main' });
+      const configLoader: RepoConfigLoader = async () => ({ baseBranch: git.toBranchName('main') });
       provider = new WorktreeProvider(configLoader);
 
       await provider.create({
@@ -2386,7 +2422,7 @@ describe('WorktreeProvider', () => {
 
     test('uses request baseOverride over configured baseBranch and request baseBranch', async () => {
       worktreeExistsSpy.mockResolvedValue(false);
-      const configLoader: RepoConfigLoader = async () => ({ baseBranch: 'main' });
+      const configLoader: RepoConfigLoader = async () => ({ baseBranch: git.toBranchName('main') });
       provider = new WorktreeProvider(configLoader);
 
       await provider.create({
@@ -2410,7 +2446,7 @@ describe('WorktreeProvider', () => {
 
       await provider.create({
         ...baseRequest,
-        canonicalRepoPath: '/test/.archon/workspaces/owner/repo/source',
+        canonicalRepoPath: git.toRepoPath('/test/.archon/workspaces/owner/repo/source'),
       });
 
       expect(syncWorkspaceSpy).toHaveBeenCalledWith(
@@ -2429,7 +2465,7 @@ describe('WorktreeProvider', () => {
         ...baseRequest,
         workflowType: 'task',
         identifier: 'test-feature',
-        fromBranch: 'dev',
+        fromBranch: git.toBranchName('dev'),
       };
 
       await provider.create(request);
@@ -2443,14 +2479,14 @@ describe('WorktreeProvider', () => {
 
     test('uses configuredBaseBranch over fromBranch when both are set', async () => {
       worktreeExistsSpy.mockResolvedValue(false);
-      const configLoader: RepoConfigLoader = async () => ({ baseBranch: 'main' });
+      const configLoader: RepoConfigLoader = async () => ({ baseBranch: git.toBranchName('main') });
       provider = new WorktreeProvider(configLoader);
 
       const request: IsolationRequest = {
         ...baseRequest,
         workflowType: 'task',
         identifier: 'test-feature',
-        fromBranch: 'dev',
+        fromBranch: git.toBranchName('dev'),
       };
 
       await provider.create(request);
@@ -2467,10 +2503,10 @@ describe('WorktreeProvider', () => {
       provider = new WorktreeProvider(configLoader);
 
       // baseRequest has workflowType 'issue', not 'task' — fromBranch is ignored, auto-detects
-      const request: IsolationRequest = {
+      const request = {
         ...baseRequest,
-        fromBranch: 'dev',
-      };
+        fromBranch: git.toBranchName('dev'),
+      } as unknown as IsolationRequest;
 
       await provider.create(request);
 
@@ -2484,7 +2520,7 @@ describe('WorktreeProvider', () => {
     test('passes configured base branch to workspace sync when provided', async () => {
       worktreeExistsSpy.mockResolvedValue(false);
       const configLoader: RepoConfigLoader = async () => ({
-        baseBranch: 'develop',
+        baseBranch: git.toBranchName('develop'),
       });
       provider = new WorktreeProvider(configLoader);
 
@@ -2521,7 +2557,7 @@ describe('WorktreeProvider', () => {
 
     test('throws error when configured base branch does not exist', async () => {
       const configLoader: RepoConfigLoader = async () => ({
-        baseBranch: 'does-not-exist',
+        baseBranch: git.toBranchName('does-not-exist'),
       });
       provider = new WorktreeProvider(configLoader);
 
@@ -2557,7 +2593,7 @@ describe('WorktreeProvider', () => {
       // last-two-segments heuristic.
       const request: IsolationRequest = {
         codebaseId: 'cb-123',
-        canonicalRepoPath: '/home/dev/projects/repo',
+        canonicalRepoPath: git.toRepoPath('/home/dev/projects/repo'),
         workflowType: 'issue',
         identifier: '42',
       };
@@ -2574,7 +2610,7 @@ describe('WorktreeProvider', () => {
       // repo path under the workspaces tree still yields owner/repo.
       const request: IsolationRequest = {
         codebaseId: 'cb-123',
-        canonicalRepoPath: `${join(TEST_ARCHON_HOME, 'workspaces')}\\owner\\repo`,
+        canonicalRepoPath: git.toRepoPath(`${join(TEST_ARCHON_HOME, 'workspaces')}\\owner\\repo`),
         workflowType: 'issue',
         identifier: '42',
       };
@@ -2588,7 +2624,7 @@ describe('WorktreeProvider', () => {
     test('getWorktreePath handles mixed separator paths under workspaces/', () => {
       const request: IsolationRequest = {
         codebaseId: 'cb-123',
-        canonicalRepoPath: `${join(TEST_ARCHON_HOME, 'workspaces')}/owner\\repo`,
+        canonicalRepoPath: git.toRepoPath(`${join(TEST_ARCHON_HOME, 'workspaces')}/owner\\repo`),
         workflowType: 'issue',
         identifier: '42',
       };
@@ -2604,7 +2640,7 @@ describe('WorktreeProvider', () => {
       // the shared fallback resolves them like any other checkout.
       const request: IsolationRequest = {
         codebaseId: 'cb-123',
-        canonicalRepoPath: '/repo', // only one segment
+        canonicalRepoPath: git.toRepoPath('/repo'), // only one segment
         workflowType: 'issue',
         identifier: '42',
       };
@@ -2617,7 +2653,7 @@ describe('WorktreeProvider', () => {
     test('getWorktreePath throws for a degenerate repo path with no basename', () => {
       const request: IsolationRequest = {
         codebaseId: 'cb-123',
-        canonicalRepoPath: '/',
+        canonicalRepoPath: git.toRepoPath('/'),
         workflowType: 'issue',
         identifier: '42',
       };
@@ -2631,7 +2667,7 @@ describe('WorktreeProvider', () => {
       const request: IsolationRequest = {
         codebaseId: 'cb-123',
         codebaseName: 'Widinglabs/sasha-demo',
-        canonicalRepoPath: '/Users/rasmus/Projects/sasha-demo', // not under workspaces
+        canonicalRepoPath: git.toRepoPath('/Users/rasmus/Projects/sasha-demo'), // not under workspaces
         workflowType: 'task',
         identifier: 'fix-issue-42',
       };
@@ -2650,7 +2686,7 @@ describe('WorktreeProvider', () => {
     const baseRequest: IsolationRequest = {
       codebaseId: 'cb-local-1',
       codebaseName: 'owner/myapp',
-      canonicalRepoPath: '/Users/dev/Projects/myapp',
+      canonicalRepoPath: git.toRepoPath('/Users/dev/Projects/myapp'),
       workflowType: 'task',
       identifier: 'add-feature',
     };
@@ -2690,7 +2726,7 @@ describe('WorktreeProvider', () => {
       const request: IsolationRequest = {
         codebaseId: 'cb-local-2',
         codebaseName: 'owner/repo',
-        canonicalRepoPath: join(TEST_ARCHON_HOME, 'workspaces', 'owner', 'repo'),
+        canonicalRepoPath: git.toRepoPath(join(TEST_ARCHON_HOME, 'workspaces', 'owner', 'repo')),
         workflowType: 'task',
         identifier: 'my-task',
       };
@@ -2736,8 +2772,8 @@ describe('WorktreeProvider', () => {
 
   describe('destroy() — additional scenarios', () => {
     test('branchDeleted is true when branch already gone ("not found" error)', async () => {
-      const worktreePath = '/workspace/worktrees/repo/issue-42';
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/issue-42');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
 
       execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
         if (args.includes('branch') && args.includes('-D')) {
@@ -2748,7 +2784,9 @@ describe('WorktreeProvider', () => {
         return { stdout: '', stderr: '' };
       });
 
-      const result = await provider.destroy(worktreePath, { branchName: 'issue-42' });
+      const result = await provider.destroy(worktreePath, {
+        branchName: git.toBranchName('issue-42'),
+      });
 
       expect(result.worktreeRemoved).toBe(true);
       // "not found" counts as already deleted — should be true, not false
@@ -2757,8 +2795,8 @@ describe('WorktreeProvider', () => {
     });
 
     test('branchDeleted is true when branch already gone ("did not match any" error)', async () => {
-      const worktreePath = '/workspace/worktrees/repo/issue-42';
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/issue-42');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
 
       execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
         if (args.includes('branch') && args.includes('-D')) {
@@ -2771,15 +2809,17 @@ describe('WorktreeProvider', () => {
         return { stdout: '', stderr: '' };
       });
 
-      const result = await provider.destroy(worktreePath, { branchName: 'issue-42' });
+      const result = await provider.destroy(worktreePath, {
+        branchName: git.toBranchName('issue-42'),
+      });
 
       expect(result.branchDeleted).toBe(true);
       expect(result.warnings).toHaveLength(0);
     });
 
     test('remoteBranchDeleted is true when remote ref not found via "couldn\'t find remote ref"', async () => {
-      const worktreePath = '/workspace/worktrees/repo/feature-x';
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/feature-x');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
 
       execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
         if (args.includes('push') && args.includes('--delete')) {
@@ -2791,7 +2831,7 @@ describe('WorktreeProvider', () => {
       });
 
       const result = await provider.destroy(worktreePath, {
-        branchName: 'feature-x',
+        branchName: git.toBranchName('feature-x'),
         deleteRemoteBranch: true,
       });
 
@@ -2801,12 +2841,12 @@ describe('WorktreeProvider', () => {
     });
 
     test('all options together: force + branchName + deleteRemoteBranch', async () => {
-      const worktreePath = '/workspace/worktrees/repo/feature-y';
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/feature-y');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
 
       const result = await provider.destroy(worktreePath, {
         force: true,
-        branchName: 'feature-y',
+        branchName: git.toBranchName('feature-y'),
         deleteRemoteBranch: true,
       });
 
@@ -2845,16 +2885,16 @@ describe('WorktreeProvider', () => {
     });
 
     test('deletes remote branch via canonicalRepoPath when worktree path is already gone', async () => {
-      const worktreePath = '/workspace/worktrees/repo/feature-z';
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/feature-z');
       const enoentError = Object.assign(new Error('ENOENT: no such file or directory'), {
         code: 'ENOENT',
       });
       mockAccess.mockRejectedValueOnce(enoentError);
 
       const result = await provider.destroy(worktreePath, {
-        branchName: 'feature-z',
+        branchName: git.toBranchName('feature-z'),
         deleteRemoteBranch: true,
-        canonicalRepoPath: '/workspace/repo',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
       });
 
       // No worktree remove (path gone)
@@ -2884,8 +2924,8 @@ describe('WorktreeProvider', () => {
     });
 
     test('result has correct shape on minimal destroy (no options)', async () => {
-      const worktreePath = '/workspace/worktrees/repo/issue-1';
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/issue-1');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
 
       const result = await provider.destroy(worktreePath);
 
@@ -2901,12 +2941,12 @@ describe('WorktreeProvider', () => {
 
   describe('get() — environment shape', () => {
     test('returned environment has correct id, workingPath, provider, status, and metadata', async () => {
-      const worktreePath = '/workspace/worktrees/repo/issue-55';
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/issue-55');
       worktreeExistsSpy.mockResolvedValue(true);
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
       listWorktreesSpy.mockResolvedValue([
-        { path: '/workspace/repo', branch: 'main' },
-        { path: worktreePath, branch: 'issue-55' },
+        { path: git.toWorktreePath('/workspace/repo'), branch: git.toBranchName('main') },
+        { path: git.toWorktreePath(worktreePath), branch: git.toBranchName('issue-55') },
       ]);
 
       const result = await provider.get(worktreePath);
@@ -2916,33 +2956,39 @@ describe('WorktreeProvider', () => {
       expect(result!.workingPath).toBe(worktreePath);
       expect(result!.provider).toBe('worktree');
       expect(result!.status).toBe('active');
-      expect(result!.branchName).toBe('issue-55');
+      expect(result!.branchName).toBe(git.toBranchName('issue-55'));
       expect(result!.metadata).toEqual({ adopted: false });
       expect(result!.createdAt).toBeInstanceOf(Date);
     });
 
     test('returned environment branchName matches worktree branch with slashes', async () => {
-      const worktreePath = '/workspace/worktrees/repo/feature-auth';
+      const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/feature-auth');
       worktreeExistsSpy.mockResolvedValue(true);
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
       listWorktreesSpy.mockResolvedValue([
-        { path: '/workspace/repo', branch: 'main' },
-        { path: worktreePath, branch: 'feature/auth' },
+        { path: git.toWorktreePath('/workspace/repo'), branch: git.toBranchName('main') },
+        { path: git.toWorktreePath(worktreePath), branch: git.toBranchName('feature/auth') },
       ]);
 
       const result = await provider.get(worktreePath);
 
       expect(result).not.toBeNull();
-      expect(result!.branchName).toBe('feature/auth');
+      expect(result!.branchName).toBe(git.toBranchName('feature/auth'));
     });
   });
 
   describe('list() — environment shape', () => {
     test('each listed environment has correct provider, status, and metadata shape', async () => {
       listWorktreesSpy.mockResolvedValue([
-        { path: '/workspace/repo', branch: 'main' },
-        { path: '/workspace/worktrees/repo/issue-10', branch: 'issue-10' },
-        { path: '/workspace/worktrees/repo/issue-20', branch: 'issue-20' },
+        { path: git.toWorktreePath('/workspace/repo'), branch: git.toBranchName('main') },
+        {
+          path: git.toWorktreePath('/workspace/worktrees/repo/issue-10'),
+          branch: git.toBranchName('issue-10'),
+        },
+        {
+          path: git.toWorktreePath('/workspace/worktrees/repo/issue-20'),
+          branch: git.toBranchName('issue-20'),
+        },
       ]);
 
       const results = await provider.list('/workspace/repo');
@@ -2957,12 +3003,12 @@ describe('WorktreeProvider', () => {
     });
 
     test('id and workingPath equal the worktree path for each entry', async () => {
-      const path1 = '/workspace/worktrees/repo/issue-10';
-      const path2 = '/workspace/worktrees/repo/pr-99';
+      const path1 = git.toWorktreePath('/workspace/worktrees/repo/issue-10');
+      const path2 = git.toWorktreePath('/workspace/worktrees/repo/pr-99');
       listWorktreesSpy.mockResolvedValue([
-        { path: '/workspace/repo', branch: 'main' },
-        { path: path1, branch: 'issue-10' },
-        { path: path2, branch: 'pr-99' },
+        { path: git.toWorktreePath('/workspace/repo'), branch: git.toBranchName('main') },
+        { path: git.toWorktreePath(path1), branch: git.toBranchName('issue-10') },
+        { path: git.toWorktreePath(path2), branch: git.toBranchName('pr-99') },
       ]);
 
       const results = await provider.list('/workspace/repo');
@@ -2974,7 +3020,9 @@ describe('WorktreeProvider', () => {
     });
 
     test('returns empty array when listWorktrees returns only main repo entry', async () => {
-      listWorktreesSpy.mockResolvedValue([{ path: '/workspace/repo', branch: 'main' }]);
+      listWorktreesSpy.mockResolvedValue([
+        { path: git.toWorktreePath('/workspace/repo'), branch: git.toBranchName('main') },
+      ]);
 
       const results = await provider.list('/workspace/repo');
 
@@ -2993,12 +3041,12 @@ describe('WorktreeProvider', () => {
 
   describe('adopt() — environment shape', () => {
     test('returned environment has id equal to the provided path', async () => {
-      const adoptPath = '/workspace/worktrees/repo/feature-auth';
+      const adoptPath = git.toWorktreePath('/workspace/worktrees/repo/feature-auth');
       worktreeExistsSpy.mockResolvedValue(true);
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
       listWorktreesSpy.mockResolvedValue([
-        { path: '/workspace/repo', branch: 'main' },
-        { path: adoptPath, branch: 'feature/auth' },
+        { path: git.toWorktreePath('/workspace/repo'), branch: git.toBranchName('main') },
+        { path: git.toWorktreePath(adoptPath), branch: git.toBranchName('feature/auth') },
       ]);
 
       const result = await provider.adopt(adoptPath);
@@ -3009,12 +3057,12 @@ describe('WorktreeProvider', () => {
     });
 
     test('returned environment has correct status, provider, and createdAt', async () => {
-      const adoptPath = '/workspace/worktrees/repo/task-my-task';
+      const adoptPath = git.toWorktreePath('/workspace/worktrees/repo/task-my-task');
       worktreeExistsSpy.mockResolvedValue(true);
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
       listWorktreesSpy.mockResolvedValue([
-        { path: '/workspace/repo', branch: 'main' },
-        { path: adoptPath, branch: 'task-my-task' },
+        { path: git.toWorktreePath('/workspace/repo'), branch: git.toBranchName('main') },
+        { path: git.toWorktreePath(adoptPath), branch: git.toBranchName('task-my-task') },
       ]);
 
       const result = await provider.adopt(adoptPath);
@@ -3027,12 +3075,12 @@ describe('WorktreeProvider', () => {
     });
 
     test('adopt sets metadata.adopted to true (not false)', async () => {
-      const adoptPath = '/workspace/worktrees/repo/review-7';
+      const adoptPath = git.toWorktreePath('/workspace/worktrees/repo/review-7');
       worktreeExistsSpy.mockResolvedValue(true);
-      getCanonicalRepoPathSpy.mockResolvedValue('/workspace/repo');
+      getCanonicalRepoPathSpy.mockResolvedValue(git.toRepoPath('/workspace/repo'));
       listWorktreesSpy.mockResolvedValue([
-        { path: '/workspace/repo', branch: 'main' },
-        { path: adoptPath, branch: 'review-7' },
+        { path: git.toWorktreePath('/workspace/repo'), branch: git.toBranchName('main') },
+        { path: git.toWorktreePath(adoptPath), branch: git.toBranchName('review-7') },
       ]);
 
       const result = await provider.adopt(adoptPath);
@@ -3068,7 +3116,7 @@ describe('WorktreeProvider', () => {
   describe('custom remote support', () => {
     const baseRequest: IsolationRequest = {
       codebaseId: 'cb-123',
-      canonicalRepoPath: '/workspace/repo',
+      canonicalRepoPath: git.toRepoPath('/workspace/repo'),
       workflowType: 'issue',
       identifier: '42',
     };
@@ -3079,7 +3127,7 @@ describe('WorktreeProvider', () => {
 
     test('uses configured remote from worktree config', async () => {
       const customProvider = new WorktreeProvider(async () => ({
-        baseBranch: 'main',
+        baseBranch: git.toBranchName('main'),
         remote: 'mar',
       }));
 
@@ -3104,7 +3152,9 @@ describe('WorktreeProvider', () => {
 
     test('auto-detects remote when not configured', async () => {
       getDefaultRemoteSpy.mockResolvedValue('upstream');
-      const autoProvider = new WorktreeProvider(async () => ({ baseBranch: 'main' }));
+      const autoProvider = new WorktreeProvider(async () => ({
+        baseBranch: git.toBranchName('main'),
+      }));
 
       await autoProvider.create(baseRequest);
 
@@ -3120,11 +3170,11 @@ describe('WorktreeProvider', () => {
         ...baseRequest,
         workflowType: 'task',
         identifier: 'my-feature',
-        fromBranch: 'develop',
+        fromBranch: git.toBranchName('develop'),
       };
 
       const customProvider = new WorktreeProvider(async () => ({
-        baseBranch: 'main',
+        baseBranch: git.toBranchName('main'),
         remote: 'upstream',
       }));
 
@@ -3148,7 +3198,9 @@ describe('WorktreeProvider', () => {
         return { stdout: '', stderr: '' };
       });
 
-      const ambiguousProvider = new WorktreeProvider(async () => ({ baseBranch: 'main' }));
+      const ambiguousProvider = new WorktreeProvider(async () => ({
+        baseBranch: git.toBranchName('main'),
+      }));
 
       await expect(ambiguousProvider.create(baseRequest)).rejects.toThrow(
         /Cannot determine git remote.*jan, feb, mar.*Set worktree\.remote/s
@@ -3160,7 +3212,9 @@ describe('WorktreeProvider', () => {
     test('throws actionable error when no remote is configured', async () => {
       getDefaultRemoteSpy.mockResolvedValue(null);
 
-      const localProvider = new WorktreeProvider(async () => ({ baseBranch: 'main' }));
+      const localProvider = new WorktreeProvider(async () => ({
+        baseBranch: git.toBranchName('main'),
+      }));
       const creation = localProvider.create(baseRequest);
 
       await expect(creation).rejects.toThrow(
@@ -3173,15 +3227,15 @@ describe('WorktreeProvider', () => {
     test('uses custom remote for same-repo PR fetch and tracking', async () => {
       const prRequest: PRIsolationRequest = {
         codebaseId: 'cb-123',
-        canonicalRepoPath: '/workspace/repo',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
         workflowType: 'pr',
         identifier: '42',
-        prBranch: 'feature/auth',
+        prBranch: git.toBranchName('feature/auth'),
         isForkPR: false,
       };
 
       const customProvider = new WorktreeProvider(async () => ({
-        baseBranch: 'main',
+        baseBranch: git.toBranchName('main'),
         remote: 'upstream',
       }));
 
@@ -3205,15 +3259,15 @@ describe('WorktreeProvider', () => {
     test('uses custom remote for fork PR fetch', async () => {
       const forkPrRequest: PRIsolationRequest = {
         codebaseId: 'cb-123',
-        canonicalRepoPath: '/workspace/repo',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
         workflowType: 'pr',
         identifier: '42',
-        prBranch: 'feature/auth',
+        prBranch: git.toBranchName('feature/auth'),
         isForkPR: true,
       };
 
       const customProvider = new WorktreeProvider(async () => ({
-        baseBranch: 'main',
+        baseBranch: git.toBranchName('main'),
         remote: 'upstream',
       }));
 

--- a/packages/isolation/src/providers/worktree.test.ts
+++ b/packages/isolation/src/providers/worktree.test.ts
@@ -69,11 +69,11 @@ let getDefaultRemoteSpy: Mock<typeof git.getDefaultRemote>;
 let syncWorkspaceSpy: Mock<typeof git.syncWorkspace>;
 
 // Mock fs.promises.access for destroy() existence check
-const mockAccess = mock((_path?: unknown) => Promise.resolve());
+const mockAccess = mock((_path?: unknown): Promise<void> => Promise.resolve());
 const mockReadFile = mock(
   (_path?: unknown): Promise<string> => Promise.reject(new Error('ENOENT'))
 );
-const mockRm = mock((_path?: unknown) => Promise.resolve());
+const mockRm = mock((_path?: unknown): Promise<void> => Promise.resolve());
 mock.module('node:fs/promises', () => ({
   access: mockAccess,
   readFile: mockReadFile,
@@ -93,7 +93,9 @@ describe('WorktreeProvider', () => {
   let getCanonicalRepoPathSpy: Mock<typeof git.getCanonicalRepoPath>;
 
   beforeEach(() => {
-    mockConfigLoader = async () => ({ baseBranch: git.toBranchName('main') });
+    mockConfigLoader = async (): Promise<{ baseBranch: git.BranchName }> => ({
+      baseBranch: git.toBranchName('main'),
+    });
     provider = new WorktreeProvider(mockConfigLoader);
     execSpy = spyOn(git, 'execFileAsync');
     mkdirSpy = spyOn(git, 'mkdirAsync');
@@ -115,7 +117,7 @@ describe('WorktreeProvider', () => {
     // Most paths exist by default (directoryExists checks for destroy etc.),
     // but .gitmodules is absent by default — most repos don't use submodules,
     // and default-on submodule init must skip cleanly in that case.
-    mockAccess.mockImplementation(async (path: unknown) => {
+    mockAccess.mockImplementation(async (path: unknown): Promise<void> => {
       if (typeof path === 'string' && path.endsWith('.gitmodules')) {
         const err = new Error('ENOENT') as NodeJS.ErrnoException;
         err.code = 'ENOENT';

--- a/packages/isolation/src/resolver.test.ts
+++ b/packages/isolation/src/resolver.test.ts
@@ -701,7 +701,7 @@ describe('IsolationResolver', () => {
     const resolver = createResolver({
       provider: {
         ...makeMockProvider(),
-        create: async (request: IsolationRequest) => {
+        create: async (request: IsolationRequest): Promise<IsolatedEnvironment> => {
           capturedRequests.push(request);
           return {
             id: '/worktrees/new-branch',
@@ -736,7 +736,7 @@ describe('IsolationResolver', () => {
     const resolver = createResolver({
       provider: {
         ...makeMockProvider(),
-        create: async (request: IsolationRequest) => {
+        create: async (request: IsolationRequest): Promise<IsolatedEnvironment> => {
           capturedRequests.push(request);
           return {
             id: '/worktrees/new-branch',
@@ -774,7 +774,7 @@ describe('IsolationResolver', () => {
     const resolver = createResolver({
       provider: {
         ...makeMockProvider(),
-        create: async (request: IsolationRequest) => {
+        create: async (request: IsolationRequest): Promise<IsolatedEnvironment> => {
           capturedRequests.push(request);
           return {
             id: '/worktrees/new-branch',

--- a/packages/isolation/src/resolver.test.ts
+++ b/packages/isolation/src/resolver.test.ts
@@ -17,7 +17,7 @@ mock.module('@archon/paths', () => ({
 import { IsolationResolver } from './resolver';
 import type { IsolationResolverDeps } from './resolver';
 import type { IIsolationStore } from './store';
-import type { IsolationEnvironmentRow, IsolatedEnvironment } from './types';
+import type { IsolationEnvironmentRow, IsolatedEnvironment, IsolationRequest } from './types';
 
 function makeEnvRow(overrides?: Partial<IsolationEnvironmentRow>): IsolationEnvironmentRow {
   return {
@@ -31,6 +31,7 @@ function makeEnvRow(overrides?: Partial<IsolationEnvironmentRow>): IsolationEnvi
     status: 'active',
     created_at: new Date(),
     created_by_platform: 'web',
+    created_by_user_id: null,
     metadata: {},
     ...overrides,
   };
@@ -61,7 +62,7 @@ function makeMockProvider() {
       id: '/worktrees/new-branch',
       provider: 'worktree',
       workingPath: '/worktrees/new-branch',
-      branchName: 'new-branch',
+      branchName: git.toBranchName('new-branch'),
       status: 'active',
       createdAt: new Date(),
       metadata: { adopted: false },
@@ -314,7 +315,7 @@ describe('IsolationResolver', () => {
     const result = await resolver.resolve({
       existingEnvId: null,
       codebase: defaultCodebase,
-      hints: { workflowType: 'pr', workflowId: '99', prBranch: 'feature-branch' },
+      hints: { workflowType: 'pr', workflowId: '99', prBranch: git.toBranchName('feature-branch') },
       platformType: 'web',
     });
 
@@ -354,7 +355,7 @@ describe('IsolationResolver', () => {
             id: '/worktrees/new-branch',
             provider: 'worktree',
             workingPath: '/worktrees/new-branch',
-            branchName: 'new-branch',
+            branchName: git.toBranchName('new-branch'),
             status: 'active',
             createdAt: new Date(),
             metadata: { adopted: false },
@@ -369,7 +370,7 @@ describe('IsolationResolver', () => {
       hints: {
         workflowType: 'task',
         workflowId: 'test-adapters',
-        fromBranch: 'feature/extract-adapters',
+        fromBranch: git.toBranchName('feature/extract-adapters'),
       },
       platformType: 'web',
     });
@@ -378,7 +379,7 @@ describe('IsolationResolver', () => {
       expect.objectContaining({
         workflowType: 'task',
         identifier: 'test-adapters',
-        fromBranch: 'feature/extract-adapters',
+        fromBranch: git.toBranchName('feature/extract-adapters'),
       })
     );
   });
@@ -429,7 +430,7 @@ describe('IsolationResolver', () => {
       platformType: 'web',
     });
 
-    expect(updatedStatus).toBe('destroyed');
+    expect(updatedStatus as string | null).toBe('destroyed');
   });
 
   test('findReusable marks stale DB record as destroyed when worktree gone', async () => {
@@ -458,8 +459,8 @@ describe('IsolationResolver', () => {
     });
 
     // Should have cleaned up the stale record and then created a new environment
-    expect(updatedId).toBe('env-1');
-    expect(updatedStatus).toBe('destroyed');
+    expect(updatedId as string | null).toBe('env-1');
+    expect(updatedStatus as string | null).toBe('destroyed');
     expect(result.status).toBe('resolved');
     if (result.status === 'resolved') {
       expect(result.method.type).toBe('created');
@@ -497,8 +498,8 @@ describe('IsolationResolver', () => {
       platformType: 'web',
     });
 
-    expect(updatedId).toBe('env-linked');
-    expect(updatedStatus).toBe('destroyed');
+    expect(updatedId as string | null).toBe('env-linked');
+    expect(updatedStatus as string | null).toBe('destroyed');
     // Should proceed to create new since linked env was stale
     expect(result.status).toBe('resolved');
     if (result.status === 'resolved') {
@@ -655,7 +656,7 @@ describe('IsolationResolver', () => {
           id: '/worktrees/new-branch',
           provider: 'worktree',
           workingPath: '/worktrees/new-branch',
-          branchName: 'new-branch',
+          branchName: git.toBranchName('new-branch'),
           status: 'active',
           createdAt: new Date(),
           metadata: { adopted: false },
@@ -700,13 +701,13 @@ describe('IsolationResolver', () => {
     const resolver = createResolver({
       provider: {
         ...makeMockProvider(),
-        create: async (request: unknown) => {
+        create: async (request: IsolationRequest) => {
           capturedRequests.push(request);
           return {
             id: '/worktrees/new-branch',
             provider: 'worktree' as const,
             workingPath: '/worktrees/new-branch',
-            branchName: 'new-branch',
+            branchName: git.toBranchName('new-branch'),
             status: 'active' as const,
             createdAt: new Date(),
             metadata: { adopted: false },
@@ -735,13 +736,13 @@ describe('IsolationResolver', () => {
     const resolver = createResolver({
       provider: {
         ...makeMockProvider(),
-        create: async (request: unknown) => {
+        create: async (request: IsolationRequest) => {
           capturedRequests.push(request);
           return {
             id: '/worktrees/new-branch',
             provider: 'worktree' as const,
             workingPath: '/worktrees/new-branch',
-            branchName: 'new-branch',
+            branchName: git.toBranchName('new-branch'),
             status: 'active' as const,
             createdAt: new Date(),
             metadata: { adopted: false },
@@ -773,13 +774,13 @@ describe('IsolationResolver', () => {
     const resolver = createResolver({
       provider: {
         ...makeMockProvider(),
-        create: async (request: unknown) => {
+        create: async (request: IsolationRequest) => {
           capturedRequests.push(request);
           return {
             id: '/worktrees/new-branch',
             provider: 'worktree' as const,
             workingPath: '/worktrees/new-branch',
-            branchName: 'new-branch',
+            branchName: git.toBranchName('new-branch'),
             status: 'active' as const,
             createdAt: new Date(),
             metadata: { adopted: false },
@@ -811,7 +812,7 @@ describe('IsolationResolver', () => {
     const resolver = createResolver({
       provider: {
         ...makeMockProvider(),
-        create: async (request: unknown): Promise<IsolatedEnvironment> => {
+        create: async (request: IsolationRequest): Promise<IsolatedEnvironment> => {
           capturedRequests.push(request);
           throw new Error('provider.create must not be called for folder projects');
         },

--- a/packages/isolation/src/worktree-copy.test.ts
+++ b/packages/isolation/src/worktree-copy.test.ts
@@ -8,7 +8,6 @@ import {
   copyWorktreeFile,
   copyWorktreeFiles,
   isPathWithinRoot,
-  type CopyFileEntry,
 } from '@archon/isolation';
 
 describe('worktree-copy', () => {

--- a/packages/isolation/tsconfig.json
+++ b/packages/isolation/tsconfig.json
@@ -4,5 +4,5 @@
     "noEmit": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/paths/src/env-integration.test.ts
+++ b/packages/paths/src/env-integration.test.ts
@@ -314,7 +314,7 @@ describe('env isolation integration', () => {
 
     // Simulate managed env merge (what dag-executor does via requestOptions.env)
     const managedEnv = { MANAGED_SECRET: 'from-db', ELEVENLABS_API_KEY: 'el-managed' };
-    const finalEnv = { ...subprocessEnv, ...managedEnv };
+    const finalEnv: NodeJS.ProcessEnv = { ...subprocessEnv, ...managedEnv };
 
     // CWD keys still stripped
     expect(finalEnv.ANTHROPIC_API_KEY).toBeUndefined();

--- a/packages/paths/src/telemetry.test.ts
+++ b/packages/paths/src/telemetry.test.ts
@@ -625,11 +625,15 @@ describe('new capture functions are fire-and-forget no-throw', () => {
     delete process.env.CI;
     delete process.env.POSTHOG_API_KEY;
     const bodies: (string | Blob)[] = [];
-    const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation((_url, options) => {
-      const body = (options as { body?: unknown } | undefined)?.body;
-      if (typeof body === 'string' || body instanceof Blob) bodies.push(body);
-      return Promise.resolve(new Response('{"status":"ok"}', { status: 200 }));
-    });
+    const fetchImpl = Object.assign(
+      (_url: Parameters<typeof fetch>[0], options?: Parameters<typeof fetch>[1]) => {
+        const body = (options as { body?: unknown } | undefined)?.body;
+        if (typeof body === 'string' || body instanceof Blob) bodies.push(body);
+        return Promise.resolve(new Response('{"status":"ok"}', { status: 200 }));
+      },
+      { preconnect: (): void => undefined }
+    );
+    const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(fetchImpl);
     try {
       captureArchonStarted({
         surface: 'server',
@@ -682,11 +686,15 @@ describe('new capture functions are fire-and-forget no-throw', () => {
     delete process.env.CI;
     delete process.env.POSTHOG_API_KEY;
     const bodies: (string | Blob)[] = [];
-    const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation((_url, options) => {
-      const body = (options as { body?: unknown } | undefined)?.body;
-      if (typeof body === 'string' || body instanceof Blob) bodies.push(body);
-      return Promise.resolve(new Response('{"status":"ok"}', { status: 200 }));
-    });
+    const fetchImpl = Object.assign(
+      (_url: Parameters<typeof fetch>[0], options?: Parameters<typeof fetch>[1]) => {
+        const body = (options as { body?: unknown } | undefined)?.body;
+        if (typeof body === 'string' || body instanceof Blob) bodies.push(body);
+        return Promise.resolve(new Response('{"status":"ok"}', { status: 200 }));
+      },
+      { preconnect: (): void => undefined }
+    );
+    const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(fetchImpl);
     try {
       captureChatTurn({
         platform: 'web',

--- a/packages/paths/src/telemetry.test.ts
+++ b/packages/paths/src/telemetry.test.ts
@@ -626,7 +626,10 @@ describe('new capture functions are fire-and-forget no-throw', () => {
     delete process.env.POSTHOG_API_KEY;
     const bodies: (string | Blob)[] = [];
     const fetchImpl = Object.assign(
-      (_url: Parameters<typeof fetch>[0], options?: Parameters<typeof fetch>[1]) => {
+      (
+        _url: Parameters<typeof fetch>[0],
+        options?: Parameters<typeof fetch>[1]
+      ): Promise<Response> => {
         const body = (options as { body?: unknown } | undefined)?.body;
         if (typeof body === 'string' || body instanceof Blob) bodies.push(body);
         return Promise.resolve(new Response('{"status":"ok"}', { status: 200 }));
@@ -687,7 +690,10 @@ describe('new capture functions are fire-and-forget no-throw', () => {
     delete process.env.POSTHOG_API_KEY;
     const bodies: (string | Blob)[] = [];
     const fetchImpl = Object.assign(
-      (_url: Parameters<typeof fetch>[0], options?: Parameters<typeof fetch>[1]) => {
+      (
+        _url: Parameters<typeof fetch>[0],
+        options?: Parameters<typeof fetch>[1]
+      ): Promise<Response> => {
         const body = (options as { body?: unknown } | undefined)?.body;
         if (typeof body === 'string' || body instanceof Blob) bodies.push(body);
         return Promise.resolve(new Response('{"status":"ok"}', { status: 200 }));

--- a/packages/paths/src/update-check.test.ts
+++ b/packages/paths/src/update-check.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, spyOn, beforeEach, afterEach } from 'bun:test';
 import { join } from 'path';
-import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'fs';
+import { mkdirSync, writeFileSync, readFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import {
   isNewerVersion,

--- a/packages/paths/tsconfig.json
+++ b/packages/paths/tsconfig.json
@@ -4,5 +4,5 @@
     "noEmit": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/providers/src/claude/container-spawn.test.ts
+++ b/packages/providers/src/claude/container-spawn.test.ts
@@ -20,17 +20,18 @@ function makeSpawnOptions(over: Partial<SpawnOptions> = {}): SpawnOptions {
 
 /** Fake ChildProcess with real streams + a recording kill(). */
 function fakeChild(): ChildProcess & { killSignals: string[] } {
-  const emitter = new EventEmitter() as ChildProcess & { killSignals: string[] };
-  emitter.stdin = new PassThrough() as unknown as ChildProcess['stdin'];
-  emitter.stdout = new PassThrough() as unknown as ChildProcess['stdout'];
-  emitter.killed = false;
-  emitter.exitCode = null;
-  emitter.killSignals = [];
-  emitter.kill = ((signal?: NodeJS.Signals) => {
-    emitter.killSignals.push(signal ?? 'SIGTERM');
-    return true;
-  }) as ChildProcess['kill'];
-  return emitter;
+  const killSignals: string[] = [];
+  return Object.assign(new EventEmitter(), {
+    stdin: new PassThrough(),
+    stdout: new PassThrough(),
+    killed: false,
+    exitCode: null,
+    killSignals,
+    kill: (signal?: NodeJS.Signals) => {
+      killSignals.push(signal ?? 'SIGTERM');
+      return true;
+    },
+  }) as unknown as ChildProcess & { killSignals: string[] };
 }
 
 /** Recording spawner returning a fresh fake child per call. */
@@ -45,7 +46,7 @@ function recordingSpawner(): Spawner & {
     const child = fakeChild();
     children.push(child);
     return child;
-  }) as Spawner & { calls: typeof calls; children: ChildProcess[] };
+  }) as unknown as Spawner & { calls: typeof calls; children: ChildProcess[] };
   fn.calls = calls;
   fn.children = children;
   return fn;

--- a/packages/providers/src/claude/provider.test.ts
+++ b/packages/providers/src/claude/provider.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, mock, beforeEach, afterEach, spyOn } from 'bun:
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { Options, query as sdkQuery } from '@anthropic-ai/claude-agent-sdk';
 import { createMockLogger } from '../test/mocks/logger';
 
 const mockLogger = createMockLogger();
@@ -9,8 +10,11 @@ mock.module('@archon/paths', () => ({
   createLogger: mock(() => mockLogger),
 }));
 
-// Create mock query function
-const mockQuery = mock(async function* () {
+type MockQuery = (...args: Parameters<typeof sdkQuery>) => AsyncGenerator<unknown, void, unknown>;
+
+// Keep the SDK input signature while allowing tests to exercise malformed and
+// forward-compatible events at the provider's runtime validation boundary.
+const mockQuery = mock<MockQuery>(async function* (_params) {
   // Empty generator by default
 });
 
@@ -1183,11 +1187,9 @@ describe('ClaudeProvider', () => {
     }, 5_000);
 
     test('captures all stderr output for diagnostics', async () => {
-      mockQuery.mockImplementation(async function* (args: {
-        options: { stderr?: (data: string) => void };
-      }) {
+      mockQuery.mockImplementation(async function* (args) {
         // Simulate non-error stderr output followed by crash
-        if (args.options.stderr) {
+        if (args.options?.stderr) {
           args.options.stderr('Spawning Claude Code process: node cli.js');
           args.options.stderr('AJV validation: schema loaded');
           args.options.stderr('startup diagnostic: ready');
@@ -1202,12 +1204,13 @@ describe('ClaudeProvider', () => {
       };
 
       // Use rejects so assertions always execute
-      const err = await consumeGenerator().catch((e: unknown) => e as Error);
-      expect(err).toBeInstanceOf(Error);
+      const thrown = await consumeGenerator().catch((error: unknown) => error);
+      expect(thrown).toBeInstanceOf(Error);
+      if (!(thrown instanceof Error)) throw new Error('Expected consumeGenerator to throw');
       // The error should contain stderr context from ALL captured lines
-      expect(err.message).toContain('stderr:');
-      expect(err.message).toContain('AJV validation');
-      expect(err.message).toContain('startup diagnostic');
+      expect(thrown.message).toContain('stderr:');
+      expect(thrown.message).toContain('AJV validation');
+      expect(thrown.message).toContain('startup diagnostic');
     }, 5_000);
 
     test('passes settingSources from assistantConfig', async () => {
@@ -1914,10 +1917,8 @@ describe('sendQuery decomposition behaviors', () => {
   }, 5_000);
 
   test('enriched error (with stderr) is thrown at retry exhaustion, not raw error', async () => {
-    mockQuery.mockImplementation(async function* (args: {
-      options: { stderr?: (data: string) => void };
-    }) {
-      if (args.options.stderr) {
+    mockQuery.mockImplementation(async function* (args) {
+      if (args.options?.stderr) {
         args.options.stderr('diagnostic: something broke');
       }
       throw new Error('process exited with code 1');
@@ -1929,34 +1930,44 @@ describe('sendQuery decomposition behaviors', () => {
       }
     };
 
-    const err = await consumeGenerator().catch((e: unknown) => e as Error);
-    expect(err).toBeInstanceOf(Error);
+    const thrown = await consumeGenerator().catch((error: unknown) => error);
+    expect(thrown).toBeInstanceOf(Error);
+    if (!(thrown instanceof Error)) throw new Error('Expected consumeGenerator to throw');
     // Must contain stderr context, not just the raw error
-    expect(err.message).toContain('stderr:');
-    expect(err.message).toContain('diagnostic: something broke');
+    expect(thrown.message).toContain('stderr:');
+    expect(thrown.message).toContain('diagnostic: something broke');
   }, 5_000);
 
   test('PostToolUse hooks preserve success, failure, and interruption outcomes', async () => {
-    mockQuery.mockImplementation(async function* (args: {
-      options: {
-        hooks?: Record<string, Array<{ hooks: Array<(input: unknown) => Promise<unknown>> }>>;
-      };
-    }) {
-      const successHook = args.options.hooks?.PostToolUse?.[0]?.hooks?.[0];
-      const failureHook = args.options.hooks?.PostToolUseFailure?.[0]?.hooks?.[0];
-      await successHook?.({ tool_name: 'Read', tool_use_id: 'success-id', tool_response: 'ok' });
-      await failureHook?.({
-        tool_name: 'Bash',
-        tool_use_id: 'error-id',
-        error: 'exit 1',
-        is_interrupt: false,
-      });
-      await failureHook?.({
-        tool_name: 'Task',
-        tool_use_id: 'interrupt-id',
-        error: 'stopped',
-        is_interrupt: true,
-      });
+    mockQuery.mockImplementation(async function* (args) {
+      const successHook = args.options?.hooks?.PostToolUse?.[0]?.hooks?.[0];
+      const failureHook = args.options?.hooks?.PostToolUseFailure?.[0]?.hooks?.[0];
+      const hookOptions = { signal: new AbortController().signal };
+      await successHook?.(
+        { tool_name: 'Read', tool_use_id: 'success-id', tool_response: 'ok' } as never,
+        'success-id',
+        hookOptions
+      );
+      await failureHook?.(
+        {
+          tool_name: 'Bash',
+          tool_use_id: 'error-id',
+          error: 'exit 1',
+          is_interrupt: false,
+        } as never,
+        'error-id',
+        hookOptions
+      );
+      await failureHook?.(
+        {
+          tool_name: 'Task',
+          tool_use_id: 'interrupt-id',
+          error: 'stopped',
+          is_interrupt: true,
+        } as never,
+        'interrupt-id',
+        hookOptions
+      );
       yield { type: 'assistant', message: { content: [{ type: 'text', text: 'done' }] } };
     });
 
@@ -1989,14 +2000,14 @@ describe('sendQuery decomposition behaviors', () => {
   });
 
   test('terminal tool result queue drain preserves hook outcome', async () => {
-    mockQuery.mockImplementation(async function* (args: {
-      options: {
-        hooks?: Record<string, Array<{ hooks: Array<(input: unknown) => Promise<unknown>> }>>;
-      };
-    }) {
+    mockQuery.mockImplementation(async function* (args) {
       yield { type: 'assistant', message: { content: [{ type: 'text', text: 'done' }] } };
-      const successHook = args.options.hooks?.PostToolUse?.[0]?.hooks?.[0];
-      await successHook?.({ tool_name: 'Read', tool_use_id: 'late-id', tool_response: 'ok' });
+      const successHook = args.options?.hooks?.PostToolUse?.[0]?.hooks?.[0];
+      await successHook?.(
+        { tool_name: 'Read', tool_use_id: 'late-id', tool_response: 'ok' } as never,
+        'late-id',
+        { signal: new AbortController().signal }
+      );
     });
 
     const chunks = [];
@@ -2012,21 +2023,21 @@ describe('sendQuery decomposition behaviors', () => {
   });
 
   test('PostToolUse hook handles circular reference without crashing', async () => {
-    mockQuery.mockImplementation(async function* (args: {
-      options: {
-        hooks?: Record<string, Array<{ hooks: Array<(input: unknown) => Promise<unknown>> }>>;
-      };
-    }) {
+    mockQuery.mockImplementation(async function* (args) {
       // Simulate a tool use that triggers the PostToolUse hook with circular data
-      const hooks = args.options.hooks?.PostToolUse;
+      const hooks = args.options?.hooks?.PostToolUse;
       if (hooks?.[0]?.hooks?.[0]) {
         const circular: Record<string, unknown> = { key: 'val' };
         circular.self = circular; // circular reference
-        await hooks[0].hooks[0]({
-          tool_name: 'TestTool',
-          tool_use_id: 'tc-circ',
-          tool_response: circular,
-        });
+        await hooks[0].hooks[0](
+          {
+            tool_name: 'TestTool',
+            tool_use_id: 'tc-circ',
+            tool_response: circular,
+          } as never,
+          'tc-circ',
+          { signal: new AbortController().signal }
+        );
       }
       yield {
         type: 'assistant',

--- a/packages/providers/src/codex/provider.test.ts
+++ b/packages/providers/src/codex/provider.test.ts
@@ -1,7 +1,9 @@
-import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import { describe, test, expect, mock, beforeEach, type Mock } from 'bun:test';
 import { mkdtemp, rm, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import type { Codex as SdkCodex, Thread as SdkThread } from '@openai/codex-sdk';
+import type { MessageChunk } from '../types';
 import { createMockLogger } from '../test/mocks/logger';
 
 const mockLogger = createMockLogger();
@@ -10,10 +12,26 @@ mock.module('@archon/paths', () => ({
 }));
 
 /** Default usage matching Codex SDK's Usage type (required on TurnCompletedEvent) */
-const defaultUsage = { input_tokens: 10, cached_input_tokens: 0, output_tokens: 5 };
+const defaultUsage = {
+  input_tokens: 10,
+  cached_input_tokens: 0,
+  output_tokens: 5,
+  reasoning_output_tokens: 0,
+};
+
+type MockRunStreamed = (
+  ...args: Parameters<SdkThread['runStreamed']>
+) => Promise<{ events: AsyncGenerator<unknown, void, unknown> }>;
+type MockThread = { id: string | null; runStreamed: Mock<MockRunStreamed> };
+type MockStartThread = (...args: Parameters<SdkCodex['startThread']>) => MockThread;
+type MockResumeThread = (...args: Parameters<SdkCodex['resumeThread']>) => MockThread;
+type MockCodexConstructor = (...args: ConstructorParameters<typeof SdkCodex>) => {
+  startThread: Mock<MockStartThread>;
+  resumeThread: Mock<MockResumeThread>;
+};
 
 // Create mock runStreamed first (before it's referenced)
-const mockRunStreamed = mock(() =>
+const mockRunStreamed = mock<MockRunStreamed>((_input, _options) =>
   Promise.resolve({
     events: (async function* () {
       yield { type: 'turn.completed', usage: defaultUsage };
@@ -22,17 +40,17 @@ const mockRunStreamed = mock(() =>
 );
 
 // Create a mock thread object factory
-const createMockThread = (id: string) => ({
+const createMockThread = (id: string | null): MockThread => ({
   id,
   runStreamed: mockRunStreamed,
 });
 
 // Create mock functions for Codex SDK that use createMockThread
-const mockStartThread = mock(() => createMockThread('new-thread-id'));
-const mockResumeThread = mock(() => createMockThread('resumed-thread-id'));
+const mockStartThread = mock<MockStartThread>(() => createMockThread('new-thread-id'));
+const mockResumeThread = mock<MockResumeThread>(() => createMockThread('resumed-thread-id'));
 
 // Mock Codex class
-const MockCodex = mock(() => ({
+const MockCodex = mock<MockCodexConstructor>(() => ({
   startThread: mockStartThread,
   resumeThread: mockResumeThread,
 }));
@@ -165,7 +183,7 @@ describe('CodexProvider', () => {
         });
       });
 
-      const chunks = [];
+      const chunks: MessageChunk[] = [];
       try {
         for await (const chunk of client.sendQuery('test prompt', testDir, 'existing-thread', {
           nodeConfig: { nodeId: 'investigate', mcp: 'mcp.json' },
@@ -220,7 +238,7 @@ describe('CodexProvider', () => {
         })(),
       });
 
-      const chunks = [];
+      const chunks: MessageChunk[] = [];
       await expect(
         (async (): Promise<void> => {
           for await (const chunk of client.sendQuery('test prompt', '/workspace', undefined, {
@@ -1308,8 +1326,8 @@ describe('CodexProvider', () => {
       // the forwarding once-listener (covered by separate tests below).
       const call = mockRunStreamed.mock.calls[0];
       expect(call[0]).toBe('test prompt');
-      expect(call[1].signal).toBeInstanceOf(AbortSignal);
-      expect(call[1].signal).not.toBe(controller.signal);
+      expect(call[1]?.signal).toBeInstanceOf(AbortSignal);
+      expect(call[1]?.signal).not.toBe(controller.signal);
     });
 
     test('passes a per-attempt AbortSignal in TurnOptions even when caller provides none', async () => {
@@ -2465,10 +2483,11 @@ describe('sendQuery decomposition behaviors', () => {
       }
     };
 
-    const err = await consumeGenerator().catch((e: unknown) => e as Error);
-    expect(err).toBeInstanceOf(Error);
+    const thrown = await consumeGenerator().catch((error: unknown) => error);
+    expect(thrown).toBeInstanceOf(Error);
+    if (!(thrown instanceof Error)) throw new Error('Expected consumeGenerator to throw');
     // Must contain the enriched classification prefix
-    expect(err.message).toContain('Codex crash');
+    expect(thrown.message).toContain('Codex crash');
   }, 5_000);
 
   test('todo_list dedup state resets between retry attempts', async () => {
@@ -2524,7 +2543,8 @@ describe('sendQuery decomposition behaviors', () => {
     // spawn() captures the signal at its own call) but misleading here.
     const signalsAtCallTime: Array<{ signal: AbortSignal; aborted: boolean }> = [];
     let callCount = 0;
-    mockRunStreamed.mockImplementation((_prompt: unknown, opts: { signal?: AbortSignal }) => {
+    mockRunStreamed.mockImplementation((_prompt, opts) => {
+      if (!opts) throw new Error('Expected per-attempt options');
       const s = opts.signal!;
       signalsAtCallTime.push({ signal: s, aborted: s.aborted });
       callCount++;
@@ -2567,7 +2587,8 @@ describe('sendQuery decomposition behaviors', () => {
     const callerController = new AbortController();
 
     let capturedSignal: AbortSignal | undefined;
-    mockRunStreamed.mockImplementation((_prompt, opts: { signal?: AbortSignal }) => {
+    mockRunStreamed.mockImplementation((_prompt, opts) => {
+      if (!opts) throw new Error('Expected per-attempt options');
       capturedSignal = opts.signal;
       return Promise.resolve({
         events: (async function* () {
@@ -2609,7 +2630,7 @@ describe('sendQuery decomposition behaviors', () => {
   // The fix removes the explicit abort() — the per-attempt controller is short-lived
   // and goes out of scope naturally.
   test('successful attempt does not throw from stale abort cleanup (#1735)', async () => {
-    mockRunStreamed.mockImplementation((_prompt, opts: { signal?: AbortSignal }) => {
+    mockRunStreamed.mockImplementation((_prompt, _opts) => {
       return Promise.resolve({
         events: (async function* () {
           yield {

--- a/packages/providers/src/community/copilot/event-bridge.test.ts
+++ b/packages/providers/src/community/copilot/event-bridge.test.ts
@@ -7,7 +7,7 @@ mock.module('@archon/paths', () => ({
 
 import type { SessionEvent } from '@github/copilot-sdk';
 
-import type { MessageChunk, TokenUsage } from '../../types';
+import type { TokenUsage } from '../../types';
 import {
   AsyncQueue,
   mapCopilotEvent,

--- a/packages/providers/src/community/opencode/provider.test.ts
+++ b/packages/providers/src/community/opencode/provider.test.ts
@@ -132,6 +132,7 @@ mock.module('@opencode-ai/sdk', () => ({
 }));
 
 import { OpencodeProvider, resetEmbeddedRuntime } from './provider';
+import type { NodeConfig } from '../../types';
 
 /** Default model for tests — satisfies the model-or-agent validation */
 const TEST_MODEL = { model: 'test/mock-model' };
@@ -1306,7 +1307,7 @@ describe('OpencodeProvider', () => {
           // No prompt field
         },
       },
-    };
+    } as unknown as NodeConfig;
 
     const { error } = await consume(
       new OpencodeProvider().sendQuery('fallback node prompt', cwd, undefined, {

--- a/packages/providers/src/community/pi/event-bridge.test.ts
+++ b/packages/providers/src/community/pi/event-bridge.test.ts
@@ -160,7 +160,7 @@ describe('buildResultChunk', () => {
       type: 'result',
       isError: true,
       errorSubtype: 'missing_assistant_message',
-    };
+    } as const;
     expect(buildResultChunk([])).toEqual(expected);
     expect(buildResultChunk([{ role: 'user', content: [] }])).toEqual(expected);
   });
@@ -382,6 +382,7 @@ describe('mapPiEvent', () => {
     };
     const chunks = mapPiEvent({
       type: 'agent_end',
+      willRetry: false,
       messages: [{ role: 'assistant', usage, stopReason: 'stop', content: [] } as never],
     });
     expect(chunks).toHaveLength(1);

--- a/packages/providers/src/community/pi/provider.test.ts
+++ b/packages/providers/src/community/pi/provider.test.ts
@@ -35,7 +35,7 @@ type FakeEvent = AgentSessionEvent;
 let capturedListener: ((event: FakeEvent) => void) | undefined;
 
 const scriptedEvents: FakeEvent[] = [];
-const mockPrompt = mock(async () => {
+const mockPrompt = mock(async (_prompt: string) => {
   for (const ev of scriptedEvents) capturedListener?.(ev);
 });
 const mockAbort = mock(async () => undefined);
@@ -65,11 +65,19 @@ const mockSession = {
   sessionId: 'mock-session-uuid',
 };
 
-const mockCreateAgentSession = mock(async (_options?: unknown) => ({
-  session: mockSession,
-  extensionsResult: { extensions: [], errors: [], runtime: {} },
-  modelFallbackMessage: undefined,
-}));
+type MockSessionResult = {
+  session: typeof mockSession;
+  extensionsResult: { extensions: never[]; errors: never[]; runtime: Record<string, never> };
+  modelFallbackMessage: string | undefined;
+};
+
+const mockCreateAgentSession = mock(
+  async (_options?: unknown): Promise<MockSessionResult> => ({
+    session: mockSession,
+    extensionsResult: { extensions: [], errors: [], runtime: {} },
+    modelFallbackMessage: undefined,
+  })
+);
 
 // Per-test state backing the AuthStorage mock. `fileCreds` emulates what's
 // in ~/.pi/agent/auth.json; `runtimeOverrides` emulates env-var passthrough
@@ -99,9 +107,17 @@ const mockModelRegistryFind = mock((provider: string, modelId: string) => {
   if (provider === 'nonexistent') return undefined;
   return { id: modelId, provider, name: `${provider}/${modelId}` };
 });
-const mockModelRegistryCreate = mock(() => ({
-  find: mockModelRegistryFind,
-}));
+type MockModelRegistry = {
+  find: (
+    provider: string,
+    modelId: string
+  ) => { id: string; provider: string; name: string } | undefined;
+};
+const mockModelRegistryCreate = mock(
+  (): MockModelRegistry => ({
+    find: mockModelRegistryFind,
+  })
+);
 
 // SessionManager mocks. Each returns a tagged session-manager stub so tests
 // can assert whether resume resolved to an existing session or fell through
@@ -112,7 +128,7 @@ const mockSessionList = mock(
   async (_cwd: string) => [] as { id: string; path: string; cwd: string }[]
 );
 
-const mockSettingsManagerDrainErrors = mock(() => []);
+const mockSettingsManagerDrainErrors = mock((): { scope: string; error: Error }[] => []);
 const mockSettingsManagerGetGlobalSettings = mock(() => ({}));
 const mockSettingsManagerGetProjectSettings = mock(() => ({}));
 const mockSettingsManagerCreate = mock(() => ({
@@ -215,6 +231,10 @@ function resetScript(events: FakeEvent[]): void {
   scriptedEvents.push(...events);
 }
 
+function readEnv(name: string): string | undefined {
+  return process.env[name];
+}
+
 // ─── Test suite ─────────────────────────────────────────────────────────
 
 describe('PiProvider', () => {
@@ -294,14 +314,14 @@ describe('PiProvider', () => {
     delete process.env.PI_PACKAGE_DIR;
     expect(process.env.PI_PACKAGE_DIR).toBeUndefined();
     await consume(new PiProvider().sendQuery('hi', '/tmp'));
-    expect(process.env.PI_PACKAGE_DIR).toBeDefined();
-    expect(process.env.PI_PACKAGE_DIR).toContain('archon-pi-shim');
+    expect(readEnv('PI_PACKAGE_DIR')).toBeDefined();
+    expect(readEnv('PI_PACKAGE_DIR')).toContain('archon-pi-shim');
 
     // Stub contents are load-bearing: Pi reads `version` to populate its
     // user-agent and `piConfig` (even when empty) to opt into the defaults
     // path instead of erroring on missing config. Asserting on shape so a
     // regression here surfaces in the test suite, not in a Pi runtime crash.
-    const shimDir = process.env.PI_PACKAGE_DIR;
+    const shimDir = readEnv('PI_PACKAGE_DIR');
     expect(shimDir).toBe(join(tmpdir(), 'archon-pi-shim'));
     const stub = JSON.parse(readFileSync(join(shimDir!, 'package.json'), 'utf8')) as {
       name: string;
@@ -476,9 +496,14 @@ describe('PiProvider', () => {
     resetScript([
       {
         type: 'agent_end',
+        willRetry: false,
         messages: [
           {
             role: 'assistant',
+            api: 'test',
+            provider: 'test',
+            model: 'test',
+            timestamp: 0,
             usage: {
               input: 1,
               output: 1,
@@ -552,9 +577,14 @@ describe('PiProvider', () => {
     resetScript([
       {
         type: 'agent_end',
+        willRetry: false,
         messages: [
           {
             role: 'assistant',
+            api: 'test',
+            provider: 'test',
+            model: 'test',
+            timestamp: 0,
             usage: {
               input: 1,
               output: 1,
@@ -590,9 +620,14 @@ describe('PiProvider', () => {
     resetScript([
       {
         type: 'agent_end',
+        willRetry: false,
         messages: [
           {
             role: 'assistant',
+            api: 'test',
+            provider: 'test',
+            model: 'test',
+            timestamp: 0,
             usage: {
               input: 1,
               output: 1,
@@ -624,9 +659,14 @@ describe('PiProvider', () => {
     resetScript([
       {
         type: 'agent_end',
+        willRetry: false,
         messages: [
           {
             role: 'assistant',
+            api: 'test',
+            provider: 'test',
+            model: 'test',
+            timestamp: 0,
             usage: {
               input: 1,
               output: 1,
@@ -655,9 +695,14 @@ describe('PiProvider', () => {
     resetScript([
       {
         type: 'agent_end',
+        willRetry: false,
         messages: [
           {
             role: 'assistant',
+            api: 'test',
+            provider: 'test',
+            model: 'test',
+            timestamp: 0,
             usage: {
               input: 1,
               output: 1,
@@ -691,9 +736,14 @@ describe('PiProvider', () => {
     resetScript([
       {
         type: 'agent_end',
+        willRetry: false,
         messages: [
           {
             role: 'assistant',
+            api: 'test',
+            provider: 'test',
+            model: 'test',
+            timestamp: 0,
             usage: {
               input: 1,
               output: 1,
@@ -722,24 +772,34 @@ describe('PiProvider', () => {
     resetScript([
       {
         type: 'message_update',
-        message: { role: 'assistant' },
-        assistantMessageEvent: { type: 'text_delta', contentIndex: 0, delta: 'Hello', partial: {} },
+        message: { role: 'assistant' } as never,
+        assistantMessageEvent: {
+          type: 'text_delta',
+          contentIndex: 0,
+          delta: 'Hello',
+          partial: {} as never,
+        },
       },
       {
         type: 'message_update',
-        message: { role: 'assistant' },
+        message: { role: 'assistant' } as never,
         assistantMessageEvent: {
           type: 'text_delta',
           contentIndex: 0,
           delta: ' world',
-          partial: {},
+          partial: {} as never,
         },
       },
       {
         type: 'agent_end',
+        willRetry: false,
         messages: [
           {
             role: 'assistant',
+            api: 'test',
+            provider: 'test',
+            model: 'test',
+            timestamp: 0,
             usage: {
               input: 1,
               output: 2,
@@ -788,9 +848,14 @@ describe('PiProvider', () => {
       },
       {
         type: 'agent_end',
+        willRetry: false,
         messages: [
           {
             role: 'assistant',
+            api: 'test',
+            provider: 'test',
+            model: 'test',
+            timestamp: 0,
             usage: {
               input: 1,
               output: 1,
@@ -833,9 +898,14 @@ describe('PiProvider', () => {
     resetScript([
       {
         type: 'agent_end',
+        willRetry: false,
         messages: [
           {
             role: 'assistant',
+            api: 'test',
+            provider: 'test',
+            model: 'test',
+            timestamp: 0,
             usage: {
               input: 1,
               output: 1,
@@ -881,9 +951,14 @@ describe('PiProvider', () => {
     resetScript([
       {
         type: 'agent_end',
+        willRetry: false,
         messages: [
           {
             role: 'assistant',
+            api: 'test',
+            provider: 'test',
+            model: 'test',
+            timestamp: 0,
             usage: {
               input: 1,
               output: 1,
@@ -942,9 +1017,14 @@ describe('PiProvider', () => {
     resetScript([
       {
         type: 'agent_end',
+        willRetry: false,
         messages: [
           {
             role: 'assistant',
+            api: 'test',
+            provider: 'test',
+            model: 'test',
+            timestamp: 0,
             usage: {
               input: 1,
               output: 1,
@@ -974,9 +1054,14 @@ describe('PiProvider', () => {
     return [
       {
         type: 'agent_end',
+        willRetry: false,
         messages: [
           {
             role: 'assistant',
+            api: 'test',
+            provider: 'test',
+            model: 'test',
+            timestamp: 0,
             usage: {
               input: 1,
               output: 1,
@@ -1605,9 +1690,14 @@ describe('PiProvider', () => {
       controller.abort();
       capturedListener?.({
         type: 'agent_end',
+        willRetry: false,
         messages: [
           {
             role: 'assistant',
+            api: 'test',
+            provider: 'test',
+            model: 'test',
+            timestamp: 0,
             usage: {
               input: 1,
               output: 1,
@@ -2088,8 +2178,8 @@ describe('PiProvider', () => {
         })
       );
 
-      expect(process.env.PI_TEST_ONE).toBe('one');
-      expect(process.env.PI_TEST_TWO).toBe('two');
+      expect(readEnv('PI_TEST_ONE')).toBe('one');
+      expect(readEnv('PI_TEST_TWO')).toBe('two');
     } finally {
       delete process.env.PI_TEST_ONE;
       delete process.env.PI_TEST_TWO;

--- a/packages/providers/src/community/pi/provider.test.ts
+++ b/packages/providers/src/community/pi/provider.test.ts
@@ -3,7 +3,13 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
-import type { AgentSessionEvent } from '@earendil-works/pi-coding-agent';
+import type {
+  AgentSessionEvent,
+  CreateAgentSessionOptions,
+  CreateAgentSessionResult,
+  ModelRegistry,
+} from '@earendil-works/pi-coding-agent';
+import type { Api, Model } from '@earendil-works/pi-ai';
 
 // Typed against the real registration shape (config: ProviderConfig) so the
 // mock runtime drifts loudly, not silently, if the SDK/type changes — same
@@ -35,7 +41,7 @@ type FakeEvent = AgentSessionEvent;
 let capturedListener: ((event: FakeEvent) => void) | undefined;
 
 const scriptedEvents: FakeEvent[] = [];
-const mockPrompt = mock(async (_prompt: string) => {
+const mockPrompt = mock(async (_prompt: string): Promise<void> => {
   for (const ev of scriptedEvents) capturedListener?.(ev);
 });
 const mockAbort = mock(async () => undefined);
@@ -65,18 +71,19 @@ const mockSession = {
   sessionId: 'mock-session-uuid',
 };
 
-type MockSessionResult = {
-  session: typeof mockSession;
-  extensionsResult: { extensions: never[]; errors: never[]; runtime: Record<string, never> };
-  modelFallbackMessage: string | undefined;
-};
-
-const mockCreateAgentSession = mock(
-  async (_options?: unknown): Promise<MockSessionResult> => ({
+function createMockSessionResult(modelFallbackMessage?: string): CreateAgentSessionResult {
+  return {
     session: mockSession,
     extensionsResult: { extensions: [], errors: [], runtime: {} },
-    modelFallbackMessage: undefined,
-  })
+    modelFallbackMessage,
+  } as unknown as CreateAgentSessionResult;
+}
+
+const mockCreateAgentSession = mock<
+  typeof import('@earendil-works/pi-coding-agent').createAgentSession
+>(
+  async (_options?: CreateAgentSessionOptions): Promise<CreateAgentSessionResult> =>
+    createMockSessionResult()
 );
 
 // Per-test state backing the AuthStorage mock. `fileCreds` emulates what's
@@ -103,18 +110,32 @@ const mockAuthCreate = mock(() => ({
   getApiKey: mockGetApiKey,
 }));
 
-const mockModelRegistryFind = mock((provider: string, modelId: string) => {
+function createMockModel(provider: string, modelId: string): Model<Api> {
+  return {
+    id: modelId,
+    provider,
+    name: `${provider}/${modelId}`,
+    api: 'openai-completions',
+    baseUrl: 'https://example.invalid',
+    reasoning: false,
+    input: ['text'],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 8_192,
+  };
+}
+
+const mockModelRegistryFind = mock<ModelRegistry['find']>((provider, modelId) => {
   if (provider === 'nonexistent') return undefined;
-  return { id: modelId, provider, name: `${provider}/${modelId}` };
+  return createMockModel(provider, modelId);
 });
-type MockModelRegistry = {
-  find: (
-    provider: string,
-    modelId: string
-  ) => { id: string; provider: string; name: string } | undefined;
-};
-const mockModelRegistryCreate = mock(
-  (): MockModelRegistry => ({
+type MockModelRegistry = Pick<ModelRegistry, 'find'> &
+  Partial<Pick<ModelRegistry, 'getError' | 'registerProvider'>>;
+type MockModelRegistryCreate = (
+  ...args: Parameters<typeof import('@earendil-works/pi-coding-agent').ModelRegistry.create>
+) => MockModelRegistry;
+const mockModelRegistryCreate = mock<MockModelRegistryCreate>(
+  (_authStorage): MockModelRegistry => ({
     find: mockModelRegistryFind,
   })
 );
@@ -551,11 +572,9 @@ describe('PiProvider', () => {
     // Phase 1: model not in static catalog (extension provider path).
     // Phase 2: extension registers the model during bindExtensions() and find() succeeds.
     mockModelRegistryFind.mockImplementationOnce(() => undefined);
-    mockModelRegistryFind.mockImplementationOnce(() => ({
-      id: 'custom-model',
-      provider: 'extension-provider',
-      name: 'extension-provider/custom-model',
-    }));
+    mockModelRegistryFind.mockImplementationOnce(() =>
+      createMockModel('extension-provider', 'custom-model')
+    );
     resetScript(scriptedAgentEnd());
 
     const { error } = await consume(
@@ -1724,11 +1743,10 @@ describe('PiProvider', () => {
 
   test('modelFallbackMessage yields a system chunk before the agent runs', async () => {
     process.env.GEMINI_API_KEY = 'sk-test';
-    mockCreateAgentSession.mockImplementationOnce(async () => ({
-      session: mockSession,
-      extensionsResult: { extensions: [], errors: [], runtime: {} },
-      modelFallbackMessage: 'Requested sonnet-5 not available, using haiku.',
-    }));
+    mockCreateAgentSession.mockImplementationOnce(
+      async (): Promise<CreateAgentSessionResult> =>
+        createMockSessionResult('Requested sonnet-5 not available, using haiku.')
+    );
     resetScript(scriptedAgentEnd());
 
     const { chunks } = await consume(
@@ -2485,22 +2503,17 @@ describe('PiProvider', () => {
      * registered into it — like the real one, whose static catalog does not
      * contain extension providers such as 'cursor'.
      */
-    function fakeExtensionAwareRegistry(): {
-      registered: Map<string, unknown>;
-      find: (
-        provider: string,
-        modelId: string
-      ) => { id: string; provider: string; name: string } | undefined;
-      registerProvider: (name: string, config: unknown) => void;
+    type ExtensionProviderConfig = Parameters<ModelRegistry['registerProvider']>[1];
+
+    function fakeExtensionAwareRegistry(): MockModelRegistry & {
+      registered: Map<string, ExtensionProviderConfig>;
     } {
-      const registered = new Map<string, unknown>();
+      const registered = new Map<string, ExtensionProviderConfig>();
       return {
         registered,
         find: (provider: string, modelId: string) =>
-          registered.has(provider)
-            ? { id: modelId, provider, name: `${provider}/${modelId}` }
-            : undefined,
-        registerProvider: (name: string, config: unknown) => {
+          registered.has(provider) ? createMockModel(provider, modelId) : undefined,
+        registerProvider: (name: string, config: ExtensionProviderConfig): void => {
           registered.set(name, config);
         },
       };
@@ -2512,20 +2525,17 @@ describe('PiProvider', () => {
      * registry, then clear it (the SDK reassigns to []).
      */
     function drainQueueOnceIntoSessionRegistry(): void {
-      mockCreateAgentSession.mockImplementationOnce(async (options?: unknown) => {
-        const { modelRegistry } = options as {
-          modelRegistry: { registerProvider: (name: string, config: unknown) => void };
-        };
-        for (const { name, config } of mockLoaderRuntime.pendingProviderRegistrations) {
-          modelRegistry.registerProvider(name, config);
+      mockCreateAgentSession.mockImplementationOnce(
+        async (options?: CreateAgentSessionOptions): Promise<CreateAgentSessionResult> => {
+          const modelRegistry = options?.modelRegistry;
+          if (!modelRegistry) throw new Error('Expected a model registry');
+          for (const { name, config } of mockLoaderRuntime.pendingProviderRegistrations) {
+            modelRegistry.registerProvider(name, config);
+          }
+          mockLoaderRuntime.pendingProviderRegistrations = [];
+          return createMockSessionResult();
         }
-        mockLoaderRuntime.pendingProviderRegistrations = [];
-        return {
-          session: mockSession,
-          extensionsResult: { extensions: [], errors: [], runtime: {} },
-          modelFallbackMessage: undefined,
-        };
-      });
+      );
     }
 
     test('extension-registered model resolves on the 2nd+ sendQuery (the issue #2064 scenario)', async () => {

--- a/packages/providers/src/community/pi/ui-context-stub.test.ts
+++ b/packages/providers/src/community/pi/ui-context-stub.test.ts
@@ -29,6 +29,10 @@ describe('createArchonUIBridge', () => {
 });
 
 describe('createArchonUIContext', () => {
+  function assistantContent(chunk: MessageChunk | undefined): string | undefined {
+    return chunk?.type === 'assistant' ? chunk.content : undefined;
+  }
+
   function mk() {
     const bridge = createArchonUIBridge();
     const chunks: MessageChunk[] = [];
@@ -51,15 +55,15 @@ describe('createArchonUIContext', () => {
   test('notify defaults to info when type omitted', () => {
     const { ui, chunks } = mk();
     ui.notify('bare message');
-    expect(chunks[0]?.content).toBe('\n[pi extension ℹ️] bare message\n');
+    expect(assistantContent(chunks[0])).toBe('\n[pi extension ℹ️] bare message\n');
   });
 
   test('notify("warning") and notify("error") use distinct glyphs', () => {
     const { ui, chunks } = mk();
     ui.notify('soft', 'warning');
     ui.notify('hard', 'error');
-    expect(chunks[0]?.content).toBe('\n[pi extension ⚠️] soft\n');
-    expect(chunks[1]?.content).toBe('\n[pi extension ❌] hard\n');
+    expect(assistantContent(chunks[0])).toBe('\n[pi extension ⚠️] soft\n');
+    expect(assistantContent(chunks[1])).toBe('\n[pi extension ❌] hard\n');
   });
 
   test('select resolves to undefined (no operator to answer)', async () => {

--- a/packages/providers/src/registry.test.ts
+++ b/packages/providers/src/registry.test.ts
@@ -15,7 +15,7 @@ import { registerPiProvider } from './community/pi/registration';
 import { registerCopilotProvider } from './community/copilot/registration';
 import { registerOpencodeProvider } from './community/opencode/registration';
 import { UnknownProviderError } from './errors';
-import type { ProviderRegistration, IAgentProvider, ProviderCapabilities } from './types';
+import type { ProviderRegistration, IAgentProvider } from './types';
 
 /** Minimal mock provider for testing registration. */
 function makeMockProvider(id: string): IAgentProvider {
@@ -37,6 +37,7 @@ function makeMockProvider(id: string): IAgentProvider {
       sandbox: false,
       nativeTools: false,
       containerExec: false,
+      settingSources: false,
     }),
     async *sendQuery() {
       yield { type: 'result' as const };

--- a/packages/providers/tsconfig.json
+++ b/packages/providers/tsconfig.json
@@ -4,5 +4,5 @@
     "noEmit": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/workflows/src/condition-evaluator.test.ts
+++ b/packages/workflows/src/condition-evaluator.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, mock } from 'bun:test';
 
 // --- Mock logger (MUST come before imports of modules under test) ---
 
-const mockLogFn = mock((_data: unknown, _message?: string) => {});
+const mockLogFn = mock((_data: unknown, _message?: string): void => {});
 const mockLogger = {
   info: mockLogFn,
   warn: mockLogFn,

--- a/packages/workflows/src/condition-evaluator.test.ts
+++ b/packages/workflows/src/condition-evaluator.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, mock } from 'bun:test';
 
 // --- Mock logger (MUST come before imports of modules under test) ---
 
-const mockLogFn = mock(() => {});
+const mockLogFn = mock((_data: unknown, _message?: string) => {});
 const mockLogger = {
   info: mockLogFn,
   warn: mockLogFn,

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -58,6 +58,7 @@ import {
   clearRegistry,
   getProviderCapabilities,
 } from '@archon/providers';
+import type { SendQueryOptions } from '@archon/providers';
 clearRegistry();
 registerBuiltinProviders();
 // Pi is a community provider (best-effort structured output) — register it so the
@@ -92,7 +93,7 @@ import type {
   WorkflowRun,
   WorkflowDefinition,
 } from './schemas';
-import { dagNodeSchema } from './schemas';
+import { dagNodeSchema, workflowDefinitionSchema } from './schemas';
 import { discoverWorkflows } from './workflow-discovery';
 import { parseWorkflow } from './loader';
 import { expandWorkflowIncludes } from './include-expander';
@@ -109,6 +110,7 @@ import {
   isLiteralSpec,
   resolveModelSpec,
   type ModelAliasPreset,
+  type RawTiersConfig,
 } from './model-validation';
 
 // --- Mock helpers ---
@@ -19684,12 +19686,12 @@ describe('executeDagWorkflow -- a workflow runs as authored, standalone or compo
   }
 
   function wfDef(name: string, nodes: unknown[], workflowLevel: object = {}): WorkflowDefinition {
-    return {
+    return workflowDefinitionSchema.parse({
       name,
       description: name,
       nodes: nodes.map(n => dagNodeSchema.parse(n)),
       ...workflowLevel,
-    } as WorkflowDefinition;
+    });
   }
 
   const collapseConfig: WorkflowConfig = {
@@ -19711,7 +19713,7 @@ describe('executeDagWorkflow -- a workflow runs as authored, standalone or compo
   async function effectiveConfigs(
     defs: readonly WorkflowDefinition[],
     runName: string,
-    options: { expand?: boolean; profileProvider?: string; tiers?: Record<string, unknown> } = {}
+    options: { expand?: boolean; profileProvider?: string; tiers?: RawTiersConfig } = {}
   ): Promise<Map<string, EffectiveConfig>> {
     let workflow: WorkflowDefinition;
     if (options.expand === false) {
@@ -19723,7 +19725,7 @@ describe('executeDagWorkflow -- a workflow runs as authored, standalone or compo
     }
 
     const aiProfile = buildAiProfile(options.profileProvider ?? collapseConfig.assistant, {
-      ...(options.tiers ? { repoTiers: options.tiers as never } : {}),
+      ...(options.tiers ? { repoTiers: options.tiers } : {}),
     });
 
     // --- mirror of executor.ts's workflow-level resolution ---
@@ -19743,24 +19745,24 @@ describe('executeDagWorkflow -- a workflow runs as authored, standalone or compo
     workflowModel ??= collapseConfig.assistants[workflowProvider]?.model as string | undefined;
     // --- end mirror ---
 
-    const seen: { provider: string; options: Record<string, unknown> }[] = [];
+    const seen: { provider: string; options: SendQueryOptions }[] = [];
     const deps: WorkflowDeps = {
       store: createMockStore(),
-      getAgentProvider: mock((provider: string) => ({
-        sendQuery: mock(function* (
-          _prompt: string,
-          _cwd: string,
-          _resume: unknown,
-          queryOptions: Record<string, unknown>
-        ) {
-          seen.push({ provider, options: queryOptions });
-          yield { type: 'assistant', content: 'ok' };
-          yield { type: 'result', sessionId: `sid-${String(seen.length)}` };
-        }),
-        getType: () => provider,
-        getCapabilities: provider === 'codex' ? mockCodexCapabilities : mockClaudeCapabilities,
-      })) as unknown as WorkflowDeps['getAgentProvider'],
-      loadConfig: mock(() => Promise.resolve(collapseConfig)),
+      getAgentProvider: mock<WorkflowDeps['getAgentProvider']>(
+        (provider): ReturnType<WorkflowDeps['getAgentProvider']> => ({
+          sendQuery: mock<ReturnType<WorkflowDeps['getAgentProvider']>['sendQuery']>(
+            async function* (_prompt, _cwd, _resume, queryOptions) {
+              if (!queryOptions) throw new Error('Expected provider query options');
+              seen.push({ provider, options: queryOptions });
+              yield { type: 'assistant', content: 'ok' };
+              yield { type: 'result', sessionId: `sid-${String(seen.length)}` };
+            }
+          ),
+          getType: (): string => provider,
+          getCapabilities: provider === 'codex' ? mockCodexCapabilities : mockClaudeCapabilities,
+        })
+      ),
+      loadConfig: mock<WorkflowDeps['loadConfig']>(async _cwd => collapseConfig),
     };
 
     await executeDagWorkflow(
@@ -19788,7 +19790,8 @@ describe('executeDagWorkflow -- a workflow runs as authored, standalone or compo
 
     const result = new Map<string, EffectiveConfig>();
     for (const { provider, options: queryOptions } of seen) {
-      const nodeConfig = queryOptions.nodeConfig as Record<string, unknown>;
+      const nodeConfig = queryOptions.nodeConfig;
+      if (!nodeConfig) throw new Error('Expected workflow node configuration');
       const rawId = String(nodeConfig.nodeId);
       const id = rawId.includes('__') ? rawId.slice(rawId.lastIndexOf('__') + 2) : rawId;
       result.set(id, {
@@ -19901,7 +19904,7 @@ describe('executeDagWorkflow -- a workflow runs as authored, standalone or compo
     );
     expect(errors).toEqual([]);
     const expanded = workflows.get('parent')!;
-    const byId = new Map(expanded.nodes.map(n => [n.id, n as Record<string, unknown>]));
+    const byId = new Map(expanded.nodes.map(n => [n.id, n]));
     expect(byId.get('own')?.provider).toBe('claude');
     expect(byId.get('a__run')?.provider).toBe('pi');
     expect(byId.get('b__run')?.provider).toBe('codex');
@@ -19953,14 +19956,11 @@ describe('executeDagWorkflow -- a workflow runs as authored, standalone or compo
     );
     expect(errors).toEqual([]);
     const group = workflows.get('top')!.nodes.find(n => n.id === 'm__in__group')!;
-    expect((group as Record<string, unknown>).provider).toBe('codex');
+    expect(group.provider).toBe('codex');
     // The body node carries the INNER file's provider, not mid's or top's.
-    const body = (group as { loop_group: { nodes: DagNode[] } }).loop_group.nodes[0] as Record<
-      string,
-      unknown
-    >;
-    expect(body.provider).toBe('codex');
-    expect(body.model).toBe('gpt-5.6-sol');
+    const body = group.loop_group?.nodes[0];
+    expect(body?.provider).toBe('codex');
+    expect(body?.model).toBe('gpt-5.6-sol');
   });
 });
 
@@ -19977,7 +19977,7 @@ describe('executeDagWorkflow -- composed-workflow run-time boundaries', () => {
     testDir = join(tmpdir(), `dag-comp-rt-${Date.now()}-${Math.random().toString(36).slice(2)}`);
     await mkdir(testDir, { recursive: true });
     mockSendQueryDag.mockClear();
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'response' };
       yield { type: 'result', sessionId: 'session-1' };
     });
@@ -19992,19 +19992,17 @@ describe('executeDagWorkflow -- composed-workflow run-time boundaries', () => {
   });
 
   function buildWf(name: string, nodes: unknown[], extra: object = {}): WorkflowDefinition {
-    return {
+    return workflowDefinitionSchema.parse({
       name,
       description: name,
       nodes: nodes.map(n => dagNodeSchema.parse(n)),
       ...extra,
-    } as WorkflowDefinition;
+    });
   }
 
   /** The `node_output` a completed node persisted, read from its node_completed event. */
-  function nodeOutputOf(store: IWorkflowStore, stepName: string): string | undefined {
-    const event = (
-      store.createWorkflowEvent as Mock<(e: Record<string, unknown>) => Promise<void>>
-    ).mock.calls
+  function nodeOutputOf(store: MockWorkflowStore, stepName: string): string | undefined {
+    const event = store.createWorkflowEvent.mock.calls
       .map(c => c[0])
       .find(e => e.event_type === 'node_completed' && e.step_name === stepName);
     return (event?.data as { node_output?: string } | undefined)?.node_output;
@@ -20148,12 +20146,10 @@ describe('executeDagWorkflow -- composed-workflow run-time boundaries', () => {
 
     const store = createMockStore();
     const deps = createMockDeps(store);
-    deps.loadConfig = mock(() =>
-      Promise.resolve({
-        ...minimalConfig,
-        envVars: { INPUTS_PLAN: 'from-project-env', ARGUMENTS: 'hijacked' },
-      })
-    ) as WorkflowDeps['loadConfig'];
+    deps.loadConfig = mock<WorkflowDeps['loadConfig']>(async _cwd => ({
+      ...minimalConfig,
+      envVars: { INPUTS_PLAN: 'from-project-env', ARGUMENTS: 'hijacked' },
+    }));
 
     const { workflows, errors } = expandWorkflowIncludes(
       new Map([
@@ -20214,7 +20210,7 @@ describe('executeDagWorkflow -- systemPrompt and agents are runtime substitution
     testDir = join(tmpdir(), `dag-aicfg-${Date.now()}-${Math.random().toString(36).slice(2)}`);
     await mkdir(testDir, { recursive: true });
     mockSendQueryDag.mockClear();
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'response' };
       yield { type: 'result', sessionId: 'session-1' };
     });
@@ -20231,13 +20227,13 @@ describe('executeDagWorkflow -- systemPrompt and agents are runtime substitution
   async function runNodes(
     nodes: unknown[],
     run = makeWorkflowRun('aicfg-run')
-  ): Promise<Record<string, unknown>[]> {
+  ): Promise<SendQueryOptions[]> {
     await executeDagWorkflow(
       createMockDeps(),
       createMockPlatform(),
       'conv-dag',
       testDir,
-      { name: 'aicfg', description: 'aicfg', nodes: nodes.map(n => dagNodeSchema.parse(n)) },
+      { name: 'aicfg', nodes: nodes.map(n => dagNodeSchema.parse(n)) },
       run,
       'claude',
       undefined,
@@ -20248,7 +20244,11 @@ describe('executeDagWorkflow -- systemPrompt and agents are runtime substitution
       'docs/',
       minimalConfig
     );
-    return mockSendQueryDag.mock.calls.map(c => c[3] as Record<string, unknown>);
+    return mockSendQueryDag.mock.calls.map(call => {
+      const options = call[3];
+      if (!options) throw new Error('Expected provider query options');
+      return options;
+    });
   }
 
   it('AC15 — all three surfaces resolve workflow variables and $node.output refs', async () => {
@@ -20271,9 +20271,8 @@ describe('executeDagWorkflow -- systemPrompt and agents are runtime substitution
     const artifacts = join(testDir, 'artifacts');
     const last = options.at(-1)!;
     expect(last.systemPrompt).toBe(`artifacts=${artifacts} upstream=UPSTREAM`);
-    const nodeConfig = last.nodeConfig as { agents: Record<string, Record<string, string>> };
-    expect(nodeConfig.agents.helper.description).toBe('handles UPSTREAM');
-    expect(nodeConfig.agents.helper.prompt).toBe(`work on UPSTREAM in ${artifacts}`);
+    expect(last.nodeConfig?.agents?.helper?.description).toBe('handles UPSTREAM');
+    expect(last.nodeConfig?.agents?.helper?.prompt).toBe(`work on UPSTREAM in ${artifacts}`);
   });
 
   it('AC15 — the node definition is not mutated, so a second pass is not double-substituted', async () => {
@@ -20287,7 +20286,7 @@ describe('executeDagWorkflow -- systemPrompt and agents are runtime substitution
       createMockPlatform(),
       'conv-dag',
       testDir,
-      { name: 'aicfg2', description: 'aicfg2', nodes: [definition] },
+      { name: 'aicfg2', nodes: [definition] },
       makeWorkflowRun('aicfg-run-2'),
       'claude',
       undefined,
@@ -20298,7 +20297,7 @@ describe('executeDagWorkflow -- systemPrompt and agents are runtime substitution
       'docs/',
       minimalConfig
     );
-    expect((definition as Record<string, unknown>).systemPrompt).toBe('dir=$ARTIFACTS_DIR');
+    expect(definition.systemPrompt).toBe('dir=$ARTIFACTS_DIR');
   });
 
   it('AC15 — $INPUTS in a systemPrompt produces the same text standalone as composed', async () => {
@@ -20346,9 +20345,7 @@ describe('executeDagWorkflow -- systemPrompt and agents are runtime substitution
       'docs/',
       minimalConfig
     );
-    expect((mockSendQueryDag.mock.calls.at(-1)![3] as Record<string, unknown>).systemPrompt).toBe(
-      'mode=strict'
-    );
+    expect(mockSendQueryDag.mock.calls.at(-1)?.[3]?.systemPrompt).toBe('mode=strict');
   });
 });
 
@@ -20366,7 +20363,7 @@ describe('executeDagWorkflow -- composition governance survives the collapse', (
     testDir = join(tmpdir(), `dag-gov-${Date.now()}-${Math.random().toString(36).slice(2)}`);
     await mkdir(testDir, { recursive: true });
     mockSendQueryDag.mockClear();
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'response' };
       yield { type: 'result', sessionId: 'session-1' };
     });
@@ -20381,12 +20378,12 @@ describe('executeDagWorkflow -- composition governance survives the collapse', (
   });
 
   function buildWf(name: string, nodes: unknown[], extra: object = {}): WorkflowDefinition {
-    return {
+    return workflowDefinitionSchema.parse({
       name,
       description: name,
       nodes: nodes.map(n => dagNodeSchema.parse(n)),
       ...extra,
-    } as WorkflowDefinition;
+    });
   }
 
   it('AC13 — a run paused BEFORE the collapse resumes with collapsed config afterwards', async () => {
@@ -20420,15 +20417,17 @@ describe('executeDagWorkflow -- composition governance survives the collapse', (
     const seen: string[] = [];
     const deps: WorkflowDeps = {
       store,
-      getAgentProvider: mock((provider: string) => {
-        seen.push(provider);
-        return {
-          sendQuery: mockSendQueryDag,
-          getType: () => provider,
-          getCapabilities: provider === 'codex' ? mockCodexCapabilities : mockClaudeCapabilities,
-        };
-      }) as unknown as WorkflowDeps['getAgentProvider'],
-      loadConfig: mock(() => Promise.resolve(minimalConfig)),
+      getAgentProvider: mock<WorkflowDeps['getAgentProvider']>(
+        (provider): ReturnType<WorkflowDeps['getAgentProvider']> => {
+          seen.push(provider);
+          return {
+            sendQuery: mockSendQueryDag,
+            getType: (): string => provider,
+            getCapabilities: provider === 'codex' ? mockCodexCapabilities : mockClaudeCapabilities,
+          };
+        }
+      ),
+      loadConfig: mock<WorkflowDeps['loadConfig']>(async _cwd => minimalConfig),
     };
 
     await executeDagWorkflow(
@@ -20451,9 +20450,7 @@ describe('executeDagWorkflow -- composition governance survives the collapse', (
       prior
     );
 
-    const events = (
-      store.createWorkflowEvent as Mock<(e: Record<string, unknown>) => Promise<void>>
-    ).mock.calls.map(c => c[0]);
+    const events = store.createWorkflowEvent.mock.calls.map(call => call[0]);
     expect(
       events.some(
         e => e.event_type === 'node_skipped_prior_success' && e.step_name === 'inc__first'
@@ -20502,9 +20499,7 @@ describe('executeDagWorkflow -- composition governance survives the collapse', (
       minimalConfig
     );
 
-    const pauseCalls = (
-      store.pauseWorkflowRun as Mock<(id: string, ctx: Record<string, unknown>) => Promise<void>>
-    ).mock.calls;
+    const pauseCalls = store.pauseWorkflowRun.mock.calls;
     expect(pauseCalls.length).toBe(1);
     // One addressable run: the composition pauses the run that composed it. A `workflow:`
     // node would instead pause a second row the human approves by its own id.
@@ -20523,7 +20518,7 @@ describe('executeDagWorkflow -- a workflow-level provider/model conflict is repo
     testDir = join(tmpdir(), `dag-conflict-${Date.now()}-${Math.random().toString(36).slice(2)}`);
     await mkdir(testDir, { recursive: true });
     mockSendQueryDag.mockClear();
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'ok' };
       yield { type: 'result', sessionId: 'sid' };
     });
@@ -20545,7 +20540,7 @@ describe('executeDagWorkflow -- a workflow-level provider/model conflict is repo
       new Map([
         [
           'conflict',
-          {
+          workflowDefinitionSchema.parse({
             name: 'conflict',
             description: 'conflict',
             provider: 'claude',
@@ -20555,7 +20550,7 @@ describe('executeDagWorkflow -- a workflow-level provider/model conflict is repo
               dagNodeSchema.parse({ id: 'b', prompt: 'b', depends_on: ['a'] }),
               dagNodeSchema.parse({ id: 'c', prompt: 'c', depends_on: ['b'] }),
             ],
-          } as WorkflowDefinition,
+          }),
         ],
       ])
     );
@@ -20586,9 +20581,7 @@ describe('executeDagWorkflow -- a workflow-level provider/model conflict is repo
       })
     );
 
-    const conflictMessages = (
-      platform.sendMessage as Mock<(conversationId: string, message: string) => Promise<void>>
-    ).mock.calls
+    const conflictMessages = platform.sendMessage.mock.calls
       .map(c => c[1])
       .filter(m => typeof m === 'string' && m.includes("resolves to provider 'codex'"));
     expect(conflictMessages).toHaveLength(1);

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -17,7 +17,7 @@ import * as git from '@archon/git';
 
 // --- Mock logger (MUST come before imports of modules under test) ---
 
-const mockLogFn = mock(() => {});
+const mockLogFn = mock((_data: unknown, _message?: string) => {});
 const mockLogger = {
   info: mockLogFn,
   warn: mockLogFn,
@@ -29,7 +29,9 @@ const mockLogger = {
 };
 // Hoisted telemetry mock — declared before the mock.module factory runs so the
 // completion-telemetry tests can assert on it.
-const mockCaptureWorkflowCompleted = mock(() => {});
+const mockCaptureWorkflowCompleted = mock<typeof import('@archon/paths').captureWorkflowCompleted>(
+  _props => {}
+);
 mock.module('@archon/paths', () => ({
   createLogger: mock(() => mockLogger),
   getCommandFolderSearchPaths: (folder?: string) => {
@@ -82,6 +84,7 @@ import { getWorkflowEventEmitter, type WorkflowEmitterEvent } from './event-emit
 import { loadMcpConfig } from '@archon/providers/mcp/config';
 import type {
   DagNode,
+  CommandNode,
   BashNode,
   ScriptNode,
   NodeOutput,
@@ -109,69 +112,75 @@ import {
 
 // --- Mock helpers ---
 
-function createMockStore(): IWorkflowStore {
+type MockWorkflowStore = {
+  [K in keyof IWorkflowStore]: IWorkflowStore[K] extends (...args: infer Args) => infer Result
+    ? Mock<(...args: Args) => Result>
+    : IWorkflowStore[K];
+};
+
+function mockWorkflowRun(id = 'mock-run-id'): WorkflowRun {
   return {
-    createWorkflowRun: mock(() =>
-      Promise.resolve({
-        id: 'mock-run-id',
-        workflow_name: 'mock',
-        conversation_id: 'conv-mock',
-        parent_conversation_id: null,
-        codebase_id: null,
-        status: 'running' as const,
-        user_message: 'mock message',
-        metadata: {},
-        started_at: new Date(),
-        completed_at: null,
-        last_activity_at: null,
-        working_path: null,
-        parent_run_id: null,
-      })
+    id,
+    workflow_name: 'mock',
+    conversation_id: 'conv-mock',
+    parent_conversation_id: null,
+    codebase_id: null,
+    status: 'running',
+    user_message: 'mock message',
+    metadata: {},
+    started_at: new Date(),
+    completed_at: null,
+    last_activity_at: null,
+    working_path: null,
+    user_id: null,
+    parent_run_id: null,
+    output_root: null,
+  };
+}
+
+function createMockStore(): MockWorkflowStore {
+  return {
+    createWorkflowRun: mock<IWorkflowStore['createWorkflowRun']>(async _data => mockWorkflowRun()),
+    getWorkflowRun: mock<IWorkflowStore['getWorkflowRun']>(async _id => null),
+    findChildRuns: mock<IWorkflowStore['findChildRuns']>(async _parentRunId => []),
+    getRunAncestry: mock<IWorkflowStore['getRunAncestry']>(async _runId => []),
+    getActiveWorkflowRunByPath: mock<IWorkflowStore['getActiveWorkflowRunByPath']>(
+      async (_workingPath, _self) => null
     ),
-    getWorkflowRun: mock(() => Promise.resolve(null)),
-    findChildRuns: mock(() => Promise.resolve([])),
-    getRunAncestry: mock(() => Promise.resolve([])),
-    getActiveWorkflowRunByPath: mock(() => Promise.resolve(null)),
-    failOrphanedRuns: mock(() => Promise.resolve({ count: 0 })),
-    findResumableRun: mock(() => Promise.resolve(null)),
-    resumeWorkflowRun: mock(() =>
-      Promise.resolve({
-        id: 'mock-run-id',
-        workflow_name: 'mock',
-        conversation_id: 'conv-mock',
-        parent_conversation_id: null,
-        codebase_id: null,
-        status: 'running' as const,
-        user_message: 'mock message',
-        metadata: {},
-        started_at: new Date(),
-        completed_at: null,
-        last_activity_at: null,
-        working_path: null,
-        parent_run_id: null,
-      })
+    failOrphanedRuns: mock<IWorkflowStore['failOrphanedRuns']>(async () => ({ count: 0 })),
+    findResumableRun: mock<IWorkflowStore['findResumableRun']>(
+      async (_workflowName, _workingPath) => null
     ),
-    updateWorkflowRun: mock(() => Promise.resolve()),
-    updateWorkflowActivity: mock(() => Promise.resolve()),
-    getWorkflowRunStatus: mock(() => Promise.resolve('running' as const)),
-    completeWorkflowRun: mock(() => Promise.resolve()),
-    failWorkflowRun: mock(() => Promise.resolve()),
-    pauseWorkflowRun: mock(() => Promise.resolve()),
-    claimWriteback: mock(() => Promise.resolve({ claimed: true })),
-    releaseWritebackClaim: mock(() => Promise.resolve()),
-    cancelWorkflowRun: mock(() => Promise.resolve()),
-    createWorkflowEvent: mock(() => Promise.resolve()),
-    getDagResumeSnapshot: mock(() =>
+    resumeWorkflowRun: mock<IWorkflowStore['resumeWorkflowRun']>(async _id => mockWorkflowRun()),
+    updateWorkflowRun: mock<IWorkflowStore['updateWorkflowRun']>(async (_id, _updates) => {}),
+    updateWorkflowActivity: mock<IWorkflowStore['updateWorkflowActivity']>(async _id => {}),
+    getWorkflowRunStatus: mock<IWorkflowStore['getWorkflowRunStatus']>(async _id => 'running'),
+    completeWorkflowRun: mock<IWorkflowStore['completeWorkflowRun']>(async (_id, _metadata) => {}),
+    failWorkflowRun: mock<IWorkflowStore['failWorkflowRun']>(async (_id, _error) => {}),
+    pauseWorkflowRun: mock<IWorkflowStore['pauseWorkflowRun']>(
+      async (_id, _approvalContext, _extraMetadata) => {}
+    ),
+    claimWriteback: mock<IWorkflowStore['claimWriteback']>(async _id => ({ claimed: true })),
+    releaseWritebackClaim: mock<IWorkflowStore['releaseWritebackClaim']>(async _id => {}),
+    cancelWorkflowRun: mock<IWorkflowStore['cancelWorkflowRun']>(async _id => ({
+      cancelled: false,
+    })),
+    createWorkflowEvent: mock<IWorkflowStore['createWorkflowEvent']>(async _data => {}),
+    getDagResumeSnapshot: mock<IWorkflowStore['getDagResumeSnapshot']>(async _workflowRunId =>
       Promise.resolve({
         completedNodeOutputs: new Map<string, string>(),
         tokens: { input: 0, output: 0 },
       })
     ),
-    getCodebase: mock(() => Promise.resolve(null)),
-    getCodebaseEnvVars: mock(() => Promise.resolve({})),
-    getWorkflowNodeSession: mock(() => Promise.resolve(null)),
-    upsertWorkflowNodeSession: mock(() => Promise.resolve()),
-    deleteWorkflowNodeSessions: mock(() => Promise.resolve({ deleted: 0 })),
+    getCodebase: mock<IWorkflowStore['getCodebase']>(async _id => null),
+    getCodebaseEnvVars: mock<IWorkflowStore['getCodebaseEnvVars']>(async _codebaseId => ({})),
+    getWorkflowNodeSession: mock<IWorkflowStore['getWorkflowNodeSession']>(async _key => null),
+    upsertWorkflowNodeSession: mock<IWorkflowStore['upsertWorkflowNodeSession']>(
+      async _params => {}
+    ),
+    deleteWorkflowNodeSessions: mock<IWorkflowStore['deleteWorkflowNodeSessions']>(
+      async _filter => ({ deleted: 0 })
+    ),
   };
 }
 
@@ -191,6 +200,8 @@ const mockClaudeCapabilities = () => ({
   fallbackModel: true,
   sandbox: true,
   settingSources: true,
+  nativeTools: true,
+  containerExec: true,
 });
 /** Limited capabilities for Codex mock */
 const mockCodexCapabilities = () => ({
@@ -210,42 +221,66 @@ const mockCodexCapabilities = () => ({
   fallbackModel: false,
   sandbox: false,
   settingSources: false,
+  nativeTools: true,
+  containerExec: false,
 });
 
 /** Mock AI sendQuery generator */
-const mockSendQueryDag = mock(function* () {
-  yield { type: 'assistant', content: 'DAG AI response' };
-  yield { type: 'result', sessionId: 'dag-session-id' };
-});
+const mockSendQueryDag = mock<ReturnType<WorkflowDeps['getAgentProvider']>['sendQuery']>(
+  async function* (_prompt, _cwd, _resumeSessionId, _options) {
+    yield { type: 'assistant', content: 'DAG AI response' };
+    yield { type: 'result', sessionId: 'dag-session-id' };
+  }
+);
 
-const mockGetAgentProviderDag = mock(() => ({
+const mockGetAgentProviderDag = mock<WorkflowDeps['getAgentProvider']>(_provider => ({
   sendQuery: mockSendQueryDag,
   getType: () => 'claude',
   getCapabilities: mockClaudeCapabilities,
 }));
 
-function createMockDeps(storeOverride?: IWorkflowStore): WorkflowDeps {
+type MockWorkflowDeps<TStore extends IWorkflowStore> = Omit<
+  WorkflowDeps,
+  'store' | 'getAgentProvider' | 'loadConfig'
+> & {
+  store: TStore;
+  getAgentProvider: typeof mockGetAgentProviderDag;
+  loadConfig: Mock<WorkflowDeps['loadConfig']>;
+};
+
+function createMockDeps<TStore extends IWorkflowStore = MockWorkflowStore>(
+  storeOverride?: TStore
+): MockWorkflowDeps<TStore> {
   const store = storeOverride ?? createMockStore();
   return {
-    store,
+    store: store as TStore,
     getAgentProvider: mockGetAgentProviderDag,
-    loadConfig: mock(() =>
-      Promise.resolve({
-        assistant: 'claude' as const,
-        commands: {},
-        defaults: { loadDefaultCommands: false, loadDefaultWorkflows: false },
-        assistants: { claude: {}, codex: {} },
-      })
-    ),
+    loadConfig: mock<WorkflowDeps['loadConfig']>(async _cwd => ({
+      assistant: 'claude' as const,
+      commands: {},
+      defaults: { loadDefaultCommands: false, loadDefaultWorkflows: false },
+      assistants: { claude: {}, codex: {} },
+    })),
   };
 }
 
-function createMockPlatform(): IWorkflowPlatform {
+type MockWorkflowPlatform = {
+  sendMessage: Mock<IWorkflowPlatform['sendMessage']>;
+  getStreamingMode: Mock<IWorkflowPlatform['getStreamingMode']>;
+  getPlatformType: Mock<IWorkflowPlatform['getPlatformType']>;
+  sendStructuredEvent: Mock<NonNullable<IWorkflowPlatform['sendStructuredEvent']>>;
+};
+
+function createMockPlatform(): MockWorkflowPlatform {
   return {
-    sendMessage: mock(() => Promise.resolve()),
-    getStreamingMode: mock(() => 'batch' as const),
-    getPlatformType: mock(() => 'test'),
-    sendStructuredEvent: mock(() => Promise.resolve()),
+    sendMessage: mock<IWorkflowPlatform['sendMessage']>(
+      async (_conversationId, _message, _metadata) => {}
+    ),
+    getStreamingMode: mock<IWorkflowPlatform['getStreamingMode']>(() => 'batch'),
+    getPlatformType: mock<IWorkflowPlatform['getPlatformType']>(() => 'test'),
+    sendStructuredEvent: mock<NonNullable<IWorkflowPlatform['sendStructuredEvent']>>(
+      async (_conversationId, _event) => {}
+    ),
   };
 }
 
@@ -258,7 +293,7 @@ const minimalConfig: WorkflowConfig = {
 
 // --- Helpers ---
 
-function node(id: string, depends_on?: string[], opts?: Partial<DagNode>): DagNode {
+function node(id: string, depends_on?: string[], opts?: Partial<CommandNode>): CommandNode {
   return { id, command: id, ...(depends_on?.length ? { depends_on } : {}), ...opts };
 }
 
@@ -301,9 +336,17 @@ function makeWorkflowRun(id = 'dag-test-run-id', overrides?: Partial<WorkflowRun
     completed_at: null,
     last_activity_at: null,
     working_path: null,
+    user_id: null,
     parent_run_id: null,
+    output_root: null,
     ...overrides,
   };
+}
+
+function loaderBypassingWorkflow(
+  workflow: Parameters<typeof executeDagWorkflow>[4] & { modelReasoningEffort: string }
+): Parameters<typeof executeDagWorkflow>[4] {
+  return workflow;
 }
 
 // --- Tests ---
@@ -804,7 +847,7 @@ describe('substituteNodeOutputRefs', () => {
       (call: unknown[]) => call[1] === 'dag_node_output_ref_unknown_node'
     );
     expect(warnCalls.length).toBe(1);
-    expect(warnCalls[0][0]).toEqual(expect.objectContaining({ nodeId: 'missing' }));
+    expect(warnCalls[0]?.[0]).toEqual(expect.objectContaining({ nodeId: 'missing' }));
   });
 
   it('dot notation extracts JSON field', () => {
@@ -1158,7 +1201,7 @@ describe('executeDagWorkflow -- tool restrictions', () => {
     mockSendQueryDag.mockClear();
     mockGetAgentProviderDag.mockClear();
 
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'DAG AI response' };
       yield { type: 'result', sessionId: 'dag-session-id' };
     });
@@ -1968,7 +2011,7 @@ describe('executeDagWorkflow -- bash nodes', () => {
     mockSendQueryDag.mockClear();
     mockGetAgentProviderDag.mockClear();
 
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'DAG AI response' };
       yield { type: 'result', sessionId: 'dag-session-id' };
     });
@@ -2749,7 +2792,7 @@ describe('executeDagWorkflow -- output_format structured output', () => {
     const structuredJson = { run_code_review: 'true', run_tests: 'false' };
 
     // Mock yields prose + JSON as assistant text, then result with structuredOutput
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'Let me analyze the PR scope...\n' };
       yield { type: 'assistant', content: JSON.stringify(structuredJson) };
       yield { type: 'result', sessionId: 'sid-1', structuredOutput: structuredJson };
@@ -2812,7 +2855,7 @@ describe('executeDagWorkflow -- output_format structured output', () => {
 
   it('does NOT override nodeOutputText with structuredOutput when output_format is absent', async () => {
     // Even if the SDK returns structuredOutput, nodes without output_format use concatenated text
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'prose analysis text' };
       yield { type: 'result', sessionId: 'sid-no-fmt', structuredOutput: { type: 'BUG' } };
     });
@@ -2859,7 +2902,7 @@ describe('executeDagWorkflow -- output_format structured output', () => {
 
   it('falls back to concatenated text when structuredOutput is absent', async () => {
     // Mock without structuredOutput on result — backward compatible
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'plain text response' };
       yield { type: 'result', sessionId: 'sid-2' };
     });
@@ -2912,7 +2955,7 @@ describe('executeDagWorkflow -- output_format structured output', () => {
       getType: () => 'codex',
       getCapabilities: mockCodexCapabilities,
     }));
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: JSON.stringify(classifyJson) };
       yield { type: 'result', sessionId: 'codex-sid-1', structuredOutput: classifyJson };
     });
@@ -2984,7 +3027,7 @@ describe('executeDagWorkflow -- output_format structured output', () => {
       getType: () => 'codex',
       getCapabilities: mockCodexCapabilities,
     }));
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: '{"status":"ok"}' };
       yield { type: 'result', sessionId: 'codex-sid-2', structuredOutput: { status: 'ok' } };
     });
@@ -3046,7 +3089,7 @@ describe('executeDagWorkflow -- when condition parse errors (fail-closed)', () =
       getType: () => 'claude',
       getCapabilities: mockClaudeCapabilities,
     }));
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'AI response' };
       yield { type: 'result', sessionId: 'sess-parse-err' };
     });
@@ -3179,7 +3222,7 @@ describe('executeDagWorkflow -- node-level retry for transient errors', () => {
       getType: () => 'claude',
       getCapabilities: mockClaudeCapabilities,
     }));
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'DAG AI response' };
       yield { type: 'result', sessionId: 'dag-session-id' };
     });
@@ -3200,7 +3243,7 @@ describe('executeDagWorkflow -- node-level retry for transient errors', () => {
 
   it('node succeeds on retry after a transient error', async () => {
     let callCount = 0;
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       callCount++;
       if (callCount === 1) {
         throw new Error('Claude Code crash: process exited with code 1');
@@ -3241,7 +3284,7 @@ describe('executeDagWorkflow -- node-level retry for transient errors', () => {
 
   it('workflow fails after exhausting all node retries', async () => {
     let callCount = 0;
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       callCount++;
       throw new Error('Claude Code crash: process exited with code 1');
     });
@@ -3278,7 +3321,7 @@ describe('executeDagWorkflow -- node-level retry for transient errors', () => {
 
   it('node with FATAL error does not retry (call count = 1)', async () => {
     let callCount = 0;
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       callCount++;
       throw new Error('Claude Code auth error: unauthorized');
     });
@@ -3315,7 +3358,7 @@ describe('executeDagWorkflow -- node-level retry for transient errors', () => {
 
   it('sends retry notification to platform before each delay', async () => {
     let callCount = 0;
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       callCount++;
       if (callCount === 1) {
         throw new Error('Claude Code crash: process exited with code 1');
@@ -3565,7 +3608,7 @@ describe('executeDagWorkflow -- tool_called event persistence', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'Reading file...' };
       yield { type: 'tool', toolName: 'read_file', toolInput: { path: '/tmp/test.ts' } };
       yield { type: 'result', sessionId: 'dag-session-id' };
@@ -3609,10 +3652,10 @@ describe('executeDagWorkflow -- tool_called event persistence', () => {
     const mockStore = createMockStore();
     const mockDeps = createMockDeps(mockStore);
     const platform = createMockPlatform();
-    (platform.getStreamingMode as Mock).mockReturnValue('stream');
+    platform.getStreamingMode.mockReturnValue('stream');
     const workflowRun = makeWorkflowRun();
 
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'tool', toolName: 'Write', toolInput: { path: '/bar', content: 'x' } };
       yield { type: 'result', sessionId: 'dag-session-tool' };
     });
@@ -3677,7 +3720,7 @@ describe('executeDagWorkflow -- tool_completed event emission', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'tool', toolName: 'read_file', toolInput: { path: '/a' } };
       yield { type: 'tool', toolName: 'write_file', toolInput: { path: '/b', content: 'x' } };
       yield { type: 'result', sessionId: 'dag-sess-1' };
@@ -3721,7 +3764,7 @@ describe('executeDagWorkflow -- tool_completed event emission', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'tool', toolName: 'read_file', toolInput: { path: '/a' } };
       yield { type: 'result', sessionId: 'dag-sess-2' };
     });
@@ -3763,7 +3806,7 @@ describe('executeDagWorkflow -- tool_completed event emission', () => {
     const workflowRun = makeWorkflowRun();
 
     setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'tool', toolName: 'read_file', toolInput: { path: '/a' } };
       setSystemTime(new Date('2026-01-01T00:00:00.050Z'));
       yield {
@@ -3799,13 +3842,11 @@ describe('executeDagWorkflow -- tool_completed event emission', () => {
       setSystemTime();
     }
 
-    const completedEvents = (
-      mockStore.createWorkflowEvent as ReturnType<typeof mock>
-    ).mock.calls.filter(
-      ([event]: [{ event_type: string }]) => event.event_type === 'tool_completed'
+    const completedEvents = mockStore.createWorkflowEvent.mock.calls.filter(
+      ([event]) => event.event_type === 'tool_completed'
     );
     expect(completedEvents).toHaveLength(1);
-    expect(completedEvents[0][0].data).toMatchObject({
+    expect(completedEvents[0]?.[0].data).toMatchObject({
       tool_name: 'read_file',
       duration_ms: 50,
       tool_call_id: 'anonymous-1',
@@ -3821,7 +3862,7 @@ describe('executeDagWorkflow -- tool_completed event emission', () => {
     const workflowRun = makeWorkflowRun();
 
     setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'tool', toolName: 'read_file', toolCallId: 'id-a' };
       setSystemTime(new Date('2026-01-01T00:00:00.010Z'));
       yield { type: 'tool', toolName: 'write_file', toolCallId: 'id-b' };
@@ -3829,6 +3870,7 @@ describe('executeDagWorkflow -- tool_completed event emission', () => {
       yield {
         type: 'tool_result',
         toolName: 'read_file',
+        toolOutput: '',
         toolCallId: 'id-a',
         toolOutcome: 'success',
       };
@@ -3836,6 +3878,7 @@ describe('executeDagWorkflow -- tool_completed event emission', () => {
       yield {
         type: 'tool_result',
         toolName: 'write_file',
+        toolOutput: '',
         toolCallId: 'id-b',
         toolOutcome: 'error',
         exitCode: 2,
@@ -3864,9 +3907,9 @@ describe('executeDagWorkflow -- tool_completed event emission', () => {
       setSystemTime();
     }
 
-    const completedEvents = (mockStore.createWorkflowEvent as ReturnType<typeof mock>).mock.calls
-      .filter(([event]: [{ event_type: string }]) => event.event_type === 'tool_completed')
-      .map(([event]: [{ data: Record<string, unknown> }]) => event.data);
+    const completedEvents = mockStore.createWorkflowEvent.mock.calls
+      .filter(([event]) => event.event_type === 'tool_completed')
+      .map(([event]) => event.data ?? {});
     expect(completedEvents).toEqual(
       expect.arrayContaining([
         {
@@ -3892,7 +3935,7 @@ describe('executeDagWorkflow -- tool_completed event emission', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'DAG AI response' };
       yield { type: 'result', sessionId: 'dag-sess-3' };
     });
@@ -4190,7 +4233,7 @@ describe('executeDagWorkflow -- skills options', () => {
     mockSendQueryDag.mockClear();
     mockGetAgentProviderDag.mockClear();
 
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'DAG AI response' };
       yield { type: 'result', sessionId: 'dag-session-id' };
     });
@@ -4679,7 +4722,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     mockSendQueryDag.mockClear();
     mockGetAgentProviderDag.mockClear();
 
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'AI response' };
       yield { type: 'result', sessionId: 'session-id' };
     });
@@ -4743,7 +4786,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     const workflowRun = makeWorkflowRun();
 
     let capturedPrompt = '';
-    mockSendQueryDag.mockImplementation(function* (prompt: string) {
+    mockSendQueryDag.mockImplementation(async function* (prompt: string) {
       capturedPrompt = prompt;
       yield { type: 'assistant', content: 'step2 result' };
       yield { type: 'result', sessionId: 'session-id' };
@@ -4822,6 +4865,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         (call[0] as { step_name: string }).step_name === 'step1'
     );
     expect(skippedEvent).toBeDefined();
+    if (!skippedEvent) throw new Error('Expected prior-success skip event');
     expect(skippedEvent[0].data.node_output).toBe('prior output');
   });
 
@@ -4869,6 +4913,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         (call[0] as { step_name: string }).step_name === 'step1'
     );
     expect(skippedEvent).toBeDefined();
+    if (!skippedEvent) throw new Error('Expected prior-success skip event');
     // The ?? '' fallback kicks in when the map value is undefined
     expect(skippedEvent[0].data.node_output).toBe('');
   });
@@ -4923,7 +4968,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     };
 
     let firstInvocationCall = 0;
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       firstInvocationCall++;
       if (firstInvocationCall === 1) {
         yield { type: 'assistant', content: 'first execution output' };
@@ -4990,7 +5035,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     expect(priorCompletedNodes).toEqual(new Map([['step1', 'first execution output']]));
     expect(priorTokenUsage).toEqual({ input: 40, output: 4 });
 
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'resumed execution output' };
       yield {
         type: 'result',
@@ -5066,7 +5111,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     const workflowRun = makeWorkflowRun('resume-declared-optional');
 
     let capturedPrompt = '';
-    mockSendQueryDag.mockImplementation(function* (prompt: string) {
+    mockSendQueryDag.mockImplementation(async function* (prompt: string) {
       capturedPrompt = prompt;
       yield { type: 'assistant', content: 'step2 result' };
       yield { type: 'result', sessionId: 'session-id' };
@@ -5169,6 +5214,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         (call[0] as { step_name: string }).step_name === 'step2'
     );
     expect(failedEvent).toBeDefined();
+    if (!failedEvent) throw new Error('Expected node-failed event');
     expect((failedEvent[0].data as { error: string }).error).toContain('is not declared in node');
   });
 
@@ -5402,7 +5448,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun('output-persist-run');
 
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'the node output text' };
       yield {
         type: 'result',
@@ -5452,7 +5498,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
   });
 
   it('omits tokens from a direct AI node_completed event when the provider reports no usage', async () => {
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'the node output text' };
       yield { type: 'result', sessionId: 'no-usage-sid' };
     });
@@ -5488,7 +5534,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
   });
 
   it('persists only {input, output} — provider-defined total/cost are not part of the shape', async () => {
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'out' };
       // Pi/OpenCode shape: `total` folds in cache/reasoning tokens, so it is NOT
       // input + output. Persisting it would hand consumers a field they cannot
@@ -5530,7 +5576,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
   });
 
   it('drops non-finite provider token counts instead of persisting them', async () => {
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'out' };
       yield { type: 'result', sessionId: 'nan-sid', tokens: { input: NaN, output: 10 } };
     });
@@ -5608,7 +5654,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     };
 
     it('waits past a result with live background tasks and captures the follow-up output', async () => {
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield {
           type: 'background_tasks',
           tasks: [{ taskId: 't-1', taskType: 'local_agent', description: 'bg research' }],
@@ -5642,7 +5688,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     });
 
     it('records background_tasks_incomplete and warns when the stream ends with live tasks', async () => {
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield {
           type: 'background_tasks',
           tasks: [{ taskId: 't-orphan', taskType: 'local_agent', description: 'never drains' }],
@@ -5673,7 +5719,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       // setSystemTime jumps past CANCEL_CHECK_INTERVAL_MS between chunks so the
       // second status check fires deterministically (no real waiting).
       let tasksDelivered = false;
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield {
           type: 'background_tasks',
           tasks: [{ taskId: 't-live', taskType: 'local_agent', description: 'still running' }],
@@ -5716,7 +5762,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     });
 
     it('breaks at the first result when no background_tasks chunk was seen (unchanged behavior)', async () => {
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield { type: 'assistant', content: 'normal output' };
         yield { type: 'result', sessionId: 'sid' };
         // Anything after the result must NOT be consumed
@@ -5734,7 +5780,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     });
 
     it('persists output_file on task_notification task_activity events', async () => {
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield { type: 'assistant', content: 'delegating' };
         yield {
           type: 'task_notification',
@@ -5773,7 +5819,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const workflowRun = makeWorkflowRun('loop-tool-result-run');
 
       setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield { type: 'tool', toolName: 'read_file', toolInput: { path: '/a' } };
         setSystemTime(new Date('2026-01-01T00:00:00.050Z'));
         yield {
@@ -5799,6 +5845,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
               {
                 id: 'my-loop',
                 loop: {
+                  fresh_context: false,
                   prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
                   until: 'COMPLETE',
                   max_iterations: 5,
@@ -5820,13 +5867,11 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         setSystemTime();
       }
 
-      const completedEvents = (
-        store.createWorkflowEvent as ReturnType<typeof mock>
-      ).mock.calls.filter(
-        ([event]: [{ event_type: string }]) => event.event_type === 'tool_completed'
+      const completedEvents = store.createWorkflowEvent.mock.calls.filter(
+        ([event]) => event.event_type === 'tool_completed'
       );
       expect(completedEvents).toHaveLength(1);
-      expect(completedEvents[0][0].data).toMatchObject({
+      expect(completedEvents[0]?.[0].data).toMatchObject({
         tool_name: 'read_file',
         duration_ms: 50,
         tool_call_id: 'anonymous-1',
@@ -5841,7 +5886,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const workflowRun = makeWorkflowRun('loop-interleaved-tools-run');
 
       setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield { type: 'tool', toolName: 'read_file', toolCallId: 'id-a' };
         setSystemTime(new Date('2026-01-01T00:00:00.010Z'));
         yield { type: 'tool', toolName: 'write_file', toolCallId: 'id-b' };
@@ -5849,6 +5894,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         yield {
           type: 'tool_result',
           toolName: 'read_file',
+          toolOutput: '',
           toolCallId: 'id-a',
           toolOutcome: 'success',
         };
@@ -5856,6 +5902,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         yield {
           type: 'tool_result',
           toolName: 'write_file',
+          toolOutput: '',
           toolCallId: 'id-b',
           toolOutcome: 'error',
         };
@@ -5874,7 +5921,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             nodes: [
               {
                 id: 'my-loop',
-                loop: { prompt: 'Complete the task.', until: 'COMPLETE', max_iterations: 1 },
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Complete the task.',
+                  until: 'COMPLETE',
+                  max_iterations: 1,
+                },
               },
             ],
           },
@@ -5892,9 +5944,9 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         setSystemTime();
       }
 
-      const completedEvents = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls
-        .filter(([event]: [{ event_type: string }]) => event.event_type === 'tool_completed')
-        .map(([event]: [{ data: Record<string, unknown> }]) => event.data);
+      const completedEvents = store.createWorkflowEvent.mock.calls
+        .filter(([event]) => event.event_type === 'tool_completed')
+        .map(([event]) => event.data ?? {});
       expect(completedEvents).toEqual(
         expect.arrayContaining([
           {
@@ -5914,7 +5966,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     });
 
     it('completes on <promise>COMPLETE</promise> signal in first iteration', async () => {
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield { type: 'assistant', content: 'Did the task. <promise>COMPLETE</promise>' };
         yield { type: 'result', sessionId: 'loop-session-1' };
       });
@@ -5934,6 +5986,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'my-loop',
               loop: {
+                fresh_context: false,
                 prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
                 until: 'COMPLETE',
                 max_iterations: 5,
@@ -5970,7 +6023,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       // Loop nodes own their sendQuery loop, so they need their own half of the
       // #2314 record: the requested alias on node_started, the concrete model
       // the provider reported on node_completed.
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield { type: 'assistant', content: 'Did the task. <promise>COMPLETE</promise>' };
         yield {
           type: 'result',
@@ -6000,6 +6053,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
               id: 'my-loop',
               model: 'large',
               loop: {
+                fresh_context: false,
                 prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
                 until: 'COMPLETE',
                 max_iterations: 5,
@@ -6049,7 +6103,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     it('omits model_usage on node_completed when the provider reports no resolved model (#2314)', async () => {
       // Codex cannot report a concrete model — absence must stay absent rather
       // than being back-filled with the requested alias.
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield { type: 'assistant', content: 'Did the task. <promise>COMPLETE</promise>' };
         yield { type: 'result', sessionId: 'loop-no-model-sid' };
       });
@@ -6070,6 +6124,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'my-loop',
               loop: {
+                fresh_context: false,
                 prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
                 until: 'COMPLETE',
                 max_iterations: 5,
@@ -6106,7 +6161,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       // -- fabricated attribution, which is the defect #2314 exists to prevent.
       // Two results in ONE iteration, via the background-task wait (same shape as the
       // #2083 cost test): the first reports a model, the final one does not.
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield {
           type: 'background_tasks',
           tasks: [{ taskId: 't-1', taskType: 'local_agent', description: 'bg work' }],
@@ -6135,6 +6190,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'my-loop',
               loop: {
+                fresh_context: false,
                 prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
                 until: 'COMPLETE',
                 max_iterations: 5,
@@ -6164,7 +6220,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     });
 
     it('does not double-count cost when an iteration sees two results (background-task wait, #2083)', async () => {
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield {
           type: 'background_tasks',
           tasks: [{ taskId: 't-1', taskType: 'local_agent', description: 'bg work' }],
@@ -6192,6 +6248,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'my-loop',
               loop: {
+                fresh_context: false,
                 prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
                 until: 'COMPLETE',
                 max_iterations: 5,
@@ -6227,7 +6284,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       // node_completed event must carry the UNION of dangling ids — last-iteration
       // reporting would hide t-a and t-b behind the clean final iteration.
       let callCount = 0;
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         callCount++;
         if (callCount === 1) {
           yield {
@@ -6267,6 +6324,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'my-loop',
               loop: {
+                fresh_context: false,
                 prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
                 until: 'COMPLETE',
                 max_iterations: 5,
@@ -6303,7 +6361,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     });
 
     it('omits background_tasks_incomplete from node_completed when every iteration drains cleanly', async () => {
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield {
           type: 'background_tasks',
           tasks: [{ taskId: 't-1', taskType: 'local_agent', description: 'bg work' }],
@@ -6330,6 +6388,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'my-loop',
               loop: {
+                fresh_context: false,
                 prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
                 until: 'COMPLETE',
                 max_iterations: 5,
@@ -6367,7 +6426,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       // only noticed cancellation BETWEEN iterations), fail the node with the
       // observed status, and suppress the incompleteness warning.
       let tasksDelivered = false;
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield {
           type: 'background_tasks',
           tasks: [{ taskId: 't-loop', taskType: 'local_agent', description: 'still running' }],
@@ -6400,6 +6459,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
               {
                 id: 'my-loop',
                 loop: {
+                  fresh_context: false,
                   prompt: 'Do tasks.',
                   until: 'COMPLETE',
                   max_iterations: 5,
@@ -6442,7 +6502,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
 
     it('completes after multiple iterations', async () => {
       let callCount = 0;
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         callCount++;
         if (callCount < 3) {
           yield { type: 'assistant', content: `Iteration ${String(callCount)} progress` };
@@ -6468,6 +6528,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'my-loop',
               loop: {
+                fresh_context: false,
                 prompt: 'Do next task.',
                 until: 'COMPLETE',
                 max_iterations: 10,
@@ -6494,7 +6555,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       // We then assert the prompt sent to the AI: iteration 1 strips $LOOP_PREV_OUTPUT
       // to empty, iteration 2 receives iteration 1's cleaned output.
       let callCount = 0;
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         callCount++;
         if (callCount === 1) {
           yield { type: 'assistant', content: 'Iter1 output: 2 type errors in users.ts' };
@@ -6552,7 +6613,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
 
     it('strips <promise> tags from $LOOP_PREV_OUTPUT (uses cleaned output)', async () => {
       let callCount = 0;
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         callCount++;
         if (callCount === 1) {
           // Iteration 1 includes a non-completion XML tag in its output. The cleaned
@@ -6622,7 +6683,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       // resumes with metadata.approval populated and runs iteration 2.
 
       // ---- Call 1: fresh run, iteration 1 emits no completion → pauses at gate
-      mockSendQueryDag.mockImplementationOnce(function* () {
+      mockSendQueryDag.mockImplementationOnce(async function* () {
         yield { type: 'assistant', content: 'Iter1 output: 2 type errors in users.ts' };
         yield { type: 'result', sessionId: 'loop-session-1' };
       });
@@ -6641,6 +6702,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'refine',
               loop: {
+                fresh_context: false,
                 prompt:
                   'User: $LOOP_USER_INPUT. PREV=<<$LOOP_PREV_OUTPUT>>. Continue or emit COMPLETE.',
                 until: 'COMPLETE',
@@ -6670,9 +6732,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       expect(promptIter1).toContain('User: .');
       // Fresh interactive loop must pause at the gate, not return early.
       const pauseCalls1 = (
-        mockDeps1.store.pauseWorkflowRun as Mock<
-          (id: string, ctx: Record<string, unknown>) => Promise<void>
-        >
+        mockDeps1.store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>
       ).mock.calls;
       expect(pauseCalls1.length).toBe(1);
       expect(pauseCalls1[0][1]).toMatchObject({
@@ -6683,7 +6743,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
 
       // ---- Call 2: resumed run — metadata carries iter 1 + user input.
       // iter 2 emits the completion signal so the loop exits cleanly.
-      mockSendQueryDag.mockImplementationOnce(function* () {
+      mockSendQueryDag.mockImplementationOnce(async function* () {
         yield { type: 'assistant', content: 'All clear. <promise>COMPLETE</promise>' };
         yield { type: 'result', sessionId: 'loop-session-2' };
       });
@@ -6713,6 +6773,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'refine',
               loop: {
+                fresh_context: false,
                 prompt:
                   'User: $LOOP_USER_INPUT. PREV=<<$LOOP_PREV_OUTPUT>>. Continue or emit COMPLETE.',
                 until: 'COMPLETE',
@@ -6746,15 +6807,13 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       expect(promptResumeIter).toContain('User: looks good, ship it.');
       // Resume call exits via completion, not via a second pause at the gate.
       const pauseCalls2 = (
-        mockDeps2.store.pauseWorkflowRun as Mock<
-          (id: string, ctx: Record<string, unknown>) => Promise<void>
-        >
+        mockDeps2.store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>
       ).mock.calls;
       expect(pauseCalls2.length).toBe(0);
     });
 
     it('fails when max_iterations exceeded', async () => {
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield { type: 'assistant', content: 'Still working...' };
         yield { type: 'result', sessionId: 'loop-session' };
       });
@@ -6774,6 +6833,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'my-loop',
               loop: {
+                fresh_context: false,
                 prompt: 'Do task.',
                 until: 'COMPLETE',
                 max_iterations: 2,
@@ -6803,7 +6863,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
 
     it('completes on final iteration with XML-wrapped signal (<COMPLETE>SIGNAL</COMPLETE>)', async () => {
       let callCount = 0;
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         callCount++;
         if (callCount < 3) {
           yield { type: 'assistant', content: `Iteration ${String(callCount)} progress` };
@@ -6830,6 +6890,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'fix-and-review',
               loop: {
+                fresh_context: false,
                 prompt: 'Fix and review. When done, output <COMPLETE>ALL_CLEAN</COMPLETE>.',
                 until: 'ALL_CLEAN',
                 max_iterations: 3,
@@ -6873,7 +6934,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
 
     it('loop node output available to downstream nodes via $nodeId.output', async () => {
       let loopCallCount = 0;
-      mockSendQueryDag.mockImplementation(function* (prompt: string) {
+      mockSendQueryDag.mockImplementation(async function* (prompt: string) {
         if (prompt.includes('Do task')) {
           loopCallCount++;
           if (loopCallCount >= 2) {
@@ -6907,6 +6968,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'impl',
               loop: {
+                fresh_context: false,
                 prompt: 'Do task. Output <promise>COMPLETE</promise> when done.',
                 until: 'COMPLETE',
                 max_iterations: 5,
@@ -6936,7 +6998,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
 
     it('fresh_context: true gives each iteration fresh session', async () => {
       let callCount = 0;
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         callCount++;
         if (callCount >= 2) {
           yield { type: 'assistant', content: '<promise>DONE</promise>' };
@@ -6990,7 +7052,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
 
     it('fresh_context: false threads session between iterations', async () => {
       let callCount = 0;
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         callCount++;
         if (callCount >= 2) {
           yield { type: 'assistant', content: '<promise>DONE</promise>' };
@@ -7056,7 +7118,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const counterRef = `"${counterFile.replace(/\\/g, '/')}"`;
 
       let calls = 0;
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         calls++;
         yield { type: 'assistant', content: `working, pass ${String(calls)}` };
         yield { type: 'result', sessionId: `s-${String(calls)}` };
@@ -7077,6 +7139,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'my-loop',
               loop: {
+                fresh_context: false,
                 prompt: 'Keep working.',
                 max_iterations: 5,
                 // Bumps a counter and exits 0 only on the second call.
@@ -7109,7 +7172,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const counterRef = `"${counterFile.replace(/\\/g, '/')}"`;
 
       let calls = 0;
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         calls++;
         yield {
           type: 'assistant',
@@ -7133,6 +7196,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'my-loop',
               loop: {
+                fresh_context: false,
                 prompt: 'Keep working.',
                 max_iterations: 5,
                 until_bash: `n=$(cat ${counterRef} 2>/dev/null || echo 0); n=$((n+1)); echo $n > ${counterRef}; test $n -ge 2`,
@@ -7164,7 +7228,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const sentinelRef = `"${sentinel.replace(/\\/g, '/')}"`;
 
       let calls = 0;
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         calls++;
         yield { type: 'assistant', content: 'all done\n<promise>DONE</promise>' };
         yield { type: 'result', sessionId: `s-${String(calls)}` };
@@ -7185,6 +7249,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'my-loop',
               loop: {
+                fresh_context: false,
                 prompt: 'Do work, emit DONE.',
                 until: 'DONE',
                 max_iterations: 3,
@@ -7226,7 +7291,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
 
     it('completes on the iteration whose validated payload has until_field true', async () => {
       let calls = 0;
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         calls++;
         // Grammar-constrained providers routinely emit NO prose — the whole answer
         // is the payload. The iteration must not be failed as empty for that.
@@ -7252,7 +7317,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'my-loop',
               output_format: untilFieldSchema,
-              loop: { prompt: 'Work until done.', max_iterations: 6, until_field: 'done' },
+              loop: {
+                fresh_context: false,
+                prompt: 'Work until done.',
+                max_iterations: 6,
+                until_field: 'done',
+              },
             },
           ],
         },
@@ -7274,7 +7344,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     });
 
     it('requests output_format from the provider for a loop node', async () => {
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield { type: 'result', sessionId: 's1', structuredOutput: { done: true } };
       });
 
@@ -7293,7 +7363,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'my-loop',
               output_format: untilFieldSchema,
-              loop: { prompt: 'go', max_iterations: 2, until_field: 'done' },
+              loop: { fresh_context: false, prompt: 'go', max_iterations: 2, until_field: 'done' },
             },
           ],
         },
@@ -7317,7 +7387,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     it('fails rather than degrading when a payload never satisfies the schema', async () => {
       // A string "true" is not a boolean: ajv rejects it, so this is a validation
       // miss, NOT a quiet "not complete yet" that would burn max_iterations.
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield { type: 'result', sessionId: 's1', structuredOutput: { done: 'true' } };
       });
 
@@ -7337,7 +7407,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'my-loop',
               output_format: untilFieldSchema,
-              loop: { prompt: 'go', max_iterations: 5, until_field: 'done' },
+              loop: { fresh_context: false, prompt: 'go', max_iterations: 5, until_field: 'done' },
             },
           ],
         },
@@ -7366,10 +7436,10 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     it('re-asks a best-effort provider within the iteration, then completes', async () => {
       // Attempt 1 violates the schema; attempt 2 satisfies it with done: true.
       // The reask must not consume a loop iteration — one iteration, two attempts.
-      mockSendQueryDag.mockImplementationOnce(function* () {
+      mockSendQueryDag.mockImplementationOnce(async function* () {
         yield { type: 'result', sessionId: 's1', structuredOutput: { note: 'no done key' } };
       });
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield { type: 'result', sessionId: 's2', structuredOutput: { done: true } };
       });
 
@@ -7390,7 +7460,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
               id: 'my-loop',
               provider: 'pi',
               output_format: untilFieldSchema,
-              loop: { prompt: 'go', max_iterations: 4, until_field: 'done' },
+              loop: { fresh_context: false, prompt: 'go', max_iterations: 4, until_field: 'done' },
             },
           ],
         },
@@ -7426,7 +7496,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       // conversation" — so attempt 0's session stays the thread.
       const sessions: Array<string | undefined> = [];
       let calls = 0;
-      mockSendQueryDag.mockImplementation(function* (
+      mockSendQueryDag.mockImplementation(async function* (
         _p: unknown,
         _cwd: unknown,
         resumeId: string | undefined
@@ -7500,7 +7570,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       // session is the loop's real conversation and is what iteration 2 must resume.
       const sessions: Array<string | undefined> = [];
       let calls = 0;
-      mockSendQueryDag.mockImplementation(function* (
+      mockSendQueryDag.mockImplementation(async function* (
         _p: unknown,
         _cwd: unknown,
         resumeId: string | undefined
@@ -7558,7 +7628,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       // iteration would otherwise hand the next node a single-turn throwaway.
       const sessions: Array<string | undefined> = [];
       let calls = 0;
-      mockSendQueryDag.mockImplementation(function* (
+      mockSendQueryDag.mockImplementation(async function* (
         _p: unknown,
         _cwd: unknown,
         resumeId: string | undefined
@@ -7610,7 +7680,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     });
 
     it('fails the node when best-effort re-asks are exhausted', async () => {
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield { type: 'result', sessionId: 's', structuredOutput: { note: 'still wrong' } };
       });
 
@@ -7631,7 +7701,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
               id: 'my-loop',
               provider: 'pi',
               output_format: untilFieldSchema,
-              loop: { prompt: 'go', max_iterations: 4, until_field: 'done' },
+              loop: { fresh_context: false, prompt: 'go', max_iterations: 4, until_field: 'done' },
             },
           ],
         },
@@ -7661,7 +7731,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       // `$loop.output.<declared-optional>` THROWS here while resolving to '' on the
       // identical loop that completed without a gate. Re-derived from the definition,
       // exactly like the resume-hydration path (#2091).
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield { type: 'assistant', content: 'should never run' };
         yield { type: 'result', sessionId: 'never' };
       });
@@ -7698,6 +7768,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
               id: 'judge',
               output_format: untilFieldSchema,
               loop: {
+                fresh_context: false,
                 prompt: 'judge',
                 until: 'APPROVED',
                 max_iterations: 5,
@@ -7737,7 +7808,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       // firing for every loop that declared a schema. The own-line and <promise>
       // forms survive concatenation, which is why this needs its own test.
       let calls = 0;
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         calls++;
         yield { type: 'assistant', content: 'All tasks are finished. ALLDONE' };
         yield {
@@ -7762,7 +7833,13 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'my-loop',
               output_format: untilFieldSchema,
-              loop: { prompt: 'go', until: 'ALLDONE', max_iterations: 4, until_field: 'done' },
+              loop: {
+                fresh_context: false,
+                prompt: 'go',
+                until: 'ALLDONE',
+                max_iterations: 4,
+                until_field: 'done',
+              },
             },
           ],
         },
@@ -7786,7 +7863,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       // provider the prose is empty, so detection reads the serialized payload too —
       // otherwise the declared signal channel could never fire, silently.
       let calls = 0;
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         calls++;
         yield {
           type: 'result',
@@ -7811,6 +7888,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
               id: 'my-loop',
               output_format: untilFieldSchema,
               loop: {
+                fresh_context: false,
                 prompt: 'go',
                 until: 'ALLDONE',
                 max_iterations: 4,
@@ -7835,7 +7913,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     });
 
     it('gives a downstream node strict field access to the loop output', async () => {
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield {
           type: 'result',
           sessionId: 's1',
@@ -7858,7 +7936,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'my-loop',
               output_format: untilFieldSchema,
-              loop: { prompt: 'go', max_iterations: 3, until_field: 'done' },
+              loop: { fresh_context: false, prompt: 'go', max_iterations: 3, until_field: 'done' },
             },
             {
               id: 'report',
@@ -7883,7 +7961,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     });
 
     it('strips <promise> tags from platform output', async () => {
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield { type: 'assistant', content: 'Done! <promise>COMPLETE</promise>' };
         yield { type: 'result', sessionId: 'loop-sid' };
       });
@@ -7902,11 +7980,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           nodes: [
             {
               id: 'my-loop',
-              loop: {
-                prompt: 'Task.',
-                until: 'COMPLETE',
-                max_iterations: 3,
-              },
+              loop: { fresh_context: false, prompt: 'Task.', until: 'COMPLETE', max_iterations: 3 },
             },
           ],
         },
@@ -7922,7 +7996,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       );
 
       // In batch mode, accumulated clean output is sent
-      const sendCalls = (platform.sendMessage as Mock<() => Promise<void>>).mock.calls;
+      const sendCalls = (platform.sendMessage as Mock<IWorkflowPlatform['sendMessage']>).mock.calls;
       const contentMessages = sendCalls
         .map((call: unknown[]) => call[1] as string)
         .filter((msg: string) => msg.includes('Done'));
@@ -7934,7 +8008,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
 
     it('cancellation between iterations stops the loop', async () => {
       let callCount = 0;
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         callCount++;
         yield { type: 'assistant', content: `Iteration ${String(callCount)}` };
         yield { type: 'result', sessionId: `sid-${String(callCount)}` };
@@ -7963,6 +8037,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'my-loop',
               loop: {
+                fresh_context: false,
                 prompt: 'Do tasks.',
                 until: 'COMPLETE',
                 max_iterations: 10,
@@ -7986,7 +8061,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     });
 
     it('AI error mid-iteration returns failed NodeOutput', async () => {
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         throw new Error('Claude Code auth error: unauthorized');
       });
 
@@ -8005,6 +8080,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'my-loop',
               loop: {
+                fresh_context: false,
                 prompt: 'Do task.',
                 until: 'COMPLETE',
                 max_iterations: 5,
@@ -8033,7 +8109,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     });
 
     it('detects plain completion signal (non-<promise> format)', async () => {
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield { type: 'assistant', content: 'All tasks done!\nCOMPLETE' };
         yield { type: 'result', sessionId: 'plain-sid' };
       });
@@ -8053,6 +8129,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'my-loop',
               loop: {
+                fresh_context: false,
                 prompt: 'Do task.',
                 until: 'COMPLETE',
                 max_iterations: 5,
@@ -8085,7 +8162,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     });
 
     it('does NOT detect false positive plain signal in middle of text', async () => {
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield { type: 'assistant', content: 'The task is not COMPLETE yet, more work needed.' };
         yield { type: 'result', sessionId: 'false-pos-sid' };
       });
@@ -8104,11 +8181,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           nodes: [
             {
               id: 'my-loop',
-              loop: {
-                prompt: 'Work.',
-                until: 'COMPLETE',
-                max_iterations: 2,
-              },
+              loop: { fresh_context: false, prompt: 'Work.', until: 'COMPLETE', max_iterations: 2 },
             },
           ],
         },
@@ -8135,7 +8208,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     // ─── Interactive Loop Tests ────────────────────────────────────────────
 
     it('interactive loop with gate_message pauses after first iteration', async () => {
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield { type: 'assistant', content: 'Here is the plan. Please review.' };
         yield { type: 'result', sessionId: 'loop-session-1' };
       });
@@ -8155,6 +8228,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'refine',
               loop: {
+                fresh_context: false,
                 prompt: 'User said: $LOOP_USER_INPUT. Refine the plan.',
                 until: 'APPROVED',
                 max_iterations: 10,
@@ -8179,9 +8253,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       expect(mockSendQueryDag.mock.calls.length).toBe(1);
       // Should have called pauseWorkflowRun with interactive_loop type
       const pauseCalls = (
-        mockDeps.store.pauseWorkflowRun as Mock<
-          (id: string, ctx: Record<string, unknown>) => Promise<void>
-        >
+        mockDeps.store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>
       ).mock.calls;
       expect(pauseCalls.length).toBe(1);
       expect(pauseCalls[0][1]).toMatchObject({
@@ -8199,7 +8271,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     });
 
     it('interactive loop first iteration always gates even if AI emits signal', async () => {
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield {
           type: 'assistant',
           content: 'Plan approved. Proceeding. <promise>APPROVED</promise>',
@@ -8222,6 +8294,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'refine',
               loop: {
+                fresh_context: false,
                 prompt: 'Refine.',
                 until: 'APPROVED',
                 max_iterations: 10,
@@ -8246,9 +8319,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       // at the gate even if the AI emits the completion signal. The user hasn't
       // seen anything yet — they must review before the loop can exit.
       const pauseCalls = (
-        mockDeps.store.pauseWorkflowRun as Mock<
-          (id: string, ctx: Record<string, unknown>) => Promise<void>
-        >
+        mockDeps.store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>
       ).mock.calls;
       expect(pauseCalls.length).toBe(1);
       expect(pauseCalls[0][1]).toMatchObject({
@@ -8270,7 +8341,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     });
 
     it('interactive loop exits on resume when AI emits completion signal (user approved)', async () => {
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield {
           type: 'assistant',
           content: 'Plan approved. Proceeding. <promise>APPROVED</promise>',
@@ -8305,6 +8376,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'refine',
               loop: {
+                fresh_context: false,
                 prompt: 'User said: $LOOP_USER_INPUT. Refine.',
                 until: 'APPROVED',
                 max_iterations: 10,
@@ -8328,16 +8400,14 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       // On resume with user input, the AI processes the approval and emits the
       // completion signal. The loop exits immediately without pausing at the gate.
       const pauseCalls = (
-        mockDeps.store.pauseWorkflowRun as Mock<
-          (id: string, ctx: Record<string, unknown>) => Promise<void>
-        >
+        mockDeps.store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>
       ).mock.calls;
       expect(pauseCalls.length).toBe(0);
     });
 
     it('interactive loop resumes from stored iteration with user input', async () => {
       let callCount = 0;
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         callCount++;
         yield { type: 'assistant', content: 'Updated plan. <promise>APPROVED</promise>' };
         yield { type: 'result', sessionId: `resumed-session-${String(callCount)}` };
@@ -8370,6 +8440,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'refine',
               loop: {
+                fresh_context: false,
                 prompt: 'User said: $LOOP_USER_INPUT. Refine the plan.',
                 until: 'APPROVED',
                 max_iterations: 10,
@@ -8401,7 +8472,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     });
 
     it('signal_completes: true completes the loop on a first-iteration signal without gating (#2074 B)', async () => {
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield { type: 'assistant', content: 'Validation PASS. <promise>VALIDATED</promise>' };
         yield { type: 'result', sessionId: 'sc-session-1' };
       });
@@ -8421,6 +8492,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'validate',
               loop: {
+                fresh_context: false,
                 prompt: 'Validate. Emit VALIDATED on pass.',
                 until: 'VALIDATED',
                 max_iterations: 10,
@@ -8443,7 +8515,9 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       );
 
       // No gate: the node completed autonomously on the signal.
-      const pauseCalls = (mockDeps.store.pauseWorkflowRun as Mock<() => Promise<void>>).mock.calls;
+      const pauseCalls = (
+        mockDeps.store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>
+      ).mock.calls;
       expect(pauseCalls.length).toBe(0);
       const eventCalls = (
         mockDeps.store.createWorkflowEvent as Mock<
@@ -8462,7 +8536,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     });
 
     it('finalizes at resume from persisted signaledOutput on a bare approve — no re-run (#2074 C)', async () => {
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield { type: 'assistant', content: 'should never run' };
         yield { type: 'result', sessionId: 'never' };
       });
@@ -8497,6 +8571,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'refine',
               loop: {
+                fresh_context: false,
                 prompt: 'Refine.',
                 until: 'APPROVED',
                 max_iterations: 10,
@@ -8540,7 +8615,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     });
 
     it('finalize omits tokens when the gate persisted none (legacy pause / no usage) (#2333)', async () => {
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield { type: 'assistant', content: 'should never run' };
         yield { type: 'result', sessionId: 'never' };
       });
@@ -8574,6 +8649,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'refine',
               loop: {
+                fresh_context: false,
                 prompt: 'Refine.',
                 until: 'APPROVED',
                 max_iterations: 10,
@@ -8612,7 +8688,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     });
 
     it('warns and omits malformed persisted gate token usage on bare approval', async () => {
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield { type: 'assistant', content: 'should never run' };
         yield { type: 'result', sessionId: 'never' };
       });
@@ -8646,6 +8722,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'refine',
               loop: {
+                fresh_context: false,
                 prompt: 'Refine.',
                 until: 'APPROVED',
                 max_iterations: 10,
@@ -8673,18 +8750,14 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       expect(warnCalls[0]?.[0]).toEqual(
         expect.objectContaining({ workflowRunId: workflowRun.id, nodeId: 'refine' })
       );
-      const completed = (mockDeps.store.createWorkflowEvent as Mock).mock.calls.find(
-        (call: unknown[]) =>
-          (call[0] as { event_type: string }).event_type === 'node_completed' &&
-          (call[0] as { step_name: string }).step_name === 'refine'
+      const completed = mockDeps.store.createWorkflowEvent.mock.calls.find(
+        ([event]) => event.event_type === 'node_completed' && event.step_name === 'refine'
       );
-      expect((completed?.[0] as { data: Record<string, unknown> }).data).not.toHaveProperty(
-        'tokens'
-      );
+      expect(completed?.[0].data).not.toHaveProperty('tokens');
     });
 
     it('iterates at resume when feedback was given, even on a signal-bearing gate (#2074 C)', async () => {
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield { type: 'assistant', content: 'Re-checked X. <promise>APPROVED</promise>' };
         yield { type: 'result', sessionId: 'iter-session-2' };
       });
@@ -8718,6 +8791,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'refine',
               loop: {
+                fresh_context: false,
                 prompt: 'User said: $LOOP_USER_INPUT. Refine.',
                 until: 'APPROVED',
                 max_iterations: 10,
@@ -8745,7 +8819,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     });
 
     it('iterates at resume on a non-signaled gate even without feedback (#2074 C)', async () => {
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield { type: 'assistant', content: 'Another pass. <promise>APPROVED</promise>' };
         yield { type: 'result', sessionId: 'iter-session-3' };
       });
@@ -8779,6 +8853,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'refine',
               loop: {
+                fresh_context: false,
                 prompt: 'Refine.',
                 until: 'APPROVED',
                 max_iterations: 10,
@@ -8807,7 +8882,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       // Rows paused before #2074 have neither key in metadata.approval and no
       // loop_feedback_given — the finalize path must NOT trigger; the loop runs
       // a normal resumed iteration exactly as before.
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield { type: 'assistant', content: 'Legacy pass. <promise>APPROVED</promise>' };
         yield { type: 'result', sessionId: 'legacy-session-2' };
       });
@@ -8838,6 +8913,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'refine',
               loop: {
+                fresh_context: false,
                 prompt: 'User said: $LOOP_USER_INPUT. Refine.',
                 until: 'APPROVED',
                 max_iterations: 10,
@@ -8868,7 +8944,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       // Regression test for #1208: previously the loop silently broke on isError
       // results and kept iterating with empty output, producing "5-second crashes"
       // that masqueraded as successful iterations.
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield {
           type: 'result',
           isError: true,
@@ -8894,6 +8970,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'work',
               loop: {
+                fresh_context: false,
                 prompt: 'Do the work. Say DONE.',
                 until: 'DONE',
                 max_iterations: 5,
@@ -8935,7 +9012,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       // 'success' under the Claude SDK contract; previously, the loop branch
       // threw "SDK returned success" and aborted the iteration even though
       // the AI had completed its work correctly.
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield { type: 'assistant', content: 'Done. DONE.' };
         yield {
           type: 'result',
@@ -8962,6 +9039,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'work',
               loop: {
+                fresh_context: false,
                 prompt: 'Do the work. Say DONE.',
                 until: 'DONE',
                 max_iterations: 3,
@@ -8989,7 +9067,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     });
 
     it('non-interactive loop is unaffected (no pause)', async () => {
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield { type: 'assistant', content: 'Still working...' };
         yield { type: 'result', sessionId: 'loop-session' };
       });
@@ -9009,6 +9087,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'my-loop',
               loop: {
+                fresh_context: false,
                 prompt: 'Do task.',
                 until: 'COMPLETE',
                 max_iterations: 2,
@@ -9029,9 +9108,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
 
       // pauseWorkflowRun should never be called for non-interactive loops
       const pauseCalls = (
-        mockDeps.store.pauseWorkflowRun as Mock<
-          (id: string, ctx: Record<string, unknown>) => Promise<void>
-        >
+        mockDeps.store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>
       ).mock.calls;
       expect(pauseCalls.length).toBe(0);
     });
@@ -9062,7 +9139,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       await writeFile(cmdPath, 'Command-loaded loop body. iter prev=<<$LOOP_PREV_OUTPUT>>');
 
       let callCount = 0;
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         callCount++;
         if (callCount === 1) {
           // Delete the source file *during* iteration 1 so it is gone by the
@@ -9158,6 +9235,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'missing-loop',
               loop: {
+                fresh_context: false,
                 command: 'does-not-exist-anywhere',
                 until: 'COMPLETE',
                 max_iterations: 3,
@@ -9224,6 +9302,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'empty-loop',
               loop: {
+                fresh_context: false,
                 command: 'empty-loop',
                 until: 'COMPLETE',
                 max_iterations: 3,
@@ -9276,6 +9355,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             {
               id: 'unsafe-loop',
               loop: {
+                fresh_context: false,
                 command: '../escape',
                 until: 'COMPLETE',
                 max_iterations: 3,
@@ -9321,7 +9401,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       );
 
       let callCount = 0;
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         callCount++;
         if (callCount === 1) {
           yield { type: 'assistant', content: 'iter1 result text' };
@@ -9392,7 +9472,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const cmdPath = join(testDir, '.archon', 'commands', 'gated-loop.md');
       await writeFile(cmdPath, 'ORIGINAL gated body. USER=<<$LOOP_USER_INPUT>>');
 
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield { type: 'assistant', content: 'iteration output, no signal yet' };
         yield { type: 'result', sessionId: 'sid-gated-1' };
       });
@@ -9407,6 +9487,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           {
             id: 'gated-loop',
             loop: {
+              fresh_context: false,
               command: 'gated-loop',
               until: 'COMPLETE',
               max_iterations: 5,
@@ -9436,12 +9517,10 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
 
       // Invocation 1 paused at the gate and persisted the loaded body.
       const pauseCalls = (
-        mockDeps.store.pauseWorkflowRun as Mock<
-          (id: string, ctx: Record<string, unknown>) => Promise<void>
-        >
+        mockDeps.store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>
       ).mock.calls;
       expect(pauseCalls.length).toBe(1);
-      const pausedContext = pauseCalls[0][1] as Record<string, unknown>;
+      const pausedContext = pauseCalls[0][1];
       expect(pausedContext.commandSnapshot).toContain('ORIGINAL gated body.');
       expect(mockSendQueryDag.mock.calls[0][0] as string).toContain('ORIGINAL gated body.');
 
@@ -9452,7 +9531,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       // Invocation 2: approval resume with feedback (feedback forces a real
       // resumed iteration rather than a bare-approve finalize).
       mockSendQueryDag.mockClear();
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield { type: 'assistant', content: 'refined. <promise>COMPLETE</promise>' };
         yield { type: 'result', sessionId: 'sid-gated-2' };
       });
@@ -9498,7 +9577,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     });
 
     it('reuses the pause-time prompt snapshot after a composed loop prompt is rediscovered', async () => {
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield { type: 'assistant', content: 'iteration output, no signal yet' };
         yield { type: 'result', sessionId: 'sid-prompt-1' };
       });
@@ -9512,6 +9591,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           {
             id: 'gated-loop',
             loop: {
+              fresh_context: false,
               command: 'materialized-loop-command',
               until: 'COMPLETE',
               max_iterations: 5,
@@ -9559,15 +9639,13 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       );
 
       const pauseCalls = (
-        firstDeps.store.pauseWorkflowRun as Mock<
-          (id: string, ctx: Record<string, unknown>) => Promise<void>
-        >
+        firstDeps.store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>
       ).mock.calls;
-      const pausedContext = pauseCalls[0]?.[1] as Record<string, unknown>;
+      const pausedContext = pauseCalls[0][1];
       expect(pausedContext.commandSnapshot).toContain('ORIGINAL materialized command.');
 
       mockSendQueryDag.mockClear();
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield { type: 'assistant', content: 'refined. <promise>COMPLETE</promise>' };
         yield { type: 'result', sessionId: 'sid-prompt-2' };
       });
@@ -9644,6 +9722,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         command: 'malformed-compiled-command',
         until: 'DONE',
         max_iterations: 1,
+        fresh_context: false,
       };
       loop[COMPILED_LOOP_COMMAND] = {} as CompiledLoopCommand;
       const store = createMockStore();
@@ -9690,7 +9769,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             nodes: [
               {
                 id: 'repeat',
-                loop: { command: 'empty-included-loop', until: 'DONE', max_iterations: 1 },
+                loop: {
+                  fresh_context: false,
+                  command: 'empty-included-loop',
+                  until: 'DONE',
+                  max_iterations: 1,
+                },
               },
             ],
           })
@@ -9749,7 +9833,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         'Body that never signals completion'
       );
 
-      mockSendQueryDag.mockImplementation(function* () {
+      mockSendQueryDag.mockImplementation(async function* () {
         yield { type: 'assistant', content: 'still going, no signal' };
         yield { type: 'result', sessionId: 'sid-exhaust' };
       });
@@ -9825,7 +9909,7 @@ describe('executeDagWorkflow -- always_run resume opt-out', () => {
     mockSendQueryDag.mockClear();
     mockGetAgentProviderDag.mockClear();
 
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'fresh output' };
       yield { type: 'result', sessionId: 'session-id' };
     });
@@ -9959,7 +10043,7 @@ describe('executeDagWorkflow -- always_run resume opt-out', () => {
 
     const seenPrompts: string[] = [];
     let queryCount = 0;
-    mockSendQueryDag.mockImplementation(function* (prompt: string) {
+    mockSendQueryDag.mockImplementation(async function* (prompt: string) {
       seenPrompts.push(prompt);
       queryCount++;
       // First call is the always_run producer; subsequent calls are consumers
@@ -10026,7 +10110,7 @@ describe('executeDagWorkflow -- break after result (no hang on subprocess exit)'
 
   afterEach(async () => {
     // Restore default sync generator so later tests aren't affected
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'DAG AI response' };
       yield { type: 'result', sessionId: 'dag-session-id' };
     });
@@ -10104,8 +10188,12 @@ describe('executeDagWorkflow -- break after result (no hang on subprocess exit)'
           nodes: [
             {
               id: 'loop1',
-              loop: { until: 'COMPLETE', max_iterations: 3 },
-              prompt: 'Do the thing. Say COMPLETE when done.',
+              loop: {
+                fresh_context: false,
+                prompt: 'Do the thing. Say COMPLETE when done.',
+                until: 'COMPLETE',
+                max_iterations: 3,
+              },
             },
           ],
         },
@@ -10151,7 +10239,7 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
   });
 
   afterEach(async () => {
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'DAG AI response' };
       yield { type: 'result', sessionId: 'dag-session-id' };
     });
@@ -10375,7 +10463,7 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
 
   it('output_format set but provider returns no structured output → node_failed (Task 8 fail-fast)', async () => {
     // Provider replied with prose only; no structuredOutput on the result chunk.
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'Sure, the verdict is review.' };
       yield { type: 'result', sessionId: 's' };
     });
@@ -10428,7 +10516,7 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
 
   it('output_format structured output failing schema validation → node_failed (Task 7)', async () => {
     // Provider returned a structured object missing the required `verdict` field.
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: '{"confidence":0.9}' };
       yield { type: 'result', sessionId: 's', structuredOutput: { confidence: 0.9 } };
     });
@@ -10483,7 +10571,7 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     // Regression guard: an unresolvable `.field` ref in a `when:` must fail the
     // dependent node (OutputRefError → node_failed), NOT fail-closed-skip it —
     // the exact regression that would silently revert the no-silent-drop fix.
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: '{"verdict":"review"}' };
       yield { type: 'result', sessionId: 's', structuredOutput: { verdict: 'review' } };
     });
@@ -10547,10 +10635,10 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     // Attempt 1 returns structured output missing the required `verdict`; the reask
     // loop re-runs and attempt 2 returns valid output → node COMPLETES (not failed).
     // Costs accumulate across both attempts.
-    mockSendQueryDag.mockImplementationOnce(function* () {
+    mockSendQueryDag.mockImplementationOnce(async function* () {
       yield { type: 'result', sessionId: 's1', structuredOutput: { other: 'x' }, cost: 0.01 };
     });
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield {
         type: 'result',
         sessionId: 's2',
@@ -10617,7 +10705,7 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
 
   it('best-effort provider: reask exhaustion fails loudly', async () => {
     // Every attempt returns invalid structured output → fail after 1 + maxReasks (3) tries.
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'result', sessionId: 's', structuredOutput: { other: 'x' } };
     });
 
@@ -10673,7 +10761,7 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
   it('enforced provider does NOT reask on a validation miss (exactly one sendQuery)', async () => {
     // Claude is 'enforced' → maxReasks = 0. A validation miss must fail on the
     // FIRST pass — a regressed gate would silently make 4 API calls per miss.
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'result', sessionId: 's', structuredOutput: { other: 'x' } };
     });
 
@@ -10724,11 +10812,11 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
 
   it('best-effort provider: MISSING structured output triggers reask and recovers', async () => {
     // Attempt 1 returns prose with no structuredOutput; attempt 2 returns valid JSON.
-    mockSendQueryDag.mockImplementationOnce(function* () {
+    mockSendQueryDag.mockImplementationOnce(async function* () {
       yield { type: 'assistant', content: 'Sure, here you go.' };
       yield { type: 'result', sessionId: 's1' };
     });
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'result', sessionId: 's2', structuredOutput: { verdict: 'review' } };
     });
 
@@ -11060,11 +11148,12 @@ describe('executeDagWorkflow -- cancel node', () => {
 
   it('cancel node transitions run to cancelled and sends message', async () => {
     const store = createMockStore();
-    (store.cancelWorkflowRun as Mock<() => Promise<void>>).mockResolvedValue(undefined);
+    store.cancelWorkflowRun.mockResolvedValue({ cancelled: true });
     // Track whether cancelWorkflowRun has been called to simulate status transition
     let cancelled = false;
-    (store.cancelWorkflowRun as Mock<() => Promise<void>>).mockImplementation(async () => {
+    store.cancelWorkflowRun.mockImplementation(async _id => {
       cancelled = true;
+      return { cancelled: true };
     });
     (store.getWorkflowRunStatus as Mock<() => Promise<string>>).mockImplementation(async () =>
       cancelled ? 'cancelled' : 'running'
@@ -11097,10 +11186,10 @@ describe('executeDagWorkflow -- cancel node', () => {
     );
 
     // cancelWorkflowRun should have been called
-    expect((store.cancelWorkflowRun as Mock<() => Promise<void>>).mock.calls.length).toBe(1);
+    expect(store.cancelWorkflowRun.mock.calls.length).toBe(1);
 
     // A message with the cancel reason should have been sent
-    const sendCalls = (platform.sendMessage as Mock<() => Promise<void>>).mock.calls;
+    const sendCalls = platform.sendMessage.mock.calls;
     const cancelMsg = sendCalls.find(
       (call: unknown[]) => typeof call[1] === 'string' && call[1].includes('Workflow cancelled')
     );
@@ -11138,7 +11227,7 @@ describe('executeDagWorkflow -- cancel node', () => {
 
     // cancelWorkflowRun should NOT have been called (when: condition is false)
     if (store.cancelWorkflowRun && typeof store.cancelWorkflowRun === 'function') {
-      expect((store.cancelWorkflowRun as Mock<() => Promise<void>>).mock.calls.length).toBe(0);
+      expect(store.cancelWorkflowRun.mock.calls.length).toBe(0);
     }
   });
 });
@@ -11164,7 +11253,7 @@ describe('executeDagWorkflow -- credit exhaustion', () => {
       getType: () => 'claude',
       getCapabilities: mockClaudeCapabilities,
     }));
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'DAG AI response' };
       yield { type: 'result', sessionId: 'dag-session-id' };
     });
@@ -11176,10 +11265,12 @@ describe('executeDagWorkflow -- credit exhaustion', () => {
   });
 
   it('marks node as failed when assistant output contains credit exhaustion text', async () => {
-    const creditExhaustedQuery = mock(function* () {
-      yield { type: 'assistant', content: "You're out of extra usage · resets in 2h" };
-      yield { type: 'result', sessionId: 'dag-session-credit' };
-    });
+    const creditExhaustedQuery = mock<ReturnType<WorkflowDeps['getAgentProvider']>['sendQuery']>(
+      async function* (_prompt, _cwd, _resumeSessionId, _options) {
+        yield { type: 'assistant', content: "You're out of extra usage · resets in 2h" };
+        yield { type: 'result', sessionId: 'dag-session-credit' };
+      }
+    );
     mockGetAgentProviderDag.mockReturnValue({
       sendQuery: creditExhaustedQuery,
       getType: () => 'claude',
@@ -11212,9 +11303,9 @@ describe('executeDagWorkflow -- credit exhaustion', () => {
     );
 
     // node_failed (not node_completed) must have been stored
-    const events = (store.createWorkflowEvent as Mock<() => Promise<void>>).mock.calls.map(
-      (c: unknown[]) => (c[0] as { event_type: string }).event_type
-    );
+    const events = (
+      store.createWorkflowEvent as Mock<IWorkflowStore['createWorkflowEvent']>
+    ).mock.calls.map((c: unknown[]) => (c[0] as { event_type: string }).event_type);
     expect(events).toContain('node_failed');
     expect(events).not.toContain('node_completed');
 
@@ -11292,9 +11383,8 @@ describe('executeDagWorkflow -- approval node', () => {
     expect(mockSendQueryDag.mock.calls.length).toBe(0);
 
     // pauseWorkflowRun should have been called with extended context
-    const pauseCalls = (
-      store.pauseWorkflowRun as Mock<(id: string, ctx: Record<string, unknown>) => Promise<void>>
-    ).mock.calls;
+    const pauseCalls = (store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>).mock
+      .calls;
     expect(pauseCalls.length).toBe(1);
     expect(pauseCalls[0][1]).toMatchObject({
       type: 'approval',
@@ -11338,9 +11428,8 @@ describe('executeDagWorkflow -- approval node', () => {
     );
 
     // pauseWorkflowRun context should NOT have captureResponse
-    const pauseCalls = (
-      store.pauseWorkflowRun as Mock<(id: string, ctx: Record<string, unknown>) => Promise<void>>
-    ).mock.calls;
+    const pauseCalls = (store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>).mock
+      .calls;
     expect(pauseCalls.length).toBe(1);
     expect(pauseCalls[0][1]).toMatchObject({
       type: 'approval',
@@ -11348,11 +11437,11 @@ describe('executeDagWorkflow -- approval node', () => {
       message: 'Approve?',
     });
     // captureResponse should be undefined (not set)
-    expect((pauseCalls[0][1] as Record<string, unknown>).captureResponse).toBeUndefined();
+    expect(pauseCalls[0][1].captureResponse).toBeUndefined();
   });
 
   it('on_reject runs AI prompt and re-pauses on rejection resume', async () => {
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'Fixed based on feedback' };
       yield { type: 'result', sessionId: 'reject-fix-session' };
     });
@@ -11412,14 +11501,13 @@ describe('executeDagWorkflow -- approval node', () => {
     expect(aiPrompt).toContain('Missing edge case handling');
 
     // pauseWorkflowRun should have been called (re-paused at approval gate)
-    const pauseCalls = (
-      store.pauseWorkflowRun as Mock<(id: string, ctx: Record<string, unknown>) => Promise<void>>
-    ).mock.calls;
+    const pauseCalls = (store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>).mock
+      .calls;
     expect(pauseCalls.length).toBe(1);
   });
 
   it('on_reject does not write node_completed for the approval gate node ID', async () => {
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'Fixed based on feedback' };
       yield { type: 'result', sessionId: 'reject-no-poison-session' };
     });
@@ -11541,13 +11629,12 @@ describe('executeDagWorkflow -- approval node', () => {
     expect(mockSendQueryDag.mock.calls.length).toBe(0);
 
     // cancelWorkflowRun should have been called
-    const cancelCalls = (store.cancelWorkflowRun as Mock<(id: string) => Promise<void>>).mock.calls;
+    const cancelCalls = store.cancelWorkflowRun.mock.calls;
     expect(cancelCalls.length).toBe(1);
 
     // pauseWorkflowRun should NOT have been called
-    const pauseCalls = (
-      store.pauseWorkflowRun as Mock<(id: string, ctx: Record<string, unknown>) => Promise<void>>
-    ).mock.calls;
+    const pauseCalls = (store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>).mock
+      .calls;
     expect(pauseCalls.length).toBe(0);
   });
 
@@ -11600,9 +11687,7 @@ describe('executeDagWorkflow -- approval node', () => {
 
     // Should cancel immediately, no AI call
     expect(mockSendQueryDag.mock.calls.length).toBe(0);
-    expect((store.cancelWorkflowRun as Mock<(id: string) => Promise<void>>).mock.calls.length).toBe(
-      1
-    );
+    expect(store.cancelWorkflowRun.mock.calls.length).toBe(1);
   });
 
   it('approval message substitutes $nodeId.output.field references from upstream structured output', async () => {
@@ -11620,7 +11705,7 @@ describe('executeDagWorkflow -- approval node', () => {
     await mkdir(commandsDir, { recursive: true });
     await writeFile(join(commandsDir, 'gather-context.md'), 'Gather context: $USER_MESSAGE');
 
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: JSON.stringify(structuredJson) };
       yield { type: 'result', sessionId: 'sid-approval-sub', structuredOutput: structuredJson };
     });
@@ -11675,9 +11760,8 @@ describe('executeDagWorkflow -- approval node', () => {
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
 
     // pauseWorkflowRun should receive the SUBSTITUTED message, not the literal placeholders
-    const pauseCalls = (
-      store.pauseWorkflowRun as Mock<(id: string, ctx: Record<string, unknown>) => Promise<void>>
-    ).mock.calls;
+    const pauseCalls = (store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>).mock
+      .calls;
     expect(pauseCalls.length).toBe(1);
     expect(pauseCalls[0][1]).toMatchObject({
       type: 'approval',
@@ -11702,12 +11786,12 @@ describe('executeDagWorkflow -- approval node', () => {
 
     // (b) The persisted approval_requested workflow event's data.message must be substituted.
     const approvalRequestedEvents = (
-      store.createWorkflowEvent as Mock<() => Promise<void>>
+      store.createWorkflowEvent as Mock<IWorkflowStore['createWorkflowEvent']>
     ).mock.calls.filter(
       (c: unknown[]) => (c[0] as { event_type: string }).event_type === 'approval_requested'
     );
     expect(approvalRequestedEvents.length).toBe(1);
-    expect((approvalRequestedEvents[0][0] as { data: { message: string } }).data.message).toBe(
+    expect(approvalRequestedEvents[0][0].data?.message).toBe(
       'Repo: hcr-els | App: CCELS | Port: 3012'
     );
   });
@@ -11816,7 +11900,7 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     mockGetAgentProviderDag.mockClear();
     mockLogFn.mockClear();
 
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'DAG AI response' };
       yield { type: 'result', sessionId: 'dag-session-id' };
     });
@@ -11836,7 +11920,7 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
   });
 
   it('fails node when SDK returns error_max_budget_usd result', async () => {
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield {
         type: 'result',
         isError: true,
@@ -11879,7 +11963,7 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     // 'ok' runs first (no deps), then 'capped' runs after (depends_on: ['ok'])
     // This ensures both nodes run — 'ok' succeeds, 'capped' hits the budget cap
     let callCount = 0;
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       callCount++;
       if (callCount === 1) {
         // First call: 'ok' node succeeds
@@ -11934,7 +12018,7 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     // Regression test for #1208: previously we only failed on error_max_budget_usd
     // and silently broke on all other isError subtypes, letting failed nodes
     // masquerade as successes with empty output.
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield {
         type: 'result',
         isError: true,
@@ -11989,7 +12073,7 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     // normalises this, but the executor keeps an explicit guard so a future
     // provider regression or a third-party IAgentProvider that forwards the
     // SDK pair raw cannot reintroduce the "SDK returned success" false-failure.
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'classified output' };
       yield {
         type: 'result',
@@ -12202,11 +12286,11 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
       platform,
       'conv-dag',
       testDir,
-      {
+      loaderBypassingWorkflow({
         name: 'codex-node-effort-beats-deprecated-test',
         nodes: [{ id: 'step1', command: 'my-cmd', effort: 'minimal' }],
         modelReasoningEffort: 'high',
-      },
+      }),
       workflowRun,
       'codex',
       undefined,
@@ -12334,14 +12418,14 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
       platform,
       'conv-dag',
       testDir,
-      {
+      loaderBypassingWorkflow({
         name: 'mixed-provider-preset-effort-test',
         nodes: [{ id: 'step1', command: 'my-cmd', model: 'medium' }],
         // A definition that still carries the deprecated field — only a
         // loader-bypassing caller can produce one. It affects nothing: the
         // executor never reads it (the loader translates it away).
         modelReasoningEffort: 'high',
-      },
+      }),
       workflowRun,
       'claude',
       undefined,
@@ -12422,12 +12506,12 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
       platform,
       'conv-dag',
       testDir,
-      {
+      loaderBypassingWorkflow({
         name: 'codex-effort-telemetry-test',
         nodes: [{ id: 'step1', command: 'my-cmd' }],
         effort: 'max',
         modelReasoningEffort: 'low',
-      },
+      }),
       workflowRun,
       'codex',
       undefined,
@@ -12532,7 +12616,7 @@ describe('executeDagWorkflow -- cost tracking', () => {
   });
 
   it('passes total_cost_usd to completeWorkflowRun when node yields cost', async () => {
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'done' };
       yield { type: 'result', sessionId: 'sid-cost', cost: 0.0042 };
     });
@@ -12573,7 +12657,7 @@ describe('executeDagWorkflow -- cost tracking', () => {
 
   it('sums total_cost_usd across multiple sequential nodes', async () => {
     let callCount = 0;
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       callCount++;
       yield { type: 'assistant', content: `Step ${String(callCount)} output` };
       yield { type: 'result', sessionId: `sid-${String(callCount)}`, cost: 0.001 };
@@ -12617,7 +12701,7 @@ describe('executeDagWorkflow -- cost tracking', () => {
   });
 
   it('omits total_cost_usd from completeWorkflowRun when no cost yielded', async () => {
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'Some output' };
       yield { type: 'result', sessionId: 'sid-no-cost' };
     });
@@ -12655,7 +12739,7 @@ describe('executeDagWorkflow -- cost tracking', () => {
 
   it('accumulates cost across loop iterations and includes in completeWorkflowRun', async () => {
     let callCount = 0;
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       callCount++;
       if (callCount < 3) {
         yield { type: 'assistant', content: 'Still working...' };
@@ -12681,7 +12765,7 @@ describe('executeDagWorkflow -- cost tracking', () => {
         nodes: [
           {
             id: 'my-loop',
-            loop: { prompt: 'Work.', until: 'COMPLETE', max_iterations: 5 },
+            loop: { fresh_context: false, prompt: 'Work.', until: 'COMPLETE', max_iterations: 5 },
           },
         ],
       },
@@ -12720,7 +12804,7 @@ describe('executeDagWorkflow -- script nodes', () => {
     mockSendQueryDag.mockClear();
     mockGetAgentProviderDag.mockClear();
 
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'DAG AI response' };
       yield { type: 'result', sessionId: 'dag-session-id' };
     });
@@ -13495,7 +13579,7 @@ describe('executeDagWorkflow -- MCP failure filtering', () => {
     systemContent: string,
     nodeMcpPath?: string
   ): Promise<IWorkflowPlatform> {
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'system', content: systemContent };
       yield { type: 'assistant', content: 'ok' };
       yield { type: 'result', sessionId: 'sess' };
@@ -13629,7 +13713,7 @@ describe('executeDagWorkflow -- final status derivation', () => {
 
     mockSendQueryDag.mockClear();
     mockGetAgentProviderDag.mockClear();
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'DAG AI response' };
       yield { type: 'result', sessionId: 'dag-session-id' };
     });
@@ -13733,19 +13817,24 @@ describe('executeDagWorkflow -- final status derivation', () => {
     expect(failMsg).toBeDefined();
   });
 
-  it('trigger_rule: none_failed skips dependent node + anyFailed still marks run failed', async () => {
+  it('trigger_rule: none_failed_min_one_success skips dependent node + anyFailed still marks run failed', async () => {
     const mockStore = createMockStore();
     const mockDeps = createMockDeps(mockStore);
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun('dag-status-run-3');
 
     // Layer 1: A and B run in parallel. B fails.
-    // Layer 2: C depends on B with trigger_rule: none_failed — so C is skipped.
+    // Layer 2: C depends on B with trigger_rule: none_failed_min_one_success — so C is skipped.
     // Expected: anyFailed=true (from B), so run must be marked failed even though C is only skipped.
     const nodes: DagNode[] = [
       { id: 'a', bash: 'echo a' } as BashNode,
       { id: 'b', bash: 'exit 1' } as BashNode,
-      { id: 'c', bash: 'echo c', depends_on: ['b'], trigger_rule: 'none_failed' } as BashNode,
+      {
+        id: 'c',
+        bash: 'echo c',
+        depends_on: ['b'],
+        trigger_rule: 'none_failed_min_one_success',
+      } as BashNode,
     ];
 
     await executeDagWorkflow(
@@ -13999,7 +14088,7 @@ describe('provider resolution -- regression for #1610', () => {
     mockSendQueryDag.mockClear();
     mockGetAgentProviderDag.mockClear();
 
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'response' };
       yield { type: 'result', sessionId: 'session-id' };
     });
@@ -14111,7 +14200,7 @@ describe('bundled opus nodes -- provider annotation invariant (#1610)', () => {
       if (!('workflow' in result)) continue; // skip load errors
 
       const wf = result.workflow;
-      if (!('nodes' in wf) || !wf.nodes) continue; // skip non-DAG workflows
+      if (!wf || !('nodes' in wf) || !wf.nodes) continue; // skip non-DAG workflows
 
       const workflowProvider: string | undefined = (wf as { provider?: string }).provider;
 
@@ -14145,7 +14234,7 @@ describe('executeDagWorkflow -- typed artifacts (output_type)', () => {
 
     mockSendQueryDag.mockClear();
     mockGetAgentProviderDag.mockClear();
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'AI response' };
       yield { type: 'result', sessionId: 'new-session-id' };
     });
@@ -14308,7 +14397,7 @@ describe('executeDagWorkflow -- persist_session', () => {
 
     mockSendQueryDag.mockClear();
     mockGetAgentProviderDag.mockClear();
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'AI response' };
       yield { type: 'result', sessionId: 'new-session-id' };
     });
@@ -14443,7 +14532,7 @@ describe('executeDagWorkflow -- persist_session', () => {
     mockSendQueryDag.mockClear();
     // The provider could not resume the prior session and ran cold (already a
     // clean fresh session). The executor must keep this run, not re-run it.
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'cold run' };
       yield { type: 'result', sessionId: 'cold-id', resumed: false };
     });
@@ -14498,7 +14587,7 @@ describe('executeDagWorkflow -- persist_session', () => {
       updated_at: '2026-05-01T00:00:00Z',
     });
     mockSendQueryDag.mockClear();
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'cold run' };
       yield { type: 'result', sessionId: 'cold-id', resumed: false };
     });
@@ -14776,7 +14865,7 @@ describe('executeDagWorkflow -- persist_session', () => {
   });
 
   it('persist_session: true but provider returns no sessionId → delete stale row', async () => {
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'AI response' };
       yield { type: 'result' }; // no sessionId
     });
@@ -15140,7 +15229,7 @@ describe('executeDagWorkflow -- completion telemetry', () => {
   }
 
   it('emits outcome=completed with node counts and the threaded source on success', async () => {
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'done' };
       yield { type: 'result', sessionId: 'sid-ok' };
     });
@@ -15158,7 +15247,7 @@ describe('executeDagWorkflow -- completion telemetry', () => {
       })
     );
     // No node reported usage — the fields must be OMITTED, not sent as zero.
-    const captured = mockCaptureWorkflowCompleted.mock.calls[0][0] as Record<string, unknown>;
+    const captured = mockCaptureWorkflowCompleted.mock.calls[0][0];
     expect('costUsd' in captured).toBe(false);
     expect('tokensIn' in captured).toBe(false);
     expect('tokensOut' in captured).toBe(false);
@@ -15166,7 +15255,7 @@ describe('executeDagWorkflow -- completion telemetry', () => {
   });
 
   it('threads provider-reported cost and tokens into the completion telemetry', async () => {
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'done' };
       yield {
         type: 'result',
@@ -15191,7 +15280,7 @@ describe('executeDagWorkflow -- completion telemetry', () => {
 
   it('ignores non-finite token values without poisoning the run totals', async () => {
     let call = 0;
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       call++;
       yield { type: 'assistant', content: `ok ${call}` };
       if (call === 1) {
@@ -15218,7 +15307,7 @@ describe('executeDagWorkflow -- completion telemetry', () => {
   it('emits outcome=failed exit_reason=no_nodes_completed when the only node fails', async () => {
     // A result chunk with no assistant text fails the node (see "produced no
     // assistant output" guard), leaving zero completed nodes.
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'result', sessionId: 'sid-empty' };
     });
 
@@ -15242,7 +15331,7 @@ describe('executeDagWorkflow -- completion telemetry', () => {
     // node2 depends on node1, so order is deterministic: node1 yields assistant
     // text (completes), node2 yields only a result (fails) → 1 completed, 1 failed.
     let call = 0;
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       call++;
       if (call === 1) {
         yield { type: 'assistant', content: 'first ok' };
@@ -15298,7 +15387,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
 
   it('completes a loop_group when the until signal appears on iteration N', async () => {
     let callCount = 0;
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       callCount++;
       if (callCount === 1) {
         yield { type: 'assistant', content: 'iteration 1 work, not done yet' };
@@ -15355,7 +15444,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
       join(testDir, '.archon', 'commands', 'body-loop-cmd.md'),
       'Command-file body for the inner loop.'
     );
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'inner work done. <promise>INNER_DONE</promise>\nDONE' };
       yield { type: 'result', sessionId: 'lg-cmd-sess' };
     });
@@ -15497,7 +15586,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
 
   it('fails the loop_group when max_iterations is exceeded without the until signal', async () => {
     let callCount = 0;
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       callCount++;
       yield { type: 'assistant', content: `iteration ${callCount} work, still going` };
       yield { type: 'result', sessionId: `lg-sess-${callCount}` };
@@ -15546,7 +15635,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
     // The body has 3 nodes; only `review` is AI (calls sendQuery). implement+test are
     // bash. On iteration 1 review does NOT emit DONE; on iteration 2 it does.
     let reviewCalls = 0;
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       reviewCalls++;
       const content =
         reviewCalls === 1 ? 'tests still failing, need another pass' : 'all tests green now\nDONE';
@@ -15608,7 +15697,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
     // contain "iter-1-draft" (carried via $LOOP_PREV), and iteration 2 emits DONE.
     let callCount = 0;
     const receivedPrompts: string[] = [];
-    mockSendQueryDag.mockImplementation(function* (prompt: string) {
+    mockSendQueryDag.mockImplementation(async function* (prompt: string) {
       callCount++;
       receivedPrompts.push(prompt ?? '');
       const content = callCount === 1 ? 'iter-1-draft' : 'iter-2-final\nDONE';
@@ -15730,7 +15819,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
   it('INSTANCE 4: single-node body degenerates like loop: and completes in 1 iteration', async () => {
     // A loop_group with a single prompt node that emits DONE on the very first iteration.
     let calls = 0;
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       calls++;
       yield { type: 'assistant', content: 'done immediately\nDONE' };
       yield { type: 'result', sessionId: `s-${calls}` };
@@ -15783,7 +15872,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
     // max-iterations message (the exact anti-pattern executeLoopNode already fixed).
     // The group fails fast, surfacing the failed body node's own error.
     let calls = 0;
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       calls++;
       throw new Error('body node exploded');
     });
@@ -15839,7 +15928,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
     // The loop_group depends_on an outer bash node `setup`. The body prompt references
     // $setup.output. outerNodeOutputs is seeded into the scoped map, so the ref resolves.
     let receivedPrompt = '';
-    mockSendQueryDag.mockImplementation(function* (prompt: string) {
+    mockSendQueryDag.mockImplementation(async function* (prompt: string) {
       receivedPrompt = prompt ?? '';
       yield { type: 'assistant', content: 'saw setup output\nDONE' };
       yield { type: 'result', sessionId: 's' };
@@ -16037,6 +16126,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
         loop_group: {
           until: 'DONE',
           max_iterations: 2,
+          fresh_context: false,
           nodes: [
             { id: 'polish', prompt: 'refine on $LOOP_PREV.polish.output.draft', depends_on: [] },
           ],
@@ -16064,6 +16154,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
         loop_group: {
           until: 'DONE',
           max_iterations: 2,
+          fresh_context: false,
           nodes: [
             {
               id: 'polish',
@@ -16093,6 +16184,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
           loop_group: {
             until: 'DONE',
             max_iterations: 2,
+            fresh_context: false,
             nodes: [
               { id: 'polish', prompt: 'refine on $LOOP_PREV.reviw.output.verdict', depends_on: [] },
             ],
@@ -16119,7 +16211,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
     // Inner iteration 1 → no prior output (''); inner iteration 2 → the marker from
     // iteration 1 (proving the inner loop resolved its own prior iteration).
     const capturedPrompts: string[] = [];
-    mockSendQueryDag.mockImplementation(function* (prompt: string) {
+    mockSendQueryDag.mockImplementation(async function* (prompt: string) {
       capturedPrompts.push(prompt ?? '');
       const n = capturedPrompts.length;
       // Call 1 emits MARK1 (no signal → inner iterates again); call 2 emits the signal.
@@ -16261,6 +16353,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
       {
         id: 'inner',
         loop: {
+          fresh_context: false,
           prompt: 'iterate on $LOOP_PREV.work.output',
           until: 'DONE',
           max_iterations: 2,
@@ -16282,6 +16375,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
         loop_group: {
           until: 'DONE',
           max_iterations: 2,
+          fresh_context: false,
           until_bash: 'test $LOOP_PREV.work.output = PASS',
           nodes: [{ id: 'w', prompt: 'p', depends_on: [] }],
         },
@@ -16303,7 +16397,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
     // terminal-output selection picks `a`.
     let aCalls = 0;
     let bCalls = 0;
-    mockSendQueryDag.mockImplementation(function* (prompt: string) {
+    mockSendQueryDag.mockImplementation(async function* (prompt: string) {
       // Distinguish the two body nodes by their prompt content.
       if (prompt.includes('node-a')) {
         aCalls++;
@@ -16364,7 +16458,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
     // Smoke: fresh_context:true path. We can't easily assert session reset from the mock,
     // but we verify the group completes normally with fresh_context on.
     let calls = 0;
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       calls++;
       yield { type: 'assistant', content: calls === 1 ? 'wip' : 'final\nDONE' };
       yield { type: 'result', sessionId: `s-${calls}` };
@@ -16420,7 +16514,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
       const s = statuses[Math.min(calls, statuses.length - 1)];
       return Promise.resolve(s as 'running' | 'cancelled');
     });
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       calls++;
       yield { type: 'assistant', content: `iter ${calls} work` };
       yield { type: 'result', sessionId: `s-${calls}` };
@@ -16470,7 +16564,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
     // completionDetected = signalDetected (true) short-circuits before until_bash runs.
     // We prove until_bash was skipped via a sentinel file it would create if executed.
     let calls = 0;
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       calls++;
       yield { type: 'assistant', content: 'done\nDONE' };
       yield { type: 'result', sessionId: `s-${calls}` };
@@ -16530,7 +16624,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
   it('EDGE I: max_iterations=1 single-shot completes when signal present, fails otherwise', async () => {
     // Single iteration allowed. With the signal present → completes in 1.
     let calls = 0;
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       calls++;
       yield { type: 'assistant', content: 'one-shot\nDONE' };
       yield { type: 'result', sessionId: `s-${calls}` };
@@ -16580,7 +16674,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
     // This smoke-tests that applyLoopPrevToBodyNode recurses and that a body node which is
     // itself a loop_group dispatches correctly.
     let calls = 0;
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       calls++;
       // Inner loop_group's body node runs first (emits INNER_DONE → inner completes iter 1).
       // Then the outer's review node emits OUTER_DONE. Distinguish by call order.
@@ -16650,7 +16744,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
 
   it('INTERACTIVE: interactive loop_group pauses at the gate after iteration 1', async () => {
     // Fresh interactive loop_group: iteration 1 emits no signal → pauses at the gate.
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'iteration 1 draft, awaiting review' };
       yield { type: 'result', sessionId: 'lg-gate-sess-1' };
     });
@@ -16693,11 +16787,8 @@ describe('executeDagWorkflow -- loop_group node', () => {
 
     // One AI call (iteration 1), then paused.
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
-    const pauseCalls = (
-      mockDeps.store.pauseWorkflowRun as Mock<
-        (id: string, ctx: Record<string, unknown>) => Promise<void>
-      >
-    ).mock.calls;
+    const pauseCalls = (mockDeps.store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>)
+      .mock.calls;
     expect(pauseCalls.length).toBe(1);
     expect(pauseCalls[0][1]).toMatchObject({
       type: 'interactive_loop',
@@ -16715,7 +16806,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
     // Signal on iteration 1 of a fresh interactive loop_group (no signal_completes):
     // still gates, but the pause carries completionSignaled + signaledOutput so a
     // bare approve can finalize at resume.
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'validation PASS\nAPPROVED' };
       yield { type: 'result', sessionId: 'lg-sig-sess-1' };
     });
@@ -16756,11 +16847,8 @@ describe('executeDagWorkflow -- loop_group node', () => {
       minimalConfig
     );
 
-    const pauseCalls = (
-      mockDeps.store.pauseWorkflowRun as Mock<
-        (id: string, ctx: Record<string, unknown>) => Promise<void>
-      >
-    ).mock.calls;
+    const pauseCalls = (mockDeps.store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>)
+      .mock.calls;
     expect(pauseCalls.length).toBe(1);
     expect(pauseCalls[0][1]).toMatchObject({
       type: 'interactive_loop',
@@ -16777,7 +16865,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
   });
 
   it('INTERACTIVE: loop_group signal_completes completes on a first-iteration signal without gating (#2074 B)', async () => {
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'validation PASS\nAPPROVED' };
       yield { type: 'result', sessionId: 'lg-sc-sess-1' };
     });
@@ -16819,7 +16907,8 @@ describe('executeDagWorkflow -- loop_group node', () => {
       minimalConfig
     );
 
-    const pauseCalls = (mockDeps.store.pauseWorkflowRun as Mock<() => Promise<void>>).mock.calls;
+    const pauseCalls = (mockDeps.store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>)
+      .mock.calls;
     expect(pauseCalls.length).toBe(0);
     const eventCalls = (
       mockDeps.store.createWorkflowEvent as Mock<
@@ -16837,7 +16926,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
   });
 
   it('INTERACTIVE: loop_group finalizes at resume from persisted signaledOutput on a bare approve (#2074 C)', async () => {
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'should never run' };
       yield { type: 'result', sessionId: 'never' };
     });
@@ -16915,7 +17004,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
     // Two-call pattern (mirrors the loop: resume test): call 1 pauses at the gate after
     // iteration 1 (no signal). Call 2 resumes with metadata.approval populated; iteration 2
     // emits APPROVED → completes.
-    mockSendQueryDag.mockImplementationOnce(function* () {
+    mockSendQueryDag.mockImplementationOnce(async function* () {
       yield { type: 'assistant', content: 'iter1 draft, not approved' };
       yield { type: 'result', sessionId: 'lg-resume-sess-1' };
     });
@@ -16964,9 +17053,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
     // fresh_context: false resume can continue the same conversation.
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
     const pauseCalls1 = (
-      mockDeps1.store.pauseWorkflowRun as Mock<
-        (id: string, ctx: Record<string, unknown>) => Promise<void>
-      >
+      mockDeps1.store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>
     ).mock.calls;
     expect(pauseCalls1.length).toBe(1);
     expect(pauseCalls1[0]?.[1]?.sessionId).toBe('lg-resume-sess-1');
@@ -16975,7 +17062,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
     expect(pauseCalls1[0]?.[1]?.sessionProvider).toBe('claude');
 
     // ---- Call 2: resume with metadata.approval carrying iter 1 + user input.
-    mockSendQueryDag.mockImplementationOnce(function* () {
+    mockSendQueryDag.mockImplementationOnce(async function* () {
       yield { type: 'assistant', content: 'all good, shipping\nAPPROVED' };
       yield { type: 'result', sessionId: 'lg-resume-sess-2' };
     });
@@ -17022,9 +17109,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
     expect(mockSendQueryDag.mock.calls[1][2]).toBe('lg-resume-sess-1');
     // Resume completed (no second pause at the gate).
     const pauseCalls2 = (
-      mockDeps2.store.pauseWorkflowRun as Mock<
-        (id: string, ctx: Record<string, unknown>) => Promise<void>
-      >
+      mockDeps2.store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>
     ).mock.calls;
     expect(pauseCalls2.length).toBe(0);
   });
@@ -17035,7 +17120,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
     // iteration's $LOOP_PREV.<bodyNode>.output resolves to '' — NOT to the paused run's
     // iteration-1 output. This test locks the current behavior; persisting $LOOP_PREV
     // across resume is a tracked follow-up (CodeRabbit finding #5).
-    mockSendQueryDag.mockImplementationOnce(function* () {
+    mockSendQueryDag.mockImplementationOnce(async function* () {
       yield { type: 'assistant', content: 'iter1 body output XYZ' };
       yield { type: 'result', sessionId: 'lg-prev-sess-1' };
     });
@@ -17086,7 +17171,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
     expect(iter1Prompt).toContain('PREV=<<>>');
 
     // ---- Resume: iteration 2.
-    mockSendQueryDag.mockImplementationOnce(function* () {
+    mockSendQueryDag.mockImplementationOnce(async function* () {
       yield { type: 'assistant', content: 'final\nAPPROVED' };
       yield { type: 'result', sessionId: 'lg-prev-sess-2' };
     });
@@ -17133,7 +17218,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
     // The group sums per-iteration cost into its NodeExecutionResult; the outer runLayers
     // then aggregates it into the run's total_cost_usd.
     let calls = 0;
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       calls++;
       const cost = calls === 1 ? 0.01 : 0.02;
       const content = calls === 1 ? 'work in progress' : 'done\nDONE';
@@ -17190,7 +17275,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
   it('COST: accumulates token usage across loop_group iterations', async () => {
     mockCaptureWorkflowCompleted.mockClear();
     let calls = 0;
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       calls++;
       const content = calls === 1 ? 'work in progress' : 'done\nDONE';
       yield { type: 'assistant', content };
@@ -17299,7 +17384,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
 
     // Phase 1 — iteration 1 signals but still gates (fresh interactive, no
     // signal_completes). Its body row persists 100/10, the run's ONLY real usage.
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'validation PASS\nAPPROVED' };
       yield { type: 'result', sessionId: 'lg-dbl-sess-1', tokens: { input: 100, output: 10 } };
     });
@@ -17321,14 +17406,13 @@ describe('executeDagWorkflow -- loop_group node', () => {
       minimalConfig
     );
 
-    const pauseCalls = (
-      store.pauseWorkflowRun as Mock<(id: string, ctx: Record<string, unknown>) => Promise<void>>
-    ).mock.calls;
+    const pauseCalls = (store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>).mock
+      .calls;
     expect(pauseCalls.length).toBe(1);
 
     // Phase 2 — bare approve. The resumed run carries EXACTLY the context the gate
     // persisted, so what the pause writes is what the finalize reads.
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'should never run' };
       yield { type: 'result', sessionId: 'never', tokens: { input: 999, output: 99 } };
     });
@@ -17383,7 +17467,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
   });
 
   it('omits tokens from loop_group body node_completed events when providers report no usage', async () => {
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'done\nDONE' };
       yield { type: 'result', sessionId: 'lg-no-usage-sid' };
     });
@@ -17438,7 +17522,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
 
   it('SESSION: fresh_context=false threads the body session between iterations', async () => {
     let calls = 0;
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       calls++;
       yield { type: 'assistant', content: calls >= 2 ? 'done\nDONE' : 'progress' };
       yield { type: 'result', sessionId: `lg-sess-${calls}` };
@@ -17487,7 +17571,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
 
   it('SESSION: fresh_context=true starts a fresh body session every iteration', async () => {
     let calls = 0;
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       calls++;
       yield { type: 'assistant', content: calls >= 2 ? 'done\nDONE' : 'progress' };
       yield { type: 'result', sessionId: `lg-fresh-${calls}` };
@@ -17538,7 +17622,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
     // 'go' → work runs and emits DONE. Proves (1) when: evaluates against the SAME
     // iteration's scoped outputs and (2) skip state doesn't leak into iteration 2.
     let gateCalls = 0;
-    mockSendQueryDag.mockImplementation(function* (prompt: string) {
+    mockSendQueryDag.mockImplementation(async function* (prompt: string) {
       if (prompt.includes('GATE')) {
         gateCalls++;
         yield { type: 'assistant', content: gateCalls === 1 ? 'stop' : 'go' };
@@ -17601,7 +17685,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
     // Multi-node body: implement fails → verify (depends_on implement) is skipped by
     // trigger-rule semantics → group fails fast with implement's error, one iteration.
     let calls = 0;
-    mockSendQueryDag.mockImplementation(function* (prompt: string) {
+    mockSendQueryDag.mockImplementation(async function* (prompt: string) {
       calls++;
       if (prompt.includes('IMPLEMENT')) {
         throw new Error('implement blew up');
@@ -17664,7 +17748,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
     // nodes/{groupId}.md from the group's NodeExecutionResult.output (= final iteration's
     // terminal output).
     let calls = 0;
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       calls++;
       const content = calls === 1 ? 'draft v1' : 'final result v2\nDONE';
       yield { type: 'assistant', content };
@@ -17757,7 +17841,7 @@ describe('executeDagWorkflow -- loop_group body step_name namespacing (#2090)', 
   it('namespaces body node lifecycle step_name and tags iteration; top-level node stays bare', async () => {
     // `work` (AI) does not emit DONE on iteration 1, emits it on iteration 2 → 2 iterations.
     let calls = 0;
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       calls++;
       yield {
         type: 'assistant',
@@ -17832,7 +17916,7 @@ describe('executeDagWorkflow -- loop_group body step_name namespacing (#2090)', 
     // Inner group completes in 1 iteration (INNER_DONE); outer completes when review emits
     // OUTER_DONE. Mirrors the EDGE H harness above.
     let calls = 0;
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       calls++;
       yield {
         type: 'assistant',
@@ -17906,7 +17990,7 @@ describe('executeDagWorkflow -- loop_group body step_name namespacing (#2090)', 
   });
 
   it('keeps the in-process emitter payload raw (unprefixed nodeId) for body events', async () => {
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'done\nDONE' };
       yield { type: 'result', sessionId: 's-1' };
     });
@@ -17971,7 +18055,7 @@ describe('executeDagWorkflow -- loop_group body step_name namespacing (#2090)', 
     // AND a namespaced body key. The group must be skipped as a unit (body does NOT re-run),
     // and the un-namespaced body key must NOT be mistaken for the still-pending top-level node.
     let calls = 0;
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       calls++;
       yield { type: 'assistant', content: 'finalize output' };
       yield { type: 'result', sessionId: `s-${calls}` };
@@ -18002,7 +18086,7 @@ describe('executeDagWorkflow -- loop_group body step_name namespacing (#2090)', 
     ];
 
     let finalizePrompt = '';
-    mockSendQueryDag.mockImplementation(function* (prompt: string) {
+    mockSendQueryDag.mockImplementation(async function* (prompt: string) {
       calls++;
       finalizePrompt = prompt;
       yield { type: 'assistant', content: 'finalize output' };
@@ -18150,7 +18234,7 @@ describe('executeDagWorkflow -- provider-boundary session threading (#1992)', ()
   }
 
   it('sequential node on a DIFFERENT provider gets a fresh session (no cross-provider resume)', async () => {
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'step done' };
       yield { type: 'result', sessionId: 'sess-a' };
     });
@@ -18169,7 +18253,7 @@ describe('executeDagWorkflow -- provider-boundary session threading (#1992)', ()
   });
 
   it('sequential node on the SAME provider still threads the session', async () => {
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'step done' };
       yield { type: 'result', sessionId: 'sess-a' };
     });
@@ -18182,7 +18266,7 @@ describe('executeDagWorkflow -- provider-boundary session threading (#1992)', ()
   });
 
   it('node after a loop node on a DIFFERENT provider gets a fresh session', async () => {
-    mockSendQueryDag.mockImplementation(function* (prompt: string) {
+    mockSendQueryDag.mockImplementation(async function* (prompt: string) {
       if (prompt.includes('Iterate')) {
         yield { type: 'assistant', content: 'all done <promise>COMPLETE</promise>' };
         yield { type: 'result', sessionId: 'loop-sess' };
@@ -18199,7 +18283,12 @@ describe('executeDagWorkflow -- provider-boundary session threading (#1992)', ()
         nodes: [
           {
             id: 'work',
-            loop: { prompt: 'Iterate until done.', until: 'COMPLETE', max_iterations: 3 },
+            loop: {
+              fresh_context: false,
+              prompt: 'Iterate until done.',
+              until: 'COMPLETE',
+              max_iterations: 3,
+            },
           },
           { id: 'after', prompt: 'Summarize', depends_on: ['work'], provider: 'codex' },
         ],
@@ -18214,7 +18303,7 @@ describe('executeDagWorkflow -- provider-boundary session threading (#1992)', ()
   });
 
   it('node after a loop node on the SAME provider still threads the loop session', async () => {
-    mockSendQueryDag.mockImplementation(function* (prompt: string) {
+    mockSendQueryDag.mockImplementation(async function* (prompt: string) {
       if (prompt.includes('Iterate')) {
         yield { type: 'assistant', content: 'all done <promise>COMPLETE</promise>' };
         yield { type: 'result', sessionId: 'loop-sess' };
@@ -18231,7 +18320,12 @@ describe('executeDagWorkflow -- provider-boundary session threading (#1992)', ()
         nodes: [
           {
             id: 'work',
-            loop: { prompt: 'Iterate until done.', until: 'COMPLETE', max_iterations: 3 },
+            loop: {
+              fresh_context: false,
+              prompt: 'Iterate until done.',
+              until: 'COMPLETE',
+              max_iterations: 3,
+            },
           },
           { id: 'after', prompt: 'Summarize', depends_on: ['work'] },
         ],
@@ -18249,7 +18343,7 @@ describe('executeDagWorkflow -- provider-boundary session threading (#1992)', ()
     // iteration, and each cross-iteration handoff (y's codex cursor into x, x's claude
     // cursor into y) is a provider boundary too.
     let yCalls = 0;
-    mockSendQueryDag.mockImplementation(function* (prompt: string) {
+    mockSendQueryDag.mockImplementation(async function* (prompt: string) {
       if (prompt.includes('analyze')) {
         yield { type: 'assistant', content: 'analysis output' };
         yield { type: 'result', sessionId: 'sess-x' };
@@ -18301,7 +18395,7 @@ describe('executeDagWorkflow -- provider-boundary session threading (#1992)', ()
     // iter1: x fresh, y resumes x's session; iter2 seeds y's iter-1 session into x,
     // then y resumes x's iter-2 session.
     let yCalls = 0;
-    mockSendQueryDag.mockImplementation(function* (prompt: string) {
+    mockSendQueryDag.mockImplementation(async function* (prompt: string) {
       if (prompt.includes('analyze')) {
         yield { type: 'assistant', content: 'analysis output' };
         yield { type: 'result', sessionId: `sess-x-${String(yCalls + 1)}` };
@@ -18349,7 +18443,7 @@ describe('executeDagWorkflow -- provider-boundary session threading (#1992)', ()
     // A run paused BEFORE the provider tag existed has approval metadata with a bare
     // sessionId. Restoring it untagged could thread the session into a different
     // provider, so the resume starts fresh instead (safe degradation).
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'resumed and finished\nDONE' };
       yield { type: 'result', sessionId: 'legacy-resume-sess' };
     });
@@ -18398,7 +18492,7 @@ describe('executeDagWorkflow -- provider-boundary session threading (#1992)', ()
     // sessionId/sessionProvider as explicit nulls — key omission would let SQLite's
     // json_patch deep-merge keep a stale pair from a previous pause of this run
     // (same convention as ApprovalContext.resolved).
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'checked, not done yet' };
       yield { type: 'result', sessionId: 'parallel-tail-sess' };
     });
@@ -18428,11 +18522,8 @@ describe('executeDagWorkflow -- provider-boundary session threading (#1992)', ()
       makeWorkflowRun('lg-null-pause')
     );
 
-    const pauseCalls = (
-      mockDeps.store.pauseWorkflowRun as Mock<
-        (id: string, ctx: Record<string, unknown>) => Promise<void>
-      >
-    ).mock.calls;
+    const pauseCalls = (mockDeps.store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>)
+      .mock.calls;
     expect(pauseCalls.length).toBe(1);
     const pauseCtx = pauseCalls[0][1];
     // Keys present with explicit null — NOT omitted, NOT a live session pair.
@@ -18813,9 +18904,8 @@ describe('executeDagWorkflow -- approval node inside an included block', () => {
       minimalConfig
     );
 
-    const pauseCalls = (
-      store.pauseWorkflowRun as Mock<(id: string, ctx: Record<string, unknown>) => Promise<void>>
-    ).mock.calls;
+    const pauseCalls = (store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>).mock
+      .calls;
     expect(pauseCalls.length).toBe(1);
     // The gate pauses under the namespaced approval id, not the bare block id.
     expect(pauseCalls[0][1]).toMatchObject({
@@ -19460,16 +19550,16 @@ describe('executeDagWorkflow -- gate pause vs external transition (#1123)', () =
 
     // The lost CAS must NOT cascade into a node failure or any terminal write —
     // the external transition owns the run's final state.
-    const events = (store.createWorkflowEvent as Mock<() => Promise<void>>).mock.calls.map(
-      (c: unknown[]) => (c[0] as { event_type: string }).event_type
-    );
+    const events = (
+      store.createWorkflowEvent as Mock<IWorkflowStore['createWorkflowEvent']>
+    ).mock.calls.map((c: unknown[]) => (c[0] as { event_type: string }).event_type);
     expect(events).not.toContain('node_failed');
     expect(store.failWorkflowRun).not.toHaveBeenCalled();
     expect(store.completeWorkflowRun).not.toHaveBeenCalled();
   });
 
   it('interactive loop gate that loses the pause CAS halts cleanly', async () => {
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'Here is the plan. Please review.' };
       yield { type: 'result', sessionId: 'loop-session-race' };
     });
@@ -19496,6 +19586,7 @@ describe('executeDagWorkflow -- gate pause vs external transition (#1123)', () =
             {
               id: 'refine',
               loop: {
+                fresh_context: false,
                 prompt: 'User said: $LOOP_USER_INPUT. Refine the plan.',
                 until: 'APPROVED',
                 max_iterations: 10,
@@ -19520,9 +19611,9 @@ describe('executeDagWorkflow -- gate pause vs external transition (#1123)', () =
     }
 
     expect(emitted).not.toContain('approval_pending');
-    const events = (store.createWorkflowEvent as Mock<() => Promise<void>>).mock.calls.map(
-      (c: unknown[]) => (c[0] as { event_type: string }).event_type
-    );
+    const events = (
+      store.createWorkflowEvent as Mock<IWorkflowStore['createWorkflowEvent']>
+    ).mock.calls.map((c: unknown[]) => (c[0] as { event_type: string }).event_type);
     expect(events).not.toContain('node_failed');
     expect(store.failWorkflowRun).not.toHaveBeenCalled();
     expect(store.completeWorkflowRun).not.toHaveBeenCalled();
@@ -19558,9 +19649,9 @@ describe('executeDagWorkflow -- gate pause vs external transition (#1123)', () =
       minimalConfig
     );
 
-    const events = (store.createWorkflowEvent as Mock<() => Promise<void>>).mock.calls.map(
-      (c: unknown[]) => (c[0] as { event_type: string }).event_type
-    );
+    const events = (
+      store.createWorkflowEvent as Mock<IWorkflowStore['createWorkflowEvent']>
+    ).mock.calls.map((c: unknown[]) => (c[0] as { event_type: string }).event_type);
     expect(events).toContain('node_failed');
     expect(store.failWorkflowRun).toHaveBeenCalled();
   });

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -17,7 +17,7 @@ import * as git from '@archon/git';
 
 // --- Mock logger (MUST come before imports of modules under test) ---
 
-const mockLogFn = mock((_data: unknown, _message?: string) => {});
+const mockLogFn = mock((_data: unknown, _message?: string): void => {});
 const mockLogger = {
   info: mockLogFn,
   warn: mockLogFn,
@@ -56,6 +56,7 @@ import {
   registerPiProvider,
   registerOpencodeProvider,
   clearRegistry,
+  getProviderCapabilities,
 } from '@archon/providers';
 clearRegistry();
 registerBuiltinProviders();
@@ -203,27 +204,9 @@ const mockClaudeCapabilities = () => ({
   nativeTools: true,
   containerExec: true,
 });
-/** Limited capabilities for Codex mock */
-const mockCodexCapabilities = () => ({
-  sessionResume: true,
-  mcp: true,
-  hooks: false,
-  skills: true,
-  agents: false,
-  toolRestrictions: false,
-  structuredOutput: 'enforced' as const,
-  envInjection: true,
-  costControl: false,
-  // Codex takes the node-level `effort:` field and translates it to the SDK's
-  // modelReasoningEffort internally (#2556) — mirrors CODEX_CAPABILITIES.
-  effortControl: true,
-  thinkingControl: false,
-  fallbackModel: false,
-  sandbox: false,
-  settingSources: false,
-  nativeTools: true,
-  containerExec: false,
-});
+/** Canonical capabilities for Codex-backed test nodes. */
+const mockCodexCapabilities = (): ReturnType<typeof getProviderCapabilities> =>
+  getProviderCapabilities('codex');
 
 /** Mock AI sendQuery generator */
 const mockSendQueryDag = mock<ReturnType<WorkflowDeps['getAgentProvider']>['sendQuery']>(

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -8735,10 +8735,11 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       expect(warnCalls[0]?.[0]).toEqual(
         expect.objectContaining({ workflowRunId: workflowRun.id, nodeId: 'refine' })
       );
-      const completed = mockDeps.store.createWorkflowEvent.mock.calls.find(
+      const completed = mockDeps.store.createWorkflowEvent.mock.calls.filter(
         ([event]) => event.event_type === 'node_completed' && event.step_name === 'refine'
       );
-      expect(completed?.[0].data).not.toHaveProperty('tokens');
+      expect(completed.length).toBe(1);
+      expect(completed[0][0].data).not.toHaveProperty('tokens');
     });
 
     it('iterates at resume when feedback was given, even on a signal-bearing gate (#2074 C)', async () => {

--- a/packages/workflows/src/defaults/bundled-defaults.test.ts
+++ b/packages/workflows/src/defaults/bundled-defaults.test.ts
@@ -101,6 +101,12 @@ describe('bundled-defaults', () => {
 
     it('packaged bundle metadata is internally consistent', () => {
       for (const [workflow, owner] of Object.entries(BUNDLED_WORKFLOW_OWNERS)) {
+        if (!owner?.pack || !owner.workflow) throw new Error(`Missing owner for ${workflow}`);
+        const resourceOwner = {
+          source: 'bundled' as const,
+          pack: owner.pack,
+          workflow: owner.workflow,
+        };
         expect(BUNDLED_WORKFLOWS[workflow]).toBeDefined();
         expect(owner.pack.length).toBeGreaterThan(0);
         expect(owner.workflow.length).toBeGreaterThan(0);
@@ -115,7 +121,7 @@ describe('bundled-defaults', () => {
         if (existsSync(commandDir)) {
           for (const entry of readdirSync(commandDir).filter(entry => entry.endsWith('.md'))) {
             const localName = entry.slice(0, -'.md'.length);
-            const key = formatPackagedResourceReference({ source: 'bundled', ...owner }, localName);
+            const key = formatPackagedResourceReference(resourceOwner, localName);
             expect(BUNDLED_COMMANDS[key]).toBe(
               readFileSync(join(commandDir, entry), 'utf-8').replace(/\r\n/g, '\n')
             );

--- a/packages/workflows/src/event-emitter.test.ts
+++ b/packages/workflows/src/event-emitter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, mock, beforeEach, spyOn } from 'bun:test';
+import { describe, it, expect, mock, beforeEach } from 'bun:test';
 
 // --- Mock logger (MUST come before imports of modules under test) ---
 // event-emitter.ts uses a lazy-initialized logger via getLog(), so we must
@@ -83,7 +83,7 @@ function makeArtifactEvent(runId = 'run-1'): WorkflowEmitterEvent {
   return {
     type: 'workflow_artifact',
     runId,
-    artifactType: 'log',
+    artifactType: 'file_created',
     label: 'Execution log',
     path: '/tmp/workflow.log',
   };
@@ -614,7 +614,7 @@ describe('WorkflowEventEmitter', () => {
       emitter.emit({
         type: 'workflow_artifact',
         runId,
-        artifactType: 'log',
+        artifactType: 'file_created',
         label: 'build output',
         path: '/tmp/out.log',
       });

--- a/packages/workflows/src/executor-preamble.test.ts
+++ b/packages/workflows/src/executor-preamble.test.ts
@@ -92,6 +92,8 @@ import { executeWorkflow } from './executor';
 function makeStore(overrides: Partial<IWorkflowStore> = {}): IWorkflowStore {
   return {
     getActiveWorkflowRunByPath: mock(async () => null),
+    findChildRuns: mock(async () => []),
+    getRunAncestry: mock(async () => []),
     failOrphanedRuns: mock(async () => ({ count: 0 })),
     createWorkflowRun: mock(async () => makeRun()),
     updateWorkflowRun: mock(async () => {}),
@@ -107,6 +109,15 @@ function makeStore(overrides: Partial<IWorkflowStore> = {}): IWorkflowStore {
     resumeWorkflowRun: mock(async () => makeRun()),
     getCodebase: mock(async () => null),
     getCodebaseEnvVars: mock(async () => ({})),
+    updateWorkflowActivity: mock(async () => {}),
+    completeWorkflowRun: mock(async () => {}),
+    pauseWorkflowRun: mock(async () => {}),
+    claimWriteback: mock(async () => ({ claimed: true })),
+    releaseWritebackClaim: mock(async () => {}),
+    cancelWorkflowRun: mock(async () => ({ cancelled: false })),
+    getWorkflowNodeSession: mock(async () => null),
+    upsertWorkflowNodeSession: mock(async () => {}),
+    deleteWorkflowNodeSessions: mock(async () => ({ deleted: 0 })),
     ...overrides,
   };
 }
@@ -150,9 +161,18 @@ function makeRun(overrides: Partial<WorkflowRun> = {}): WorkflowRun {
     id: 'run-123',
     workflow_name: 'test-workflow',
     conversation_id: 'conv-1',
+    parent_conversation_id: null,
+    codebase_id: null,
     status: 'running',
-    started_at: new Date().toISOString(),
+    user_message: 'test',
     metadata: {},
+    started_at: new Date(),
+    completed_at: null,
+    last_activity_at: null,
+    working_path: null,
+    user_id: null,
+    parent_run_id: null,
+    output_root: null,
     ...overrides,
   };
 }
@@ -201,7 +221,7 @@ describe('executeWorkflow preamble', () => {
 
   describe('concurrent run guard', () => {
     it('should block new workflow when a running workflow exists on the same path', async () => {
-      const recentTime = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+      const recentTime = new Date(Date.now() - 5 * 60 * 1000);
       const activeRun = makeRun({
         id: 'active-workflow-id',
         workflow_name: 'active-workflow',
@@ -227,6 +247,7 @@ describe('executeWorkflow preamble', () => {
       );
 
       expect(result.success).toBe(false);
+      if (result.success) throw new Error('Expected active-workflow rejection');
       expect(result.error).toContain('already active');
 
       // Actionable rejection message was sent (mentions worktree-in-use,
@@ -290,7 +311,7 @@ describe('executeWorkflow preamble', () => {
         makeWorkflow(),
         'test message',
         'db-conv-456',
-        'codebase-789'
+        { codebaseId: 'codebase-789' }
       );
 
       const activeCheckCalls = (store.getActiveWorkflowRunByPath as ReturnType<typeof mock>).mock
@@ -320,6 +341,7 @@ describe('executeWorkflow preamble', () => {
       );
 
       expect(result.success).toBe(false);
+      if (result.success) throw new Error('Expected active-workflow lookup failure');
       expect(result.error).toContain('Database error');
 
       // The row is created BEFORE the guard runs (so the guard can exclude

--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -1277,9 +1277,10 @@ describe('executeWorkflow', () => {
         'db-conv-1'
       );
       expect(result.success).toBe(true);
-      if (result.success && !('paused' in result)) {
-        expect(result.summary).toBe('This is the workflow summary');
+      if (!result.success || 'paused' in result) {
+        throw new Error('Expected completed workflow result');
       }
+      expect(result.summary).toBe('This is the workflow summary');
     });
 
     it('passes undefined summary when executeDagWorkflow returns undefined', async () => {
@@ -1296,9 +1297,10 @@ describe('executeWorkflow', () => {
         'db-conv-1'
       );
       expect(result.success).toBe(true);
-      if (result.success && !('paused' in result)) {
-        expect(result.summary).toBeUndefined();
+      if (!result.success || 'paused' in result) {
+        throw new Error('Expected completed workflow result');
       }
+      expect(result.summary).toBeUndefined();
     });
   });
 

--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -22,8 +22,12 @@ const mockLogger = {
 };
 // Telemetry is fire-and-forget; mock as no-ops so the executor can call them.
 // Hoisted so tests can assert on the completion call (outcome / exit reason).
-const mockCaptureWorkflowInvoked = mock(() => {});
-const mockCaptureWorkflowCompleted = mock(() => {});
+const mockCaptureWorkflowInvoked = mock<typeof import('@archon/paths').captureWorkflowInvoked>(
+  _props => {}
+);
+const mockCaptureWorkflowCompleted = mock<typeof import('@archon/paths').captureWorkflowCompleted>(
+  _props => {}
+);
 /**
  * Deterministic stand-ins for the shared identity→paths resolver (#2200). They
  * mirror the real branch order and layout, so `resolveProjectPaths` is exercised
@@ -113,7 +117,8 @@ mock.module('@archon/git', () => ({
 }));
 
 // --- Mock dag-executor ---
-const mockExecuteDagWorkflow = mock(async (): Promise<string | undefined> => undefined);
+type ExecuteDagWorkflow = typeof import('./dag-executor').executeDagWorkflow;
+const mockExecuteDagWorkflow = mock<ExecuteDagWorkflow>(async () => undefined);
 mock.module('./dag-executor', () => ({
   executeDagWorkflow: mockExecuteDagWorkflow,
   // Passthrough for the sub-run outcome mapper (#2121) — executor.ts imports it;
@@ -180,6 +185,15 @@ function makeStore(overrides: Partial<IWorkflowStore> = {}): IWorkflowStore {
     resumeWorkflowRun: mock(async () => makeRun()),
     getCodebase: mock(async () => null),
     getCodebaseEnvVars: mock(async () => ({})),
+    updateWorkflowActivity: mock(async () => {}),
+    completeWorkflowRun: mock(async () => {}),
+    pauseWorkflowRun: mock(async () => {}),
+    claimWriteback: mock(async () => ({ claimed: true })),
+    releaseWritebackClaim: mock(async () => {}),
+    cancelWorkflowRun: mock(async () => ({ cancelled: false })),
+    getWorkflowNodeSession: mock(async () => null),
+    upsertWorkflowNodeSession: mock(async () => {}),
+    deleteWorkflowNodeSessions: mock(async () => ({ deleted: 0 })),
     ...overrides,
   };
 }
@@ -225,9 +239,18 @@ function makeRun(overrides: Partial<WorkflowRun> = {}): WorkflowRun {
     id: 'run-123',
     workflow_name: 'test-workflow',
     conversation_id: 'conv-1',
+    parent_conversation_id: null,
+    codebase_id: null,
     status: 'running',
-    started_at: new Date().toISOString(),
+    user_message: 'test message',
     metadata: {},
+    started_at: new Date(),
+    completed_at: null,
+    last_activity_at: null,
+    working_path: null,
+    user_id: null,
+    parent_run_id: null,
+    output_root: null,
     ...overrides,
   };
 }
@@ -241,7 +264,7 @@ describe('executeWorkflow', () => {
     mockEmitter.emit.mockClear();
     mockGetDefaultBranch.mockClear();
     mockGetDefaultBranch.mockImplementation(async () => 'main');
-    mockExecuteDagWorkflow.mockImplementation(async (): Promise<string | undefined> => undefined);
+    mockExecuteDagWorkflow.mockImplementation(async () => undefined);
   });
 
   // -------------------------------------------------------------------------
@@ -267,6 +290,7 @@ describe('executeWorkflow', () => {
         { preCreatedRun, priorCompletedNodes: new Map([['node1', 'out']]) }
       );
       expect(result.success).toBe(false);
+      if (result.success) throw new Error('Expected missing-container-context failure');
       expect(result.error).toMatch(/executed inside an isolation container/);
       expect(failSpy).toHaveBeenCalledTimes(1);
       // The DAG is never entered — the guard returns before any execution.
@@ -344,6 +368,7 @@ describe('executeWorkflow', () => {
         'db-conv-1'
       );
       expect(result.success).toBe(false);
+      if (result.success) throw new Error('Expected workflow guard failure');
       expect(result.error).toContain('Database error');
       // Blocked before the execution window — keep-awake must never have fired.
       expect(keepAwake.activeCount()).toBe(0);
@@ -353,7 +378,7 @@ describe('executeWorkflow', () => {
       const activeRun = makeRun({
         id: 'other-run-456',
         status: 'running',
-        started_at: new Date().toISOString(), // Recent — not stale
+        started_at: new Date(), // Recent — not stale
       });
       const store = makeStore({
         getActiveWorkflowRunByPath: mock(async () => activeRun),
@@ -369,6 +394,7 @@ describe('executeWorkflow', () => {
         'db-conv-1'
       );
       expect(result.success).toBe(false);
+      if (result.success) throw new Error('Expected active-workflow rejection');
       expect(result.error).toContain('already active');
     });
 
@@ -431,7 +457,10 @@ describe('executeWorkflow', () => {
       // The guard runs AFTER workflowRun is finalized so we always have
       // a self-ID. Without these args, the dispatch's own row would match
       // and falsely trigger the guard.
-      const selfRun = makeRun({ id: 'self-run-789', started_at: '2026-04-14T10:00:00.000Z' });
+      const selfRun = makeRun({
+        id: 'self-run-789',
+        started_at: new Date('2026-04-14T10:00:00.000Z'),
+      });
       const getActiveSpy = mock(async () => null);
       const store = makeStore({
         createWorkflowRun: mock(async () => selfRun),
@@ -486,9 +515,11 @@ describe('executeWorkflow', () => {
         id: 'abc12345-rest-of-uuid',
         workflow_name: 'archon-implement',
         status: 'running',
-        started_at: new Date(Date.now() - 125000).toISOString(), // 2m 5s ago
+        started_at: new Date(Date.now() - 125000), // 2m 5s ago
       });
-      const sendMessageSpy = mock(async () => {});
+      const sendMessageSpy = mock<IWorkflowPlatform['sendMessage']>(
+        async (_conversationId, _message, _metadata) => {}
+      );
       const platform = {
         sendMessage: sendMessageSpy,
         getPlatformType: mock(() => 'test' as const),
@@ -553,6 +584,7 @@ describe('executeWorkflow', () => {
         'db-conv-1'
       );
       expect(result.success).toBe(false);
+      if (result.success) throw new Error('Expected checkout-lock rejection');
       expect(result.error).toContain('already active');
     });
 
@@ -583,6 +615,7 @@ describe('executeWorkflow', () => {
 
       // Cleanup failure must not mask the "in use" outcome.
       expect(result.success).toBe(false);
+      if (result.success) throw new Error('Expected checkout-lock rejection');
       expect(result.error).toContain('already active');
     });
   });
@@ -675,7 +708,7 @@ describe('executeWorkflow', () => {
 
   describe('workflow_started configuration snapshot', () => {
     it('persists the resolved configuration and top-level platform origin', async () => {
-      const createEventSpy = mock(async () => {});
+      const createEventSpy = mock<IWorkflowStore['createWorkflowEvent']>(async _data => {});
       const store = makeStore({
         createWorkflowRun: mock(async () =>
           makeRun({
@@ -739,7 +772,7 @@ describe('executeWorkflow', () => {
     });
 
     it('persists explicit nulls for an in-place run without a model or user', async () => {
-      const createEventSpy = mock(async () => {});
+      const createEventSpy = mock<IWorkflowStore['createWorkflowEvent']>(async _data => {});
       const store = makeStore({
         createWorkflowRun: mock(async () =>
           makeRun({ user_message: 'folder input', user_id: null, parent_run_id: null })
@@ -772,7 +805,7 @@ describe('executeWorkflow', () => {
     });
 
     it('classifies a container execution ahead of a worktree context', async () => {
-      const createEventSpy = mock(async () => {});
+      const createEventSpy = mock<IWorkflowStore['createWorkflowEvent']>(async _data => {});
       const store = makeStore({
         createWorkflowRun: mock(async () =>
           makeRun({ user_message: 'container input', user_id: null, parent_run_id: null })
@@ -802,7 +835,7 @@ describe('executeWorkflow', () => {
     });
 
     it('uses persisted child-run attribution and input instead of caller values', async () => {
-      const createEventSpy = mock(async () => {});
+      const createEventSpy = mock<IWorkflowStore['createWorkflowEvent']>(async _data => {});
       const preCreatedRun = makeRun({
         id: 'child-run',
         user_message: 'persisted child input',
@@ -843,7 +876,7 @@ describe('executeWorkflow', () => {
       // Recorded HERE rather than at the chat dispatch site so the finding does
       // not depend on a notification being deliverable — and so CLI- and
       // REST-started runs, which have no conversation to post into, get it too.
-      const createEventSpy = mock(async () => {});
+      const createEventSpy = mock<IWorkflowStore['createWorkflowEvent']>(async _data => {});
       const store = makeStore({ createWorkflowEvent: createEventSpy });
 
       await executeWorkflow(
@@ -867,7 +900,7 @@ describe('executeWorkflow', () => {
     });
 
     it('records nothing for a clean workflow', async () => {
-      const createEventSpy = mock(async () => {});
+      const createEventSpy = mock<IWorkflowStore['createWorkflowEvent']>(async _data => {});
       const store = makeStore({ createWorkflowEvent: createEventSpy });
 
       await executeWorkflow(
@@ -891,7 +924,7 @@ describe('executeWorkflow', () => {
       // The engine's record must not be coupled to platform delivery in any
       // way — this is the whole reason the event exists rather than relying on
       // the best-effort chat message.
-      const createEventSpy = mock(async () => {});
+      const createEventSpy = mock<IWorkflowStore['createWorkflowEvent']>(async _data => {});
       const store = makeStore({ createWorkflowEvent: createEventSpy });
       const brokenPlatform = {
         sendMessage: mock(() => Promise.reject(new Error('platform down'))),
@@ -1244,7 +1277,7 @@ describe('executeWorkflow', () => {
         'db-conv-1'
       );
       expect(result.success).toBe(true);
-      if (result.success) {
+      if (result.success && !('paused' in result)) {
         expect(result.summary).toBe('This is the workflow summary');
       }
     });
@@ -1263,7 +1296,7 @@ describe('executeWorkflow', () => {
         'db-conv-1'
       );
       expect(result.success).toBe(true);
-      if (result.success) {
+      if (result.success && !('paused' in result)) {
         expect(result.summary).toBeUndefined();
       }
     });
@@ -1543,9 +1576,11 @@ describe('executeWorkflow', () => {
         id: 'paused-run-id',
         workflow_name: 'archon-implement',
         status: 'paused',
-        started_at: new Date(Date.now() - 10000).toISOString(),
+        started_at: new Date(Date.now() - 10000),
       });
-      const sendMessageSpy = mock(async () => {});
+      const sendMessageSpy = mock<IWorkflowPlatform['sendMessage']>(
+        async (_conversationId, _message, _metadata) => {}
+      );
       const platform = {
         sendMessage: sendMessageSpy,
         getPlatformType: mock(() => 'test' as const),
@@ -1569,9 +1604,11 @@ describe('executeWorkflow', () => {
         id: 'pending-run',
         workflow_name: 'archon-implement',
         status: 'pending',
-        started_at: new Date(Date.now() - 500).toISOString(),
+        started_at: new Date(Date.now() - 500),
       });
-      const sendMessageSpy = mock(async () => {});
+      const sendMessageSpy = mock<IWorkflowPlatform['sendMessage']>(
+        async (_conversationId, _message, _metadata) => {}
+      );
       const platform = {
         sendMessage: sendMessageSpy,
         getPlatformType: mock(() => 'test' as const),
@@ -1590,9 +1627,11 @@ describe('executeWorkflow', () => {
         id: 'running-run',
         workflow_name: 'archon-implement',
         status: 'running',
-        started_at: new Date(Date.now() - 60000).toISOString(),
+        started_at: new Date(Date.now() - 60000),
       });
-      const sendMessageSpy = mock(async () => {});
+      const sendMessageSpy = mock<IWorkflowPlatform['sendMessage']>(
+        async (_conversationId, _message, _metadata) => {}
+      );
       const platform = {
         sendMessage: sendMessageSpy,
         getPlatformType: mock(() => 'test' as const),

--- a/packages/workflows/src/include-expander.test.ts
+++ b/packages/workflows/src/include-expander.test.ts
@@ -1665,7 +1665,8 @@ describe('expandWorkflowIncludes — where a workflow-level model: travels (#176
       provider: 'codex',
       model: 'gpt-5.6-sol',
     });
-    expect(nodes[0]?.model).toBeUndefined();
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].model).toBeUndefined();
   });
 
   test('does NOT travel when the workflow declares a model but no provider — the known divergence', () => {

--- a/packages/workflows/src/include-expander.test.ts
+++ b/packages/workflows/src/include-expander.test.ts
@@ -616,7 +616,7 @@ describe('expandWorkflowIncludes — nested', () => {
 
     expect(errors).toHaveLength(0);
     const group = nodeById(workflows.get('parent')!, 'outer__inner__group');
-    const repeat = group && 'loop_group' in group ? group.loop_group.nodes[0] : undefined;
+    const repeat = group?.loop_group?.nodes[0];
     expect(compiledLoopPrompt(repeat)).toBe(
       'Use $outer__inner__seed.output with bound value and continue.'
     );
@@ -732,12 +732,8 @@ describe('expandWorkflowIncludes — refs in Markdown code spans', () => {
     const { workflows, errors } = expandWorkflowIncludes(mapOf(block, parent));
     expect(errors).toHaveLength(0);
     const gate = nodeById(workflows.get('parent')!, 'inc__gate');
-    expect(gate && 'approval' in gate ? gate.approval.message : '').toBe(
-      'Approve $inc__plan.output'
-    );
-    expect(gate && 'approval' in gate ? gate.approval.on_reject?.prompt : '').toBe(
-      'Revise $inc__plan.output'
-    );
+    expect(gate?.approval?.message ?? '').toBe('Approve $inc__plan.output');
+    expect(gate?.approval?.on_reject?.prompt ?? '').toBe('Revise $inc__plan.output');
   });
 
   // #2121 Phase 2: a `workflow:` (sub-run) node inside an included block is a live
@@ -957,7 +953,7 @@ describe('expandWorkflowIncludes — included command compilation', () => {
     expect(errors).toHaveLength(0);
     const repeat = nodeById(workflows.get('parent')!, 'inc__repeat');
     expect(compiledLoopPrompt(repeat)).toBe('Review prod.');
-    expect(repeat && 'loop' in repeat ? repeat.loop.command : undefined).toBe('loop-cmd');
+    expect(repeat?.loop?.command).toBe('loop-cmd');
   });
 
   test('binds a declared include input named output in a loop command', () => {
@@ -1020,7 +1016,7 @@ describe('expandWorkflowIncludes — included command compilation', () => {
     );
     expect(errors).toHaveLength(0);
     const group = nodeById(workflows.get('parent')!, 'inc__group');
-    const repeat = group && 'loop_group' in group ? group.loop_group.nodes[0] : undefined;
+    const repeat = group?.loop_group?.nodes[0];
     expect(compiledLoopPrompt(repeat)).toBe('Read $inc__seed.output and continue.');
   });
 
@@ -1053,8 +1049,8 @@ describe('expandWorkflowIncludes — included command compilation', () => {
 
     expect(errors).toHaveLength(0);
     const outer = nodeById(workflows.get('parent')!, 'inc__outer');
-    const inner = outer && 'loop_group' in outer ? outer.loop_group.nodes[0] : undefined;
-    const review = inner && 'loop_group' in inner ? inner.loop_group.nodes[0] : undefined;
+    const inner = outer?.loop_group?.nodes[0];
+    const review = inner?.loop_group?.nodes[0];
     expect(review && 'prompt' in review ? review.prompt : '').toBe(
       'Read $inc__seed.output and continue.'
     );
@@ -1086,7 +1082,7 @@ describe('expandWorkflowIncludes — included command compilation', () => {
     );
     expect(errors).toHaveLength(0);
     const group = nodeById(workflows.get('parent')!, 'inc__group');
-    const repeat = group && 'loop_group' in group ? group.loop_group.nodes[0] : undefined;
+    const repeat = group?.loop_group?.nodes[0];
     expect(compiledLoopPrompt(repeat)).toBe('Review prod.');
   });
 

--- a/packages/workflows/src/include-expander.test.ts
+++ b/packages/workflows/src/include-expander.test.ts
@@ -1337,7 +1337,7 @@ describe('expandWorkflowIncludes — determinism', () => {
     // provider does NOT inherit the other provider's model string, matching what the
     // executor does with a workflow-level model today.
     expect(nodeById(expanded, 'b')).toMatchObject({ provider: 'codex' });
-    expect((nodeById(expanded, 'b') as Record<string, unknown>).model).toBeUndefined();
+    expect(nodeById(expanded, 'b')?.model).toBeUndefined();
     // The input is never mutated — discovery hands the same object to display surfaces.
     expect(plain.provider).toBe('pi');
   });
@@ -1665,7 +1665,7 @@ describe('expandWorkflowIncludes — where a workflow-level model: travels (#176
       provider: 'codex',
       model: 'gpt-5.6-sol',
     });
-    expect((nodes[0] as Record<string, unknown>).model).toBeUndefined();
+    expect(nodes[0]?.model).toBeUndefined();
   });
 
   test('does NOT travel when the workflow declares a model but no provider — the known divergence', () => {
@@ -1677,8 +1677,8 @@ describe('expandWorkflowIncludes — where a workflow-level model: travels (#176
       ...wf('w', [{ id: 'n', prompt: 'p', provider: 'codex' }]),
       model: 'large',
     });
-    expect((nodes[0] as Record<string, unknown>).model).toBeUndefined();
-    expect((nodes[0] as Record<string, unknown>).provider).toBe('codex');
+    expect(nodes[0]?.model).toBeUndefined();
+    expect(nodes[0]?.provider).toBe('codex');
   });
 
   test('every other node-affecting field travels regardless of the node provider', () => {

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -5246,7 +5246,9 @@ nodes:
       const nodes = result.workflows[0].workflow.nodes;
       const group = nodes.find(n => n.id === 'group');
       expect(group?.loop_group).toBeDefined();
-      expect(group?.loop_group?.nodes[0]?.persist_session).toBeUndefined();
+      const body = group?.loop_group?.nodes[0];
+      expect(body).toBeDefined();
+      expect(body?.persist_session).toBeUndefined();
       // The top-level AI node still receives it — only the body is excluded.
       expect(nodes.find(n => n.id === 'after')?.persist_session).toBe(true);
     });

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -6,13 +6,14 @@ import { tmpdir } from 'os';
 const isWindows = process.platform === 'win32';
 
 // Inline mock logger to suppress noisy output during tests
+type MockLog = (data: unknown, message?: string, ...args: unknown[]) => undefined;
 const mockLogger = {
-  fatal: mock(() => undefined),
-  error: mock(() => undefined),
-  warn: mock(() => undefined),
-  info: mock(() => undefined),
-  debug: mock(() => undefined),
-  trace: mock(() => undefined),
+  fatal: mock<MockLog>(() => undefined),
+  error: mock<MockLog>(() => undefined),
+  warn: mock<MockLog>(() => undefined),
+  info: mock<MockLog>(() => undefined),
+  debug: mock<MockLog>(() => undefined),
+  trace: mock<MockLog>(() => undefined),
   child: mock(function () {
     return mockLogger;
   }),
@@ -2181,7 +2182,7 @@ nodes:
 `
       );
 
-      (mockLogger.warn as Mock<() => undefined>).mockClear();
+      mockLogger.warn.mockClear();
       const result = await discoverWorkflows(testDir, { loadDefaults: false });
       expect(result.errors).toHaveLength(0);
       expect(result.workflows).toHaveLength(1);
@@ -2190,7 +2191,7 @@ nodes:
       expect(isLoopNode(node)).toBe(true);
 
       // model and provider should NOT trigger a warning
-      const warnCalls = (mockLogger.warn as Mock<() => undefined>).mock.calls;
+      const warnCalls = mockLogger.warn.mock.calls;
       const aiFieldWarnings = warnCalls.filter(
         call => typeof call[1] === 'string' && call[1].includes('ai_fields_ignored')
       );
@@ -2217,12 +2218,12 @@ nodes:
 `
       );
 
-      (mockLogger.warn as Mock<() => undefined>).mockClear();
+      mockLogger.warn.mockClear();
       const result = await discoverWorkflows(testDir, { loadDefaults: false });
       expect(result.errors).toHaveLength(0);
 
       // Should warn about mcp but NOT about model
-      const warnCalls = (mockLogger.warn as Mock<() => undefined>).mock.calls;
+      const warnCalls = mockLogger.warn.mock.calls;
       const aiFieldWarnings = warnCalls.filter(
         call => typeof call[1] === 'string' && call[1].includes('ai_fields_ignored')
       );
@@ -2259,11 +2260,11 @@ nodes:
 `
       );
 
-      (mockLogger.warn as Mock<() => undefined>).mockClear();
+      mockLogger.warn.mockClear();
       const result = await discoverWorkflows(testDir, { loadDefaults: false });
       expect(result.errors).toHaveLength(0);
 
-      const aiFieldWarnings = (mockLogger.warn as Mock<() => undefined>).mock.calls.filter(
+      const aiFieldWarnings = mockLogger.warn.mock.calls.filter(
         call => typeof call[1] === 'string' && call[1].includes('ai_fields_ignored')
       );
       expect(aiFieldWarnings).toHaveLength(0);
@@ -2302,7 +2303,7 @@ nodes:
 `
       );
 
-      (mockLogger.warn as Mock<() => undefined>).mockClear();
+      mockLogger.warn.mockClear();
       const result = await discoverWorkflows(testDir, { loadDefaults: false });
       expect(result.errors).toHaveLength(0);
       expect(result.workflows).toHaveLength(1);
@@ -2314,7 +2315,7 @@ nodes:
         extensionFlags: { plan: false },
       });
 
-      const warnCalls = (mockLogger.warn as Mock<() => undefined>).mock.calls;
+      const warnCalls = mockLogger.warn.mock.calls;
       const aiFieldWarnings = warnCalls.filter(
         call => typeof call[1] === 'string' && call[1].includes('ai_fields_ignored')
       );
@@ -5043,7 +5044,9 @@ nodes:
           ? (repeat.loop as typeof repeat.loop & LoopWithCompiledCommand)[COMPILED_LOOP_COMMAND]
           : undefined;
       expect(compiled?.prompt).toBe('Review production.');
-      expect(repeat && 'loop' in repeat ? repeat.loop.command : undefined).toBe('loop-review');
+      expect(repeat && 'loop' in repeat && repeat.loop ? repeat.loop.command : undefined).toBe(
+        'loop-review'
+      );
     });
   });
 
@@ -5276,6 +5279,9 @@ nodes:
           thinkingControl: false,
           fallbackModel: false,
           sandbox: false,
+          settingSources: false,
+          nativeTools: false,
+          containerExec: false,
         },
         factory: () => ({
           getType: () => 'no-resume-skip-test',
@@ -5293,6 +5299,9 @@ nodes:
             thinkingControl: false,
             fallbackModel: false,
             sandbox: false,
+            settingSources: false,
+            nativeTools: false,
+            containerExec: false,
           }),
           // eslint-disable-next-line require-yield
           async *sendQuery() {
@@ -5339,6 +5348,9 @@ nodes:
           thinkingControl: false,
           fallbackModel: false,
           sandbox: false,
+          settingSources: false,
+          nativeTools: false,
+          containerExec: false,
         },
         factory: () => ({
           getType: () => 'no-resume-test',
@@ -5356,6 +5368,9 @@ nodes:
             thinkingControl: false,
             fallbackModel: false,
             sandbox: false,
+            settingSources: false,
+            nativeTools: false,
+            containerExec: false,
           }),
           // eslint-disable-next-line require-yield
           async *sendQuery() {

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -5224,7 +5224,7 @@ nodes:
       expect(result.errors).toEqual([]);
       const expanded = result.workflows[0].workflow;
       expect(expanded.persist_sessions).toBeUndefined();
-      const byId = new Map(expanded.nodes.map(n => [n.id, n as Record<string, unknown>]));
+      const byId = new Map(expanded.nodes.map(n => [n.id, n]));
       expect(byId.get('planner')?.persist_session).toBe(true);
       expect(byId.get('shell')?.persist_session).toBeUndefined();
     });
@@ -5244,14 +5244,11 @@ nodes:
       const result = await discoverWorkflows(testDir, { loadDefaults: false });
       expect(result.errors).toEqual([]);
       const nodes = result.workflows[0].workflow.nodes;
-      const group = nodes.find(n => n.id === 'group') as {
-        loop_group: { nodes: Record<string, unknown>[] };
-      };
-      expect(group.loop_group.nodes[0].persist_session).toBeUndefined();
+      const group = nodes.find(n => n.id === 'group');
+      expect(group?.loop_group).toBeDefined();
+      expect(group?.loop_group?.nodes[0]?.persist_session).toBeUndefined();
       // The top-level AI node still receives it — only the body is excluded.
-      expect((nodes.find(n => n.id === 'after') as Record<string, unknown>).persist_session).toBe(
-        true
-      );
+      expect(nodes.find(n => n.id === 'after')?.persist_session).toBe(true);
     });
 
     it('does NOT capability-check non-AI nodes when persist_sessions is workflow-level', async () => {

--- a/packages/workflows/src/schemas.test.ts
+++ b/packages/workflows/src/schemas.test.ts
@@ -19,7 +19,6 @@ import {
   readSubrunMetadata,
 } from './schemas';
 import type {
-  WorkflowDefinition,
   DagNode,
   CommandNode,
   PromptNode,
@@ -38,12 +37,6 @@ const commandNode: CommandNode = { id: 'n1', command: 'build' };
 const promptNode: PromptNode = { id: 'n2', prompt: 'Do this inline.' };
 const bashNode: BashNode = { id: 'n3', bash: 'echo hello' };
 const cancelNode: CancelNode = { id: 'n5', cancel: 'Precondition failed' };
-
-const dagWorkflow: WorkflowDefinition = {
-  name: 'dag-workflow',
-  description: 'DAG execution',
-  nodes: [commandNode, promptNode, bashNode],
-};
 
 // ---------------------------------------------------------------------------
 // isBashNode

--- a/packages/workflows/src/script-discovery.test.ts
+++ b/packages/workflows/src/script-discovery.test.ts
@@ -2,7 +2,9 @@ import { describe, test, expect, mock, beforeEach } from 'bun:test';
 
 // Mock fs/promises before importing the module under test
 const mockReaddir = mock(async (_path: string): Promise<string[]> => []);
-const mockStat = mock(async (_path: string) => ({ isDirectory: () => false }));
+const mockStat = mock(
+  async (_path: string): Promise<{ isDirectory: () => boolean }> => ({ isDirectory: () => false })
+);
 
 mock.module('fs/promises', () => ({
   access: mock(async () => undefined),

--- a/packages/workflows/src/script-node-deps.test.ts
+++ b/packages/workflows/src/script-node-deps.test.ts
@@ -68,9 +68,14 @@ function createMockStore(): IWorkflowStore {
         completed_at: null,
         last_activity_at: null,
         working_path: null,
+        user_id: null,
+        parent_run_id: null,
+        output_root: null,
       })
     ),
     getWorkflowRun: mock(() => Promise.resolve(null)),
+    findChildRuns: mock(() => Promise.resolve([])),
+    getRunAncestry: mock(() => Promise.resolve([])),
     getActiveWorkflowRunByPath: mock(() => Promise.resolve(null)),
     failOrphanedRuns: mock(() => Promise.resolve({ count: 0 })),
     findResumableRun: mock(() => Promise.resolve(null)),
@@ -88,6 +93,9 @@ function createMockStore(): IWorkflowStore {
         completed_at: null,
         last_activity_at: null,
         working_path: null,
+        user_id: null,
+        parent_run_id: null,
+        output_root: null,
       })
     ),
     updateWorkflowRun: mock(() => Promise.resolve()),
@@ -96,7 +104,9 @@ function createMockStore(): IWorkflowStore {
     completeWorkflowRun: mock(() => Promise.resolve()),
     failWorkflowRun: mock(() => Promise.resolve()),
     pauseWorkflowRun: mock(() => Promise.resolve()),
-    cancelWorkflowRun: mock(() => Promise.resolve()),
+    claimWriteback: mock(() => Promise.resolve({ claimed: true })),
+    releaseWritebackClaim: mock(() => Promise.resolve()),
+    cancelWorkflowRun: mock(() => Promise.resolve({ cancelled: false })),
     createWorkflowEvent: mock(() => Promise.resolve()),
     getDagResumeSnapshot: mock(() =>
       Promise.resolve({
@@ -106,17 +116,40 @@ function createMockStore(): IWorkflowStore {
     ),
     getCodebase: mock(() => Promise.resolve(null)),
     getCodebaseEnvVars: mock(() => Promise.resolve({})),
+    getWorkflowNodeSession: mock(() => Promise.resolve(null)),
+    upsertWorkflowNodeSession: mock(() => Promise.resolve()),
+    deleteWorkflowNodeSessions: mock(() => Promise.resolve({ deleted: 0 })),
   };
 }
 
-const mockSendQuery = mock(function* () {
-  yield { type: 'assistant', content: 'AI response' };
-  yield { type: 'result', sessionId: 'session-id' };
-});
+const mockSendQuery = mock<ReturnType<WorkflowDeps['getAgentProvider']>['sendQuery']>(
+  async function* (_prompt, _cwd, _resumeSessionId, _options) {
+    yield { type: 'assistant', content: 'AI response' };
+    yield { type: 'result', sessionId: 'session-id' };
+  }
+);
 
-const mockGetAgentProvider = mock(() => ({
+const mockGetAgentProvider = mock<WorkflowDeps['getAgentProvider']>(_provider => ({
   sendQuery: mockSendQuery,
   getType: () => 'claude',
+  getCapabilities: () => ({
+    sessionResume: true,
+    mcp: true,
+    hooks: true,
+    skills: true,
+    agents: true,
+    toolRestrictions: true,
+    structuredOutput: 'enforced' as const,
+    envInjection: true,
+    costControl: true,
+    effortControl: true,
+    thinkingControl: true,
+    fallbackModel: true,
+    sandbox: true,
+    settingSources: true,
+    nativeTools: true,
+    containerExec: true,
+  }),
 }));
 
 function createMockDeps(): WorkflowDeps {
@@ -157,6 +190,9 @@ function makeWorkflowRun(id: string): WorkflowRun {
     completed_at: null,
     last_activity_at: null,
     working_path: null,
+    user_id: null,
+    parent_run_id: null,
+    output_root: null,
   };
 }
 

--- a/packages/workflows/src/subrun.test.ts
+++ b/packages/workflows/src/subrun.test.ts
@@ -104,6 +104,7 @@ class InMemoryStore implements IWorkflowStore {
       working_path: data.working_path ?? null,
       user_id: data.user_id ?? null,
       parent_run_id: data.parent_run_id ?? null,
+      output_root: null,
     };
     this.runs.set(id, row);
     return Promise.resolve(this.clone(row));
@@ -1002,8 +1003,9 @@ nodes:
     expect(result.success).toBe(false);
     const child = [...store.runs.values()].find(r => r.workflow_name === 'child-plain');
     expect(child).toBeDefined();
+    if (!child) throw new Error('Expected child run');
     // The child must be TERMINAL — not a 'pending'/'running' zombie holding the lock.
-    expect(['cancelled', 'failed']).toContain(child?.status);
+    expect(['cancelled', 'failed']).toContain(child.status);
     const parentRun = [...store.runs.values()].find(r => r.workflow_name === 'parent-plain');
     expect(parentRun?.status).toBe('failed');
   });
@@ -1196,9 +1198,11 @@ nodes:
     expect(result.success).toBe(true);
     // The resolver was invoked once, for the `sub` node, carrying the parent run.
     expect(calls).toHaveLength(1);
+    if (!calls[0]) throw new Error('Expected resolver call');
     expect(calls[0].nodeId).toBe('sub');
     const parentRun = [...store.runs.values()].find(r => r.workflow_name === 'parent-iso');
-    expect(calls[0].parentRun.id).toBe(parentRun?.id);
+    if (!parentRun) throw new Error('Expected parent run');
+    expect(calls[0].parentRun.id).toBe(parentRun.id);
     // The child ran in the resolver's worktree cwd — NOT the parent's checkout.
     const child = [...store.runs.values()].find(r => r.workflow_name === 'child-iso');
     expect(child?.status).toBe('completed');
@@ -1802,8 +1806,9 @@ nodes:
     // each in its OWN worktree (distinct working paths, none the parent's checkout).
     const children = [...store.runs.values()].filter(r => r.workflow_name === 'fan-child');
     expect(children).toHaveLength(3);
+    if (!parentRun) throw new Error('Expected parent run');
     for (const c of children) {
-      expect(c.parent_run_id).toBe(parentRun?.id);
+      expect(c.parent_run_id).toBe(parentRun.id);
       expect((c.metadata as Record<string, unknown>).parent_node_id).toBe('work');
       expect(c.status).toBe('completed');
       expect(c.working_path).not.toBe(cwd);
@@ -3355,7 +3360,7 @@ nodes:
 
     const wf = await discover('parent-forward-ref');
     const issues = await validateWorkflowResources(wf, cwd);
-    const errors = issues.filter(i => i.severity === 'error');
+    const errors = issues.filter(i => i.level === 'error');
     expect(errors).toHaveLength(0);
   });
 

--- a/packages/workflows/src/utils/tool-formatter.test.ts
+++ b/packages/workflows/src/utils/tool-formatter.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from 'bun:test';
 import { formatToolCall, formatThinking } from './tool-formatter';
 
 describe('tool-formatter', () => {

--- a/packages/workflows/src/workflow-discovery-command-scan.test.ts
+++ b/packages/workflows/src/workflow-discovery-command-scan.test.ts
@@ -62,13 +62,12 @@ describe('discoverWorkflows — nested included command compilation', () => {
     expect(result.errors.filter(error => error.filename === 'parent.yaml')).toHaveLength(0);
     const parent = result.workflows.find(item => item.workflow.name === 'parent')?.workflow;
     const group = parent?.nodes.find(node => node.id === 'inc__group');
-    const repeat = group && 'loop_group' in group ? group.loop_group.nodes[0] : undefined;
-    const compiled =
-      repeat && 'loop' in repeat
-        ? (repeat.loop as typeof repeat.loop & LoopWithCompiledCommand)[COMPILED_LOOP_COMMAND]
-        : undefined;
+    const repeat = group?.loop_group?.nodes[0];
+    const compiled = repeat?.loop
+      ? (repeat.loop as typeof repeat.loop & LoopWithCompiledCommand)[COMPILED_LOOP_COMMAND]
+      : undefined;
     expect(compiled?.prompt).toBe('Read $inc__seed.output and continue.');
-    expect(repeat && 'loop' in repeat ? repeat.loop.command : undefined).toBe('nested-command');
+    expect(repeat?.loop?.command).toBe('nested-command');
   });
 
   test('rejects a command-body caller ref even when the parent has the same node id', async () => {

--- a/packages/workflows/tsconfig.json
+++ b/packages/workflows/tsconfig.json
@@ -4,5 +4,5 @@
     "noEmit": true
   },
   "include": ["src/**/*", "src/defaults/text-imports.d.ts"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Problem and outcome

The normal repository type-check excluded every test in `paths`, `git`, `isolation`, `providers`, and `workflows`, so production contract drift across 95 test files could pass the authoritative build gate.

- **Outcome:** All 95 tests now compile in their package's ordinary strict TypeScript project and therefore in `bun run type-check` and CI.
- **Invariant:** Existing runtime assertions and package test-process boundaries remain unchanged while test doubles and fixtures stay aligned with current production and SDK contracts.
- **Scope boundary:** This does not include the dependency-ordered `core`/`adapters`/`server`/`cli` pass from #2407 or the #2486-#2492 workflow primitive refactors.
- **Root cause:** Each package already included `src/**/*`, but its `tsconfig.json` explicitly subtracted `**/*.test.ts`; the root command consequently reported success without compiling those tests.

## Review guidance

- **Feedback requested:** Verify the fixture corrections accurately reflect current contracts without weakening the behavioral assertions.
- **Start here:** `packages/workflows/tsconfig.json:6` — representative load-bearing change that moves tests into the existing strict project.
- **Review order:** The five `tsconfig.json` changes, branded git/isolation fixtures, provider SDK-shaped mocks, then workflow store/run/node fixtures.
- **Post-#2604 integration:** This branch is rebased onto `c41ed69d`. The four overlapping workflow test files and their production schemas/helpers were audited; #2604's composition behavior and assertions are preserved. Its newly added fixtures now implement the current async provider, executable-workflow, config-loader, and store contracts.
- **Post-#2603 integration:** This branch is now rebased onto `3634d158` after #2615/#2620. There is no direct file overlap and all five feature commits remain patch-equivalent. The expanded paths/dry-run tests and #2603 inventory guard are part of the compatibility gate.
- **Independent-review correction:** Both executor summary tests now fail unless the workflow result is successful and non-paused before asserting the summary, preserving the original fail-loud behavior across the current result union.
- **Lower-attention areas:** Repeated branded constructors, complete capability objects, and async-generator annotations are mechanical corrections validated by the unchanged runtime suites.
- **Known risk or uncertainty:** None.

## Solution

Each target package now excludes only dependencies and build output, allowing its existing `src/**/*` include to own production and test code together. The newly exposed diagnostics were resolved at test boundaries by using existing branded constructors, exact interface/SDK mock signatures, complete schema-derived fixtures, and explicit discriminated-union narrowing. No parallel test config, production type redesign, `any`, or `@ts-expect-error` escape hatch was added.

## Validation

- Target inventory vs `tsc --listFilesOnly` — 95/95 included, 0 missing: paths 9/9, git 2/2, isolation 12/12, providers 34/34, workflows 38/38.
- Each target package's existing `type-check` and `test` scripts — exit 0.
- Focused post-#2604 workflow type-check and composition/schema test suites — exit 0.
- `bun run validate` after rebasing onto #2604 — exit 0 as the authoritative composed pre-PR gate, including generated-artifact checks, all workspace and script type-checks, lint with zero warnings, formatting, installer tests, and all repository runtime suites.
- Original/current target set comparison — all original 95 test files remain and current inventory is 95; every file appears in its ordinary package compiler list.
- Expanded new-base checks — strict paths/workflows type-checks passed; `archon-paths.test.ts` passed 130 tests, `dry-run.test.ts` passed 39 tests, and #2603's inventory guard passed without selector drift.
- `bun run validate` after rebasing onto `3634d158` — exit 0, including the inventory guard in the normal root script-test batch.
- R10 focused correction checks — workflow strict type-check passed and all 84 `executor.test.ts` tests passed.
- `bun run validate` after the R10 correction — exit 0 at `03ffc80b`.
- **In progress:** Exact-head GitHub checks and a fresh full independent review at `03ffc80b`.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | Build-time enforcement expands; no runtime or data migration exists. | Existing package and repository runtime suites pass after rebasing onto #2604 and #2603/#2615/#2620. |
| Rollout / rollback | Package-local and reversible by restoring the exclusions and fixture-only corrections. | No production source file changed. |
| Observability | Future test/contract drift fails the normal root type-check and CI rather than a parallel optional check. | All 95 tests appear in ordinary package compiler lists. |

## Links

- Closes #2406
- Related #2407
- [Implementation plan](https://github.com/coleam00/Archon/issues/2406#issuecomment-5326489011)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Strengthened type validation across Git, isolation, workflows, and AI provider test suites.
  - Added coverage for workflow retries, cancellation, provider events, artifact handling, and lifecycle scenarios.
  - Updated fixtures and assertions to reflect current workflow and provider behavior.
  - Test files are now included in TypeScript compilation to catch compatibility issues earlier.
- **Refactor**
  - Cleaned up unused imports and improved test mock consistency without changing runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
