### PR TITLE
fix(workflows): a run records what it spent even when it fails or is cancelled

### DIFF
--- a/packages/core/src/db/workflow-events.test.ts
+++ b/packages/core/src/db/workflow-events.test.ts
@@ -495,6 +495,37 @@ describe('workflow-events', () => {
       expect(mockLogger.warn).not.toHaveBeenCalled();
     });
 
+    // #2469: a loop_group writes a roll-up node_completed row whose cost_usd restates
+    // what its own `<groupId>.<nodeId>` body rows already carry. Summing both counted
+    // that group twice — the same silently-wrong number this work exists to remove,
+    // pointing the other way. The roll-up is marked `aggregate: true` and skipped here.
+    test('excludes usage on aggregate rows while keeping their output', async () => {
+      mockQuery.mockResolvedValueOnce(
+        createQueryResult([
+          {
+            step_name: 'group.body',
+            event_type: 'node_completed',
+            data: { node_output: 'iteration 1', cost_usd: 0.01, tokens: { input: 10, output: 1 } },
+          },
+          {
+            step_name: 'group',
+            event_type: 'node_completed',
+            data: { node_output: 'last iteration', cost_usd: 0.01, aggregate: true },
+          },
+        ])
+      );
+
+      const result = await getDagResumeSnapshot('run-loop-group');
+
+      // The leaves are authoritative: 0.01 total, not 0.02.
+      expect(result.costUsd).toBeCloseTo(0.01, 10);
+      expect(result.tokens).toEqual({ input: 10, output: 1 });
+      // The roll-up still marks the group node completed, so resume skips it rather
+      // than re-running the whole group.
+      expect(result.completedNodeOutputs.get('group')).toBe('last iteration');
+      expect(result.completedNodeOutputs.get('group.body')).toBe('iteration 1');
+    });
+
     test('returns an empty snapshot when no events exist', async () => {
       mockQuery.mockResolvedValueOnce(createQueryResult([]));
 

--- a/packages/core/src/db/workflow-events.test.ts
+++ b/packages/core/src/db/workflow-events.test.ts
@@ -401,6 +401,100 @@ describe('workflow-events', () => {
       expect(result.tokens).toEqual({ input: 10, output: 3 });
     });
 
+    // #2469: cost is restored across resume passes exactly like tokens. Before this,
+    // only tokens were summed, so a resumed run's cost silently reset to the current
+    // pass — and once a FAILED run started persisting cost, the figure would have gone
+    // down after a successful resume.
+    test('sums cost_usd from node_completed events', async () => {
+      mockQuery.mockResolvedValueOnce(
+        createQueryResult([
+          {
+            step_name: 'node-a',
+            event_type: 'node_completed',
+            data: { node_output: 'output A', cost_usd: 0.02, tokens: { input: 40, output: 4 } },
+          },
+          {
+            step_name: 'node-b',
+            event_type: 'node_completed',
+            data: { node_output: 'output B', cost_usd: 0.03 },
+          },
+        ])
+      );
+
+      const result = await getDagResumeSnapshot('run-cost');
+
+      expect(result.costUsd).toBeCloseTo(0.05, 10);
+      expect(result.tokens).toEqual({ input: 40, output: 4 });
+    });
+
+    test('excludes cost_usd on node_skipped_prior_success rows (multi-resume)', async () => {
+      // A prior-success replay must not re-charge a node an earlier pass already
+      // counted — otherwise every resume multiplies that node's cost.
+      mockQuery.mockResolvedValueOnce(
+        createQueryResult([
+          {
+            step_name: 'node-a',
+            event_type: 'node_completed',
+            data: { node_output: 'output A', cost_usd: 0.02 },
+          },
+          {
+            step_name: 'node-b',
+            event_type: 'node_skipped_prior_success',
+            data: { reason: 'prior_success', node_output: 'output B', cost_usd: 999 },
+          },
+        ])
+      );
+
+      const result = await getDagResumeSnapshot('run-cost-resume');
+
+      expect(result.costUsd).toBeCloseTo(0.02, 10);
+    });
+
+    test('ignores malformed and non-finite cost_usd while keeping valid rows', async () => {
+      mockQuery.mockResolvedValueOnce(
+        createQueryResult([
+          {
+            step_name: 'node-a',
+            event_type: 'node_completed',
+            data: { node_output: 'valid', cost_usd: 0.01 },
+          },
+          {
+            step_name: 'node-b',
+            event_type: 'node_completed',
+            data: { node_output: 'string cost', cost_usd: '0.5' },
+          },
+          {
+            step_name: 'node-c',
+            event_type: 'node_completed',
+            data: { node_output: 'nan cost', cost_usd: Number.NaN },
+          },
+        ])
+      );
+
+      const result = await getDagResumeSnapshot('run-cost-malformed');
+
+      expect(result.costUsd).toBeCloseTo(0.01, 10);
+      expect(result.completedNodeOutputs.size).toBe(3);
+      expect(mockLogger.warn).toHaveBeenCalledTimes(2);
+    });
+
+    test('does not warn when completed events omit optional cost', async () => {
+      mockQuery.mockResolvedValueOnce(
+        createQueryResult([
+          {
+            step_name: 'node-a',
+            event_type: 'node_completed',
+            data: { node_output: 'no cost reported', tokens: { input: 5, output: 1 } },
+          },
+        ])
+      );
+
+      const result = await getDagResumeSnapshot('run-cost-absent');
+
+      expect(result.costUsd).toBe(0);
+      expect(mockLogger.warn).not.toHaveBeenCalled();
+    });
+
     test('returns an empty snapshot when no events exist', async () => {
       mockQuery.mockResolvedValueOnce(createQueryResult([]));
 
@@ -408,6 +502,7 @@ describe('workflow-events', () => {
 
       expect(result.completedNodeOutputs.size).toBe(0);
       expect(result.tokens).toEqual({ input: 0, output: 0 });
+      expect(result.costUsd).toBe(0);
     });
 
     test('throws on DB query error', async () => {

--- a/packages/core/src/db/workflow-events.ts
+++ b/packages/core/src/db/workflow-events.ts
@@ -218,9 +218,19 @@ export async function listWorkflowEventsSince(
  * run. Used by the DAG executor to restore state when resuming a failed run.
  * Throws on DB error — caller owns the degradation policy.
  *
- * Both usage axes are summed from `node_completed` rows only. `node_skipped_prior_success`
- * rows are deliberately excluded: they replay a node an earlier pass already counted, so
- * counting them would multiply that node's usage by the number of resume passes.
+ * Both usage axes are summed from `node_completed` rows only, and only from rows that are
+ * not marked `data.aggregate`. Two distinct duplication hazards:
+ *
+ * - `node_skipped_prior_success` rows replay a node an earlier pass already counted, so
+ *   counting them would multiply that node's usage by the number of resume passes.
+ * - `aggregate: true` rows are derived from other rows already in this log — a
+ *   `loop_group`'s roll-up restates the `cost_usd` its own `<groupId>.<nodeId>` body rows
+ *   carry, so summing both counts that group twice (#2469).
+ *
+ * Rows written before the `aggregate` marker existed carry no flag, so a run that
+ * completed a loop_group under an older build and is resumed under this one can still
+ * double-count its cost. Bounded and self-clearing: only cost is affected (the roll-up
+ * never carried `tokens`), and only until those runs reach a terminal state.
  */
 export async function getDagResumeSnapshot(workflowRunId: string): Promise<{
   completedNodeOutputs: Map<string, string>;
@@ -255,6 +265,8 @@ export async function getDagResumeSnapshot(workflowRunId: string): Promise<{
     if (typeof data.node_output === 'string') {
       completedNodeOutputs.set(row.step_name, data.node_output);
     }
+    // A derived row restates usage that other rows in this same log already carry.
+    if (data.aggregate === true) continue;
     if (row.event_type === 'node_completed' && data.tokens !== undefined) {
       const eventTokens = data.tokens;
       if (

--- a/packages/core/src/db/workflow-events.ts
+++ b/packages/core/src/db/workflow-events.ts
@@ -214,13 +214,18 @@ export async function listWorkflowEventsSince(
 }
 
 /**
- * Return completed node outputs and cumulative token usage for a workflow run.
- * Used by the DAG executor to restore state when resuming a failed run.
+ * Return completed node outputs and cumulative usage (tokens AND cost) for a workflow
+ * run. Used by the DAG executor to restore state when resuming a failed run.
  * Throws on DB error — caller owns the degradation policy.
+ *
+ * Both usage axes are summed from `node_completed` rows only. `node_skipped_prior_success`
+ * rows are deliberately excluded: they replay a node an earlier pass already counted, so
+ * counting them would multiply that node's usage by the number of resume passes.
  */
 export async function getDagResumeSnapshot(workflowRunId: string): Promise<{
   completedNodeOutputs: Map<string, string>;
   tokens: { input: number; output: number };
+  costUsd: number;
 }> {
   const result = await pool.query<{
     step_name: string | null;
@@ -234,6 +239,7 @@ export async function getDagResumeSnapshot(workflowRunId: string): Promise<{
   );
   const completedNodeOutputs = new Map<string, string>();
   const tokens = { input: 0, output: 0 };
+  let costUsd = 0;
   for (const row of result.rows) {
     if (!row.step_name) continue;
     let data: Record<string, unknown>;
@@ -270,6 +276,20 @@ export async function getDagResumeSnapshot(workflowRunId: string): Promise<{
         );
       }
     }
+    if (row.event_type === 'node_completed' && data.cost_usd !== undefined) {
+      const eventCost = data.cost_usd;
+      // Same guard shape as tokens: a non-finite value from a provider must not
+      // silently poison the total (NaN > 0 is false, which would drop the run's
+      // cost from the persisted metadata with no trace).
+      if (typeof eventCost === 'number' && Number.isFinite(eventCost)) {
+        costUsd += eventCost;
+      } else {
+        getLog().warn(
+          { runId: workflowRunId, stepName: row.step_name, costUsd: eventCost },
+          'db.workflow_dag_node_cost_invalid_ignored'
+        );
+      }
+    }
   }
-  return { completedNodeOutputs, tokens };
+  return { completedNodeOutputs, tokens, costUsd };
 }

--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -1432,7 +1432,10 @@ sub-pipeline.**
   hard subprocess kill yet).
 - **Cost roll-up.** The child's total cost rolls up into the `workflow:` node's cost and
   the parent's aggregate, and `parent_run_id` on the child row makes the run tree visible
-  in `archon workflow runs` and the console.
+  in `archon workflow runs` and the console. A run records what it spent whatever its
+  outcome, so a child that burned tokens and then failed or was cancelled still counts —
+  a partly-failed fan-out reports the spend of every child, not just the ones that
+  finished.
 
 ### Choosing the child's checkout with `isolation:`
 

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -10728,6 +10728,61 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     expect(cost).toBeCloseTo(0.03, 5);
   });
 
+  it('best-effort provider: a non-finite reask cost does not erase prior valid cost', async () => {
+    mockSendQueryDag.mockImplementationOnce(function* () {
+      yield { type: 'result', sessionId: 's1', structuredOutput: { other: 'x' }, cost: 0.01 };
+    });
+    mockSendQueryDag.mockImplementation(function* () {
+      yield {
+        type: 'result',
+        sessionId: 's2',
+        structuredOutput: { verdict: 'review' },
+        cost: Number.NaN,
+      };
+    });
+
+    const store = createMockStore();
+
+    await executeDagWorkflow(
+      createMockDeps(store),
+      createMockPlatform(),
+      'conv-dag',
+      testDir,
+      {
+        name: 'reask-nan-cost',
+        nodes: [
+          {
+            id: 'classify',
+            prompt: 'decide',
+            provider: 'pi',
+            output_format: {
+              type: 'object',
+              properties: { verdict: { type: 'string' } },
+              required: ['verdict'],
+            },
+            retry: { max_attempts: 0 },
+          },
+        ],
+      },
+      makeWorkflowRun(),
+      'pi',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      { ...minimalConfig, assistant: 'pi' }
+    );
+
+    expect(runUsageWrites(store)).toEqual([{ total_cost_usd: 0.01 }]);
+    expect(
+      (mockLogFn as unknown as Mock<(obj: unknown, msg?: string) => void>).mock.calls.some(
+        call => call[1] === 'dag_node.usage_cost_non_finite_ignored'
+      )
+    ).toBe(true);
+  });
+
   it('best-effort provider: reask exhaustion fails loudly', async () => {
     // Every attempt returns invalid structured output → fail after 1 + maxReasks (3) tries.
     mockSendQueryDag.mockImplementation(async function* () {
@@ -12760,16 +12815,24 @@ describe('executeDagWorkflow -- cost tracking', () => {
     expect(completeCalls[0][1]).not.toHaveProperty('total_cost_usd');
   });
 
-  it('accumulates cost across loop iterations', async () => {
+  it('accumulates finite loop costs and ignores a later non-finite cost', async () => {
     let callCount = 0;
     mockSendQueryDag.mockImplementation(async function* () {
       callCount++;
-      if (callCount < 3) {
+      if (callCount < 4) {
         yield { type: 'assistant', content: 'Still working...' };
-        yield { type: 'result', sessionId: `loop-sid-${String(callCount)}`, cost: 0.001 };
+        yield {
+          type: 'result',
+          sessionId: `loop-sid-${String(callCount)}`,
+          cost: callCount < 3 ? 0.001 : 0.002,
+        };
       } else {
         yield { type: 'assistant', content: 'All done! <promise>COMPLETE</promise>' };
-        yield { type: 'result', sessionId: `loop-sid-${String(callCount)}`, cost: 0.002 };
+        yield {
+          type: 'result',
+          sessionId: `loop-sid-${String(callCount)}`,
+          cost: Number.NaN,
+        };
       }
     });
 
@@ -12803,8 +12866,13 @@ describe('executeDagWorkflow -- cost tracking', () => {
       minimalConfig
     );
 
-    // 3 iterations: 0.001 + 0.001 + 0.002 = 0.004
+    // The final NaN is omitted without erasing the first three iterations.
     expect(runUsageWrites(store)).toEqual([{ total_cost_usd: 0.004 }]);
+    expect(
+      (mockLogFn as unknown as Mock<(obj: unknown, msg?: string) => void>).mock.calls.some(
+        call => call[1] === 'loop_node.usage_cost_non_finite_ignored'
+      )
+    ).toBe(true);
   });
 });
 
@@ -13053,7 +13121,7 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
     ]);
     expect(
       (mockLogFn as unknown as Mock<(obj: unknown, msg?: string) => void>).mock.calls.some(
-        call => call[1] === 'dag.usage_cost_non_finite_ignored'
+        call => call[1] === 'dag_node.usage_cost_non_finite_ignored'
       )
     ).toBe(true);
   });

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -10729,10 +10729,10 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
   });
 
   it('best-effort provider: a non-finite reask cost does not erase prior valid cost', async () => {
-    mockSendQueryDag.mockImplementationOnce(function* () {
+    mockSendQueryDag.mockImplementationOnce(async function* () {
       yield { type: 'result', sessionId: 's1', structuredOutput: { other: 'x' }, cost: 0.01 };
     });
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield {
         type: 'result',
         sessionId: 's2',
@@ -12910,7 +12910,7 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
 
   it('records what a FAILED run burned before it died', async () => {
     let call = 0;
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       call++;
       if (call === 1) {
         yield { type: 'assistant', content: 'first output' };
@@ -12964,7 +12964,7 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
     // fan-out cancelling a child), so the cancelling side has no usage in scope. The
     // executing side notices at its next status check and bails out of BOTH terminal
     // writers — which is exactly why the usage write cannot live in either of them.
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'work done before the cancel landed' };
       yield {
         type: 'result',
@@ -12980,7 +12980,7 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
     // during-streaming cancel check never tears the node down mid-stream.
     let nodeFinished = false;
     const realCreateEvent = store.createWorkflowEvent;
-    store.createWorkflowEvent = mock((data: { event_type: string }) => {
+    store.createWorkflowEvent = mock<IWorkflowStore['createWorkflowEvent']>(data => {
       if (data.event_type === 'node_completed') nodeFinished = true;
       return realCreateEvent(data);
     });
@@ -13016,7 +13016,7 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
   it('records usage accumulated before an approval gate PAUSES the run', async () => {
     // A fan-out child that pauses at a gate is cancelled by the parent (`fan_out_gate`),
     // so the pause is its only chance to record what it spent.
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'analysis' };
       yield {
         type: 'result',
@@ -13072,7 +13072,7 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
     // the run, silently — the exact loss this work exists to remove, arriving through a
     // provider instead of a code path. Tokens have carried this guard; cost had not.
     let call = 0;
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       call++;
       if (call === 1) {
         yield { type: 'assistant', content: 'good node' };
@@ -13131,7 +13131,7 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
     // otherwise-fine run into a failed one. Documented, but never watched failing — and
     // the `finally` makes it the last thing standing between the run and its own
     // completion, so a throw here would be maximally disruptive.
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'done' };
       yield {
         type: 'result',
@@ -13191,7 +13191,7 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
     // per-node try; the catch's own message throws too, rejecting the node promise; the
     // allSettled `rejected` branch then throws a third time OUTSIDE any try — out of
     // runLayers entirely.
-    mockSendQueryDag.mockImplementation(function* () {
+    mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'spent before the platform died' };
       yield {
         type: 'result',
@@ -13204,7 +13204,7 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
     const store = createMockStore();
     let nodeFinished = false;
     const realCreateEvent = store.createWorkflowEvent;
-    store.createWorkflowEvent = mock((data: { event_type: string }) => {
+    store.createWorkflowEvent = mock<IWorkflowStore['createWorkflowEvent']>(data => {
       if (data.event_type === 'node_completed') nodeFinished = true;
       return realCreateEvent(data);
     });

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -12999,6 +12999,65 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
     ]);
   });
 
+  it("one node reporting a non-finite cost does not erase the whole run's cost", async () => {
+    // NaN > 0 is false, so an unguarded NaN would drop total_cost_usd for EVERY node in
+    // the run, silently — the exact loss this work exists to remove, arriving through a
+    // provider instead of a code path. Tokens have carried this guard; cost had not.
+    let call = 0;
+    mockSendQueryDag.mockImplementation(function* () {
+      call++;
+      if (call === 1) {
+        yield { type: 'assistant', content: 'good node' };
+        yield { type: 'result', sessionId: 'sid-ok', cost: 0.05, tokens: { input: 10, output: 2 } };
+        return;
+      }
+      yield { type: 'assistant', content: 'bad provider' };
+      yield {
+        type: 'result',
+        sessionId: 'sid-nan',
+        cost: Number.NaN,
+        tokens: { input: 4, output: 1 },
+      };
+    });
+
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+
+    await executeDagWorkflow(
+      mockDeps,
+      createMockPlatform(),
+      'conv-usage',
+      testDir,
+      {
+        name: 'usage-nan-cost',
+        nodes: [
+          { id: 'good', prompt: 'Spend normally.' },
+          { id: 'bad', prompt: 'Report a broken cost.', depends_on: ['good'] },
+        ],
+      },
+      makeWorkflowRun(),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    // The healthy node's spend survives; only the broken node's contribution is dropped.
+    // Tokens are unaffected — both nodes reported finite ones.
+    expect(runUsageWrites(store)).toEqual([
+      { total_cost_usd: 0.05, total_tokens_in: 14, total_tokens_out: 3 },
+    ]);
+    expect(
+      (mockLogFn as unknown as Mock<(obj: unknown, msg?: string) => void>).mock.calls.some(
+        call => call[1] === 'dag.usage_cost_non_finite_ignored'
+      )
+    ).toBe(true);
+  });
+
   it('a failed usage write is logged and never fails the run', async () => {
     // persistRunUsage is documented best-effort: a bookkeeping write must not turn an
     // otherwise-fine run into a failed one. Documented, but never watched failing — and

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -6302,6 +6302,64 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       expect((completedEvent![0] as { data: { cost_usd?: number } }).data.cost_usd).toBe(0.3);
     });
 
+    it('keeps a finite loop cost when a later result in the same iteration is non-finite', async () => {
+      mockSendQueryDag.mockImplementation(async function* () {
+        yield {
+          type: 'background_tasks',
+          tasks: [{ taskId: 't-1', taskType: 'local_agent', description: 'bg work' }],
+        };
+        yield { type: 'assistant', content: 'Done. <promise>COMPLETE</promise>' };
+        yield { type: 'result', sessionId: 'loop-sid', cost: 0.1 };
+        yield { type: 'background_tasks', tasks: [] };
+        yield { type: 'result', sessionId: 'loop-sid', cost: Number.NaN };
+      });
+
+      const store = createMockStore();
+
+      await executeDagWorkflow(
+        createMockDeps(store),
+        createMockPlatform(),
+        'conv-dag',
+        testDir,
+        {
+          name: 'dag-loop-nan-cost',
+          nodes: [
+            {
+              id: 'my-loop',
+              loop: {
+                fresh_context: false,
+                prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
+                until: 'COMPLETE',
+                max_iterations: 5,
+              },
+            },
+          ],
+        },
+        makeWorkflowRun('loop-nan-cost-run'),
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'state'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+
+      const completedEvent = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls.find(
+        (call: unknown[]) =>
+          (call[0] as { event_type: string }).event_type === 'node_completed' &&
+          (call[0] as { step_name: string }).step_name === 'my-loop'
+      );
+      expect(completedEvent).toBeDefined();
+      expect((completedEvent![0] as { data: { cost_usd?: number } }).data.cost_usd).toBe(0.1);
+      expect(
+        (mockLogFn as unknown as Mock<(obj: unknown, msg?: string) => void>).mock.calls.some(
+          call => call[1] === 'loop_node.usage_cost_non_finite_ignored'
+        )
+      ).toBe(true);
+    });
+
     it('records the cross-iteration union of dangling background tasks on node_completed (#2083)', async () => {
       // Iterations 1 and 2 each end with a different task still live (subprocess
       // death analog); iteration 3 finishes cleanly and signals completion. The

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -12998,6 +12998,75 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
       { total_cost_usd: 0.04, total_tokens_in: 60, total_tokens_out: 6 },
     ]);
   });
+
+  it('records usage when a FATAL platform error throws out of runLayers', async () => {
+    // The `finally` around runLayers exists for exactly this: a throw that skips every
+    // disposition below and unwinds to executeWorkflow's catch-all, which marks the run
+    // FAILED. Without this case the other three would pass with a plain call, so the
+    // guard would never be seen firing and a refactor could drop it silently.
+    //
+    // The reachable path is a platform whose auth dies mid-run: safeSendMessage rethrows
+    // FATAL-classified errors instead of swallowing them (`executor-shared.ts:830-832`,
+    // 'unauthorized' is in FATAL_PATTERNS). A `cancel:` node's message throws inside the
+    // per-node try; the catch's own message throws too, rejecting the node promise; the
+    // allSettled `rejected` branch then throws a third time OUTSIDE any try — out of
+    // runLayers entirely.
+    mockSendQueryDag.mockImplementation(function* () {
+      yield { type: 'assistant', content: 'spent before the platform died' };
+      yield {
+        type: 'result',
+        sessionId: 'sid-throw',
+        cost: 0.01,
+        tokens: { input: 20, output: 2 },
+      };
+    });
+
+    const store = createMockStore();
+    let nodeFinished = false;
+    const realCreateEvent = store.createWorkflowEvent;
+    store.createWorkflowEvent = mock((data: { event_type: string }) => {
+      if (data.event_type === 'node_completed') nodeFinished = true;
+      return realCreateEvent(data);
+    });
+
+    // Auth dies only once the AI node has completed, so its usage is accumulated first.
+    const platform = createMockPlatform();
+    platform.sendMessage = mock(() =>
+      nodeFinished ? Promise.reject(new Error('unauthorized')) : Promise.resolve()
+    );
+
+    await expect(
+      executeDagWorkflow(
+        createMockDeps(store),
+        platform,
+        'conv-usage',
+        testDir,
+        {
+          name: 'usage-on-throw',
+          nodes: [
+            { id: 'spend', prompt: 'Burn some tokens.' },
+            { id: 'stop', cancel: 'platform is gone', depends_on: ['spend'] },
+          ],
+        },
+        makeWorkflowRun(),
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'state'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      )
+    ).rejects.toThrow(/authentication\/permission/i);
+
+    // Neither terminal writer ran — the throw skipped them both — yet the spend survived.
+    expect(store.completeWorkflowRun).not.toHaveBeenCalled();
+    expect(store.failWorkflowRun).not.toHaveBeenCalled();
+    expect(runUsageWrites(store)).toEqual([
+      { total_cost_usd: 0.01, total_tokens_in: 20, total_tokens_out: 2 },
+    ]);
+  });
 });
 
 describe('executeDagWorkflow -- script nodes', () => {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -12999,6 +12999,59 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
     ]);
   });
 
+  it('a failed usage write is logged and never fails the run', async () => {
+    // persistRunUsage is documented best-effort: a bookkeeping write must not turn an
+    // otherwise-fine run into a failed one. Documented, but never watched failing — and
+    // the `finally` makes it the last thing standing between the run and its own
+    // completion, so a throw here would be maximally disruptive.
+    mockSendQueryDag.mockImplementation(function* () {
+      yield { type: 'assistant', content: 'done' };
+      yield {
+        type: 'result',
+        sessionId: 'sid-dbfail',
+        cost: 0.02,
+        tokens: { input: 9, output: 3 },
+      };
+    });
+
+    const store = createMockStore();
+    store.updateWorkflowRun = mock(
+      (_id: string, updates: { metadata?: Record<string, unknown> }): Promise<void> =>
+        updates.metadata && 'total_cost_usd' in updates.metadata
+          ? Promise.reject(new Error('Workflow run not found (id: gone)'))
+          : Promise.resolve()
+    );
+    const mockDeps = createMockDeps(store);
+
+    await executeDagWorkflow(
+      mockDeps,
+      createMockPlatform(),
+      'conv-usage',
+      testDir,
+      { name: 'usage-write-fails', nodes: [{ id: 'spend', prompt: 'Burn some tokens.' }] },
+      makeWorkflowRun(),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    // The run still completes normally — the usage figure is simply absent, and every
+    // reader type-guards that. Absent is safe; plausible-and-wrong is the failure mode.
+    expect(store.completeWorkflowRun).toHaveBeenCalled();
+    expect(store.failWorkflowRun).not.toHaveBeenCalled();
+    // ...and the loss is recorded rather than swallowed.
+    expect(
+      (mockLogFn as unknown as Mock<(obj: unknown, msg?: string) => void>).mock.calls.some(
+        call => call[1] === 'dag.run_usage_persist_failed'
+      )
+    ).toBe(true);
+  });
+
   it('records usage when a FATAL platform error throws out of runLayers', async () => {
     // The `finally` around runLayers exists for exactly this: a throw that skips every
     // disposition below and unwinds to executeWorkflow's catch-all, which marks the run
@@ -17560,6 +17613,31 @@ describe('executeDagWorkflow -- loop_group node', () => {
     expect(calls).toBe(2);
     // 0.01 + 0.02 = 0.03 accumulated across the group's 2 iterations.
     expect(runUsageWrites(store)).toEqual([{ total_cost_usd: 0.03 }]);
+
+    // #2469 producer half: the group's own node_completed row restates the cost its
+    // `<groupId>.<nodeId>` body rows already carry, so it must be marked as derived —
+    // getDagResumeSnapshot skips marked rows when rebuilding cost across a resume.
+    // Without the marker a resumed run seeds ~2x the true prior spend, silently.
+    const completedEvents = (
+      store.createWorkflowEvent as Mock<
+        (data: {
+          event_type: string;
+          step_name?: string;
+          data?: Record<string, unknown>;
+        }) => Promise<void>
+      >
+    ).mock.calls
+      .map(call => call[0])
+      .filter(e => e.event_type === 'node_completed');
+
+    const groupRollUp = completedEvents.find(e => e.step_name === 'paid');
+    expect(groupRollUp?.data?.cost_usd).toBeCloseTo(0.03, 5);
+    expect(groupRollUp?.data?.aggregate).toBe(true);
+
+    // The body rows are the authoritative leaves and must NOT be marked.
+    const bodyRows = completedEvents.filter(e => e.step_name?.startsWith('paid.'));
+    expect(bodyRows.length).toBeGreaterThan(0);
+    for (const row of bodyRows) expect(row.data?.aggregate).toBeUndefined();
   });
 
   it('COST: accumulates token usage across loop_group iterations', async () => {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -173,6 +173,7 @@ function createMockStore(): MockWorkflowStore {
       Promise.resolve({
         completedNodeOutputs: new Map<string, string>(),
         tokens: { input: 0, output: 0 },
+        costUsd: 0,
       })
     ),
     getCodebase: mock<IWorkflowStore['getCodebase']>(async _id => null),
@@ -185,6 +186,25 @@ function createMockStore(): MockWorkflowStore {
       async _filter => ({ deleted: 0 })
     ),
   };
+}
+
+/**
+ * The run-level usage metadata the executor persisted, in call order (#2469). Usage is
+ * written through `updateWorkflowRun` at the run tail on EVERY disposition, so this is
+ * the single surface a usage assertion should read — regardless of whether the run then
+ * completed, failed, was cancelled, or paused. Other `updateWorkflowRun` writes
+ * (output_root, evidence_validation, …) are filtered out by key.
+ */
+function runUsageWrites(store: ReturnType<typeof createMockStore>): Record<string, unknown>[] {
+  return (store.updateWorkflowRun as ReturnType<typeof mock>).mock.calls
+    .map((call: unknown[]) => (call[1] as { metadata?: Record<string, unknown> })?.metadata)
+    .filter(
+      (metadata): metadata is Record<string, unknown> =>
+        metadata !== undefined &&
+        ('total_cost_usd' in metadata ||
+          'total_tokens_in' in metadata ||
+          'total_tokens_out' in metadata)
+    );
 }
 
 /** All-true capabilities for Claude mock */
@@ -4939,7 +4959,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     expect(mockSendQueryDag.mock.calls.length).toBe(2);
   });
 
-  it('reconciles total tokens across a failed run and its resume', async () => {
+  it('reconciles total usage across a failed run and its resume', async () => {
     const store = createMockStore();
     const mockDeps = createMockDeps(store);
     const platform = createMockPlatform();
@@ -4960,6 +4980,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         yield {
           type: 'result',
           sessionId: 'first-execution-session',
+          cost: 0.02,
           tokens: { input: 40, output: 4 },
         };
         return;
@@ -4989,6 +5010,13 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     expect(store.failWorkflowRun).toHaveBeenCalled();
     expect(store.completeWorkflowRun).not.toHaveBeenCalled();
 
+    // #2469 (AC1): the run FAILED, and it still recorded what step1 burned before
+    // step2 died. Before the fix this run's row carried nothing but { error }.
+    expect(runUsageWrites(store)).toEqual([
+      { total_cost_usd: 0.02, total_tokens_in: 40, total_tokens_out: 4 },
+    ]);
+    (store.updateWorkflowRun as ReturnType<typeof mock>).mockClear();
+
     const firstExecutionEvents = (
       store.createWorkflowEvent as ReturnType<typeof mock>
     ).mock.calls.map(
@@ -5000,7 +5028,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         }
     );
     const priorCompletedNodes = new Map<string, string>();
-    const priorTokenUsage = { input: 0, output: 0 };
+    const priorUsage = { tokens: { input: 0, output: 0 }, costUsd: 0 };
     for (const event of firstExecutionEvents) {
       if (event.event_type !== 'node_completed' || !event.step_name) continue;
       if (typeof event.data?.node_output === 'string') {
@@ -5013,18 +5041,25 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         Number.isFinite(eventTokens.input) &&
         Number.isFinite(eventTokens.output)
       ) {
-        priorTokenUsage.input += eventTokens.input;
-        priorTokenUsage.output += eventTokens.output;
+        priorUsage.tokens.input += eventTokens.input;
+        priorUsage.tokens.output += eventTokens.output;
+      }
+      const eventCost = event.data?.cost_usd;
+      if (typeof eventCost === 'number' && Number.isFinite(eventCost)) {
+        priorUsage.costUsd += eventCost;
       }
     }
     expect(priorCompletedNodes).toEqual(new Map([['step1', 'first execution output']]));
-    expect(priorTokenUsage).toEqual({ input: 40, output: 4 });
+    // Both axes are reconstructable from the event log — this mirrors what
+    // getDagResumeSnapshot does, and cost is now among them (#2469).
+    expect(priorUsage).toEqual({ tokens: { input: 40, output: 4 }, costUsd: 0.02 });
 
     mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'resumed execution output' };
       yield {
         type: 'result',
         sessionId: 'resumed-execution-session',
+        cost: 0.03,
         tokens: { input: 60, output: 6 },
       };
     });
@@ -5054,17 +5089,21 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       undefined,
       undefined,
       undefined,
-      priorTokenUsage
+      priorUsage
     );
 
+    // #2469 (AC4): the resumed run reports pass 1 + pass 2 on BOTH axes. Cost used to
+    // reset to 0 on every pass, so a run that failed at 0.02 and then completed would
+    // have reported 0.03 — a figure that goes DOWN.
+    expect(runUsageWrites(store)).toEqual([
+      { total_cost_usd: 0.05, total_tokens_in: 100, total_tokens_out: 10 },
+    ]);
+
+    // Usage has exactly one writer now; completeWorkflowRun carries only node_counts.
     const completionCalls = (store.completeWorkflowRun as ReturnType<typeof mock>).mock.calls;
     expect(completionCalls).toHaveLength(1);
-    expect(completionCalls[0]?.[1]).toEqual(
-      expect.objectContaining({
-        total_tokens_in: 100,
-        total_tokens_out: 10,
-      })
-    );
+    expect(completionCalls[0]?.[1]).not.toHaveProperty('total_tokens_in');
+    expect(completionCalls[0]?.[1]).not.toHaveProperty('total_cost_usd');
 
     const completedEvents = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls
       .map(
@@ -12601,7 +12640,7 @@ describe('executeDagWorkflow -- cost tracking', () => {
     }
   });
 
-  it('passes total_cost_usd to completeWorkflowRun when node yields cost', async () => {
+  it('persists total_cost_usd on the run row when a node yields cost', async () => {
     mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'done' };
       yield { type: 'result', sessionId: 'sid-cost', cost: 0.0042 };
@@ -12629,6 +12668,8 @@ describe('executeDagWorkflow -- cost tracking', () => {
       minimalConfig
     );
 
+    expect(runUsageWrites(store)).toEqual([{ total_cost_usd: 0.0042 }]);
+    // Exactly one writer: completeWorkflowRun keeps node_counts, not usage (#2469).
     const completeCalls = (
       store.completeWorkflowRun as Mock<
         (id: string, metadata?: Record<string, unknown>) => Promise<void>
@@ -12637,7 +12678,6 @@ describe('executeDagWorkflow -- cost tracking', () => {
     expect(completeCalls.length).toBe(1);
     expect(completeCalls[0][1]).toEqual({
       node_counts: { completed: 1, failed: 0, skipped: 0, total: 1 },
-      total_cost_usd: 0.0042,
     });
   });
 
@@ -12677,16 +12717,10 @@ describe('executeDagWorkflow -- cost tracking', () => {
       minimalConfig
     );
 
-    const completeCalls = (
-      store.completeWorkflowRun as Mock<
-        (id: string, metadata?: Record<string, unknown>) => Promise<void>
-      >
-    ).mock.calls;
-    expect(completeCalls.length).toBe(1);
-    expect(completeCalls[0][1]).toMatchObject({ total_cost_usd: 0.002 });
+    expect(runUsageWrites(store)).toEqual([{ total_cost_usd: 0.002 }]);
   });
 
-  it('omits total_cost_usd from completeWorkflowRun when no cost yielded', async () => {
+  it('writes no usage metadata at all when no node yielded cost or tokens', async () => {
     mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'Some output' };
       yield { type: 'result', sessionId: 'sid-no-cost' };
@@ -12714,6 +12748,9 @@ describe('executeDagWorkflow -- cost tracking', () => {
       minimalConfig
     );
 
+    // A zero must stay ABSENT, not written as 0 — a bash-only workflow reading as a
+    // free AI run is the misleading shape the `> 0` guards exist to prevent.
+    expect(runUsageWrites(store)).toEqual([]);
     const completeCalls = (
       store.completeWorkflowRun as Mock<
         (id: string, metadata?: Record<string, unknown>) => Promise<void>
@@ -12723,7 +12760,7 @@ describe('executeDagWorkflow -- cost tracking', () => {
     expect(completeCalls[0][1]).not.toHaveProperty('total_cost_usd');
   });
 
-  it('accumulates cost across loop iterations and includes in completeWorkflowRun', async () => {
+  it('accumulates cost across loop iterations', async () => {
     let callCount = 0;
     mockSendQueryDag.mockImplementation(async function* () {
       callCount++;
@@ -12767,13 +12804,199 @@ describe('executeDagWorkflow -- cost tracking', () => {
     );
 
     // 3 iterations: 0.001 + 0.001 + 0.002 = 0.004
-    const completeCalls = (
-      store.completeWorkflowRun as Mock<
-        (id: string, metadata?: Record<string, unknown>) => Promise<void>
-      >
-    ).mock.calls;
-    expect(completeCalls.length).toBe(1);
-    expect(completeCalls[0][1]).toMatchObject({ total_cost_usd: 0.004 });
+    expect(runUsageWrites(store)).toEqual([{ total_cost_usd: 0.004 }]);
+  });
+});
+
+/**
+ * #2469 — a run's spend has to survive its outcome. Usage used to be written only in
+ * the metadata argument of completeWorkflowRun, so anything other than a clean
+ * completion recorded nothing at all: the number was simply lower than reality, in the
+ * direction that does not prompt investigation.
+ */
+describe('executeDagWorkflow -- run usage survives every disposition', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = join(tmpdir(), `dag-usage-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(join(testDir, '.archon', 'commands'), { recursive: true });
+
+    mockSendQueryDag.mockClear();
+    mockGetAgentProviderDag.mockClear();
+    mockLogFn.mockClear();
+
+    mockGetAgentProviderDag.mockImplementation(() => ({
+      sendQuery: mockSendQueryDag,
+      getType: () => 'claude',
+      getCapabilities: mockClaudeCapabilities,
+    }));
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(testDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  it('records what a FAILED run burned before it died', async () => {
+    let call = 0;
+    mockSendQueryDag.mockImplementation(function* () {
+      call++;
+      if (call === 1) {
+        yield { type: 'assistant', content: 'first output' };
+        yield {
+          type: 'result',
+          sessionId: 'sid-1',
+          cost: 0.05,
+          tokens: { input: 900, output: 90 },
+        };
+        return;
+      }
+      // No assistant output → the second node fails, failing the run.
+      yield { type: 'result', sessionId: 'sid-2' };
+    });
+
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+
+    await executeDagWorkflow(
+      mockDeps,
+      createMockPlatform(),
+      'conv-usage',
+      testDir,
+      {
+        name: 'usage-on-failure',
+        nodes: [
+          { id: 'spend', prompt: 'Burn some tokens.' },
+          { id: 'die', prompt: 'Fail here.', depends_on: ['spend'] },
+        ],
+      },
+      makeWorkflowRun(),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    expect(store.failWorkflowRun).toHaveBeenCalled();
+    expect(store.completeWorkflowRun).not.toHaveBeenCalled();
+    expect(runUsageWrites(store)).toEqual([
+      { total_cost_usd: 0.05, total_tokens_in: 900, total_tokens_out: 90 },
+    ]);
+  });
+
+  it('records usage when the run is CANCELLED out of band mid-flight', async () => {
+    // A cancel is driven by another process (CLI abandon, the API abandon route, a
+    // fan-out cancelling a child), so the cancelling side has no usage in scope. The
+    // executing side notices at its next status check and bails out of BOTH terminal
+    // writers — which is exactly why the usage write cannot live in either of them.
+    mockSendQueryDag.mockImplementation(function* () {
+      yield { type: 'assistant', content: 'work done before the cancel landed' };
+      yield {
+        type: 'result',
+        sessionId: 'sid-cancel',
+        cost: 0.02,
+        tokens: { input: 30, output: 3 },
+      };
+    });
+
+    const store = createMockStore();
+    // The cancel lands the moment the node finishes — pinned to the node's own
+    // node_completed write so the run is unambiguously past accumulation and the
+    // during-streaming cancel check never tears the node down mid-stream.
+    let nodeFinished = false;
+    const realCreateEvent = store.createWorkflowEvent;
+    store.createWorkflowEvent = mock((data: { event_type: string }) => {
+      if (data.event_type === 'node_completed') nodeFinished = true;
+      return realCreateEvent(data);
+    });
+    store.getWorkflowRunStatus = mock(() =>
+      Promise.resolve(nodeFinished ? ('cancelled' as const) : ('running' as const))
+    );
+    const mockDeps = createMockDeps(store);
+
+    await executeDagWorkflow(
+      mockDeps,
+      createMockPlatform(),
+      'conv-usage',
+      testDir,
+      { name: 'usage-on-cancel', nodes: [{ id: 'spend', prompt: 'Burn some tokens.' }] },
+      makeWorkflowRun(),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    expect(store.completeWorkflowRun).not.toHaveBeenCalled();
+    expect(store.failWorkflowRun).not.toHaveBeenCalled();
+    expect(runUsageWrites(store)).toEqual([
+      { total_cost_usd: 0.02, total_tokens_in: 30, total_tokens_out: 3 },
+    ]);
+  });
+
+  it('records usage accumulated before an approval gate PAUSES the run', async () => {
+    // A fan-out child that pauses at a gate is cancelled by the parent (`fan_out_gate`),
+    // so the pause is its only chance to record what it spent.
+    mockSendQueryDag.mockImplementation(function* () {
+      yield { type: 'assistant', content: 'analysis' };
+      yield {
+        type: 'result',
+        sessionId: 'sid-pause',
+        cost: 0.04,
+        tokens: { input: 60, output: 6 },
+      };
+    });
+
+    const store = createMockStore();
+    let paused = false;
+    store.pauseWorkflowRun = mock(() => {
+      paused = true;
+      return Promise.resolve();
+    });
+    store.getWorkflowRunStatus = mock(() =>
+      Promise.resolve(paused ? ('paused' as const) : ('running' as const))
+    );
+    const mockDeps = createMockDeps(store);
+
+    await executeDagWorkflow(
+      mockDeps,
+      createMockPlatform(),
+      'conv-usage',
+      testDir,
+      {
+        name: 'usage-on-pause',
+        nodes: [
+          { id: 'analyze', prompt: 'Analyze.' },
+          { id: 'review', approval: { message: 'Ship it?' }, depends_on: ['analyze'] },
+        ],
+      },
+      makeWorkflowRun(),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    expect(store.pauseWorkflowRun).toHaveBeenCalled();
+    expect(store.completeWorkflowRun).not.toHaveBeenCalled();
+    expect(runUsageWrites(store)).toEqual([
+      { total_cost_usd: 0.04, total_tokens_in: 60, total_tokens_out: 6 },
+    ]);
   });
 });
 
@@ -17248,14 +17471,8 @@ describe('executeDagWorkflow -- loop_group node', () => {
     );
 
     expect(calls).toBe(2);
-    const completeCalls = (
-      store.completeWorkflowRun as Mock<
-        (id: string, metadata?: Record<string, unknown>) => Promise<void>
-      >
-    ).mock.calls;
-    expect(completeCalls.length).toBe(1);
     // 0.01 + 0.02 = 0.03 accumulated across the group's 2 iterations.
-    expect(completeCalls[0][1]).toMatchObject({ total_cost_usd: 0.03 });
+    expect(runUsageWrites(store)).toEqual([{ total_cost_usd: 0.03 }]);
   });
 
   it('COST: accumulates token usage across loop_group iterations', async () => {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -13029,11 +13029,26 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
       return realCreateEvent(data);
     });
 
+    // Ordering is the real discriminator. The `finally` runs AFTER runLayers throws, so
+    // the usage write must land after the fatal send. A write placed inside runLayers
+    // (per-node or per-layer) would satisfy a bare "usage was persisted" assertion while
+    // recording BEFORE the send — and would not need the finally at all.
+    const order: string[] = [];
+    const realUpdateRun = store.updateWorkflowRun;
+    store.updateWorkflowRun = mock(
+      (id: string, updates: { metadata?: Record<string, unknown> }): Promise<void> => {
+        if (updates.metadata && 'total_cost_usd' in updates.metadata) order.push('usage-write');
+        return realUpdateRun(id, updates);
+      }
+    );
+
     // Auth dies only once the AI node has completed, so its usage is accumulated first.
     const platform = createMockPlatform();
-    platform.sendMessage = mock(() =>
-      nodeFinished ? Promise.reject(new Error('unauthorized')) : Promise.resolve()
-    );
+    platform.sendMessage = mock((): Promise<void> => {
+      if (!nodeFinished) return Promise.resolve();
+      order.push('fatal-send');
+      return Promise.reject(new Error('unauthorized'));
+    });
 
     await expect(
       executeDagWorkflow(
@@ -13066,6 +13081,9 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
     expect(runUsageWrites(store)).toEqual([
       { total_cost_usd: 0.01, total_tokens_in: 20, total_tokens_out: 2 },
     ]);
+    // The usage write is the LAST thing that happens, after the send that killed the run.
+    expect(order[0]).toBe('fatal-send');
+    expect(order[order.length - 1]).toBe('usage-write');
   });
 });
 

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -425,6 +425,17 @@ type NodeExecutionResult = NodeOutput & {
 // workflow: (sub-run) node — cross-run composition (#2121 Phase 2)
 // ---------------------------------------------------------------------------
 
+/**
+ * Usage a resumed run already consumed in earlier passes, rebuilt from its persisted
+ * `node_completed` events by `getDagResumeSnapshot`. Both axes travel together because
+ * they are one concept — what this run has spent so far — and seeding only one of them
+ * is how cost came to under-report every resumed run while tokens did not (#2469).
+ */
+export interface PriorRunUsage {
+  tokens: { input: number; output: number };
+  costUsd: number;
+}
+
 /** Terminal (or paused) outcome of a child sub-run, as consumed by a `workflow:` node. */
 export interface ChildWorkflowOutcome {
   childRunId: string;
@@ -493,11 +504,12 @@ export interface RunChildWorkflowArgs {
 export type RunChildWorkflowFn = (args: RunChildWorkflowArgs) => Promise<ChildWorkflowOutcome>;
 
 /**
- * Derive a child's node-facing outcome from its persisted run row. Cost, tokens,
- * and the terminal `summary` are written into the child run's metadata at
- * completion (see executeDagWorkflow completion + Task 12), so both the
- * synchronous path (runChildWorkflow reads the row back) and the re-entry path
- * (executeWorkflowNode finds an already-terminal child) read the same source.
+ * Derive a child's node-facing outcome from its persisted run row. Cost and tokens are
+ * written into the child's metadata at its run tail regardless of outcome (#2469) and
+ * the terminal `summary` at completion, so both the synchronous path (runChildWorkflow
+ * reads the row back) and the re-entry path (executeWorkflowNode finds an
+ * already-terminal child) read the same source — and a child that burned tokens and
+ * then failed or was cancelled still reports what it spent.
  */
 export function childOutcomeFromRun(run: WorkflowRun): ChildWorkflowOutcome {
   if (run.status === 'running' || run.status === 'pending') {
@@ -6274,15 +6286,10 @@ async function resolveFanOutChildDefinition(
  * node's own `costUsd` stays absent (a misleading `0` would look like a free run) —
  * matching the run-level aggregation's "only write when > 0" posture.
  *
- * UNDER-REPORTS: this is Σ of *completed* children, not Σ of children. Usage metadata is
- * persisted in exactly one place — inside `completeWorkflowRun` — so a child that burned
- * tokens and then failed or was cancelled records no spend, and `childOutcomeFromRun`
- * returns undefined for it. A 10-item fan-out where 3 children burn tokens and fail reports
- * the spend of 7. Inherited from the 1:1 sub-run path, but fan-out is what makes it
- * material, and `all_done` being the default makes a partly-failed run the ordinary case
- * rather than the exceptional one. The real fix is upstream: `failWorkflowRun` would have
- * to persist usage the way `completeWorkflowRun` does. Tracked with the run-tree budget
- * work (#1961).
+ * This is Σ of every child, not only the completed ones: a child persists its usage at
+ * its run tail whatever its outcome (#2469), so a failed or cancelled child still
+ * contributes what it burned. That matters most here — `all_done` is the default join,
+ * which makes a partly-failed fan-out the ordinary case rather than the exceptional one.
  */
 function sumFanOutCost(outcomes: readonly ChildWorkflowOutcome[]): number | undefined {
   let sum = 0;
@@ -6297,9 +6304,8 @@ function sumFanOutCost(outcomes: readonly ChildWorkflowOutcome[]): number | unde
 }
 
 /**
- * Σ of defined child token usage; undefined when no child reported tokens. Carries the same
- * completed-only caveat as {@link sumFanOutCost} — a child that burned tokens and then
- * failed contributes nothing.
+ * Σ of defined child token usage; undefined when no child reported tokens. Like
+ * {@link sumFanOutCost}, this covers every child regardless of outcome.
  */
 function sumFanOutTokens(outcomes: readonly ChildWorkflowOutcome[]): TokenUsage | undefined {
   let input = 0;
@@ -6406,11 +6412,11 @@ async function executeFanOutWorkflowNode(
           type: 'workflow',
           fan_out: true,
           ...(costUsd !== undefined ? { cost_usd: costUsd } : {}),
-          // Tokens are the axis that survives resume: getDagResumeSnapshot rebuilds
-          // cumulative usage by summing `data.tokens` and never reads `cost_usd`, so
-          // dropping them here made every resumed run under-report by exactly the
-          // children's tokens — silently, since an absent key is skipped without warning.
-          // On Codex the loss is total, because that provider reports no cost either.
+          // Both usage keys are what survives resume: getDagResumeSnapshot rebuilds a
+          // run's cumulative usage by summing `data.tokens` and `data.cost_usd` off
+          // these events, so dropping either here makes every resumed run under-report
+          // by exactly the children's usage — silently, since an absent key is skipped
+          // without warning.
           ...(tokens !== undefined ? { tokens } : {}),
         },
       })
@@ -8502,7 +8508,7 @@ export async function executeDagWorkflow(
    */
   runChildWorkflow?: RunChildWorkflowFn,
   /** Cumulative usage restored from prior node_completed events on resume. */
-  priorTokenUsage?: { input: number; output: number }
+  priorUsage?: PriorRunUsage
 ): Promise<string | undefined> {
   const dagStartTime = Date.now();
 
@@ -8674,13 +8680,62 @@ export async function executeDagWorkflow(
     priorCompletedNodes,
     lastSequentialSession: undefined,
     warnedProviderConflicts: new Set<string>(),
-    totalCostUsd: 0,
-    totalTokensIn: priorTokenUsage?.input ?? 0,
-    totalTokensOut: priorTokenUsage?.output ?? 0,
+    totalCostUsd: priorUsage?.costUsd ?? 0,
+    totalTokensIn: priorUsage?.tokens.input ?? 0,
+    totalTokensOut: priorUsage?.tokens.output ?? 0,
     totalLoopIterations: 0,
     stepNamePrefix: '',
   };
-  await runLayers(runCtx);
+
+  /**
+   * Persist what this run spent, whatever becomes of it (#2469).
+   *
+   * Usage used to be written in exactly one place — the metadata argument of
+   * `completeWorkflowRun` below — which tied the record to a single outcome. A run
+   * that burned tokens and then failed, was cancelled out of band, or paused at a
+   * gate recorded no spend at all, and since `childOutcomeFromRun` reads cost and
+   * tokens straight off the child's row, a fan-out aggregate silently became Σ of
+   * *completed* children. With `all_done` the default join, that made partial failure
+   * — the ordinary case — under-report with no warning.
+   *
+   * Every disposition below (container pause, external cancel/pause, the two failure
+   * branches, the evidence gate, the write-back gate, completion) is reached from the
+   * one point where the accumulators are settled and identical, so the write belongs
+   * HERE rather than in each of them. It goes through `updateWorkflowRun`, not the
+   * terminal writers, because that merge carries no `WHERE status = 'running'` guard
+   * and so still lands on a row another process has already flipped to `cancelled`.
+   * Same ordering as the evidence gate: metadata first, terminal status after.
+   *
+   * Best-effort by design — a bookkeeping write must not fail an otherwise-fine run —
+   * but never silent: the whole defect was a number quietly going missing.
+   */
+  const persistRunUsage = async (): Promise<void> => {
+    const usage = {
+      // A zero stays absent: a bash-only workflow must not read as a free AI run.
+      ...(runCtx.totalCostUsd > 0 ? { total_cost_usd: runCtx.totalCostUsd } : {}),
+      ...(runCtx.totalTokensIn > 0 ? { total_tokens_in: runCtx.totalTokensIn } : {}),
+      ...(runCtx.totalTokensOut > 0 ? { total_tokens_out: runCtx.totalTokensOut } : {}),
+    };
+    if (Object.keys(usage).length === 0) return;
+    await deps.store
+      .updateWorkflowRun(workflowRun.id, { metadata: usage })
+      .catch((dbErr: Error) => {
+        getLog().error(
+          { err: dbErr, workflowRunId: workflowRun.id },
+          'dag.run_usage_persist_failed'
+        );
+      });
+  };
+
+  try {
+    await runLayers(runCtx);
+  } finally {
+    // `finally`, not a plain call: a throw out of runLayers unwinds to executor.ts's
+    // top-level handler, which marks the run FAILED — a real terminal outcome the
+    // invariant has to cover. persistRunUsage swallows its own errors, so it can
+    // never displace an in-flight exception.
+    await persistRunUsage();
+  }
   // Pull the mutated accumulators back into local scope for the terminal tally below.
   const totalCostUsd = runCtx.totalCostUsd;
   const totalTokensIn = runCtx.totalTokensIn;
@@ -8785,7 +8840,8 @@ export async function executeDagWorkflow(
       ...runUsageProps,
     });
     // Note: nodeCounts not stored for failed runs — failWorkflowRun only stores { error }.
-    // Frontend guards with isValidNodeCounts so missing node_counts is safe.
+    // Frontend guards with isValidNodeCounts so missing node_counts is safe. (Usage IS
+    // stored: persistRunUsage wrote it at the run tail, before this branch — #2469.)
     await deps.store.failWorkflowRun(workflowRun.id, failMsg).catch((dbErr: Error) => {
       getLog().error({ err: dbErr, workflowRunId: workflowRun.id }, 'dag_db_fail_failed');
     });
@@ -9004,12 +9060,9 @@ export async function executeDagWorkflow(
   try {
     await deps.store.completeWorkflowRun(workflowRun.id, {
       node_counts: nodeCounts,
-      // totalCostUsd starts at 0; only write metadata when at least one node reported cost
-      ...(totalCostUsd > 0 ? { total_cost_usd: totalCostUsd } : {}),
-      // Persist token totals (D8) so a `workflow:` parent rolls up tokens as well as
-      // cost. Only when non-zero (telemetry-only fields otherwise).
-      ...(totalTokensIn > 0 ? { total_tokens_in: totalTokensIn } : {}),
-      ...(totalTokensOut > 0 ? { total_tokens_out: totalTokensOut } : {}),
+      // Cost and token totals are NOT written here — `persistRunUsage` already wrote
+      // them at the run tail, before this branch was chosen (#2469). Keeping a second
+      // copy here would be two writers of the same three keys, free to drift.
       // A sub-run persists its terminal summary so the parent can thread it as
       // `$<node>.output` on re-entry. Gated on parent_run_id to bound metadata
       // growth to child runs only (top-level runs return the summary directly).

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -5891,8 +5891,8 @@ async function executeWorkflowNode(
       // money, and its own row now records it (#2469) — so carry it up rather than
       // dropping it here. The run-level aggregator reads `costUsd`/`tokens` off the
       // node result with no gate on `state`, and the fan-out sibling has taken these
-      // for the same reason since #2224. Absent on the pre-spawn failures below, which
-      // fail before any child exists to have spent anything.
+      // for the same reason since #2224. Cost and tokens are supplied when a settled
+      // child outcome is available; failure paths without an outcome omit them.
       ...(costUsd !== undefined ? { costUsd } : {}),
       ...(tokens !== undefined ? { tokens } : {}),
     };

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -8730,10 +8730,15 @@ export async function executeDagWorkflow(
   try {
     await runLayers(runCtx);
   } finally {
-    // `finally`, not a plain call: a throw out of runLayers unwinds to executor.ts's
-    // top-level handler, which marks the run FAILED — a real terminal outcome the
-    // invariant has to cover. persistRunUsage swallows its own errors, so it can
-    // never displace an in-flight exception.
+    // `finally`, not a plain call. runLayers guards almost everything — every store
+    // call inside the per-node try, the between-layer status check, the artifact
+    // writes — but `safeSendMessage` deliberately RETHROWS a FATAL-classified platform
+    // error (executor-shared.ts, 'unauthorized'/'forbidden'/'401'…) rather than
+    // swallowing it, and the allSettled `rejected` branch calls it outside any try. So a
+    // platform whose auth dies mid-run throws clean out of runLayers, past every
+    // disposition below, to executeWorkflow's catch-all — which marks the run FAILED, a
+    // terminal outcome the invariant has to cover. persistRunUsage swallows its own
+    // errors, so it can never displace the in-flight exception.
     await persistRunUsage();
   }
   // Pull the mutated accumulators back into local scope for the terminal tally below.

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -7926,7 +7926,19 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
         // cost/tokens must be summed here and ONLY here — adding a per-node
         // telemetry capture elsewhere would double-count against the totals
         // sent on workflow_completed/workflow_failed.
-        if (output.costUsd !== undefined) ctx.totalCostUsd += output.costUsd;
+        if (output.costUsd !== undefined) {
+          // Same guard as tokens below, and for the same reason: cost comes from
+          // providers (incl. community ones), and one NaN poisons the run total for
+          // every other node — NaN > 0 is false, so the cost is dropped from the run
+          // row and telemetry with no trace. Exactly the silent loss #2469 exists to
+          // remove. Guarded here, at the single aggregation point, so one bad node
+          // costs only its own contribution.
+          if (Number.isFinite(output.costUsd)) {
+            ctx.totalCostUsd += output.costUsd;
+          } else {
+            getLog().warn({ nodeId, costUsd: output.costUsd }, 'dag.usage_cost_non_finite_ignored');
+          }
+        }
         if (output.tokens !== undefined) {
           // Token values come from providers (incl. community ones) — guard so
           // a NaN can't silently poison the totals (NaN > 0 is false, which

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -3916,21 +3916,27 @@ async function executeLoopGroupNode(
           data: {
             duration_ms: duration,
             node_output: lastIterationOutput,
-            // NO `tokens` here, deliberately. Unlike every other node type, a
-            // loop_group's body nodes write their OWN node_completed rows (namespaced
-            // `<groupId>.<nodeId>`, one per iteration) and those already carry the
-            // tokens. Persisting the group total under the SAME field name would make
-            // a consumer summing `data.tokens` across node_completed rows count this
-            // group's usage twice with nothing in the row to mark it as an aggregate.
-            // The leaves are authoritative: they are per-provider (a body node may
-            // override `provider:`, so the group total can mix providers and is
-            // useless for the cross-provider comparison #2333 exists to enable), and
-            // the group total is recoverable by summing the `<groupId>.` prefix.
-            // The RETURN value below still carries `tokens` — that is the run-level
-            // roll-up path, which counts each group exactly once (body results land in
-            // the scoped iteration ctx, never the run ctx).
-            // NOTE: `cost_usd` has this same double-count shape and predates #2333;
-            // it is left as-is rather than silently changed under a token fix.
+            // This row is an AGGREGATE of rows that are already in the event log.
+            // Unlike every other node type, a loop_group's body nodes write their OWN
+            // node_completed rows (namespaced `<groupId>.<nodeId>`, one per iteration)
+            // carrying their own usage, so any consumer summing usage across
+            // node_completed rows would count this group twice.
+            //
+            // `tokens` is omitted outright: the leaves are authoritative (they are
+            // per-provider — a body node may override `provider:`, so the group total
+            // can mix providers and is useless for the cross-provider comparison #2333
+            // exists to enable) and the group total is recoverable by summing the
+            // `<groupId>.` prefix. The RETURN value below still carries `tokens` — that
+            // is the run-level roll-up path, which counts each group exactly once (body
+            // results land in the scoped iteration ctx, never the run ctx).
+            //
+            // `cost_usd` is KEPT, because the console renders it per event
+            // (web/.../console/primitives/event.ts) and dropping it would blank the
+            // loop_group card's cost. `aggregate: true` is what makes that safe: it
+            // marks the row as derived so a summing consumer can skip it. #2469 added
+            // the first such consumer (getDagResumeSnapshot rebuilds cost across resume
+            // passes), which turned this from a latent shape into a live double count.
+            aggregate: true,
             ...(loopTotalCostUsd !== undefined ? { cost_usd: loopTotalCostUsd } : {}),
           },
         })
@@ -5836,7 +5842,11 @@ async function executeWorkflowNode(
   // does NOT turn into an event — so without this the sub-run failure reason (cycle,
   // unknown target, cancelled child, …) would be swallowed into the run-level DAG
   // summary and never auditable per-node. Fire-and-forget like every other event.
-  const failResult = (error: string): NodeExecutionResult => {
+  const failResult = (
+    error: string,
+    costUsd?: number,
+    tokens?: TokenUsage
+  ): NodeExecutionResult => {
     deps.store
       .createWorkflowEvent({
         workflow_run_id: parentRun.id,
@@ -5857,7 +5867,19 @@ async function executeWorkflowNode(
       nodeName: node.id,
       error,
     });
-    return { state: 'failed', output: '', error };
+    return {
+      state: 'failed',
+      output: '',
+      error,
+      // A child that burned tokens and then failed or was cancelled still spent that
+      // money, and its own row now records it (#2469) — so carry it up rather than
+      // dropping it here. The run-level aggregator reads `costUsd`/`tokens` off the
+      // node result with no gate on `state`, and the fan-out sibling has taken these
+      // for the same reason since #2224. Absent on the pre-spawn failures below, which
+      // fail before any child exists to have spent anything.
+      ...(costUsd !== undefined ? { costUsd } : {}),
+      ...(tokens !== undefined ? { tokens } : {}),
+    };
   };
 
   if (!ctx.runChildWorkflow) {
@@ -6047,9 +6069,17 @@ async function executeWorkflowNode(
       case 'paused':
         return pauseParentOnChild(outcome.childRunId);
       case 'failed':
-        return failResult(outcome.error ?? `Sub-run '${node.workflow}' failed`);
+        return failResult(
+          outcome.error ?? `Sub-run '${node.workflow}' failed`,
+          outcome.costUsd,
+          outcome.tokens
+        );
       case 'cancelled':
-        return failResult(`Sub-run '${node.workflow}' was cancelled`);
+        return failResult(
+          `Sub-run '${node.workflow}' was cancelled`,
+          outcome.costUsd,
+          outcome.tokens
+        );
       default: {
         // Compile-time exhaustiveness + runtime fail-loud: without this, a status
         // outside the union would silently return `undefined` into runLayers.

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -1883,7 +1883,16 @@ async function executeNodeInternal(
             );
           }
         }
-        if (msg.cost !== undefined) nodeCostUsd = msg.cost;
+        if (msg.cost !== undefined) {
+          if (Number.isFinite(msg.cost)) {
+            nodeCostUsd = msg.cost;
+          } else {
+            getLog().warn(
+              { nodeId: node.id, costUsd: msg.cost },
+              'dag_node.usage_cost_non_finite_ignored'
+            );
+          }
+        }
         if (msg.stopReason !== undefined) nodeStopReason = msg.stopReason;
         if (msg.numTurns !== undefined) nodeNumTurns = msg.numTurns;
         // Assigned UNCONDITIONALLY. A guarded assignment cannot CLEAR a stale value:
@@ -4750,7 +4759,14 @@ async function executeLoopNode(
             // Overwrite, don't accumulate — a later result in the same iteration
             // (background-task wait, #2083) carries session-cumulative values.
             if (msg.cost !== undefined) {
-              iterationCost = msg.cost;
+              if (Number.isFinite(msg.cost)) {
+                iterationCost = msg.cost;
+              } else {
+                getLog().warn(
+                  { nodeId: node.id, iteration: i, costUsd: msg.cost },
+                  'loop_node.usage_cost_non_finite_ignored'
+                );
+              }
             }
             if (msg.tokens !== undefined) {
               // Provider-supplied numbers — see the NaN guard rationale at the

--- a/packages/workflows/src/executor-preamble.test.ts
+++ b/packages/workflows/src/executor-preamble.test.ts
@@ -105,6 +105,7 @@ function makeStore(overrides: Partial<IWorkflowStore> = {}): IWorkflowStore {
     getDagResumeSnapshot: mock(async () => ({
       completedNodeOutputs: new Map<string, string>(),
       tokens: { input: 0, output: 0 },
+      costUsd: 0,
     })),
     resumeWorkflowRun: mock(async () => makeRun()),
     getCodebase: mock(async () => null),

--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -181,6 +181,7 @@ function makeStore(overrides: Partial<IWorkflowStore> = {}): IWorkflowStore {
     getDagResumeSnapshot: mock(async () => ({
       completedNodeOutputs: new Map(),
       tokens: { input: 0, output: 0 },
+      costUsd: 0,
     })),
     resumeWorkflowRun: mock(async () => makeRun()),
     getCodebase: mock(async () => null),
@@ -319,14 +320,17 @@ describe('executeWorkflow', () => {
         {
           preCreatedRun,
           priorCompletedNodes: new Map([['node1', 'out']]),
-          priorTokenUsage: { input: 40, output: 4 },
+          priorUsage: { tokens: { input: 40, output: 4 }, costUsd: 0.5 },
           execContext: { kind: 'container', containerId: 'cid' },
           container: { envId: 'env-x', writeBack: 'approve', backend },
         }
       );
       // Guard passed → DAG entered (mocked no-op) → run completes.
       expect(mockExecuteDagWorkflow).toHaveBeenCalledTimes(1);
-      expect(mockExecuteDagWorkflow.mock.calls[0]?.[24]).toEqual({ input: 40, output: 4 });
+      expect(mockExecuteDagWorkflow.mock.calls[0]?.[24]).toEqual({
+        tokens: { input: 40, output: 4 },
+        costUsd: 0.5,
+      });
       expect(result.success).toBe(true);
     });
   });
@@ -1230,8 +1234,9 @@ describe('executeWorkflow', () => {
       const resumed = makeRun({ id: 'resumed-run', status: 'running' });
       const completedNodeOutputs = new Map([['node-a', 'first output']]);
       const tokens = { input: 40, output: 4 };
+      const costUsd = 0.25;
       const store = makeStore({
-        getDagResumeSnapshot: mock(async () => ({ completedNodeOutputs, tokens })),
+        getDagResumeSnapshot: mock(async () => ({ completedNodeOutputs, tokens, costUsd })),
         resumeWorkflowRun: mock(async () => resumed),
       });
       const deps = makeDeps(store);
@@ -1253,7 +1258,9 @@ describe('executeWorkflow', () => {
 
       const dagCall = mockExecuteDagWorkflow.mock.calls[0];
       expect(dagCall?.[16]).toBe(completedNodeOutputs);
-      expect(dagCall?.[24]).toEqual(tokens);
+      // Both usage axes travel as one `priorUsage` bundle (#2469) — cost is restored
+      // across resume exactly like tokens, so a resumed run's total never regresses.
+      expect(dagCall?.[24]).toEqual({ tokens, costUsd });
       expect(store.createWorkflowRun).not.toHaveBeenCalled();
     });
   });
@@ -2042,6 +2049,7 @@ describe('hydrateResumableRun', () => {
       getDagResumeSnapshot: mock(async () => ({
         completedNodeOutputs: priorNodes,
         tokens: { input: 40, output: 4 },
+        costUsd: 0.75,
       })),
       resumeWorkflowRun: mock(async () => resumed),
     });
@@ -2050,7 +2058,7 @@ describe('hydrateResumableRun', () => {
     expect(result).not.toBeNull();
     expect(result?.preCreatedRun).toBe(resumed);
     expect(result?.priorCompletedNodes).toBe(priorNodes);
-    expect(result?.priorTokenUsage).toEqual({ input: 40, output: 4 });
+    expect(result?.priorUsage).toEqual({ tokens: { input: 40, output: 4 }, costUsd: 0.75 });
     expect(store.resumeWorkflowRun).toHaveBeenCalledWith('prior-failed');
   });
 

--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -2068,6 +2068,7 @@ describe('hydrateResumableRun', () => {
       getDagResumeSnapshot: mock(async () => ({
         completedNodeOutputs: new Map(),
         tokens: { input: 0, output: 0 },
+        costUsd: 0,
       })),
     });
     const deps = makeDeps(store);
@@ -2088,6 +2089,7 @@ describe('hydrateResumableRun', () => {
       getDagResumeSnapshot: mock(async () => ({
         completedNodeOutputs: new Map(),
         tokens: { input: 0, output: 0 },
+        costUsd: 0,
       })),
       resumeWorkflowRun: mock(async () => resumed),
     });
@@ -2115,6 +2117,7 @@ describe('hydrateResumableRun', () => {
       getDagResumeSnapshot: mock(async () => ({
         completedNodeOutputs: new Map([['n1', 'v1']]),
         tokens: { input: 0, output: 0 },
+        costUsd: 0,
       })),
       resumeWorkflowRun: mock(async () => {
         throw new Error('DB write failed');

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -28,7 +28,7 @@ import {
   readSubrunMetadata,
 } from './schemas';
 import { executeDagWorkflow, childOutcomeFromRun } from './dag-executor';
-import type { RunChildWorkflowArgs, ChildWorkflowOutcome } from './dag-executor';
+import type { RunChildWorkflowArgs, ChildWorkflowOutcome, PriorRunUsage } from './dag-executor';
 import { discoverWorkflowsWithConfig } from './workflow-discovery';
 import { maybeWarnLegacyStatePath, maybeWarnLegacyArtifactsPath } from './state-migration';
 import { resolveWorkflowName } from './router';
@@ -437,12 +437,12 @@ type ResumePayload =
   | {
       preCreatedRun: WorkflowRun;
       priorCompletedNodes?: Map<string, string>;
-      priorTokenUsage?: { input: number; output: number };
+      priorUsage?: PriorRunUsage;
     }
   | {
       preCreatedRun?: undefined;
       priorCompletedNodes?: undefined;
-      priorTokenUsage?: undefined;
+      priorUsage?: undefined;
     };
 
 /**
@@ -578,7 +578,7 @@ export async function hydrateResumableRun(
 ): Promise<{
   preCreatedRun: WorkflowRun;
   priorCompletedNodes: Map<string, string>;
-  priorTokenUsage: { input: number; output: number };
+  priorUsage: PriorRunUsage;
 } | null> {
   const snapshot = await deps.store.getDagResumeSnapshot(candidate.id);
   const priorCompletedNodes = snapshot.completedNodeOutputs;
@@ -603,7 +603,11 @@ export async function hydrateResumableRun(
     { workflowRunId: preCreatedRun.id, priorCompletedCount: priorCompletedNodes.size },
     'workflow.dag_resuming'
   );
-  return { preCreatedRun, priorCompletedNodes, priorTokenUsage: snapshot.tokens };
+  return {
+    preCreatedRun,
+    priorCompletedNodes,
+    priorUsage: { tokens: snapshot.tokens, costUsd: snapshot.costUsd },
+  };
 }
 
 /** Depth cap on the `workflow:` sub-run tree (D9). A node nested deeper fails fast. */
@@ -1154,7 +1158,7 @@ export async function executeWorkflow(
     parentConversationId,
     preCreatedRun,
     priorCompletedNodes,
-    priorTokenUsage,
+    priorUsage,
     userId,
     source,
     parseWarnings,
@@ -1366,7 +1370,7 @@ export async function executeWorkflow(
   // preCreatedRun (from hydrateResumableRun) + priorCompletedNodes via opts.
   // When both are absent the executor creates a fresh row below.
   const dagPriorCompletedNodes = priorCompletedNodes;
-  const dagPriorTokenUsage = priorTokenUsage;
+  const dagPriorUsage = priorUsage;
   let workflowRun: WorkflowRun | undefined = preCreatedRun;
 
   if (preCreatedRun && priorCompletedNodes !== undefined) {
@@ -1911,7 +1915,7 @@ export async function executeWorkflow(
       // `isolation: 'worktree'` child gets its own worktree cwd.
       (childArgs: RunChildWorkflowArgs): Promise<ChildWorkflowOutcome> =>
         runChildWorkflow(deps, platform, childArgs, resolveChildIsolation),
-      dagPriorTokenUsage
+      dagPriorUsage
     );
 
     // executeDagWorkflow throws on fatal errors; check DB status for result

--- a/packages/workflows/src/schemas/workflow-run.ts
+++ b/packages/workflows/src/schemas/workflow-run.ts
@@ -295,9 +295,15 @@ export interface ApprovalContext {
    * row reports only the final invocation. That under-report predates this field (before
    * #2333 nothing was persisted at all) and belongs to the "preserve terminal provider
    * stats across a gate" fix tracked by #2345, which also covers the `cost_usd` and
-   * resolved-model loss at the same gate. The RUN row is no longer affected: since #2469
-   * the executor persists `total_tokens_*` / `total_cost_usd` at the run tail on every
-   * disposition, pause included, rather than only inside completeWorkflowRun.
+   * resolved-model loss at the same gate.
+   *
+   * The RUN row has the SAME per-invocation attribution, for the same root cause. Since
+   * #2469 the run-tail write is no longer skipped on pause, so a paused run's row does
+   * carry what that invocation spent — but the baseline it adds to (`priorUsage`) is
+   * rebuilt from `node_completed` rows, and a gate pause deliberately writes none. The
+   * metadata merge replaces each key it names rather than adding to it, so a loop that
+   * gates twice leaves the run row reporting only the final invocation. Same fix
+   * boundary as the node row: #2345.
    */
   signaledTokens?: { input: number; output: number } | null;
   /**

--- a/packages/workflows/src/schemas/workflow-run.ts
+++ b/packages/workflows/src/schemas/workflow-run.ts
@@ -291,14 +291,13 @@ export interface ApprovalContext {
    *
    * Scope note: this is the PAUSING invocation's total, matching what the normal
    * (re-run) completion path reports — a loop that gates more than once attributes each
-   * invocation's usage to that invocation, and EARLIER invocations' usage is reported
-   * nowhere: a pausing invocation never reaches completeWorkflowRun (the status is
-   * `paused`, so the pre-complete status check bails), and `total_tokens_*` are written
-   * only there. So on a twice-gated loop the surviving node row and the run row both
-   * report only the final invocation. That under-report predates this field (before
+   * invocation's usage to that invocation, so on a twice-gated loop the surviving NODE
+   * row reports only the final invocation. That under-report predates this field (before
    * #2333 nothing was persisted at all) and belongs to the "preserve terminal provider
    * stats across a gate" fix tracked by #2345, which also covers the `cost_usd` and
-   * resolved-model loss at the same gate.
+   * resolved-model loss at the same gate. The RUN row is no longer affected: since #2469
+   * the executor persists `total_tokens_*` / `total_cost_usd` at the run tail on every
+   * disposition, pause included, rather than only inside completeWorkflowRun.
    */
   signaledTokens?: { input: number; output: number } | null;
   /**

--- a/packages/workflows/src/script-node-deps.test.ts
+++ b/packages/workflows/src/script-node-deps.test.ts
@@ -112,6 +112,7 @@ function createMockStore(): IWorkflowStore {
       Promise.resolve({
         completedNodeOutputs: new Map<string, string>(),
         tokens: { input: 0, output: 0 },
+        costUsd: 0,
       })
     ),
     getCodebase: mock(() => Promise.resolve(null)),

--- a/packages/workflows/src/store.ts
+++ b/packages/workflows/src/store.ts
@@ -20,6 +20,8 @@ export interface DagResumeSnapshot {
     input: number;
     output: number;
   };
+  /** Cumulative USD cost of the run's already-completed nodes across prior passes. */
+  costUsd: number;
 }
 
 /** Composite primary key identifying a single persisted node session row. */

--- a/packages/workflows/src/subrun.test.ts
+++ b/packages/workflows/src/subrun.test.ts
@@ -236,6 +236,9 @@ class InMemoryStore implements IWorkflowStore {
         typeof e.step_name === 'string'
       ) {
         completedNodeOutputs.set(e.step_name, String(e.data?.node_output ?? ''));
+        // Mirrors the real store: a derived row (loop_group roll-up) restates usage
+        // other rows already carry, so it contributes output but never usage (#2469).
+        if (e.data?.aggregate === true) continue;
         const eventTokens = e.data?.tokens;
         if (
           e.event_type === 'node_completed' &&
@@ -2631,6 +2634,58 @@ nodes:
     );
     expect(workCompleted?.data?.cost_usd).toBeCloseTo(0.03, 5);
     expect(workCompleted?.data?.tokens).toBeDefined();
+  });
+
+  // #2469 (R1) — the 1:1 topology, not just fan-out. The fan-out `failResult` has
+  // carried a failed child's usage since #2224; the single-child one dropped it, so a
+  // parent with one ordinary `workflow:` node still reported zero for a child that
+  // burned tokens and then failed. That is the more common shape of the two.
+  it("rolls up a failed 1:1 child's spend into the parent (no fan_out)", async () => {
+    await writeWorkflow(
+      'solo-child-doomed',
+      `
+name: solo-child-doomed
+description: one AI turn (canned cost 0.01 / 7 in / 3 out), then fails
+mutates_checkout: false
+nodes:
+  - id: think
+    prompt: "work on $ARGUMENTS"
+  - id: fail
+    depends_on: [think]
+    bash: |
+      exit 1
+`
+    );
+    await writeWorkflow(
+      'solo-parent',
+      `
+name: solo-parent
+description: a single non-fan-out sub-run node whose child fails after spending
+nodes:
+  - id: work
+    workflow: solo-child-doomed
+    input: "the task"
+`
+    );
+
+    const store = new InMemoryStore();
+    const deps = makeDeps(store);
+    const parent = await discover('solo-parent');
+    await executeWorkflow(deps, makePlatform(), 'conv-plat', cwd, parent, 'goal', 'conv-db');
+
+    const child = [...store.runs.values()].find(r => r.workflow_name === 'solo-child-doomed');
+    expect(child?.status).toBe('failed');
+    // The child's own row records the spend (the run-tail write).
+    expect((child?.metadata as Record<string, unknown>).total_cost_usd).toBeCloseTo(0.01, 5);
+
+    // ...and so does the parent's, via the node result the failed branch now carries.
+    // The node failed, so the parent run failed too — which is exactly the case that
+    // used to report nothing at all.
+    const parentRun = [...store.runs.values()].find(r => r.workflow_name === 'solo-parent');
+    expect(parentRun?.status).toBe('failed');
+    expect((parentRun?.metadata as Record<string, unknown>).total_cost_usd).toBeCloseTo(0.01, 5);
+    expect((parentRun?.metadata as Record<string, unknown>).total_tokens_in).toBe(7);
+    expect((parentRun?.metadata as Record<string, unknown>).total_tokens_out).toBe(3);
   });
 
   // #2469 — the regression proof. `all_done` is the DEFAULT join and a failing child

--- a/packages/workflows/src/subrun.test.ts
+++ b/packages/workflows/src/subrun.test.ts
@@ -228,6 +228,7 @@ class InMemoryStore implements IWorkflowStore {
   getDagResumeSnapshot: IWorkflowStore['getDagResumeSnapshot'] = workflowRunId => {
     const completedNodeOutputs = new Map<string, string>();
     const tokens = { input: 0, output: 0 };
+    let costUsd = 0;
     for (const e of this.events) {
       if (
         e.workflow_run_id === workflowRunId &&
@@ -250,9 +251,17 @@ class InMemoryStore implements IWorkflowStore {
           tokens.input += eventTokens.input;
           tokens.output += eventTokens.output;
         }
+        const eventCost = e.data?.cost_usd;
+        if (
+          e.event_type === 'node_completed' &&
+          typeof eventCost === 'number' &&
+          Number.isFinite(eventCost)
+        ) {
+          costUsd += eventCost;
+        }
       }
     }
-    return Promise.resolve({ completedNodeOutputs, tokens });
+    return Promise.resolve({ completedNodeOutputs, tokens, costUsd });
   };
 
   getCodebase = (): Promise<null> => Promise.resolve(null);
@@ -2613,15 +2622,87 @@ nodes:
     // 3 children × 0.01 each = 0.03 rolled up to the parent (plan is bash → 0 cost).
     expect((parentRun?.metadata as Record<string, unknown>).total_cost_usd).toBeCloseTo(0.03, 5);
 
-    // Tokens must be PERSISTED on the node_completed event, not merely computed. This is
-    // the axis getDagResumeSnapshot sums to rebuild usage across resume passes — it never
-    // reads cost_usd — so dropping it here under-reports every resumed run by exactly the
-    // children's tokens, silently, and on Codex (which reports no cost) loses everything.
+    // Usage must be PERSISTED on the node_completed event, not merely computed. These
+    // are the axes getDagResumeSnapshot sums to rebuild a run's usage across resume
+    // passes, so dropping either here under-reports every resumed run by exactly the
+    // children's usage — silently, since an absent key is skipped without warning.
     const workCompleted = store.events.find(
       e => e.event_type === 'node_completed' && e.step_name === 'work'
     );
     expect(workCompleted?.data?.cost_usd).toBeCloseTo(0.03, 5);
     expect(workCompleted?.data?.tokens).toBeDefined();
+  });
+
+  // #2469 — the regression proof. `all_done` is the DEFAULT join and a failing child
+  // explicitly must not discard its siblings, so partial failure is a designed, routine
+  // outcome. Before this fix a child that burned tokens and then failed recorded no
+  // spend at all, and the fan-out reported Σ of *completed* children: plausible, lower
+  // than reality, and with no warning to prompt investigation.
+  it('rolls up the spend of EVERY child, including ones that failed after burning tokens', async () => {
+    await writeWorkflow(
+      'fan-child-partial',
+      `
+name: fan-child-partial
+description: one AI turn (canned cost 0.01 / 7 in / 3 out), then the "doomed" item fails
+mutates_checkout: false
+nodes:
+  - id: think
+    prompt: "work on $ARGUMENTS"
+  - id: check
+    depends_on: [think]
+    bash: |
+      test "$ARGUMENTS" != "doomed"
+`
+    );
+    await writeWorkflow(
+      'fan-partial',
+      `
+name: fan-partial
+description: three children, one fails AFTER its AI node already spent tokens
+nodes:
+  - id: plan
+    bash: |
+      printf '%s' '["a","doomed","c"]'
+  - id: work
+    workflow: fan-child-partial
+    depends_on: [plan]
+    fan_out:
+      items: "$plan.output"
+`
+    );
+
+    const store = new InMemoryStore();
+    const deps = makeDeps(store);
+    const parent = await discover('fan-partial');
+    const result = await executeWorkflow(
+      deps,
+      makePlatform(),
+      'conv-plat',
+      cwd,
+      parent,
+      'goal',
+      'conv-db'
+    );
+
+    // all_done: the failed child is represented in the aggregate, not fatal to the node.
+    expect(result.success).toBe(true);
+    const children = [...store.runs.values()].filter(r => r.workflow_name === 'fan-child-partial');
+    expect(children).toHaveLength(3);
+    const failedChild = children.find(r => r.status === 'failed');
+    expect(failedChild).toBeDefined();
+
+    // The failed child's OWN row carries what it spent. This is the assertion that
+    // fails on the pre-fix engine: failWorkflowRun wrote only { error }.
+    const failedMeta = failedChild?.metadata as Record<string, unknown>;
+    expect(failedMeta.total_cost_usd).toBeCloseTo(0.01, 5);
+    expect(failedMeta.total_tokens_in).toBe(7);
+    expect(failedMeta.total_tokens_out).toBe(3);
+
+    // 3 children × 0.01 = 0.03 — Σ of ALL three, not the 0.02 of the two that completed.
+    const parentRun = [...store.runs.values()].find(r => r.workflow_name === 'fan-partial');
+    expect((parentRun?.metadata as Record<string, unknown>).total_cost_usd).toBeCloseTo(0.03, 5);
+    expect((parentRun?.metadata as Record<string, unknown>).total_tokens_in).toBe(21);
+    expect((parentRun?.metadata as Record<string, unknown>).total_tokens_out).toBe(9);
   });
 
   it('parent resume re-drives only the failed instance, skipping completed ones (1:N re-entry)', async () => {


### PR DESCRIPTION
## Problem and outcome

A workflow run's cost and tokens were persisted in exactly one place — the metadata argument of `completeWorkflowRun`. Any other ending recorded no spend at all, and because `childOutcomeFromRun` reads usage straight off the child's row, a fan-out aggregate silently became Σ of *completed* children. `all_done` is the default join and a failing child explicitly must not discard its siblings, so partial failure is a designed, routine outcome: a ten-item fan-out where three children burn tokens and fail reported the spend of seven, on the happy path, with no warning. That is the worst shape for a cost figure — plausible, and wrong in the direction that does not prompt investigation.

- **Outcome:** A run records what it spent whatever its outcome. A failed run's Slack completion message and console cards (the default UI) now carry a cost where they were blank; a partly-failed fan-out reports every child.
- **Invariant:** A workflow run persists the usage it accumulated independently of how it ended — completed, failed, cancelled, or paused — so sub-run and fan-out aggregates sum every child.
- **Scope boundary:** `node_counts` is still not stored for failed runs (different concern, computed after this point). Node-level provider stats lost across an interactive loop gate stay with #2345. No run-tree budget cap (#1961). No schema change and no backfill of historical runs.
- **Root cause:** Usage is accumulated in `runCtx` at the single aggregation point `dag-executor.ts:7893-7905`, read into locals at `:8685-8688`, and serialized **only** into `completeWorkflowRun`'s metadata at `:9060`. The three `failWorkflowRun` call sites pass a message only, and `failWorkflowRun` writes `{ error }` (`core/src/db/workflows.ts:971`). The `skipIfStatusChanged` bail-out for an externally cancelled run returns before either writer. Compounding: `runCtx.totalCostUsd` was seeded to `0` every pass while tokens were seeded from prior events, because `getDagResumeSnapshot` summed `data.tokens` and never `data.cost_usd`.

## Review guidance

- **Feedback requested:** Correctness of the placement — is the run tail genuinely upstream of every disposition, and is the `finally` the right coverage for a throw out of `runLayers`?
- **Start here:** `packages/workflows/src/dag-executor.ts:8683-8737` — `persistRunUsage()` and the `try/finally` around `runLayers()`. Everything else follows from moving the write here.
- **Review order:** `dag-executor.ts` (the write, then the `completeWorkflowRun` call losing its usage keys at `:9060`) → `core/src/db/workflow-events.ts` (cost summing) → `executor.ts` + `store.ts` (the `priorUsage` bundle) → tests.
- **Lower-attention areas:** the `priorTokenUsage` → `priorUsage` rename is mechanical (6 non-test sites, type-check covers it); the four `getDagResumeSnapshot` test stubs gaining `costUsd: 0` are contract mirrors.
- **Known risk or uncertainty:** cost seeding inherits token seeding's semantics exactly, including the pre-existing over-count when an `always_run` node re-executes on resume while its earlier `node_completed` event is still summed. Deliberate — diverging the two axes would be worse than the shared, pre-existing wart.

Two residuals worth knowing before reviewing, both verified and neither introduced here:

- **A node that fails mid-stream still loses its spend from the event log.** `node_failed` writes `data: { error }` only (`dag-executor.ts:2569-2573`) while the result object carries `costUsd`/`tokens` into `ctx` (`:2582-2600`). So the failed *run's row* is now correct, but a later resume can only rebuild what `node_completed` rows hold. The figure never decreases and is never double-counted; it just cannot see a failed attempt's spend. Filed as #2609 — it needs a decision (should `total_cost_usd` mean money burned, or cost of the surviving path?) that would widen this PR.
- **The legacy dashboard card still will not show a failed run's cost.** `WorkflowRunCard.tsx:209-219` nests the cost span inside `isValidNodeCounts(run.metadata?.node_counts)`, and `node_counts` is deliberately still not written on failure. The console (the default UI) has no such gate — `primitives/run.ts:117`, `RunDetailHeader.tsx:117`, `ActiveRunCard.tsx:119`, `RecentRunRow.tsx:133` all key off cost alone — and neither does Slack. Not fixed here because the legacy dashboard is slated for removal and un-gating it would drag `node_counts`-on-failure into scope.

## Solution

The decisive observation is that all dispositions converge on one line. `runLayers(runCtx)` returns exactly once, and everything after it — the container-pause return, the `skipIfStatusChanged` bail-outs for external cancel/pause, both failure branches, the evidence gate, the write-back gate, completion — is a *disposition*, not an accumulation. So the fix is not "teach `failWorkflowRun` to carry usage too"; that satisfies half the invariant (`cancelWorkflowRun` runs in another process with no usage in scope, so a cancelled or gate-cancelled child would still record nothing) and duplicates the payload across three call sites with nothing preventing a fourth from forgetting it. Instead the write moves upstream of the branch.

It goes through `updateWorkflowRun` rather than the terminal writers for a concrete reason: that merge carries no `WHERE status = 'running'` guard, so it still lands on a row another process has already flipped to `cancelled`. `completeWorkflowRun` and `failWorkflowRun` would both refuse it. The evidence gate at `dag-executor.ts:8905` is the existing precedent for the shape — metadata write first, terminal status after. `completeWorkflowRun` now carries `node_counts` and the sub-run `summary` only, so there is one usage writer instead of one per outcome.

The `finally` is load-bearing rather than defensive, and the second commit proves it. `runLayers` guards almost everything — every store call inside the per-node try, the between-layer status check, the artifact writes — but `safeSendMessage` deliberately **rethrows** a FATAL-classified platform error rather than swallowing it (`executor-shared.ts:830-832`; `'unauthorized'`/`'forbidden'`/`'401'` are in `FATAL_PATTERNS`), and the `allSettled` rejected branch calls it outside any try. So a platform whose auth dies mid-run throws clean out of `runLayers`, past every disposition, to `executeWorkflow`'s catch-all — which marks the run **failed**. `persistRunUsage` swallows and logs its own errors so it can never displace the in-flight exception.

Cost also had to become cumulative across resume. Without it, the newly-persisted figure would *decrease*: fail at $0.50, resume, complete having spent $0.20, row reads $0.20. `getDagResumeSnapshot` now sums `data.cost_usd` from `node_completed` rows alongside `data.tokens` and seeds `runCtx.totalCostUsd`, which also closes the pre-existing under-count on every resumed run (total on Codex, which reports no cost either way). `node_skipped_prior_success` rows stay excluded from both axes, so a multi-pass resume cannot multiply a node's usage.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | `metadata.total_cost_usd` / `total_tokens_*` written only on clean completion; a fan-out reported Σ of completed children | Written at the run tail on every disposition; a fan-out reports Σ of all children |
| **Failure behavior** | A failed or cancelled run recorded no spend, silently | Its spend is recorded; a failed metadata write logs `dag.run_usage_persist_failed` and never fails the run |
| **Resumed runs** | Tokens cumulative, cost reset to the current pass | Both cumulative; the persisted figure never decreases across a resume |

## Architecture

```mermaid
flowchart TD
  RL["runLayers() returns — accumulators settled"] ==> W["persistRunUsage()<br/>updateWorkflowRun(metadata) in a finally"]
  W --> Y["metadata.total_cost_usd<br/>total_tokens_in / _out"]
  W --> D{"disposition"}
  D --> P["container pause"]
  D --> S["external cancel / pause"]
  D --> F["failWorkflowRun (3 sites)"]
  D --> C["completeWorkflowRun<br/>node_counts + summary only"]
```

### Changed seams

| Boundary or contract | Change | Evidence |
|---|---|---|
| `executeDagWorkflow → IWorkflowStore` | Usage now written via `updateWorkflowRun` at the run tail; removed from `completeWorkflowRun` | `dag-executor.ts:8683-8737`, `:9060`; `dag-executor.test.ts` "run usage survives every disposition" |
| `getDagResumeSnapshot → executeDagWorkflow` | `DagResumeSnapshot` gains `costUsd`; `priorTokenUsage` becomes a bundled `priorUsage: PriorRunUsage` | `core/src/db/workflow-events.ts:239-292`, `store.ts:17-25`, `executor.ts:603-610` |
| `child run row → childOutcomeFromRun → sumFanOutCost` | Unchanged code; now fed by failed/cancelled children too | `subrun.test.ts` "rolls up the spend of EVERY child…" |

## Review corrections

An independent `/prp-review` returned NEEDS FIXES with three blocking findings. All three were the same omission on different surfaces — the first pass fixed the cost axis where it looked and did not sweep the sites where cost and tokens are deliberately asymmetric.

- **R1 — the 1:1 `workflow:` path dropped a failed child's usage.** `failResult` (`dag-executor.ts:5839`) took only `(error)` while its fan-out sibling (`:6367`) has taken `(error, costUsd?, tokens?)` since #2224, so a parent with one ordinary `workflow:` node still reported zero for a child that burned tokens and failed — the more common topology of the two. Widened to match and passed from the two `interpret()` branches that hold a real outcome. Verified red: reverting just that call site makes the new `subrun.test.ts` case report `undefined`.
- **R2 — the new resume cost sum double-counted a completed `loop_group`.** Its body nodes write their own `node_completed` rows carrying `cost_usd`, and the group writes a roll-up row restating the sum. `tokens` was deliberately omitted from that row for exactly this reason; `cost_usd` was left because nothing summed it — and this PR added the first consumer that does. The roll-up row is now marked `aggregate: true` and `getDagResumeSnapshot` skips marked rows on both axes; the row keeps `cost_usd` so the console's loop_group card (which reads it per event) does not go blank. Covered from both ends — producer marks, consumer skips — since either half silently reintroduces it. **Known limit:** rows written before the marker existed carry no flag, so a run that completed a loop_group under an older build and is resumed under this one can still double-count cost. Bounded and self-clearing.
- **R4 — the `signaledTokens` docblock overclaimed.** It said the run row was no longer affected across a gate. A pause writes no `node_completed`, `priorUsage` is rebuilt from those rows alone, and the merge replaces rather than adds — so a twice-gated loop still reports only the final invocation. Narrowed to that, pointing at the same #2345 boundary as the node row.
- **R5 (suggestion) — fixed.** `persistRunUsage` was documented best-effort and never watched failing; a test now rejects the usage write and asserts the run still completes and `dag.run_usage_persist_failed` is logged.
- **R3 (suggestion) — declined.** It asks for the user-facing warning to cover a failed usage write. That warning says the *run status* could not be saved and the result may appear inconsistent — still accurate for its own failure. A usage-write failure leaves the cost key absent, and every reader type-guards absence and renders blank. Absent is not the failure mode this PR is about; plausible-and-wrong is. The error log carries the run id under a distinct event name, which is the right channel for a bookkeeping write.

## Validation

- `bun run validate` — exit 0 — proves types, `eslint --max-warnings 0`, format, generated-file checks and every package suite.
- `bun test src/dag-executor.test.ts` (packages/workflows) — 502 pass, 0 fail — proves usage is recorded on failure, on out-of-band cancellation, at an approval pause, and when a FATAL platform error throws out of `runLayers`; that a zero-usage run still writes nothing; and that `completeWorkflowRun` no longer carries usage keys.
- Mutation check on the `finally` (CodeRabbit's point, addressed in `47146744`): replacing it with a plain block makes the throw-path case report an empty usage-write list instead of `{0.01, 20, 2}` — the guard is observed firing rather than assumed. Note CodeRabbit's own sketch would not have worked: it proposed rejecting `getWorkflowRunStatus`, which `runLayers` wraps in try/catch at `:7980-8009`.
- `bun test src/subrun.test.ts` (packages/workflows) — 67 pass, 0 fail — the regression proof: three fan-out children, one fails *after* its AI node spent tokens, and the parent rolls up 0.03 (all three) rather than 0.02.
- `bun test src/db/workflow-events.test.ts` (packages/core) — 24 pass, 0 fail — cost summing, `node_skipped_prior_success` exclusion, malformed/non-finite handling, and no warn when cost is simply absent.
- Regression aim confirmed: with the production files stashed, the fan-out case fails at `subrun.test.ts:2694` because the failed child's `metadata.total_cost_usd` is `undefined` — it is aimed at the defect, not at the harness.
- **Not verified:** no live end-to-end run against a real repo with real provider spend. The fan-out case exercises the real recursive `executeWorkflow` against an in-memory store with a canned provider, which covers the persistence path; only the provider's own cost reporting is stubbed, and that is unchanged by this PR.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | No schema change and no key rename. Historical failed runs are **not** backfilled — they keep their absent usage. All four readers already type-guard the keys, so absence stays safe | `web/.../console/primitives/run.ts:117`, `WorkflowRunCard.tsx:213`, `slack/workflow-bridge.ts:301`, `dag-executor.ts:513` |
| Rollout / rollback | Single revertible commit, no flag, no data to unwind. Reverting restores the previous under-report | — |
| Observability | A failed usage write logs `dag.run_usage_persist_failed` with the run id rather than going quiet — the defect being fixed was a number silently going missing | `dag-executor.ts:8725` |
| Documentation / communication | The "Cost roll-up" bullet already promised an unqualified roll-up (the docs were right, the code was wrong); it now states outcome-independence explicitly | `packages/docs-web/src/content/docs/guides/authoring-workflows.md:1433` |

## Links

- Closes #2469
- Related #2224 #2345 #1961 #2356
- Follow-up filed: #2609


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow runs now track cumulative USD costs alongside token usage.
  * Costs persist across completed, failed, cancelled, paused, and resumed runs.
  * Parent workflows include spending from all child workflows, including failed or cancelled children.
  * Resumed workflows restore both prior token usage and cost totals.
  * Fan-out and loop executions aggregate usage across all child work.

* **Bug Fixes**
  * Invalid or missing cost values no longer distort usage totals.
  * Duplicate, replayed, and aggregate usage is excluded from calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->