### PR TITLE
fix(workflows): loop group checks can read body outputs

### DIFF
--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -16288,10 +16288,11 @@ describe('executeDagWorkflow -- loop_group node', () => {
     expect(receivedPrompts[1]).toContain('iter-1-draft');
   });
 
-  it('INSTANCE 3: until_bash deterministic gate completes on exit 0', async () => {
+  it('until_bash reads the current iteration body output and completes', async () => {
     // No `until` signal from AI; completion is decided solely by until_bash exit code.
-    // The body is a pure bash node that increments a counter file each iteration;
-    // until_bash exits 0 once the counter reaches 2. No AI node → sendQuery unused.
+    // The body is a pure bash node that increments a counter file each iteration and
+    // emits the count; until_bash exits 0 once that current body output reaches iter 2.
+    // No AI node → sendQuery unused.
     const counterFile = join(testDir, 'iter-counter');
     // The path is interpolated into REAL bash scripts: on Windows, join() yields
     // backslashes that bash strips as escapes. Use forward slashes + quoting so
@@ -16311,7 +16312,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
           // channel that could never fire.
           max_iterations: 5,
           fresh_context: false,
-          until_bash: `test "$(cat ${counterRef} 2>/dev/null || echo 0)" -ge 2`,
+          until_bash: "test $bump.output = 'iter 2'",
           nodes: [
             {
               id: 'bump',
@@ -16341,7 +16342,8 @@ describe('executeDagWorkflow -- loop_group node', () => {
       minimalConfig
     );
 
-    // until_bash exits 0 once the counter reaches 2 → completes after 2 iterations.
+    // until_bash sees `bump` from the current scoped output map and exits 0 once it
+    // reaches iter 2 → completes after 2 iterations.
     // The counter file holds the final iteration count (2).
     const { readFile } = await import('fs/promises');
     const finalCount = parseInt((await readFile(counterFile, 'utf8')).trim(), 10);

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -3933,6 +3933,60 @@ nodes:
       expect(result.workflows).toHaveLength(1);
     });
 
+    it('should load loop_group until_bash referencing a direct body output', async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+
+      await writeFile(
+        join(workflowDir, 'loop-group-body-completion-ref.yaml'),
+        `
+name: loop-group-body-completion-ref
+description: Group completion reads the current body output
+nodes:
+  - id: group
+    loop_group:
+      until_bash: "test $ready-flag.output = ready"
+      max_iterations: 2
+      nodes:
+        - id: ready-flag
+          bash: "echo ready"
+`
+      );
+
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      expect(result.errors).toHaveLength(0);
+      expect(result.workflows).toHaveLength(1);
+    });
+
+    it('should reject unknown loop_group until_bash refs with body-scope guidance', async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+
+      await writeFile(
+        join(workflowDir, 'loop-group-unknown-completion-ref.yaml'),
+        `
+name: loop-group-unknown-completion-ref
+description: Group completion references a node outside its visible scopes
+nodes:
+  - id: group
+    loop_group:
+      until_bash: "test $ghost.output = ready"
+      max_iterations: 2
+      nodes:
+        - id: ready-flag
+          bash: "echo ready"
+`
+      );
+
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      expect(result.workflows).toHaveLength(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].error).toContain("field 'loop_group.until_bash'");
+      expect(result.errors[0].error).toContain("unknown node '$ghost.output'");
+      expect(result.errors[0].error).toContain('loop_group body or current/enclosing DAG scope');
+      expect(result.errors[0].error).not.toContain('In a composed workflow');
+    });
+
     it('should accept a body prompt referencing an outer-DAG node via $nodeId.output', async () => {
       const workflowDir = join(testDir, '.archon', 'workflows');
       await mkdir(workflowDir, { recursive: true });

--- a/packages/workflows/src/loader.ts
+++ b/packages/workflows/src/loader.ts
@@ -509,7 +509,7 @@ export function validateDagStructure(
   const outputRefPattern = new RegExp(OUTPUT_REF_SOURCE, 'g');
   const whenRefPattern = new RegExp(WHEN_REF_SOURCE, 'g');
   for (const node of nodes) {
-    const sources: { field: string; text: string }[] = [];
+    const sources: { field: string; text: string; bodyNodes?: readonly DagNode[] }[] = [];
     if ('prompt' in node && typeof node.prompt === 'string') {
       sources.push({ field: 'prompt', text: node.prompt });
     }
@@ -562,7 +562,14 @@ export function validateDagStructure(
       }
     }
     if (isLoopGroupNode(node) && node.loop_group.until_bash) {
-      sources.push({ field: 'loop_group.until_bash', text: node.loop_group.until_bash });
+      // The group evaluates this field after each body iteration against the same output
+      // map the body populated, so its direct body nodes are visible here in addition to
+      // the current and enclosing DAG scopes.
+      sources.push({
+        field: 'loop_group.until_bash',
+        text: node.loop_group.until_bash,
+        bodyNodes: node.loop_group.nodes,
+      });
     }
     for (const source of sources) {
       let m: RegExpExecArray | null;
@@ -578,8 +585,12 @@ export function validateDagStructure(
         if (
           refNodeId !== undefined &&
           !nodesById.has(refNodeId) &&
-          !enclosingNodes?.has(refNodeId)
+          !enclosingNodes?.has(refNodeId) &&
+          !source.bodyNodes?.some(bodyNode => bodyNode.id === refNodeId)
         ) {
+          if (source.bodyNodes !== undefined) {
+            return `Node '${node.id}' field '${source.field}' references unknown node '$${refNodeId}.output'. Expected a node in the loop_group body or current/enclosing DAG scope`;
+          }
           return `Node '${node.id}' field '${source.field}' references unknown node '$${refNodeId}.output'. In a composed workflow, pass caller data through declared 'inputs:' and caller 'with:' instead of referencing a caller node directly`;
         }
       }


### PR DESCRIPTION
## Problem and outcome

`loop_group.until_bash` is documented to read the current iteration's body outputs, but load-time validation rejected those references before execution and then incorrectly suggested composition inputs as the remedy.

- **Outcome:** Completion checks can reference direct body-node outputs, and unknown references fail with an accurate body/current-scope diagnostic.
- **Invariant:** The loader accepts exactly the direct body and visible current/enclosing DAG node IDs that runtime exposes to the group after each iteration.
- **Scope boundary:** This does not change runtime substitution, schemas, reference syntax, or the separate include-in-loop-group work tracked in #2623.
- **Root cause:** The loader scanned the group's own `until_bash` against only its current and enclosing DAG maps before the later recursive validation created the body-node map.

## Review guidance

- **Feedback requested:** Correctness of the field-specific scope boundary and the unknown-reference diagnostic.
- **Start here:** `packages/workflows/src/loader.ts:509` — this is the load-bearing reference-source scan and lookup change.
- **Review order:** Loader scope change, focused loader regressions, then the strengthened runtime completion proof.
- **Lower-attention areas:** The executor implementation is unchanged; its test now drives the existing completion path from `$bump.output` instead of rereading the counter file.
- **Known risk or uncertainty:** None. Direct body visibility and nested-group aggregation are already established runtime behavior.

## Solution

The existing output-reference scan now associates only `loop_group.until_bash` with its owning group's direct body nodes. Those IDs join the current and enclosing DAG scopes for that field without broadening visibility for unrelated outer-node fields. A miss on this body-aware field gets a scope-specific error, while the existing composition guidance remains intact for other reference surfaces.

This restores the documented workflow-language pattern without adding YAML surface or changing the executor. Direct nested group nodes remain visible only through their aggregate output, matching runtime; nested descendants are not admitted.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | `until_bash: "test $ready-flag.output = ready"` was rejected while loading. | The workflow loads and the group can complete from the current body's output. |
| **Failure behavior** | A dangling body ref emitted composition-only advice. | It remains a load error and identifies the loop-group body/current DAG scope. |

## Validation

- `cd packages/workflows && bun test src/loader.test.ts -t "loop_group until_bash"` — 2 pass, 0 fail; proves valid body refs load and dangling refs fail precisely.
- `cd packages/workflows && bun test src/dag-executor.test.ts -t "until_bash reads the current iteration body output"` — 1 pass, 0 fail; proves the current body output terminates the group.
- `bun run validate` — passed on commit `9b0af728`; generated checks, type-checks, zero-warning lint, formatting, installer tests, isolated package tests, and script tests all completed successfully.
- **Not verified:** Nothing material; the focused tests cover both changed load behavior and the existing runtime contract, and the complete repository gate is green.

## Links

- Closes #2621
- Related #2623
- Plan: https://github.com/coleam00/Archon/issues/2621#issuecomment-5340449571


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Loop-group completion conditions can now reference outputs from nodes within the loop body.
  * References to nodes in the current or enclosing workflow scope are validated correctly.
  * Invalid references now provide clearer guidance about available scopes.
  * Workflow usage and costs are preserved across failures, cancellations, pauses, fatal errors, and resumed runs.
  * Loop execution correctly completes after the expected number of iterations when using body-output conditions.

* **Tests**
  * Added coverage for loop-group output references, workflow resumption, cost tracking, conditional branches, and loop event handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->