### PR TITLE
fix(cli): accept run ID prefixes for workflow events

### DIFF
--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -9,7 +9,7 @@ import { Database } from 'bun:sqlite';
 import { parseArgs } from 'util';
 import * as git from '@archon/git';
 import { spawnSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, realpathSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -83,6 +83,11 @@ describe('CLI workflow event dispatch', () => {
 
     try {
       expect(spawnSync('git', ['init', '-q', '.'], { cwd: repoDir }).status).toBe(0);
+      const repoRoot = spawnSync('git', ['rev-parse', '--show-toplevel'], {
+        cwd: repoDir,
+        encoding: 'utf8',
+      });
+      expect(repoRoot.status).toBe(0);
 
       const env = {
         ...process.env,
@@ -104,7 +109,7 @@ describe('CLI workflow event dispatch', () => {
       try {
         database.run(
           'INSERT INTO remote_agent_codebases (id, name, default_cwd) VALUES (?, ?, ?)',
-          ['codebase-1', 'fixture', realpathSync(repoDir)]
+          ['codebase-1', 'fixture', repoRoot.stdout.trim()]
         );
         database.run(
           'INSERT INTO remote_agent_conversations (id, platform_type, platform_conversation_id, codebase_id) VALUES (?, ?, ?, ?)',

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -5,15 +5,19 @@
  * Full integration tests would require mocking the database and commands.
  */
 import { describe, it, expect } from 'bun:test';
+import { Database } from 'bun:sqlite';
 import { parseArgs } from 'util';
 import * as git from '@archon/git';
 import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, realpathSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+const CLI_ENTRY = join(import.meta.dir, 'cli.ts');
+
 describe('CLI help output', () => {
   it('lists the workflow resume command', () => {
-    const result = spawnSync(process.execPath, [join(import.meta.dir, 'cli.ts'), '--help'], {
+    const result = spawnSync(process.execPath, [CLI_ENTRY, '--help'], {
       encoding: 'utf8',
     });
 
@@ -24,7 +28,7 @@ describe('CLI help output', () => {
   });
 
   it('documents workflow dry-run flags', () => {
-    const result = spawnSync(process.execPath, [join(import.meta.dir, 'cli.ts'), '--help'], {
+    const result = spawnSync(process.execPath, [CLI_ENTRY, '--help'], {
       encoding: 'utf8',
     });
 
@@ -67,6 +71,90 @@ describe('workflow get arguments', () => {
     );
     expect(result.stdout).toBe('');
   });
+});
+
+describe('CLI workflow event dispatch', () => {
+  it('resolves a run prefix using the registered effective cwd', () => {
+    const scratch = mkdtempSync(join(tmpdir(), 'archon-cli-event-'));
+    const archonHome = join(scratch, 'home');
+    const repoDir = join(scratch, 'repo');
+    mkdirSync(archonHome, { recursive: true });
+    mkdirSync(repoDir, { recursive: true });
+
+    try {
+      expect(spawnSync('git', ['init', '-q', '.'], { cwd: repoDir }).status).toBe(0);
+
+      const env = {
+        ...process.env,
+        ARCHON_HOME: archonHome,
+        ARCHON_TELEMETRY_DISABLED: '1',
+      };
+      const initialize = spawnSync(
+        process.execPath,
+        [CLI_ENTRY, 'workflow', 'status', '--cwd', repoDir],
+        { env, encoding: 'utf8' }
+      );
+      expect({ status: initialize.status, stderr: initialize.stderr }).toEqual({
+        status: 0,
+        stderr: '',
+      });
+
+      const fullRunId = '0b1ee8da-1111-2222-3333-444455556666';
+      const database = new Database(join(archonHome, 'archon.db'));
+      try {
+        database.run(
+          'INSERT INTO remote_agent_codebases (id, name, default_cwd) VALUES (?, ?, ?)',
+          ['codebase-1', 'fixture', realpathSync(repoDir)]
+        );
+        database.run(
+          'INSERT INTO remote_agent_conversations (id, platform_type, platform_conversation_id, codebase_id) VALUES (?, ?, ?, ?)',
+          ['conversation-1', 'cli', 'cli-fixture', 'codebase-1']
+        );
+        database.run(
+          'INSERT INTO remote_agent_workflow_runs (id, conversation_id, codebase_id, workflow_name, user_message) VALUES (?, ?, ?, ?, ?)',
+          [fullRunId, 'conversation-1', 'codebase-1', 'fixture', 'test']
+        );
+      } finally {
+        database.close();
+      }
+
+      const emitted = spawnSync(
+        process.execPath,
+        [
+          CLI_ENTRY,
+          'workflow',
+          'event',
+          'emit',
+          '--run-id',
+          fullRunId.slice(0, 8),
+          '--type',
+          'workflow_started',
+          '--cwd',
+          repoDir,
+        ],
+        { env, encoding: 'utf8' }
+      );
+      expect({ status: emitted.status, stderr: emitted.stderr }).toEqual({ status: 0, stderr: '' });
+
+      const verify = new Database(join(archonHome, 'archon.db'), { readonly: true });
+      try {
+        const event = verify
+          .query<
+            { workflow_run_id: string; event_type: string },
+            []
+          >('SELECT workflow_run_id, event_type FROM remote_agent_workflow_events')
+          .get();
+        expect(event).toEqual({
+          workflow_run_id: fullRunId,
+          event_type: 'workflow_started',
+        });
+      } finally {
+        verify.close();
+      }
+    } finally {
+      rmSync(scratch, { recursive: true, force: true });
+    }
+  }, 30_000);
 });
 
 // Test the argument parsing logic used in cli.ts

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -774,14 +774,14 @@ async function main(): Promise<number> {
             const eventType = values.type as string | undefined;
             if (!runId) {
               console.error(
-                'Usage: archon workflow event emit --run-id <uuid> --type <event-type>'
+                'Usage: archon workflow event emit --run-id <run-id> --type <event-type>'
               );
               console.error('Error: --run-id is required');
               return 1;
             }
             if (!eventType) {
               console.error(
-                'Usage: archon workflow event emit --run-id <uuid> --type <event-type>'
+                'Usage: archon workflow event emit --run-id <run-id> --type <event-type>'
               );
               console.error('Error: --type is required');
               return 1;
@@ -802,7 +802,7 @@ async function main(): Promise<number> {
                 );
               }
             }
-            await workflowEventEmitCommand(runId, eventType, eventData);
+            await workflowEventEmitCommand(runId, eventType, eventData, effectiveCwd);
             break;
           }
 

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -3995,6 +3995,16 @@ describe('run-id prefix resolution (short ids from `workflow runs`)', () => {
     expect(mockCreateWorkflowEvent).not.toHaveBeenCalled();
   });
 
+  it('rejects an event prefix outside a registered project before creating an event', async () => {
+    const codebaseDb = await import('@archon/core/db/codebases');
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce(null);
+
+    await expect(
+      workflowEventEmitCommand('deadbeef', 'workflow_started', undefined, '/unregistered')
+    ).rejects.toThrow("Cannot resolve run id prefix 'deadbeef' outside a registered project.");
+    expect(mockCreateWorkflowEvent).not.toHaveBeenCalled();
+  });
+
   it('rejects an ambiguous event prefix before creating an event', async () => {
     const workflowDb = await import('@archon/core/db/workflows');
     const codebaseDb = await import('@archon/core/db/codebases');

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -22,6 +22,7 @@ import {
   workflowAbandonCommand,
   workflowApproveCommand,
   workflowRejectCommand,
+  workflowEventEmitCommand,
   workflowCleanupCommand,
   workflowResetSessionsCommand,
   buildDetachedRunCmd,
@@ -40,6 +41,8 @@ const mockLogger = {
   trace: mock(() => undefined),
   child: mock(() => mockLogger),
 };
+
+const mockCreateWorkflowEvent = mock(() => Promise.resolve());
 
 // Mock @archon/paths (createLogger moved here from @archon/core)
 mock.module('@archon/paths', () => ({
@@ -98,9 +101,7 @@ mock.module('@archon/core', () => ({
   generateAndSetTitle: mock(() => Promise.resolve()),
   loadRepoConfig: mock(() => Promise.resolve(null)),
   getUserAiPrefs: mock(() => Promise.resolve({})),
-  createWorkflowStore: mock(() => ({
-    createWorkflowEvent: mock(() => Promise.resolve()),
-  })),
+  createWorkflowStore: mock(() => ({ createWorkflowEvent: mockCreateWorkflowEvent })),
   // requires: [github] gate. Default to a solo-install posture (disabled) so the
   // gate is a no-op for every existing test; the gate-specific tests below flip
   // isPerUserGitHubEnabled on per-invocation.
@@ -3696,6 +3697,7 @@ describe('run-id prefix resolution (short ids from `workflow runs`)', () => {
     (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockClear();
     (workflowDb.findWorkflowRunsByIdPrefix as ReturnType<typeof mock>).mockClear();
     (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockClear();
+    mockCreateWorkflowEvent.mockClear();
   });
 
   afterEach(() => {
@@ -3781,7 +3783,7 @@ describe('run-id prefix resolution (short ids from `workflow runs`)', () => {
     ]);
 
     await expect(workflowResumeCommand('0b1ee8da', undefined, '/repo')).rejects.toThrow(
-      'matches more than one run'
+      '0b1ee8da-1111-2222-3333-444455556666\n  0b1ee8da-9999-8888-7777-666655554444'
     );
   });
 
@@ -3927,6 +3929,28 @@ describe('run-id prefix resolution (short ids from `workflow runs`)', () => {
       action: 'reject',
       cancelled: true,
     });
+  });
+
+  it('emits an event using the resolved full run id', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce(
+      CODEBASE
+    );
+    (workflowDb.findWorkflowRunsByIdPrefix as ReturnType<typeof mock>).mockResolvedValueOnce([
+      { id: FULL_ID },
+    ]);
+
+    await workflowEventEmitCommand('0b1ee8da', 'workflow_started', undefined, '/repo');
+
+    expect(mockCreateWorkflowEvent).toHaveBeenCalledWith({
+      workflow_run_id: FULL_ID,
+      event_type: 'workflow_started',
+      data: undefined,
+    });
+    expect(consoleSpy).toHaveBeenCalledWith(
+      `Event submitted (best-effort): workflow_started for run ${FULL_ID}`
+    );
   });
 
   it('skips resolution when no cwd is provided (exact lookup only)', async () => {

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -160,6 +160,7 @@ mock.module('@archon/workflows/event-emitter', () => ({
 
 mock.module('@archon/git', () => ({
   findRepoRoot: mock(() => Promise.resolve(null)),
+  getCanonicalRepoPath: mock((path: string) => Promise.resolve(path)),
   getRemoteUrl: mock(() => Promise.resolve(null)),
   checkout: mock(() => Promise.resolve()),
   toRepoPath: mock((path: string) => path),
@@ -3951,6 +3952,64 @@ describe('run-id prefix resolution (short ids from `workflow runs`)', () => {
     expect(consoleSpy).toHaveBeenCalledWith(
       `Event submitted (best-effort): workflow_started for run ${FULL_ID}`
     );
+  });
+
+  it('resolves an event prefix from a workspace-scoped worktree', async () => {
+    const git = await import('@archon/git');
+    const workflowDb = await import('@archon/core/db/workflows');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    (git.getCanonicalRepoPath as ReturnType<typeof mock>).mockResolvedValueOnce('/canonical/repo');
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce(
+      CODEBASE
+    );
+    (workflowDb.findWorkflowRunsByIdPrefix as ReturnType<typeof mock>).mockResolvedValueOnce([
+      { id: FULL_ID },
+    ]);
+
+    await workflowEventEmitCommand(
+      '0b1ee8da',
+      'workflow_started',
+      undefined,
+      '/home/test/.archon/workspaces/owner/proj/worktrees/archon/task-2611'
+    );
+
+    expect(codebaseDb.findCodebaseByDefaultCwd).toHaveBeenCalledWith('/canonical/repo');
+    expect(mockCreateWorkflowEvent).toHaveBeenCalledWith({
+      workflow_run_id: FULL_ID,
+      event_type: 'workflow_started',
+      data: undefined,
+    });
+  });
+
+  it('rejects an unmatched event prefix before creating an event', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce(
+      CODEBASE
+    );
+    (workflowDb.findWorkflowRunsByIdPrefix as ReturnType<typeof mock>).mockResolvedValueOnce([]);
+
+    await expect(
+      workflowEventEmitCommand('deadbeef', 'workflow_started', undefined, '/repo')
+    ).rejects.toThrow("No workflow run matches prefix 'deadbeef' in this project.");
+    expect(mockCreateWorkflowEvent).not.toHaveBeenCalled();
+  });
+
+  it('rejects an ambiguous event prefix before creating an event', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce(
+      CODEBASE
+    );
+    (workflowDb.findWorkflowRunsByIdPrefix as ReturnType<typeof mock>).mockResolvedValueOnce([
+      { id: '0b1ee8da-1111-2222-3333-444455556666' },
+      { id: '0b1ee8da-9999-8888-7777-666655554444' },
+    ]);
+
+    await expect(
+      workflowEventEmitCommand('0b1ee8da', 'workflow_started', undefined, '/repo')
+    ).rejects.toThrow('matches more than one run');
+    expect(mockCreateWorkflowEvent).not.toHaveBeenCalled();
   });
 
   it('skips resolution when no cwd is provided (exact lookup only)', async () => {

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -2593,16 +2593,32 @@ const FULL_RUN_ID_RE =
  * codebase, a unique match resolves, and an ambiguous prefix errors.
  *
  * Full UUIDs skip resolution entirely — exact lookup is global, so full ids
- * keep working from any directory. When `cwd` is omitted, the cwd is not a
- * registered project, or the prefix matches nothing in this project, the
- * argument passes through unchanged so the downstream exact lookup keeps its
- * existing error surface (intentional fallback: it preserves behavior for
- * runs of other projects and non-UUID ids rather than guessing).
+ * keep working from any directory. Worktree paths are normalized to their
+ * canonical checkout before project lookup. By default, an omitted or
+ * unregistered cwd and an unmatched prefix pass through unchanged so the
+ * downstream exact lookup keeps its existing error surface. Callers without a
+ * downstream lookup can require a match instead.
  */
-async function resolveRunIdArg(runId: string, cwd?: string): Promise<string> {
-  if (cwd === undefined || FULL_RUN_ID_RE.test(runId)) return runId;
-  const codebase = await codebaseDb.findCodebaseByDefaultCwd(cwd);
-  if (!codebase) return runId;
+async function resolveRunIdArg(
+  runId: string,
+  cwd?: string,
+  requirePrefixMatch = false
+): Promise<string> {
+  if (FULL_RUN_ID_RE.test(runId)) return runId;
+  if (cwd === undefined) {
+    if (requirePrefixMatch) {
+      throw new Error(`Cannot resolve run id prefix '${runId}' without a project directory.`);
+    }
+    return runId;
+  }
+  const canonicalCwd = await git.getCanonicalRepoPath(cwd);
+  const codebase = await codebaseDb.findCodebaseByDefaultCwd(canonicalCwd);
+  if (!codebase) {
+    if (requirePrefixMatch) {
+      throw new Error(`Cannot resolve run id prefix '${runId}' outside a registered project.`);
+    }
+    return runId;
+  }
   const matches = await workflowDb.findWorkflowRunsByIdPrefix(runId, codebase.id);
   if (matches.length > 1) {
     const candidates = matches.map(match => `  ${match.id}`).join('\n');
@@ -2610,7 +2626,13 @@ async function resolveRunIdArg(runId: string, cwd?: string): Promise<string> {
       `Run id '${runId}' matches more than one run in this project:\n${candidates}\nUse more characters or the full id.`
     );
   }
-  return matches[0]?.id ?? runId;
+  if (matches.length === 0) {
+    if (requirePrefixMatch) {
+      throw new Error(`No workflow run matches prefix '${runId}' in this project.`);
+    }
+    return runId;
+  }
+  return matches[0].id;
 }
 
 async function resolveDiscoveryCwdForCodebase(
@@ -3069,7 +3091,7 @@ export async function workflowEventEmitCommand(
   data?: Record<string, unknown>,
   cwd?: string
 ): Promise<void> {
-  const resolvedId = await resolveRunIdArg(runId, cwd);
+  const resolvedId = await resolveRunIdArg(runId, cwd, true);
   const store = createWorkflowStore();
   await store.createWorkflowEvent({
     workflow_run_id: resolvedId,

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -2605,8 +2605,9 @@ async function resolveRunIdArg(runId: string, cwd?: string): Promise<string> {
   if (!codebase) return runId;
   const matches = await workflowDb.findWorkflowRunsByIdPrefix(runId, codebase.id);
   if (matches.length > 1) {
+    const candidates = matches.map(match => `  ${match.id}`).join('\n');
     throw new Error(
-      `Run id '${runId}' matches more than one run in this project — use more characters or the full id (from 'archon workflow runs --json').`
+      `Run id '${runId}' matches more than one run in this project:\n${candidates}\nUse more characters or the full id.`
     );
   }
   return matches[0]?.id ?? runId;
@@ -3055,7 +3056,8 @@ export async function workflowCleanupCommand(days: number): Promise<void> {
 
 /**
  * Emit a workflow event directly to the database.
- * Non-throwing: mirrors the fire-and-forget contract of createWorkflowEvent.
+ * Event persistence mirrors createWorkflowEvent's fire-and-forget contract;
+ * run-id resolution can still fail before the event reaches the store.
  */
 export function isValidEventType(value: string): value is WorkflowEventType {
   return (WORKFLOW_EVENT_TYPES as readonly string[]).includes(value);
@@ -3064,17 +3066,19 @@ export function isValidEventType(value: string): value is WorkflowEventType {
 export async function workflowEventEmitCommand(
   runId: string,
   eventType: WorkflowEventType,
-  data?: Record<string, unknown>
+  data?: Record<string, unknown>,
+  cwd?: string
 ): Promise<void> {
+  const resolvedId = await resolveRunIdArg(runId, cwd);
   const store = createWorkflowStore();
   await store.createWorkflowEvent({
-    workflow_run_id: runId,
+    workflow_run_id: resolvedId,
     event_type: eventType,
     data,
   });
   // createWorkflowEvent is non-throwing (fire-and-forget) — the event may not
   // have been persisted if the DB was unavailable. Check server logs if missing.
-  console.log(`Event submitted (best-effort): ${eventType} for run ${runId}`);
+  console.log(`Event submitted (best-effort): ${eventType} for run ${resolvedId}`);
 }
 
 // ─── Marketplace commands ────────────────────────────────────────────────────

--- a/packages/docs-web/src/content/docs/contributing/cli-internals.md
+++ b/packages/docs-web/src/content/docs/contributing/cli-internals.md
@@ -208,7 +208,8 @@ packages/cli/
 │ workflow.ts  workflowEventEmitCommand(..., cwd)                   │
 │              Resolve an unambiguous run-id prefix                 │
 │              createWorkflowStore().createWorkflowEvent(...)       │
-│              Non-throwing (fire-and-forget)                       │
+│              Persistence is non-throwing (fire-and-forget)        │
+│              Run-ID resolution may fail                           │
 └──────────────────────────────────────────────────────────────────┘
 ```
 

--- a/packages/docs-web/src/content/docs/contributing/cli-internals.md
+++ b/packages/docs-web/src/content/docs/contributing/cli-internals.md
@@ -193,7 +193,7 @@ packages/cli/
 
 ```
 ┌──────────────────────────────────────────────────────────────────┐
-│ archon workflow event emit --run-id <uuid> --type <type> [...]   │
+│ archon workflow event emit --run-id <run-id> --type <type> [...] │
 └──────────────────────────────┬───────────────────────────────────┘
                                │
                                ▼
@@ -205,7 +205,8 @@ packages/cli/
                                │
                                ▼
 ┌──────────────────────────────────────────────────────────────────┐
-│ workflow.ts  workflowEventEmitCommand(runId, eventType, data?)   │
+│ workflow.ts  workflowEventEmitCommand(..., cwd)                   │
+│              Resolve an unambiguous run-id prefix                 │
 │              createWorkflowStore().createWorkflowEvent(...)       │
 │              Non-throwing (fire-and-forget)                       │
 └──────────────────────────────────────────────────────────────────┘

--- a/packages/docs-web/src/content/docs/reference/cli.md
+++ b/packages/docs-web/src/content/docs/reference/cli.md
@@ -481,18 +481,20 @@ to filter by node, since this is a destructive command.
 Emit a workflow event directly to the database. Primarily used inside workflow loop prompts to record story-level lifecycle events.
 
 ```bash
-archon workflow event emit --run-id <uuid> --type <event-type> [--data <json>]
+archon workflow event emit --run-id <run-id> --type <event-type> [--data <json>]
 ```
+
+`<run-id>` accepts either the full ID or an unambiguous prefix from `workflow runs`.
 
 **Flags:**
 
 | Flag | Required | Description |
 |------|----------|-------------|
-| `--run-id` | Yes | UUID of the workflow run |
+| `--run-id` | Yes | Full workflow run ID or an unambiguous prefix |
 | `--type` | Yes | Event type (e.g., `ralph_story_started`, `node_completed`) |
 | `--data` | No | JSON string attached to the event. Invalid JSON prints a warning and is ignored. |
 
-Exit code: 0 on success, 1 when `--run-id`, `--type` is missing, or `--type` is not a valid event type. Event persistence is best-effort (non-throwing) -- check server logs if events appear missing.
+Exit code: 0 on submission, 1 when a required argument is missing, the event type is invalid, or run-ID prefix resolution fails. Event persistence is best-effort (non-throwing) -- check server logs if events appear missing.
 
 ### `isolation list`
 

--- a/packages/docs-web/src/content/docs/reference/cli.md
+++ b/packages/docs-web/src/content/docs/reference/cli.md
@@ -485,12 +485,14 @@ archon workflow event emit --run-id <run-id> --type <event-type> [--data <json>]
 ```
 
 `<run-id>` accepts either the full ID or an unambiguous prefix from `workflow runs`.
+A prefix resolves only from the originating registered project's directory, including
+its worktrees; use the full ID elsewhere.
 
 **Flags:**
 
 | Flag | Required | Description |
 |------|----------|-------------|
-| `--run-id` | Yes | Full workflow run ID or an unambiguous prefix |
+| `--run-id` | Yes | Full workflow run ID, or an unambiguous prefix used from the originating registered project's directory or one of its worktrees; use the full ID elsewhere |
 | `--type` | Yes | Event type (e.g., `ralph_story_started`, `node_completed`) |
 | `--data` | No | JSON string attached to the event. Invalid JSON prints a warning and is ignored. |
 


### PR DESCRIPTION
## Problem and outcome

`workflow runs` shows short run IDs, but `workflow event emit` required the full ID while the other run-id-taking commands already accepted an unambiguous prefix. This made the event command inconsistent with the CLI surface described in #2611.

- **Outcome:** `archon workflow event emit --run-id <prefix>` now resolves an unambiguous project-scoped prefix, and ambiguous input lists full matching IDs.
- **Invariant:** JSON command output continues to carry full run IDs.
- **Scope boundary:** This change is limited to the CLI event command and its documentation; workflow runtime and database behavior are unchanged.
- **Root cause:** The event command bypassed the existing shared `resolveRunIdArg` helper and did not receive the CLI working directory needed for project-scoped resolution.

## Review guidance

- **Feedback requested:** Confirm the event command now follows the same shared resolution contract as the other run-id-taking CLI commands.
- **Start here:** `packages/cli/src/commands/workflow.ts:3066` — resolves the supplied ID before persisting the event.
- **Review order:** Shared resolver behavior in `packages/cli/src/commands/workflow.ts`, CLI wiring in `packages/cli/src/cli.ts`, then focused regression coverage in `packages/cli/src/commands/workflow.test.ts`.
- **Lower-attention areas:** The documentation edits describe the same CLI contract and usage text.
- **Known risk or uncertainty:** None.

## Solution

The event command now reuses `resolveRunIdArg`, passing the effective CLI cwd from its entry point. The shared helper resolves one matching prefix to its full ID and reports every candidate when a prefix is ambiguous, so no command-specific resolver was added. The resolved ID is used both for persistence and the confirmation message.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | `workflow event emit` required a full run ID. | It accepts a unique prefix printed by `workflow runs`. |
| **Failure behavior** | An ambiguous or shortened ID was not resolved by this command. | An ambiguous prefix fails and lists full matching IDs. |

## Validation

- `cd packages/cli && bun test src/commands/workflow.test.ts` — passed (229 tests), including event prefix resolution and ambiguous-candidate coverage.
- `cd packages/cli && bun run type-check` — passed.
- **Not verified:** Full `bun run validate` was reported passing by the implementation run; the focused CLI test and type check above were rerun from the committed tree.

## Links

- Closes #2611


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Workflow events can be emitted using an unambiguous run-ID prefix from the associated project or worktree.
  - Commands display the resolved full run ID after successful event emission.

- **Bug Fixes**
  - Improved run-ID resolution across registered projects and worktrees.
  - Added clear errors for missing, unmatched, or ambiguous prefixes.
  - Added validation for invalid workflow command arguments.

- **Documentation**
  - Updated CLI guidance, examples, accepted identifiers, and exit-code details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->