### PR TITLE
fix(workflows): keep skipped composed blocks airtight

### DIFF
--- a/packages/workflows/src/compiled-command.ts
+++ b/packages/workflows/src/compiled-command.ts
@@ -1,3 +1,5 @@
+import type { TriggerRule } from './schemas';
+
 /** Engine-private per-node metadata attached during load-time include expansion.
  * Symbols survive object spreads but stay out of YAML, JSON, API payloads, and
  * persisted workflow definitions.
@@ -20,6 +22,18 @@ export interface LoopWithCompiledCommand {
 export const COMPOSED_NODE = Symbol('archon.composed-node');
 
 /**
+ * The caller-level predicate that decides whether one include instance is active.
+ * Every descendant carries a copy because load-time expansion removes the include node.
+ */
+export interface ComposedBlockBoundary {
+  dependsOn: string[];
+  entryTriggerRules: [TriggerRule, ...TriggerRule[]];
+  when?: string;
+  /** The node's own trigger/when fields already enforce this boundary at the entry. */
+  isEntry: boolean;
+}
+
+/**
  * Per-node record of the workflow a node was AUTHORED in, attached when that
  * workflow is inlined into a parent (#1764). It is what lets a composed node keep
  * behaving like its own file's node instead of the composing parent's:
@@ -33,11 +47,14 @@ export const COMPOSED_NODE = Symbol('archon.composed-node');
  *  - `blockEntry` — this node starts its block. The executor clears the sequential
  *    session cursor there so a composed workflow begins as coldly as it would
  *    standalone.
+ *  - `boundaries` — caller-level activation predicates for enclosing include instances,
+ *    outermost first. Non-entry descendants enforce them before their local trigger rule.
  */
 export interface ComposedNodeMeta {
   origin: string;
   inputs?: Record<string, string>;
   blockEntry?: true;
+  boundaries?: ComposedBlockBoundary[];
 }
 
 export interface NodeWithComposedMeta {

--- a/packages/workflows/src/compiled-command.ts
+++ b/packages/workflows/src/compiled-command.ts
@@ -25,13 +25,25 @@ export const COMPOSED_NODE = Symbol('archon.composed-node');
  * The caller-level predicate that decides whether one include instance is active.
  * Every descendant carries a copy because load-time expansion removes the include node.
  */
-export interface ComposedBlockBoundary {
+interface ComposedBlockBoundaryBase {
   dependsOn: string[];
   entryTriggerRules: [TriggerRule, ...TriggerRule[]];
   when?: string;
-  /** The node's own trigger/when fields already enforce this boundary at the entry. */
-  isEntry: boolean;
 }
+
+export type ComposedBlockBoundary = ComposedBlockBoundaryBase &
+  (
+    | {
+        /** The node's own trigger/when fields normally enforce this boundary at the entry. */
+        isEntry: true;
+        /** Resume needs this entry's rule rather than the block-wide rule set. */
+        entryTriggerRule: TriggerRule;
+      }
+    | {
+        isEntry: false;
+        entryTriggerRule?: never;
+      }
+  );
 
 /**
  * Per-node record of the workflow a node was AUTHORED in, attached when that

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -18677,6 +18677,36 @@ describe('executeDagWorkflow -- flattened include expansion', () => {
     return [...workflows.get('multi-sink-parent')!.nodes];
   }
 
+  function expandedMixedEntryTriggerNodes(): DagNode[] {
+    const upstream = buildWf('upstream', [
+      { id: 'start', bash: 'echo start' },
+      { id: 'good', bash: 'echo good', depends_on: ['start'] },
+      {
+        id: 'bad',
+        bash: 'echo bad',
+        depends_on: ['start'],
+        when: "$start.output == 'never'",
+      },
+    ]);
+    const downstream = buildWf('downstream', [
+      { id: 'strict', bash: 'echo strict', trigger_rule: 'all_success' },
+      { id: 'lenient', bash: 'echo lenient', trigger_rule: 'one_success' },
+    ]);
+    const parent = buildWf('mixed-entry-parent', [
+      { id: 'up', include: 'upstream' },
+      { id: 'down', include: 'downstream', depends_on: ['up'] },
+    ]);
+    const { workflows, errors } = expandWorkflowIncludes(
+      new Map([
+        ['upstream', upstream],
+        ['downstream', downstream],
+        ['mixed-entry-parent', parent],
+      ])
+    );
+    expect(errors).toHaveLength(0);
+    return [...workflows.get('mixed-entry-parent')!.nodes];
+  }
+
   function eventList(deps: WorkflowDeps): Array<{ event_type: string; step_name: string }> {
     return (deps.store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls.map(
       (call: unknown[]) => call[0] as { event_type: string; step_name: string }
@@ -18865,6 +18895,30 @@ describe('executeDagWorkflow -- flattened include expansion', () => {
     ]);
     expect(completed).toEqual(['gate']);
     expect(reused.filter(stepName => stepName.startsWith('review__'))).toEqual([]);
+  });
+
+  it("resume evaluates each cached block entry with that entry's trigger rule", async () => {
+    const priorCompletedNodes = new Map<string, string>([
+      ['up__start', 'start'],
+      ['up__good', 'good'],
+      ['down__strict', 'old-strict'],
+      ['down__lenient', 'old-lenient'],
+    ]);
+    const { events } = await executeExpanded(
+      expandedMixedEntryTriggerNodes(),
+      'inc-resume-mixed-entry-rules',
+      priorCompletedNodes
+    );
+    const skipped = events
+      .filter(event => event.event_type === 'node_skipped')
+      .map(event => event.step_name);
+    const reused = events
+      .filter(event => event.event_type === 'node_skipped_prior_success')
+      .map(event => event.step_name);
+
+    expect(skipped).toContain('down__strict');
+    expect(reused).toContain('down__lenient');
+    expect(reused).not.toContain('down__strict');
   });
 
   it('emits namespaced step_names and resolves $inc.output to the child terminal node', async () => {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -18499,11 +18499,160 @@ describe('executeDagWorkflow -- flattened include expansion', () => {
     return [...workflows.get('inc-parent')!.nodes];
   }
 
+  function expandedGatedParentNodes(
+    mode: 'false-condition' | 'skipped-dependency' | 'active'
+  ): DagNode[] {
+    const child = buildWf('review-block', [
+      { id: 'entry', bash: 'echo started' },
+      {
+        id: 'optional',
+        bash: 'echo optional',
+        depends_on: ['entry'],
+        when: "$entry.output == 'never'",
+      },
+      { id: 'required', bash: 'echo report', depends_on: ['entry'] },
+      {
+        id: 'synthesize',
+        bash: 'echo synthesized',
+        depends_on: ['optional', 'required'],
+        trigger_rule: 'all_done',
+      },
+    ]);
+    const gateNodes =
+      mode === 'skipped-dependency'
+        ? [
+            { id: 'source', bash: 'echo ready' },
+            {
+              id: 'gate',
+              bash: 'echo gate',
+              depends_on: ['source'],
+              when: "$source.output == 'never'",
+            },
+          ]
+        : [{ id: 'gate', bash: `echo ${mode === 'active' ? 'run' : 'skip'}` }];
+    const parent = buildWf('gated-parent', [
+      ...gateNodes,
+      {
+        id: 'review',
+        include: 'review-block',
+        depends_on: ['gate'],
+        ...(mode === 'skipped-dependency' ? {} : { when: "$gate.output == 'run'" }),
+      },
+      { id: 'consumer', bash: 'echo $review.output', depends_on: ['review'] },
+    ]);
+    const { workflows, errors } = expandWorkflowIncludes(
+      new Map([
+        ['review-block', child],
+        ['gated-parent', parent],
+      ])
+    );
+    expect(errors).toHaveLength(0);
+    return [...workflows.get('gated-parent')!.nodes];
+  }
+
   function eventList(deps: WorkflowDeps): Array<{ event_type: string; step_name: string }> {
     return (deps.store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls.map(
       (call: unknown[]) => call[0] as { event_type: string; step_name: string }
     );
   }
+
+  async function executeExpanded(
+    nodes: DagNode[],
+    runId: string
+  ): Promise<{ events: Array<{ event_type: string; step_name: string }>; output: string }> {
+    const mockDeps = createMockDeps();
+    const output = await executeDagWorkflow(
+      mockDeps,
+      createMockPlatform(),
+      'conv-inc',
+      testDir,
+      { name: 'gated-parent', nodes },
+      makeWorkflowRun(runId, { workflow_name: 'gated-parent' }),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+    return { events: eventList(mockDeps), output };
+  }
+
+  it('skips every composed node when the include condition is false', async () => {
+    const { events } = await executeExpanded(
+      expandedGatedParentNodes('false-condition'),
+      'inc-false-condition'
+    );
+    const skipped = events
+      .filter(event => event.event_type === 'node_skipped')
+      .map(event => event.step_name)
+      .sort();
+    const completed = events
+      .filter(event => event.event_type === 'node_completed')
+      .map(event => event.step_name)
+      .sort();
+
+    expect(skipped).toEqual([
+      'consumer',
+      'review__entry',
+      'review__optional',
+      'review__required',
+      'review__synthesize',
+    ]);
+    expect(completed).toEqual(['gate']);
+  });
+
+  it('skips every composed node when the include dependencies are ineligible', async () => {
+    const { events } = await executeExpanded(
+      expandedGatedParentNodes('skipped-dependency'),
+      'inc-skipped-dependency'
+    );
+    const skipped = events
+      .filter(event => event.event_type === 'node_skipped')
+      .map(event => event.step_name)
+      .sort();
+    const completed = events
+      .filter(event => event.event_type === 'node_completed')
+      .map(event => event.step_name)
+      .sort();
+
+    expect(skipped).toEqual([
+      'consumer',
+      'gate',
+      'review__entry',
+      'review__optional',
+      'review__required',
+      'review__synthesize',
+    ]);
+    expect(completed).toEqual(['source']);
+  });
+
+  it('keeps all_done active for intentionally skipped branches inside a running block', async () => {
+    const { events, output } = await executeExpanded(
+      expandedGatedParentNodes('active'),
+      'inc-active-block'
+    );
+    const skipped = events
+      .filter(event => event.event_type === 'node_skipped')
+      .map(event => event.step_name)
+      .sort();
+    const completed = events
+      .filter(event => event.event_type === 'node_completed')
+      .map(event => event.step_name)
+      .sort();
+
+    expect(skipped).toEqual(['review__optional']);
+    expect(completed).toEqual([
+      'consumer',
+      'gate',
+      'review__entry',
+      'review__required',
+      'review__synthesize',
+    ]);
+    expect(output).toContain('synthesized');
+  });
 
   it('emits namespaced step_names and resolves $inc.output to the child terminal node', async () => {
     const mockDeps = createMockDeps();

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -18550,6 +18550,44 @@ describe('executeDagWorkflow -- flattened include expansion', () => {
     return [...workflows.get('gated-parent')!.nodes];
   }
 
+  function expandedMultiSinkDependencyNodes(
+    entryTriggerRule: 'all_success' | 'one_success'
+  ): DagNode[] {
+    const upstream = buildWf('upstream', [
+      { id: 'start', bash: 'echo start' },
+      { id: 'good', bash: 'echo good', depends_on: ['start'] },
+      {
+        id: 'bad',
+        bash: 'echo bad',
+        depends_on: ['start'],
+        when: "$start.output == 'never'",
+      },
+    ]);
+    const downstream = buildWf('downstream', [
+      { id: 'entry', bash: 'echo entry', trigger_rule: entryTriggerRule },
+      {
+        id: 'synthesize',
+        bash: 'echo synthesized',
+        depends_on: ['entry'],
+        trigger_rule: 'all_done',
+      },
+    ]);
+    const parent = buildWf('multi-sink-parent', [
+      { id: 'up', include: 'upstream' },
+      { id: 'down', include: 'downstream', depends_on: ['up'] },
+      { id: 'consumer', bash: 'echo $down.output', depends_on: ['down'] },
+    ]);
+    const { workflows, errors } = expandWorkflowIncludes(
+      new Map([
+        ['upstream', upstream],
+        ['downstream', downstream],
+        ['multi-sink-parent', parent],
+      ])
+    );
+    expect(errors).toHaveLength(0);
+    return [...workflows.get('multi-sink-parent')!.nodes];
+  }
+
   function eventList(deps: WorkflowDeps): Array<{ event_type: string; step_name: string }> {
     return (deps.store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls.map(
       (call: unknown[]) => call[0] as { event_type: string; step_name: string }
@@ -18652,6 +18690,48 @@ describe('executeDagWorkflow -- flattened include expansion', () => {
       'review__synthesize',
     ]);
     expect(output).toContain('synthesized');
+  });
+
+  it('keeps a block inactive when one sink of an included dependency is ineligible', async () => {
+    const { events } = await executeExpanded(
+      expandedMultiSinkDependencyNodes('all_success'),
+      'inc-multi-sink-inactive'
+    );
+    const skipped = events
+      .filter(event => event.event_type === 'node_skipped')
+      .map(event => event.step_name)
+      .sort();
+    const completed = events
+      .filter(event => event.event_type === 'node_completed')
+      .map(event => event.step_name)
+      .sort();
+
+    expect(skipped).toEqual(['consumer', 'down__entry', 'down__synthesize', 'up__bad']);
+    expect(completed).toEqual(['up__good', 'up__start']);
+  });
+
+  it('keeps a one_success block active when any sink of an included dependency succeeds', async () => {
+    const { events } = await executeExpanded(
+      expandedMultiSinkDependencyNodes('one_success'),
+      'inc-multi-sink-active'
+    );
+    const skipped = events
+      .filter(event => event.event_type === 'node_skipped')
+      .map(event => event.step_name)
+      .sort();
+    const completed = events
+      .filter(event => event.event_type === 'node_completed')
+      .map(event => event.step_name)
+      .sort();
+
+    expect(skipped).toEqual(['up__bad']);
+    expect(completed).toEqual([
+      'consumer',
+      'down__entry',
+      'down__synthesize',
+      'up__good',
+      'up__start',
+    ]);
   });
 
   it('emits namespaced step_names and resolves $inc.output to the child terminal node', async () => {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -18500,7 +18500,8 @@ describe('executeDagWorkflow -- flattened include expansion', () => {
   }
 
   function expandedGatedParentNodes(
-    mode: 'false-condition' | 'skipped-dependency' | 'active'
+    mode: 'false-condition' | 'skipped-dependency' | 'active',
+    alwaysRunGateAndConsumer = false
   ): DagNode[] {
     const child = buildWf('review-block', [
       { id: 'entry', bash: 'echo started' },
@@ -18529,7 +18530,13 @@ describe('executeDagWorkflow -- flattened include expansion', () => {
               when: "$source.output == 'never'",
             },
           ]
-        : [{ id: 'gate', bash: `echo ${mode === 'active' ? 'run' : 'skip'}` }];
+        : [
+            {
+              id: 'gate',
+              bash: `echo ${mode === 'active' ? 'run' : 'skip'}`,
+              ...(alwaysRunGateAndConsumer ? { always_run: true } : {}),
+            },
+          ];
     const parent = buildWf('gated-parent', [
       ...gateNodes,
       {
@@ -18538,7 +18545,12 @@ describe('executeDagWorkflow -- flattened include expansion', () => {
         depends_on: ['gate'],
         ...(mode === 'skipped-dependency' ? {} : { when: "$gate.output == 'run'" }),
       },
-      { id: 'consumer', bash: 'echo $review.output', depends_on: ['review'] },
+      {
+        id: 'consumer',
+        bash: 'echo $review.output',
+        depends_on: ['review'],
+        ...(alwaysRunGateAndConsumer ? { always_run: true } : {}),
+      },
     ]);
     const { workflows, errors } = expandWorkflowIncludes(
       new Map([
@@ -18596,7 +18608,8 @@ describe('executeDagWorkflow -- flattened include expansion', () => {
 
   async function executeExpanded(
     nodes: DagNode[],
-    runId: string
+    runId: string,
+    priorCompletedNodes?: Map<string, string>
   ): Promise<{ events: Array<{ event_type: string; step_name: string }>; output: string }> {
     const mockDeps = createMockDeps();
     const output = await executeDagWorkflow(
@@ -18613,7 +18626,10 @@ describe('executeDagWorkflow -- flattened include expansion', () => {
       join(testDir, 'logs'),
       'main',
       'docs/',
-      minimalConfig
+      minimalConfig,
+      undefined,
+      undefined,
+      priorCompletedNodes
     );
     return { events: eventList(mockDeps), output };
   }
@@ -18732,6 +18748,43 @@ describe('executeDagWorkflow -- flattened include expansion', () => {
       'up__good',
       'up__start',
     ]);
+  });
+
+  it('resume discards cached block output when its include gate becomes inactive', async () => {
+    const priorCompletedNodes = new Map<string, string>([
+      ['gate', 'run'],
+      ['review__entry', 'started'],
+      ['review__required', 'report'],
+      ['review__synthesize', 'old-sink'],
+      ['consumer', 'old-consumer'],
+    ]);
+    const { events } = await executeExpanded(
+      expandedGatedParentNodes('false-condition', true),
+      'inc-resume-inactive-block',
+      priorCompletedNodes
+    );
+
+    const skipped = events
+      .filter(event => event.event_type === 'node_skipped')
+      .map(event => event.step_name)
+      .sort();
+    const completed = events
+      .filter(event => event.event_type === 'node_completed')
+      .map(event => event.step_name)
+      .sort();
+    const reused = events
+      .filter(event => event.event_type === 'node_skipped_prior_success')
+      .map(event => event.step_name);
+
+    expect(skipped).toEqual([
+      'consumer',
+      'review__entry',
+      'review__optional',
+      'review__required',
+      'review__synthesize',
+    ]);
+    expect(completed).toEqual(['gate']);
+    expect(reused.filter(stepName => stepName.startsWith('review__'))).toEqual([]);
   });
 
   it('emits namespaced step_names and resolves $inc.output to the child terminal node', async () => {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -18687,7 +18687,10 @@ describe('executeDagWorkflow -- flattened include expansion', () => {
     nodes: DagNode[],
     runId: string,
     priorCompletedNodes?: Map<string, string>
-  ): Promise<{ events: Array<{ event_type: string; step_name: string }>; output: string }> {
+  ): Promise<{
+    events: Array<{ event_type: string; step_name: string }>;
+    output: string | undefined;
+  }> {
     const mockDeps = createMockDeps();
     const output = await executeDagWorkflow(
       mockDeps,

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -1351,16 +1351,18 @@ function checkTriggerRuleForDependencies(
 
 /**
  * Enforce caller-level include predicates that load-time flattening attached to every
- * descendant. Entry nodes keep using their ordinary trigger/when fields so they retain
- * the existing diagnostics; only descendants need the recovered boundary guard.
+ * descendant. Entry nodes normally keep using their ordinary trigger/when fields so they
+ * retain the existing diagnostics. A cached entry is the exception: resume would otherwise
+ * return its prior output before those fields run, so its boundary must be checked here too.
  */
 export function checkComposedBlockBoundaries(
   node: DagNode,
   nodeOutputs: Map<string, NodeOutput>,
-  inputs?: Record<string, string>
+  inputs?: Record<string, string>,
+  evaluateEntryBoundary = false
 ): 'run' | 'skip' {
   for (const boundary of readComposedMeta(node)?.boundaries ?? []) {
-    if (boundary.isEntry) continue;
+    if (boundary.isEntry && !evaluateEntryBoundary) continue;
 
     const dependencyEligible = boundary.entryTriggerRules.some(
       rule => checkTriggerRuleForDependencies(boundary.dependsOn, rule, nodeOutputs) === 'run'
@@ -7188,9 +7190,21 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
               ctx.nodeOutputs
             );
 
-          // 0. Skip if this node completed successfully in a prior run (resume path).
-          // `always_run: true` opts the node out of resume caching — re-execute even
-          // when the prior run completed it.
+          // A prior success is reusable only while every enclosing include is still active.
+          // Unlike ordinary node-local rules, a composed boundary governs the whole block,
+          // so resume must not let a stale completed descendant cross a newly-false gate.
+          const isCachedPriorSuccess =
+            priorCompletedNodes?.has(node.id) === true && !node.always_run;
+          const composedBoundaryDecision = checkComposedBlockBoundaries(
+            node,
+            ctx.nodeOutputs,
+            resolveRunInputs(workflowRun),
+            isCachedPriorSuccess
+          );
+
+          // 0. Skip if this node completed successfully in a prior run (resume path),
+          // unless its composed boundary is now inactive. `always_run: true` opts the
+          // node out of resume caching and re-executes it.
           if (priorCompletedNodes?.has(node.id)) {
             if (node.always_run) {
               getLog().info({ nodeId: node.id }, 'dag.node_always_run_resume_forced');
@@ -7208,7 +7222,7 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
                   );
                 });
               // falls through to re-execute the node
-            } else {
+            } else if (composedBoundaryDecision === 'run') {
               getLog().info({ nodeId: node.id }, 'dag.node_skipped_prior_success');
               await logNodeSkip(logDir, workflowRun.id, node.id, 'prior_success').catch(
                 (err: Error) => {
@@ -7253,10 +7267,7 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
 
           // 1. Enforce every enclosing include boundary before this node's local rule.
           const triggerDecision =
-            checkComposedBlockBoundaries(node, ctx.nodeOutputs, resolveRunInputs(workflowRun)) ===
-            'skip'
-              ? 'skip'
-              : checkTriggerRule(node, ctx.nodeOutputs);
+            composedBoundaryDecision === 'skip' ? 'skip' : checkTriggerRule(node, ctx.nodeOutputs);
           if (triggerDecision === 'skip') {
             getLog().info({ nodeId: node.id, reason: 'trigger_rule' }, 'dag_node_skipped');
             await logNodeSkip(logDir, workflowRun.id, node.id, 'trigger_rule').catch(

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -1364,7 +1364,11 @@ export function checkComposedBlockBoundaries(
   for (const boundary of readComposedMeta(node)?.boundaries ?? []) {
     if (boundary.isEntry && !evaluateEntryBoundary) continue;
 
-    const dependencyEligible = boundary.entryTriggerRules.some(
+    const triggerRules =
+      boundary.isEntry && evaluateEntryBoundary
+        ? [boundary.entryTriggerRule]
+        : boundary.entryTriggerRules;
+    const dependencyEligible = triggerRules.some(
       rule => checkTriggerRuleForDependencies(boundary.dependsOn, rule, nodeOutputs) === 'run'
     );
     if (!dependencyEligible) return 'skip';

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -1315,6 +1315,14 @@ export function checkTriggerRule(
   nodeOutputs: Map<string, NodeOutput>
 ): 'run' | 'skip' {
   const nodeDeps = node.depends_on ?? [];
+  return checkTriggerRuleForDependencies(nodeDeps, node.trigger_rule ?? 'all_success', nodeOutputs);
+}
+
+function checkTriggerRuleForDependencies(
+  nodeDeps: readonly string[],
+  rule: TriggerRule,
+  nodeOutputs: Map<string, NodeOutput>
+): 'run' | 'skip' {
   if (nodeDeps.length === 0) return 'run';
 
   const upstreams = nodeDeps.map(
@@ -1326,8 +1334,6 @@ export function checkTriggerRule(
         error: `upstream '${id}' missing from outputs`,
       } as NodeOutput)
   );
-  const rule: TriggerRule = node.trigger_rule ?? 'all_success';
-
   switch (rule) {
     case 'all_success':
       return upstreams.every(u => u.state === 'completed') ? 'run' : 'skip';
@@ -1341,6 +1347,38 @@ export function checkTriggerRule(
     case 'all_done':
       return upstreams.every(u => u.state !== 'pending' && u.state !== 'running') ? 'run' : 'skip';
   }
+}
+
+/**
+ * Enforce caller-level include predicates that load-time flattening attached to every
+ * descendant. Entry nodes keep using their ordinary trigger/when fields so they retain
+ * the existing diagnostics; only descendants need the recovered boundary guard.
+ */
+export function checkComposedBlockBoundaries(
+  node: DagNode,
+  nodeOutputs: Map<string, NodeOutput>,
+  inputs?: Record<string, string>
+): 'run' | 'skip' {
+  for (const boundary of readComposedMeta(node)?.boundaries ?? []) {
+    if (boundary.isEntry) continue;
+
+    const dependencyEligible = boundary.entryTriggerRules.some(
+      rule => checkTriggerRuleForDependencies(boundary.dependsOn, rule, nodeOutputs) === 'run'
+    );
+    if (!dependencyEligible) return 'skip';
+
+    if (boundary.when !== undefined) {
+      try {
+        const condition = evaluateCondition(boundary.when, nodeOutputs, inputs);
+        if (!condition.parsed || !condition.result) return 'skip';
+      } catch {
+        // Entry nodes own the actionable missing-ref error. Descendants only need to stay
+        // inside the failed boundary, without repeating the same failure for every node.
+        return 'skip';
+      }
+    }
+  }
+  return 'run';
 }
 
 /**
@@ -7213,8 +7251,12 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
             }
           }
 
-          // 1. Evaluate trigger rule
-          const triggerDecision = checkTriggerRule(node, ctx.nodeOutputs);
+          // 1. Enforce every enclosing include boundary before this node's local rule.
+          const triggerDecision =
+            checkComposedBlockBoundaries(node, ctx.nodeOutputs, resolveRunInputs(workflowRun)) ===
+            'skip'
+              ? 'skip'
+              : checkTriggerRule(node, ctx.nodeOutputs);
           if (triggerDecision === 'skip') {
             getLog().info({ nodeId: node.id, reason: 'trigger_rule' }, 'dag_node_skipped');
             await logNodeSkip(logDir, workflowRun.id, node.id, 'trigger_rule').catch(

--- a/packages/workflows/src/dry-run.test.ts
+++ b/packages/workflows/src/dry-run.test.ts
@@ -2,12 +2,13 @@ import { afterEach, describe, expect, test } from 'bun:test';
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { makeTestWorkflow } from './test-utils';
+import { makeTestComposedWorkflow, makeTestWorkflow } from './test-utils';
 import { dryRunWorkflow, formatDryRunTrace, loadDryRunStubs } from './dry-run';
 import type { DryRunResolution } from './dry-run';
 import { buildAiProfile } from './model-validation';
 import { resolveWorkflowModelScope } from './node-model-resolution';
 import { expandWorkflowIncludes } from './include-expander';
+import type { WorkflowDefinition } from './schemas';
 
 const temporaryDirectories: string[] = [];
 
@@ -23,6 +24,42 @@ function temporaryFile(content: string): string {
   const path = join(directory, 'stubs.yaml');
   writeFileSync(path, content);
   return path;
+}
+
+function composedReviewWorkflow(gateNodes: unknown[], includeWhen?: string): WorkflowDefinition {
+  const block = makeTestWorkflow({
+    name: 'review-block',
+    nodes: [
+      { id: 'entry', bash: 'echo entry' },
+      {
+        id: 'optional',
+        bash: 'echo optional',
+        depends_on: ['entry'],
+        when: "$entry.output == 'never'",
+      },
+      { id: 'required', bash: 'echo required', depends_on: ['entry'] },
+      {
+        id: 'synthesize',
+        bash: 'echo synthesize',
+        depends_on: ['optional', 'required'],
+        trigger_rule: 'all_done',
+      },
+    ],
+  });
+  const parent = makeTestWorkflow({
+    name: 'parent',
+    nodes: [
+      ...gateNodes,
+      {
+        id: 'review',
+        include: 'review-block',
+        depends_on: ['gate'],
+        ...(includeWhen !== undefined ? { when: includeWhen } : {}),
+      },
+      { id: 'consumer', bash: 'echo consumer', depends_on: ['review'] },
+    ],
+  });
+  return makeTestComposedWorkflow([block, parent], 'parent');
 }
 
 describe('loadDryRunStubs', () => {
@@ -154,6 +191,87 @@ describe('dryRunWorkflow', () => {
     expect(states.one_success).toBe('stubbed');
     expect(states.none_failed).toBe('stubbed');
     expect(states.all_done).toBe('stubbed');
+  });
+
+  test('skips every composed node when the include condition is false', async () => {
+    const result = await dryRunWorkflow({
+      workflow: composedReviewWorkflow(
+        [{ id: 'gate', bash: 'echo gate' }],
+        "$gate.output == 'run'"
+      ),
+      userMessage: '',
+      cwd: process.cwd(),
+      stubs: {
+        gate: 'skip',
+        review__synthesize: 'must not run',
+        consumer: 'must not run',
+      },
+    });
+    const states = Object.fromEntries(result.trace.map(entry => [entry.nodeId, entry.state]));
+
+    expect(states).toEqual({
+      gate: 'stubbed',
+      review__entry: 'skipped',
+      review__optional: 'skipped',
+      review__required: 'skipped',
+      review__synthesize: 'skipped',
+      consumer: 'skipped',
+    });
+  });
+
+  test('skips every composed node when the include dependencies are ineligible', async () => {
+    const result = await dryRunWorkflow({
+      workflow: composedReviewWorkflow([
+        { id: 'source', bash: 'echo source' },
+        {
+          id: 'gate',
+          bash: 'echo gate',
+          depends_on: ['source'],
+          when: "$source.output == 'never'",
+        },
+      ]),
+      userMessage: '',
+      cwd: process.cwd(),
+      stubs: {
+        source: 'ready',
+        review__synthesize: 'must not run',
+        consumer: 'must not run',
+      },
+    });
+    const states = Object.fromEntries(result.trace.map(entry => [entry.nodeId, entry.state]));
+
+    expect(states).toEqual({
+      source: 'stubbed',
+      gate: 'skipped',
+      review__entry: 'skipped',
+      review__optional: 'skipped',
+      review__required: 'skipped',
+      review__synthesize: 'skipped',
+      consumer: 'skipped',
+    });
+  });
+
+  test('keeps all_done active for intentionally skipped branches inside a running block', async () => {
+    const result = await dryRunWorkflow({
+      workflow: composedReviewWorkflow(
+        [{ id: 'gate', bash: 'echo gate' }],
+        "$gate.output == 'run'"
+      ),
+      userMessage: '',
+      cwd: process.cwd(),
+      stubs: {
+        gate: 'run',
+        review__entry: 'started',
+        review__required: 'report',
+        review__synthesize: 'ready',
+        consumer: 'done',
+      },
+    });
+    const states = Object.fromEntries(result.trace.map(entry => [entry.nodeId, entry.state]));
+
+    expect(states.review__optional).toBe('skipped');
+    expect(states.review__synthesize).toBe('stubbed');
+    expect(states.consumer).toBe('stubbed');
   });
 
   test('keeps whole-output references lenient and fails strict unknown fields', async () => {

--- a/packages/workflows/src/dry-run.ts
+++ b/packages/workflows/src/dry-run.ts
@@ -5,7 +5,12 @@ import { createLogger, getArchonTempPath } from '@archon/paths';
 import { randomUUID } from 'node:crypto';
 import { mkdir, rm } from 'node:fs/promises';
 import { join } from 'node:path';
-import { buildTopologicalLayers, checkTriggerRule, substituteNodeOutputRefs } from './dag-executor';
+import {
+  buildTopologicalLayers,
+  checkComposedBlockBoundaries,
+  checkTriggerRule,
+  substituteNodeOutputRefs,
+} from './dag-executor';
 import { evaluateCondition } from './condition-evaluator';
 import { declaredFieldsFromSchema } from './output-ref';
 import { discoverScriptsForCwd } from './script-discovery';
@@ -615,6 +620,10 @@ async function simulateNode(
   ctx: DryRunContext,
   iteration?: number
 ): Promise<void> {
+  if (checkComposedBlockBoundaries(node, outputs, ctx.inputs) === 'skip') {
+    recordSkipped(node, outputs, ctx, 'trigger_rule', iteration);
+    return;
+  }
   if (checkTriggerRule(node, outputs) === 'skip') {
     recordSkipped(node, outputs, ctx, 'trigger_rule', iteration);
     return;

--- a/packages/workflows/src/include-expander.test.ts
+++ b/packages/workflows/src/include-expander.test.ts
@@ -1646,6 +1646,7 @@ describe('expandWorkflowIncludes — composed-node metadata survives nesting', (
         entryTriggerRules: ['all_success'],
         when: "$outer__local-gate.output == 'local'",
         isEntry: true,
+        entryTriggerRule: 'all_success',
       },
     ]);
   });

--- a/packages/workflows/src/include-expander.test.ts
+++ b/packages/workflows/src/include-expander.test.ts
@@ -5,6 +5,7 @@ import type { WorkflowDefinition, DagNode } from './schemas';
 import {
   COMPILED_LOOP_COMMAND,
   COMPOSED_NODE,
+  type ComposedBlockBoundary,
   type ComposedNodeMeta,
   type LoopWithCompiledCommand,
   type NodeWithComposedMeta,
@@ -41,6 +42,10 @@ function composedInputs(node: DagNode | undefined): Record<string, string> | und
 
 function composedOrigin(node: DagNode | undefined): string | undefined {
   return composedMeta(node)?.origin;
+}
+
+function composedBoundaries(node: DagNode | undefined): ComposedBlockBoundary[] | undefined {
+  return composedMeta(node)?.boundaries;
 }
 
 function compiledLoopPrompt(node: DagNode | undefined): string | undefined {
@@ -1525,6 +1530,94 @@ describe('expandWorkflowIncludes — composed-node metadata survives nesting', (
     // Write-once: the INNER workflow's own input name, not the outer's `topic`.
     expect(composedInputs(run)).toEqual({ plan: 'ship it' });
     expect(composedOrigin(run)).toBe('inner');
+  });
+
+  test('repeated includes keep distinct caller boundaries', () => {
+    const block = wf('gated-block', [
+      { id: 'entry', bash: 'echo entry', trigger_rule: 'all_done' },
+      { id: 'done', bash: 'echo done', depends_on: ['entry'], trigger_rule: 'all_done' },
+    ]);
+    const parent = wf('parent', [
+      { id: 'gate-a', bash: 'echo A' },
+      { id: 'gate-b', bash: 'echo B' },
+      {
+        id: 'first',
+        include: 'gated-block',
+        depends_on: ['gate-a'],
+        when: "$gate-a.output == 'A'",
+        trigger_rule: 'one_success',
+      },
+      {
+        id: 'second',
+        include: 'gated-block',
+        depends_on: ['gate-b'],
+        when: "$gate-b.output == 'B'",
+        trigger_rule: 'one_success',
+      },
+    ]);
+
+    const { workflows, errors } = expandWorkflowIncludes(mapOf(block, parent));
+    expect(errors).toHaveLength(0);
+
+    expect(composedBoundaries(nodeById(workflows.get('parent')!, 'first__done'))).toEqual([
+      {
+        dependsOn: ['gate-a'],
+        entryTriggerRules: ['all_done'],
+        when: "$gate-a.output == 'A'",
+        isEntry: false,
+      },
+    ]);
+    expect(composedBoundaries(nodeById(workflows.get('parent')!, 'second__done'))).toEqual([
+      {
+        dependsOn: ['gate-b'],
+        entryTriggerRules: ['all_done'],
+        when: "$gate-b.output == 'B'",
+        isEntry: false,
+      },
+    ]);
+  });
+
+  test('nested include boundaries retain their own namespaced predicates', () => {
+    const leaf = wf('leaf', [{ id: 'work', bash: 'echo work' }]);
+    const middle = withSignature(
+      wf('middle', [
+        { id: 'local-gate', bash: 'echo local' },
+        {
+          id: 'inner',
+          include: 'leaf',
+          depends_on: ['local-gate'],
+          when: "$local-gate.output == '$INPUTS.expected'",
+        },
+      ]),
+      { inputs: { expected: { required: true } } }
+    );
+    const top = wf('top', [
+      { id: 'outer-gate', bash: 'echo outer' },
+      {
+        id: 'outer',
+        include: 'middle',
+        depends_on: ['outer-gate'],
+        when: "$outer-gate.output == 'outer'",
+        with: { expected: 'local' },
+      },
+    ]);
+
+    const { workflows, errors } = expandWorkflowIncludes(mapOf(leaf, middle, top));
+    expect(errors).toHaveLength(0);
+    expect(composedBoundaries(nodeById(workflows.get('top')!, 'outer__inner__work'))).toEqual([
+      {
+        dependsOn: ['outer-gate'],
+        entryTriggerRules: ['all_success'],
+        when: "$outer-gate.output == 'outer'",
+        isEntry: false,
+      },
+      {
+        dependsOn: ['outer__local-gate'],
+        entryTriggerRules: ['all_success'],
+        when: "$outer__local-gate.output == 'local'",
+        isEntry: true,
+      },
+    ]);
   });
 });
 

--- a/packages/workflows/src/include-expander.test.ts
+++ b/packages/workflows/src/include-expander.test.ts
@@ -155,6 +155,40 @@ describe('expandWorkflowIncludes — namespacing', () => {
     expect(nodeById(workflows.get('parent')!, 'b__verify')?.depends_on).toEqual(['a__impl']);
   });
 
+  test('boundary dependency edges fan out to every sink while scalar refs use the primary sink', () => {
+    const upstream = wf('upstream', [
+      { id: 'primary', bash: 'echo primary' },
+      { id: 'secondary', bash: 'echo secondary' },
+    ]);
+    const downstream = wf('downstream', [
+      { id: 'entry', bash: 'echo entry', trigger_rule: 'one_success' },
+      { id: 'join', bash: 'echo join', depends_on: ['entry'], trigger_rule: 'all_done' },
+    ]);
+    const parent = wf('parent', [
+      { id: 'up', include: 'upstream' },
+      {
+        id: 'down',
+        include: 'downstream',
+        depends_on: ['up'],
+        when: "$up.output == 'primary'",
+      },
+    ]);
+
+    const { workflows, errors } = expandWorkflowIncludes(mapOf(upstream, downstream, parent));
+    expect(errors).toHaveLength(0);
+    const expanded = workflows.get('parent')!;
+
+    expect(nodeById(expanded, 'down__entry')?.depends_on).toEqual(['up__primary', 'up__secondary']);
+    expect(composedBoundaries(nodeById(expanded, 'down__join'))).toEqual([
+      {
+        dependsOn: ['up__primary', 'up__secondary'],
+        entryTriggerRules: ['one_success'],
+        when: "$up__primary.output == 'primary'",
+        isEntry: false,
+      },
+    ]);
+  });
+
   test('does not mutate the input workflow map', () => {
     const parent = wf('parent', [{ id: 'review', include: 'blk' }]);
     const raw = mapOf(blockWorkflow(), parent);

--- a/packages/workflows/src/include-expander.ts
+++ b/packages/workflows/src/include-expander.ts
@@ -353,9 +353,13 @@ function collapseWorkflowScope(raw: WorkflowDefinition): WorkflowDefinition {
  * composed and stay literal when run standalone (#2476). Those fields receive runtime
  * substitution since #1764, so they are ordinary node-ref surfaces and are walked here too.
  */
-function rewriteNodeOutputRefs(node: DagNode, rename: (id: string) => string): void {
-  const code = (text: string): string => applyOutputRefRename(text, rename);
-  const whenExpr = (text: string): string => applyWhenRefRename(text, rename);
+function rewriteNodeOutputRefs(
+  node: DagNode,
+  renameOutputRef: (id: string) => string,
+  expandDependency: (id: string) => string[]
+): void {
+  const code = (text: string): string => applyOutputRefRename(text, renameOutputRef);
+  const whenExpr = (text: string): string => applyWhenRefRename(text, renameOutputRef);
 
   if (node.when !== undefined) node.when = whenExpr(node.when);
 
@@ -368,7 +372,7 @@ function rewriteNodeOutputRefs(node: DagNode, rename: (id: string) => string): v
     for (const [key, value] of Object.entries(stamped)) stamped[key] = code(value);
   }
   for (const boundary of readComposedMeta(node)?.boundaries ?? []) {
-    boundary.dependsOn = boundary.dependsOn.map(rename);
+    boundary.dependsOn = boundary.dependsOn.flatMap(expandDependency);
     if (boundary.when !== undefined) boundary.when = whenExpr(boundary.when);
   }
 
@@ -394,7 +398,9 @@ function rewriteNodeOutputRefs(node: DagNode, rename: (id: string) => string): v
     if (node.loop_group.until_bash !== undefined) {
       node.loop_group.until_bash = code(node.loop_group.until_bash);
     }
-    for (const body of node.loop_group.nodes) rewriteNodeOutputRefs(body, rename);
+    for (const body of node.loop_group.nodes) {
+      rewriteNodeOutputRefs(body, renameOutputRef, expandDependency);
+    }
   } else if (isApprovalNode(node)) {
     node.approval.message = code(node.approval.message);
     if (node.approval.on_reject !== undefined) {
@@ -644,7 +650,7 @@ function inlineInclude(
     // Rewrite child-internal refs before inserting caller values. This ordering is
     // load-bearing: a caller ref such as `$gather.output` must remain parent-scoped even
     // when the included block also has a node named `gather`.
-    rewriteNodeOutputRefs(clone, rename);
+    rewriteNodeOutputRefs(clone, rename, id => [rename(id)]);
     applyInputsMacro(clone, resolvedInputs, missingInputs);
     // Stamped AFTER both passes, for the same reason the caller's values are inserted
     // after the rename: these are the CALLER's strings, so they stay parent-scoped here
@@ -1006,11 +1012,12 @@ export function expandWorkflowIncludes(
     //   (a) depends_on entries equal to an include id → that include's sink list
     //   (b) $includeId.output → $<primarySink>.output
     const renameIncludeRef = (id: string): string => primarySinkByIncludeId.get(id) ?? id;
+    const expandIncludeDependency = (id: string): string[] => sinksByIncludeId.get(id) ?? [id];
     for (const node of newNodes) {
       if (node.depends_on !== undefined) {
-        node.depends_on = node.depends_on.flatMap(dep => sinksByIncludeId.get(dep) ?? [dep]);
+        node.depends_on = node.depends_on.flatMap(expandIncludeDependency);
       }
-      rewriteNodeOutputRefs(node, renameIncludeRef);
+      rewriteNodeOutputRefs(node, renameIncludeRef, expandIncludeDependency);
     }
 
     // Re-validate the fully-flattened DAG. Catches a namespaced id colliding with a

--- a/packages/workflows/src/include-expander.ts
+++ b/packages/workflows/src/include-expander.ts
@@ -61,6 +61,7 @@ import {
   COMPOSED_NODE,
   isIncludeCommandReadError,
   readComposedMeta,
+  type ComposedBlockBoundary,
   type ComposedNodeMeta,
   type CompiledLoopCommand,
   type IncludeCommandContent,
@@ -149,23 +150,45 @@ class IncludeExpansionError extends Error {}
  * field: the innermost workflow that inlined this node already said the true thing,
  * and an outer level re-stating it would replace one file's answer with another's.
  * `blockEntry` is the exception — it is idempotently true, and a node can legitimately
- * be the entry of two nested blocks at once.
+ * be the entry of two nested blocks at once. `boundaries` is cumulative: each outer
+ * include prepends its own activation predicate without replacing the inner ones.
  */
 function markComposedNode(node: DagNode, patch: ComposedNodeMeta): void {
   const target = node as DagNode & NodeWithComposedMeta;
   const existing = target[COMPOSED_NODE];
+  const cloneBoundaries = (
+    boundaries: ComposedBlockBoundary[] | undefined
+  ): ComposedBlockBoundary[] | undefined => boundaries?.map(boundary => structuredClone(boundary));
   if (existing === undefined) {
-    target[COMPOSED_NODE] = { ...patch };
-  } else if (patch.blockEntry === true) {
-    existing.blockEntry = true;
+    target[COMPOSED_NODE] = {
+      ...patch,
+      ...(patch.boundaries !== undefined ? { boundaries: cloneBoundaries(patch.boundaries) } : {}),
+    };
+  } else {
+    if (patch.blockEntry === true) existing.blockEntry = true;
+    if (patch.boundaries !== undefined) {
+      existing.boundaries = [
+        ...(cloneBoundaries(patch.boundaries) ?? []),
+        ...(existing.boundaries ?? []),
+      ];
+    }
   }
   // A loop_group body node was authored in the same file and reads the same inputs, so
   // it carries the same record — minus `blockEntry`, which is a position in the OUTER
-  // graph and means nothing inside a body.
+  // graph and means nothing inside a body. A body node is likewise never the entry of an
+  // enclosing outer-graph include, though it still inherits that boundary.
   if (isLoopGroupNode(node)) {
     const inherited: ComposedNodeMeta = {
       origin: patch.origin,
       ...(patch.inputs !== undefined ? { inputs: patch.inputs } : {}),
+      ...(patch.boundaries !== undefined
+        ? {
+            boundaries: patch.boundaries.map(boundary => ({
+              ...structuredClone(boundary),
+              isEntry: false,
+            })),
+          }
+        : {}),
     };
     for (const body of node.loop_group.nodes) markComposedNode(body, inherited);
   }
@@ -344,6 +367,10 @@ function rewriteNodeOutputRefs(node: DagNode, rename: (id: string) => string): v
   if (stamped !== undefined) {
     for (const [key, value] of Object.entries(stamped)) stamped[key] = code(value);
   }
+  for (const boundary of readComposedMeta(node)?.boundaries ?? []) {
+    boundary.dependsOn = boundary.dependsOn.map(rename);
+    if (boundary.when !== undefined) boundary.when = whenExpr(boundary.when);
+  }
 
   // Node-level AI configuration is a runtime ref surface too (#2476/#1764): the executor
   // substitutes `$node.output` into these before the provider sees them, so an included
@@ -442,6 +469,9 @@ function applyInputsMacro(node: DagNode, args: Record<string, string>, missing: 
   const stamped = readComposedMeta(node)?.inputs;
   if (stamped !== undefined) {
     for (const [key, value] of Object.entries(stamped)) stamped[key] = substitute(value);
+  }
+  for (const boundary of readComposedMeta(node)?.boundaries ?? []) {
+    if (boundary.when !== undefined) boundary.when = substitute(boundary.when);
   }
 
   // Base AI-turn fields — valid on every AI node mode (command / prompt / loop_group), so
@@ -586,6 +616,16 @@ function inlineInclude(
   const sinkOriginalIds = childNodes.filter(n => !childDeps.has(n.id)).map(n => n.id);
 
   const parentDeps = includeNode.depends_on ?? [];
+  const entryTriggerRules = childNodes
+    .filter(node => (node.depends_on ?? []).length === 0)
+    .map(node => node.trigger_rule ?? includeNode.trigger_rule ?? 'all_success');
+  const [firstEntryTriggerRule, ...remainingEntryTriggerRules] = entryTriggerRules;
+  if (firstEntryTriggerRule === undefined) {
+    throw new IncludeExpansionError(
+      `Node '${includeNode.id}': included workflow '${child.name}' has no entry node`
+    );
+  }
+  const hasActivationBoundary = parentDeps.length > 0 || includeNode.when !== undefined;
   const missingInputs = new Set<string>();
   const resolvedInputs = resolveIncludeInputs(includeNode, child);
 
@@ -614,6 +654,18 @@ function inlineInclude(
       origin: child.name,
       ...(Object.keys(resolvedInputs).length > 0 ? { inputs: { ...resolvedInputs } } : {}),
       ...(wasEntry ? { blockEntry: true as const } : {}),
+      ...(hasActivationBoundary
+        ? {
+            boundaries: [
+              {
+                dependsOn: [...parentDeps],
+                entryTriggerRules: [firstEntryTriggerRule, ...remainingEntryTriggerRules],
+                ...(includeNode.when !== undefined ? { when: includeNode.when } : {}),
+                isEntry: wasEntry,
+              },
+            ],
+          }
+        : {}),
     });
     clone.id = prefix + cn.id;
 

--- a/packages/workflows/src/include-expander.ts
+++ b/packages/workflows/src/include-expander.ts
@@ -183,10 +183,16 @@ function markComposedNode(node: DagNode, patch: ComposedNodeMeta): void {
       ...(patch.inputs !== undefined ? { inputs: patch.inputs } : {}),
       ...(patch.boundaries !== undefined
         ? {
-            boundaries: patch.boundaries.map(boundary => ({
-              ...structuredClone(boundary),
-              isEntry: false,
-            })),
+            boundaries: patch.boundaries.map(boundary => {
+              const clone = structuredClone(boundary);
+              if (!clone.isEntry) return clone;
+              return {
+                dependsOn: clone.dependsOn,
+                entryTriggerRules: clone.entryTriggerRules,
+                ...(clone.when !== undefined ? { when: clone.when } : {}),
+                isEntry: false,
+              };
+            }),
           }
         : {}),
     };
@@ -646,6 +652,20 @@ function inlineInclude(
       cn.id
     );
     const wasEntry = (cn.depends_on ?? []).length === 0;
+    const boundary: ComposedBlockBoundary = wasEntry
+      ? {
+          dependsOn: [...parentDeps],
+          entryTriggerRules: [firstEntryTriggerRule, ...remainingEntryTriggerRules],
+          ...(includeNode.when !== undefined ? { when: includeNode.when } : {}),
+          isEntry: true,
+          entryTriggerRule: cn.trigger_rule ?? includeNode.trigger_rule ?? 'all_success',
+        }
+      : {
+          dependsOn: [...parentDeps],
+          entryTriggerRules: [firstEntryTriggerRule, ...remainingEntryTriggerRules],
+          ...(includeNode.when !== undefined ? { when: includeNode.when } : {}),
+          isEntry: false,
+        };
 
     // Rewrite child-internal refs before inserting caller values. This ordering is
     // load-bearing: a caller ref such as `$gather.output` must remain parent-scoped even
@@ -662,14 +682,7 @@ function inlineInclude(
       ...(wasEntry ? { blockEntry: true as const } : {}),
       ...(hasActivationBoundary
         ? {
-            boundaries: [
-              {
-                dependsOn: [...parentDeps],
-                entryTriggerRules: [firstEntryTriggerRule, ...remainingEntryTriggerRules],
-                ...(includeNode.when !== undefined ? { when: includeNode.when } : {}),
-                isEntry: wasEntry,
-              },
-            ],
+            boundaries: [boundary],
           }
         : {}),
     });


### PR DESCRIPTION
## Problem and outcome

Load-time include expansion erased whether the caller had activated a composed block. If its entry skipped, an internal `all_done` join could treat the skipped nodes as terminal, run anyway, and make downstream work reachable.

- **Outcome:** A skipped include now skips every expanded descendant, including internal `all_done` joins and downstream consumers.
- **Invariant:** Node-local trigger rules apply only after every enclosing include instance is active; `all_done` keeps its existing meaning inside an active block.
- **Scope boundary:** No public workflow syntax, database state, persisted run state, or global trigger-rule semantics changed.
- **Root cause:** The caller's dependencies and `when` were copied only to entry nodes before the include node was flattened away, leaving descendants unable to distinguish an inactive block from intentionally skipped internal branches.

## Review guidance

- **Feedback requested:** Correctness of the nested boundary invariant and parity between production execution and dry-run.
- **Start here:** `packages/workflows/src/dag-executor.ts:1352` — this is the recovered boundary check that must precede local trigger evaluation.
- **Review order:** `compiled-command.ts:24` → `include-expander.ts:618` → `dag-executor.ts:1312` → `dry-run.ts:620` → focused tests.
- **Lower-attention areas:** The test additions repeat the same three outcomes across executor and dry-run intentionally to lock their scheduling parity.
- **Known risk or uncertainty:** None.

## Solution

The existing engine-private composed-node metadata now carries an ordered list of caller-level include predicates. Expansion stamps each descendant with independently cloned dependency, effective entry-trigger, and `when` data, while the existing namespace and input-macro passes keep nested instances correct. Both schedulers reject inactive boundaries before applying each node's local trigger rule.

## Behavior change

| | Before | After |
|---|---|---|
| **Inactive include** | An internal `all_done` join could run after the entries skipped. | Every expanded node stays skipped and the block cannot feed a consumer. |
| **Active include** | `all_done` aggregated intentionally skipped internal branches. | Behavior is unchanged. |

## Validation

- `bun --cwd=packages/workflows test src/include-expander.test.ts` — 88 passed — proves repeated, nested, and multi-sink boundary metadata is isolated and correctly namespaced.
- `bun --cwd=packages/workflows test src/dag-executor.test.ts` — 503 passed — proves inactive blocks remain airtight, multi-sink entry rules stay aligned with descendants, and active-block `all_done` still runs.
- `bun --cwd=packages/workflows test src/dry-run.test.ts` — 42 passed — proves simulation matches the production scheduler.
- `bun --filter @archon/workflows test` — passed — proves workflow-package regression safety.
- `bun run validate` — passed — proves repository-wide generated checks, types, lint, formatting, builds, and tests.
- **Not verified:** Nothing material; the change is deterministic load-time metadata and scheduling logic covered at expansion, production-execution, and dry-run boundaries.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | Workflows that accidentally relied on a dead block escaping through `all_done` stop doing unintended work. No migration is required. | Executor and dry-run regressions |
| Rollout / rollback | This is a focused engine fix with no persistent state; reverting the commit restores prior behavior. | Single commit, private metadata only |
| Observability | Existing skipped-node logs and workflow events remain the observable contract. | Existing executor skip path reused |
| Documentation / communication | Existing docs already describe include `when` as gating the whole block; no syntax documentation changes are needed. | No public language change |

## Links

- Closes #2622
- Plan: https://github.com/coleam00/Archon/issues/2622#issuecomment-5339139576


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed workflow resume behavior so inactive included sections no longer reuse stale cached results.
  - Ensured dependent steps are skipped when included sections become ineligible.
  - Improved handling of nested and repeated included workflows with separate activation conditions.
  - Updated dry runs to accurately reflect include conditions, dependencies, and trigger rules.

- **Workflow Execution**
  - Improved boundary and downstream dependency evaluation during execution and resumption.
  - Preserved correct trigger-rule behavior for active included sections.
  - Added support for independently evaluating activation rules across included workflow boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->