### PR TITLE
fix(web): align builder node reference validation

### DIFF
--- a/packages/web/src/experiments/console/builder/validation/content.test.ts
+++ b/packages/web/src/experiments/console/builder/validation/content.test.ts
@@ -47,6 +47,21 @@ describe('validateContent', () => {
     expect(issues.filter(i => i.rule === 'content.var.unknown')).toEqual([]);
   });
 
+  test('a workflow input named output is not treated as a node ref', () => {
+    const issues = validateContent(
+      wf([
+        {
+          id: 'use',
+          variant: 'prompt',
+          base: {},
+          data: { prompt: 'Read $INPUTS.output.' },
+        },
+      ])
+    );
+
+    expect(issues.filter(i => i.rule === 'content.var.unknown')).toEqual([]);
+  });
+
   test('self-reference warns (a node is not its own upstream)', () => {
     const issues = validateContent(
       wf([{ id: 'me', variant: 'prompt', base: {}, data: { prompt: 'loop on $me.output' } }])
@@ -207,6 +222,75 @@ describe('validateContent', () => {
       ])
     );
     expect(bad.some(i => i.rule === 'content.when.parse')).toBe(true);
+  });
+
+  test('an unknown node ref in when warns', () => {
+    const issues = validateContent(
+      wf([
+        {
+          id: 'use',
+          variant: 'prompt',
+          base: { when: "$ghost.output == 'YES'" },
+          data: { prompt: 'y' },
+        },
+      ])
+    );
+
+    expect(issues).toContainEqual(
+      expect.objectContaining({
+        rule: 'content.var.unknown',
+        severity: 'warning',
+        path: { nodeId: 'use', field: 'when' },
+      })
+    );
+  });
+
+  test('every non-upstream node in a compound when warns, including shorthand', () => {
+    const issues = validateContent(
+      wf([
+        { id: 'sibling', variant: 'bash', base: {}, data: { bash: 'exit 0' } },
+        {
+          id: 'use',
+          variant: 'prompt',
+          base: {
+            when: "$ghost.output == 'YES' || $sibling.exit_code == 0 && $INPUTS.mode == 'fast'",
+          },
+          data: { prompt: 'y' },
+        },
+      ])
+    );
+
+    const warnings = issues.filter(i => i.rule === 'content.var.unknown');
+    expect(warnings).toHaveLength(2);
+    expect(warnings.every(i => i.path.field === 'when')).toBe(true);
+    expect(warnings.map(i => i.message).join('\n')).toContain("node 'ghost'");
+    expect(warnings.map(i => i.message).join('\n')).toContain("node 'sibling'");
+    expect(warnings.map(i => i.message).join('\n')).not.toContain('INPUTS');
+  });
+
+  test('direct and transitive upstream when refs pass in canonical and shorthand forms', () => {
+    const issues = validateContent(
+      wf([
+        { id: 'root', variant: 'prompt', base: {}, data: { prompt: 'x' } },
+        {
+          id: 'middle',
+          variant: 'bash',
+          base: { depends_on: ['root'] },
+          data: { bash: 'exit 0' },
+        },
+        {
+          id: 'use',
+          variant: 'prompt',
+          base: {
+            depends_on: ['middle'],
+            when: "$root.output.status == 'ready' && $middle.exit_code == 0 && $INPUTS.mode == 'fast'",
+          },
+          data: { prompt: 'y' },
+        },
+      ])
+    );
+
+    expect(issues.filter(i => i.rule === 'content.var.unknown')).toEqual([]);
   });
 });
 

--- a/packages/web/src/experiments/console/builder/validation/content.ts
+++ b/packages/web/src/experiments/console/builder/validation/content.ts
@@ -1,8 +1,8 @@
 /**
  * Content validation: scan text bodies for `$<nodeId>.output` references that
  * point outside the node's transitive upstream set, and verify each `when:`
- * expression parses. Code spans are stripped first so referenced ids inside
- * fenced/inline code are not flagged.
+ * expression parses and references only upstream nodes. Code spans are stripped
+ * first so referenced ids inside fenced/inline code are not flagged.
  *
  * `content.var.unknown` is a deliberately conservative heuristic: it requires
  * the referenced node to be reachable via explicit `depends_on` edges. A
@@ -124,6 +124,26 @@ export function validateContent(workflow: BuilderWorkflow): Issue[] {
             path: { nodeId: node.id, field: 'when' },
           })
         );
+      } else {
+        const refIds = new Set<string>();
+        for (const group of result.ast.or) {
+          for (const atom of group) {
+            if (atom.kind === 'node') refIds.add(atom.nodeId);
+          }
+        }
+        for (const refId of refIds) {
+          if (!upstream.has(refId)) {
+            issues.push(
+              makeIssue({
+                rule: 'content.var.unknown',
+                severity: 'warning',
+                source: 'client-debounced',
+                message: `node '${node.id}' when references node '${refId}' which is not an upstream dependency`,
+                path: { nodeId: node.id, field: 'when' },
+              })
+            );
+          }
+        }
       }
     }
   }

--- a/packages/web/src/hooks/useBuilderValidation.test.ts
+++ b/packages/web/src/hooks/useBuilderValidation.test.ts
@@ -59,4 +59,16 @@ describe('getDebouncedIssues — $nodeId.output references', () => {
   test('ignores a reference whose id starts with a digit', () => {
     expect(refIssues([node('use', { promptText: 'cost is $1.output' })])).toEqual([]);
   });
+
+  test('does not treat the reserved $INPUTS.output macro as a node ref', () => {
+    expect(
+      refIssues([
+        node('use', {
+          when: "$INPUTS.output == 'ready'",
+          promptText: 'read $INPUTS.output',
+          bashScript: 'echo $INPUTS.output',
+        }),
+      ])
+    ).toEqual([]);
+  });
 });

--- a/packages/web/src/lib/node-ref.test.ts
+++ b/packages/web/src/lib/node-ref.test.ts
@@ -26,6 +26,12 @@ describe('findOutputRefs', () => {
     expect(findOutputRefs('$1step.output')).toEqual(new Set());
   });
 
+  test('skips the reserved INPUTS scope while preserving ordinary near-name ids', () => {
+    expect(
+      findOutputRefs('$INPUTS.output and $real.output and $INPUTSX.output and $inputs.output')
+    ).toEqual(new Set(['real', 'INPUTSX', 'inputs']));
+  });
+
   test('repeated calls are independent — no lastIndex carried between scans', () => {
     // A shared `g` regex would resume from the previous match and lose the
     // first ref on the second call.

--- a/packages/web/src/lib/node-ref.ts
+++ b/packages/web/src/lib/node-ref.ts
@@ -45,7 +45,9 @@ export function findOutputRefs(text: string): Set<string> {
   const refs = new Set<string>();
   for (const match of text.matchAll(new RegExp(OUTPUT_REF_SOURCE, 'g'))) {
     const id = match[1];
-    if (id !== undefined) refs.add(id);
+    // `$INPUTS.output` names the workflow input `output`, not a node. The engine
+    // gives that reserved scope precedence after the same lexical match.
+    if (id !== undefined && id !== 'INPUTS') refs.add(id);
   }
   return refs;
 }

--- a/scripts/node-ref-parity.test.ts
+++ b/scripts/node-ref-parity.test.ts
@@ -47,10 +47,12 @@ import {
   whenAtoms,
   type WhenAtom,
 } from '../packages/workflows/src/when-atom';
+import { parseWorkflow } from '../packages/workflows/src/loader';
 import {
   ATOM_PATTERN,
   parse,
 } from '../packages/web/src/experiments/console/builder/validation/when-grammar';
+import { findOutputRefs } from '../packages/web/src/lib/node-ref';
 import { dagNodeSchema } from '../packages/workflows/src/schemas';
 import { validateStructural } from '../packages/web/src/experiments/console/builder/validation/structural';
 
@@ -143,6 +145,28 @@ describe('node-ref parity: @archon/web mirrors the engine', () => {
 
     expect(nodeId.test('check-reproduction')).toBe(true);
     expect(nodeId.test('classify-testability')).toBe(true);
+  });
+
+  test('both effective scans reserve $INPUTS.output for workflow inputs', () => {
+    const text = 'compare $INPUTS.output';
+    expect(findOutputRefs(text)).toEqual(new Set());
+
+    const engine = parseWorkflow(
+      `
+name: output-input-parity
+description: Reserved input scope parity
+inputs:
+  output:
+    description: Value named output
+    required: false
+nodes:
+  - id: use
+    prompt: "${text}"
+`,
+      'output-input-parity.yaml'
+    );
+    expect(engine.error).toBeNull();
+    expect(engine.workflow).not.toBeNull();
   });
 });
 


### PR DESCRIPTION
## Problem and outcome

The workflow builder checked `when:` syntax without checking whether its node references were valid, and its shared output-reference scan incorrectly treated the reserved `$INPUTS.output` macro as a node named `INPUTS`.

- **Outcome:** Builder validation now warns for unknown or non-upstream `when:` node references, including `$node.exit_code`, while accepting `$INPUTS.output` in both current and legacy builder validation.
- **Invariant:** Web validation remains aligned with the engine's existing grammar and reserved input scope without importing runtime code from `@archon/workflows`.
- **Scope boundary:** This changes authoring-time builder diagnostics only; workflow engine execution and YAML grammar are unchanged.
- **Root cause:** The builder discarded the AST after a successful `when:` parse, and the web scanner copied the engine's lexical pattern without its post-match `INPUTS` exclusion.

## Review guidance

- **Feedback requested:** Correctness of upstream reference validation and web/engine parity at the reserved input scope.
- **Start here:** `packages/web/src/experiments/console/builder/validation/content.ts:113` — the successful `when:` AST is now reused to validate node references.
- **Review order:** `content.ts`, `node-ref.ts`, their focused consumer tests, then `scripts/node-ref-parity.test.ts`.
- **Lower-attention areas:** Test corpus additions are focused regressions for unknown, non-upstream, shorthand, transitive-upstream, and reserved-scope references.
- **Known risk or uncertainty:** None.

## Solution

Successful `when:` parses already produce discriminated node and input atoms, so the builder now collects only node atoms and checks them against the same transitive upstream set used by content-reference validation. The shared web scanner keeps its existing engine-aligned lexical pattern and excludes exact-case `INPUTS` after matching, matching the engine while preserving ordinary near-name node ids.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Invalid `when:` node references were accepted by the builder, while `$INPUTS.output` raised false unknown-node warnings. | Invalid or non-upstream `when:` node references warn, and `$INPUTS.output` is accepted by both builder validation paths. |
| **Failure behavior** | Some workflows failed only when loaded by the engine; valid input references looked invalid while editing. | The builder reports the invalid `when:` reference at its `when` field and preserves the engine's reserved input scope. |

## Validation

- `cd packages/web && bun test src/lib/node-ref.test.ts src/hooks/useBuilderValidation.test.ts src/experiments/console/builder/validation/content.test.ts src/experiments/console/builder/validation/when-grammar.test.ts src/experiments/console/builder/validation/validate.test.ts` — 59 pass, 0 fail, 129 assertions — proves both builder consumers and `when:` reference validation.
- `bun test ./scripts/node-ref-parity.test.ts` — 73 pass, 0 fail, 123 assertions — proves effective reserved-scope parity between the web helper and engine loader.
- `bun run validate` — exit 0 — proves generated checks, type-checks, zero-warning lint, formatting, installer tests, package tests, and script tests.
- **Not verified:** Nothing material; the changed observable outputs are deterministic validation issues covered by focused tests, and the full repository gate passed.

## Links

- Closes #2607
- Closes #2590
- Plan: https://github.com/coleam00/Archon/issues/2607#issuecomment-5340495205
- Companion plan publication: https://github.com/coleam00/Archon/issues/2590#issuecomment-5340576974


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workflow validation no longer flags reserved `$INPUTS` references as dangling node references.
  * Added validation for `when` expressions to warn about references outside a node’s upstream dependencies.
  * Improved handling of direct, compound, shorthand, and transitive node references.
* **Tests**
  * Expanded coverage for valid workflow inputs and reference-parsing edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->