### PR TITLE
fix(cli): linked worktrees keep their registered project identity

### DIFF
--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -4050,8 +4050,11 @@ describe('workflowRunsCommand', () => {
   });
 
   it('scopes to the cwd-resolved codebase id', async () => {
+    const git = await import('@archon/git');
     const workflowDb = await import('@archon/core/db/workflows');
     const codebaseDb = await import('@archon/core/db/codebases');
+    const canonicalSpy = git.getCanonicalRepoPath as ReturnType<typeof mock>;
+    canonicalSpy.mockClear();
     (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce({
       id: 'cb-proj',
       name: 'owner/repo',
@@ -4066,6 +4069,7 @@ describe('workflowRunsCommand', () => {
     expect(listSpy).toHaveBeenCalledWith(
       expect.objectContaining({ codebaseId: 'cb-proj', limit: 20 })
     );
+    expect(canonicalSpy).not.toHaveBeenCalled();
   });
 
   it('scopes a linked worktree to its registered primary checkout', async () => {
@@ -4075,11 +4079,13 @@ describe('workflowRunsCommand', () => {
     (git.getCanonicalRepoPath as ReturnType<typeof mock>).mockResolvedValueOnce(
       '/registered/primary'
     );
-    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce({
-      id: 'cb-primary',
-      name: 'owner/repo',
-      default_cwd: '/registered/primary',
-    });
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: 'cb-primary',
+        name: 'owner/repo',
+        default_cwd: '/registered/primary',
+      });
     const listSpy = workflowDb.listDashboardRuns as ReturnType<typeof mock>;
     listSpy.mockClear();
     listSpy.mockResolvedValueOnce({ runs: [], total: 0, counts: EMPTY_COUNTS });
@@ -4092,6 +4098,29 @@ describe('workflowRunsCommand', () => {
       expect.objectContaining({ codebaseId: 'cb-primary', limit: 20 })
     );
     expect(consoleSpy).not.toHaveBeenCalledWith('(not a registered project — showing all runs)');
+  });
+
+  it('preserves a codebase registered at the exact linked-worktree path', async () => {
+    const git = await import('@archon/git');
+    const workflowDb = await import('@archon/core/db/workflows');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    const canonicalSpy = git.getCanonicalRepoPath as ReturnType<typeof mock>;
+    canonicalSpy.mockClear();
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'cb-worktree',
+      name: 'owner/repo-worktree',
+      default_cwd: '/workspace/registered-worktree',
+    });
+    const listSpy = workflowDb.listDashboardRuns as ReturnType<typeof mock>;
+    listSpy.mockClear();
+    listSpy.mockResolvedValueOnce({ runs: [], total: 0, counts: EMPTY_COUNTS });
+
+    await workflowRunsCommand('/workspace/registered-worktree', {});
+
+    expect(canonicalSpy).not.toHaveBeenCalled();
+    expect(listSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ codebaseId: 'cb-worktree', limit: 20 })
+    );
   });
 
   it('prints the unregistered-cwd note and lists globally when no codebase resolves', async () => {

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -4068,6 +4068,32 @@ describe('workflowRunsCommand', () => {
     );
   });
 
+  it('scopes a linked worktree to its registered primary checkout', async () => {
+    const git = await import('@archon/git');
+    const workflowDb = await import('@archon/core/db/workflows');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    (git.getCanonicalRepoPath as ReturnType<typeof mock>).mockResolvedValueOnce(
+      '/registered/primary'
+    );
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'cb-primary',
+      name: 'owner/repo',
+      default_cwd: '/registered/primary',
+    });
+    const listSpy = workflowDb.listDashboardRuns as ReturnType<typeof mock>;
+    listSpy.mockClear();
+    listSpy.mockResolvedValueOnce({ runs: [], total: 0, counts: EMPTY_COUNTS });
+
+    await workflowRunsCommand('/workspace/sibling-worktree', {});
+
+    expect(git.getCanonicalRepoPath).toHaveBeenCalledWith('/workspace/sibling-worktree');
+    expect(codebaseDb.findCodebaseByDefaultCwd).toHaveBeenCalledWith('/registered/primary');
+    expect(listSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ codebaseId: 'cb-primary', limit: 20 })
+    );
+    expect(consoleSpy).not.toHaveBeenCalledWith('(not a registered project — showing all runs)');
+  });
+
   it('prints the unregistered-cwd note and lists globally when no codebase resolves', async () => {
     const workflowDb = await import('@archon/core/db/workflows');
     const codebaseDb = await import('@archon/core/db/codebases');

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -158,9 +158,27 @@ mock.module('@archon/workflows/event-emitter', () => ({
   })),
 }));
 
+class MockCanonicalRepoPathUnavailableError extends Error {
+  constructor(
+    readonly checkoutPath: string,
+    readonly commonGitDir: string
+  ) {
+    super(`Cannot determine the primary checkout for ${checkoutPath}`);
+    this.name = 'CanonicalRepoPathUnavailableError';
+  }
+}
+
 mock.module('@archon/git', () => ({
   findRepoRoot: mock(() => Promise.resolve(null)),
   getCanonicalRepoPath: mock((path: string) => Promise.resolve(path)),
+  getGitCheckoutIdentity: mock((path: string) =>
+    Promise.resolve({
+      gitDir: `${path}/.git`,
+      commonGitDir: `${path}/.git`,
+      linkedWorktree: false,
+    })
+  ),
+  CanonicalRepoPathUnavailableError: MockCanonicalRepoPathUnavailableError,
   getRemoteUrl: mock(() => Promise.resolve(null)),
   checkout: mock(() => Promise.resolve()),
   toRepoPath: mock((path: string) => path),
@@ -180,6 +198,7 @@ mock.module('@archon/core/db/conversations', () => ({
 
 mock.module('@archon/core/db/codebases', () => ({
   findCodebaseByDefaultCwd: mock(() => Promise.resolve(null)),
+  listCodebases: mock(() => Promise.resolve([])),
   findCodebaseByPathPrefix: mock(() => Promise.resolve(null)),
   getCodebase: mock(() => Promise.resolve(null)),
 }));
@@ -4148,6 +4167,44 @@ describe('workflowRunsCommand', () => {
     expect(canonicalSpy).not.toHaveBeenCalled();
     expect(listSpy).toHaveBeenCalledWith(
       expect.objectContaining({ codebaseId: 'cb-worktree', limit: 20 })
+    );
+  });
+
+  it('scopes an external-git-dir worktree through its registered Git identity', async () => {
+    const git = await import('@archon/git');
+    const workflowDb = await import('@archon/core/db/workflows');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    const cwd = '/workspace/external-linked';
+    const commonGitDir = '/metadata/repository';
+    const registered = {
+      id: 'cb-external',
+      name: 'owner/repo',
+      default_cwd: '/workspace/primary',
+      kind: 'repo',
+    };
+    (git.getCanonicalRepoPath as ReturnType<typeof mock>).mockRejectedValueOnce(
+      new git.CanonicalRepoPathUnavailableError(cwd, commonGitDir)
+    );
+    (git.getGitCheckoutIdentity as ReturnType<typeof mock>)
+      .mockResolvedValueOnce({
+        gitDir: `${commonGitDir}/worktrees/linked`,
+        commonGitDir,
+        linkedWorktree: true,
+      })
+      .mockResolvedValueOnce({
+        gitDir: commonGitDir,
+        commonGitDir,
+        linkedWorktree: false,
+      });
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce(null);
+    (codebaseDb.listCodebases as ReturnType<typeof mock>).mockResolvedValueOnce([registered]);
+    const listSpy = workflowDb.listDashboardRuns as ReturnType<typeof mock>;
+    listSpy.mockResolvedValueOnce({ runs: [], total: 0, counts: EMPTY_COUNTS });
+
+    await workflowRunsCommand(cwd, {});
+
+    expect(listSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ codebaseId: 'cb-external', limit: 20 })
     );
   });
 

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -3959,9 +3959,9 @@ describe('run-id prefix resolution (short ids from `workflow runs`)', () => {
     const workflowDb = await import('@archon/core/db/workflows');
     const codebaseDb = await import('@archon/core/db/codebases');
     (git.getCanonicalRepoPath as ReturnType<typeof mock>).mockResolvedValueOnce('/canonical/repo');
-    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce(
-      CODEBASE
-    );
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(CODEBASE);
     (workflowDb.findWorkflowRunsByIdPrefix as ReturnType<typeof mock>).mockResolvedValueOnce([
       { id: FULL_ID },
     ]);
@@ -3974,6 +3974,34 @@ describe('run-id prefix resolution (short ids from `workflow runs`)', () => {
     );
 
     expect(codebaseDb.findCodebaseByDefaultCwd).toHaveBeenCalledWith('/canonical/repo');
+    expect(mockCreateWorkflowEvent).toHaveBeenCalledWith({
+      workflow_run_id: FULL_ID,
+      event_type: 'workflow_started',
+      data: undefined,
+    });
+  });
+
+  it('resolves an event prefix from an exact registered linked worktree', async () => {
+    const git = await import('@archon/git');
+    const workflowDb = await import('@archon/core/db/workflows');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    const canonicalSpy = git.getCanonicalRepoPath as ReturnType<typeof mock>;
+    canonicalSpy.mockClear();
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce(
+      CODEBASE
+    );
+    (workflowDb.findWorkflowRunsByIdPrefix as ReturnType<typeof mock>).mockResolvedValueOnce([
+      { id: FULL_ID },
+    ]);
+
+    await workflowEventEmitCommand(
+      '0b1ee8da',
+      'workflow_started',
+      undefined,
+      '/workspace/registered-worktree'
+    );
+
+    expect(canonicalSpy).not.toHaveBeenCalled();
     expect(mockCreateWorkflowEvent).toHaveBeenCalledWith({
       workflow_run_id: FULL_ID,
       event_type: 'workflow_started',

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -40,6 +40,7 @@ import { mkdirSync, openSync, closeSync, readFileSync, writeSync } from 'node:fs
 import { spawn, type ChildProcess } from 'node:child_process';
 import { createWorkflowDeps } from '@archon/core/workflows/store-adapter';
 import { createChildWorktreeResolver } from '@archon/core/workflows/child-isolation-resolver';
+import { findCodebaseForCheckoutPath } from '@archon/core/services/codebase-checkout-resolver';
 import { discoverWorkflowsWithConfig } from '@archon/workflows/workflow-discovery';
 import { resolveWorkflowName } from '@archon/workflows/router';
 import { executeWorkflow, hydrateResumableRun } from '@archon/workflows/executor';
@@ -2484,17 +2485,6 @@ function readParseWarningEvents(events: readonly WorkflowEventRow[]): string[] {
  * status. `--all` drops the project scope (lists across all projects);
  * `--status` filters to one status; `--limit` caps the count (default 20).
  */
-async function findCodebaseForCheckoutPath(
-  cwd: string
-): Promise<Awaited<ReturnType<typeof codebaseDb.findCodebaseByDefaultCwd>>> {
-  const exact = await codebaseDb.findCodebaseByDefaultCwd(cwd);
-  if (exact) return exact;
-
-  const canonicalCwd = await git.getCanonicalRepoPath(cwd);
-  if (canonicalCwd === cwd) return null;
-  return codebaseDb.findCodebaseByDefaultCwd(canonicalCwd);
-}
-
 export async function workflowRunsCommand(
   cwd: string,
   opts: { json?: boolean; all?: boolean; status?: string; limit?: number } = {}

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -2503,17 +2503,23 @@ export async function workflowRunsCommand(
     statusFilter = parsed.data;
   }
 
-  // Scope to this project through the checkout's canonical repository path.
-  // A linked worktree shares identity with its registered primary checkout,
-  // while an ordinary clone remains unchanged by getCanonicalRepoPath (#2613).
+  // Scope to this project by exact registration first, then through the
+  // checkout's canonical repository path. This preserves an explicitly
+  // registered linked worktree while allowing another linked worktree to share
+  // its registered primary checkout. Ordinary clones remain unchanged (#2613).
   // --all opts out of scoping. A lookup failure or an unregistered cwd both
   // fall back to the global list — never a silent wrong-scope (the human path
   // prints an explicit note below).
   let codebase = null;
   if (!opts.all) {
     try {
-      const canonicalCwd = await git.getCanonicalRepoPath(cwd);
-      codebase = await codebaseDb.findCodebaseByDefaultCwd(canonicalCwd);
+      codebase = await codebaseDb.findCodebaseByDefaultCwd(cwd);
+      if (!codebase) {
+        const canonicalCwd = await git.getCanonicalRepoPath(cwd);
+        if (canonicalCwd !== cwd) {
+          codebase = await codebaseDb.findCodebaseByDefaultCwd(canonicalCwd);
+        }
+      }
     } catch (error) {
       getLog().warn({ err: error as Error, cwd }, 'cli.workflow_runs_codebase_lookup_failed');
     }

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -2503,14 +2503,17 @@ export async function workflowRunsCommand(
     statusFilter = parsed.data;
   }
 
-  // Scope to this project by resolving the codebase from cwd (mirror
-  // workflowRunCommand). --all opts out of scoping. A lookup failure or an
-  // unregistered cwd both fall back to the global list — never a silent
-  // wrong-scope (the human path prints an explicit note below).
+  // Scope to this project through the checkout's canonical repository path.
+  // A linked worktree shares identity with its registered primary checkout,
+  // while an ordinary clone remains unchanged by getCanonicalRepoPath (#2613).
+  // --all opts out of scoping. A lookup failure or an unregistered cwd both
+  // fall back to the global list — never a silent wrong-scope (the human path
+  // prints an explicit note below).
   let codebase = null;
   if (!opts.all) {
     try {
-      codebase = await codebaseDb.findCodebaseByDefaultCwd(cwd);
+      const canonicalCwd = await git.getCanonicalRepoPath(cwd);
+      codebase = await codebaseDb.findCodebaseByDefaultCwd(canonicalCwd);
     } catch (error) {
       getLog().warn({ err: error as Error, cwd }, 'cli.workflow_runs_codebase_lookup_failed');
     }

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -2484,6 +2484,17 @@ function readParseWarningEvents(events: readonly WorkflowEventRow[]): string[] {
  * status. `--all` drops the project scope (lists across all projects);
  * `--status` filters to one status; `--limit` caps the count (default 20).
  */
+async function findCodebaseForCheckoutPath(
+  cwd: string
+): Promise<Awaited<ReturnType<typeof codebaseDb.findCodebaseByDefaultCwd>>> {
+  const exact = await codebaseDb.findCodebaseByDefaultCwd(cwd);
+  if (exact) return exact;
+
+  const canonicalCwd = await git.getCanonicalRepoPath(cwd);
+  if (canonicalCwd === cwd) return null;
+  return codebaseDb.findCodebaseByDefaultCwd(canonicalCwd);
+}
+
 export async function workflowRunsCommand(
   cwd: string,
   opts: { json?: boolean; all?: boolean; status?: string; limit?: number } = {}
@@ -2513,13 +2524,7 @@ export async function workflowRunsCommand(
   let codebase = null;
   if (!opts.all) {
     try {
-      codebase = await codebaseDb.findCodebaseByDefaultCwd(cwd);
-      if (!codebase) {
-        const canonicalCwd = await git.getCanonicalRepoPath(cwd);
-        if (canonicalCwd !== cwd) {
-          codebase = await codebaseDb.findCodebaseByDefaultCwd(canonicalCwd);
-        }
-      }
+      codebase = await findCodebaseForCheckoutPath(cwd);
     } catch (error) {
       getLog().warn({ err: error as Error, cwd }, 'cli.workflow_runs_codebase_lookup_failed');
     }
@@ -2602,11 +2607,11 @@ const FULL_RUN_ID_RE =
  * codebase, a unique match resolves, and an ambiguous prefix errors.
  *
  * Full UUIDs skip resolution entirely — exact lookup is global, so full ids
- * keep working from any directory. Worktree paths are normalized to their
- * canonical checkout before project lookup. By default, an omitted or
- * unregistered cwd and an unmatched prefix pass through unchanged so the
- * downstream exact lookup keeps its existing error surface. Callers without a
- * downstream lookup can require a match instead.
+ * keep working from any directory. Project lookup preserves an exact checkout
+ * registration, then falls back to a linked worktree's canonical checkout. By
+ * default, an omitted or unregistered cwd and an unmatched prefix pass through
+ * unchanged so the downstream exact lookup keeps its existing error surface.
+ * Callers without a downstream lookup can require a match instead.
  */
 async function resolveRunIdArg(
   runId: string,
@@ -2620,8 +2625,7 @@ async function resolveRunIdArg(
     }
     return runId;
   }
-  const canonicalCwd = await git.getCanonicalRepoPath(cwd);
-  const codebase = await codebaseDb.findCodebaseByDefaultCwd(canonicalCwd);
+  const codebase = await findCodebaseForCheckoutPath(cwd);
   if (!codebase) {
     if (requirePrefixMatch) {
       throw new Error(`Cannot resolve run id prefix '${runId}' outside a registered project.`);

--- a/packages/core/src/handlers/clone.test.ts
+++ b/packages/core/src/handlers/clone.test.ts
@@ -32,7 +32,7 @@ const mockFindCodebaseByRepoUrl = mock(() => Promise.resolve(null));
 const mockFindCodebaseByDefaultCwd = mock(() => Promise.resolve(null));
 const mockFindCodebaseByName = mock(() => Promise.resolve(null));
 const mockUpdateCodebase = mock(() => Promise.resolve());
-const mockCreateProjectSourceSymlink = mock(() => Promise.resolve());
+const mockCreateProjectSourceSymlink = mock((): Promise<void> => Promise.resolve());
 
 mock.module('../db/codebases', () => ({
   createCodebase: mockCreateCodebase,
@@ -115,8 +115,9 @@ function setupSpies(): void {
     stdout: '',
     stderr: '',
   });
-  spyGetCanonicalRepoPath = spyOn(gitUtils, 'getCanonicalRepoPath').mockImplementation(async path =>
-    gitUtils.toRepoPath(path)
+  spyGetCanonicalRepoPath = spyOn(gitUtils, 'getCanonicalRepoPath').mockImplementation(
+    (path: string): ReturnType<typeof gitUtils.getCanonicalRepoPath> =>
+      Promise.resolve(gitUtils.toRepoPath(path))
   );
 }
 

--- a/packages/core/src/handlers/clone.test.ts
+++ b/packages/core/src/handlers/clone.test.ts
@@ -32,6 +32,7 @@ const mockFindCodebaseByRepoUrl = mock(() => Promise.resolve(null));
 const mockFindCodebaseByDefaultCwd = mock(() => Promise.resolve(null));
 const mockFindCodebaseByName = mock(() => Promise.resolve(null));
 const mockUpdateCodebase = mock(() => Promise.resolve());
+const mockCreateProjectSourceSymlink = mock(() => Promise.resolve());
 
 mock.module('../db/codebases', () => ({
   createCodebase: mockCreateCodebase,
@@ -54,7 +55,7 @@ mock.module('@archon/paths', () => ({
   getProjectSourcePath: mock(
     (owner: string, repo: string) => `/home/test/.archon/workspaces/${owner}/${repo}/source`
   ),
-  createProjectSourceSymlink: mock(() => Promise.resolve()),
+  createProjectSourceSymlink: mockCreateProjectSourceSymlink,
   parseOwnerRepo: mock((name: string) => {
     const parts = name.split('/');
     return parts.length === 2 ? { owner: parts[0], repo: parts[1] } : null;
@@ -94,6 +95,7 @@ let spyFsRm: ReturnType<typeof spyOn>;
 let spyFsStat: ReturnType<typeof spyOn>;
 let spyFsRealpath: ReturnType<typeof spyOn>;
 let spyExecFileAsync: ReturnType<typeof spyOn>;
+let spyGetCanonicalRepoPath: ReturnType<typeof spyOn>;
 
 function setupSpies(): void {
   // Default: .git does NOT exist (no pre-existing clone)
@@ -113,6 +115,9 @@ function setupSpies(): void {
     stdout: '',
     stderr: '',
   });
+  spyGetCanonicalRepoPath = spyOn(gitUtils, 'getCanonicalRepoPath').mockImplementation(async path =>
+    gitUtils.toRepoPath(path)
+  );
 }
 
 function restoreSpies(): void {
@@ -121,6 +126,7 @@ function restoreSpies(): void {
   spyFsRealpath?.mockRestore();
   spyFsStat?.mockRestore();
   spyExecFileAsync?.mockRestore();
+  spyGetCanonicalRepoPath?.mockRestore();
 }
 
 function clearMocks(): void {
@@ -133,6 +139,7 @@ function clearMocks(): void {
   mockFindCodebaseByDefaultCwd.mockReset();
   mockFindCodebaseByName.mockReset();
   mockUpdateCodebase.mockReset();
+  mockCreateProjectSourceSymlink.mockClear();
   mockFindMarkdownFilesRecursive.mockReset();
   mockLoadConfig.mockReset();
   mockLoadConfig.mockResolvedValue({ assistant: 'claude' });
@@ -953,6 +960,33 @@ describe('registerRepository', () => {
     expect(result.codebaseId).toBe('existing-codebase-id');
     // createCodebase should NOT be called
     expect(mockCreateCodebase.mock.calls.length).toBe(0);
+  });
+
+  test('reuses the registered primary checkout for a linked worktree', async () => {
+    spyExecFileAsync.mockResolvedValue({ stdout: '.git', stderr: '' });
+    spyGetCanonicalRepoPath.mockResolvedValueOnce(
+      gitUtils.toRepoPath('/home/user/primary-checkout')
+    );
+    const existingCodebase = makeCodebase({
+      id: 'primary-codebase-id',
+      default_cwd: '/home/user/primary-checkout',
+    });
+    mockFindCodebaseByDefaultCwd
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(existingCodebase);
+
+    const result = await registerRepository('/home/user/sibling-worktree');
+
+    expect(mockFindCodebaseByDefaultCwd).toHaveBeenNthCalledWith(1, '/home/user/sibling-worktree');
+    expect(mockFindCodebaseByDefaultCwd).toHaveBeenNthCalledWith(2, '/home/user/primary-checkout');
+    expect(result).toMatchObject({
+      alreadyExisted: true,
+      codebaseId: 'primary-codebase-id',
+      defaultCwd: '/home/user/primary-checkout',
+    });
+    expect(mockCreateProjectSourceSymlink).not.toHaveBeenCalled();
+    expect(mockCreateCodebase).not.toHaveBeenCalled();
+    expect(mockUpdateCodebase).not.toHaveBeenCalled();
   });
 
   // ── Validation ─────────────────────────────────────────────────────────

--- a/packages/core/src/handlers/clone.test.ts
+++ b/packages/core/src/handlers/clone.test.ts
@@ -11,6 +11,11 @@ import { describe, test, expect, mock, beforeEach, afterAll, afterEach, spyOn } 
 import { resolve } from 'path';
 import * as fsPromises from 'fs/promises';
 import * as gitUtils from '@archon/git';
+import type { Codebase } from '../types';
+import {
+  findCodebaseForCheckoutPath,
+  type CodebaseCheckoutResolverDeps,
+} from '../services/codebase-checkout-resolver';
 import { createMockLogger } from '../test/mocks/logger';
 
 // ── DB mocks ────────────────────────────────────────────────────────────────
@@ -30,6 +35,7 @@ const mockGetCodebaseCommands = mock(() => Promise.resolve({}));
 const mockUpdateCodebaseCommands = mock(() => Promise.resolve());
 const mockFindCodebaseByRepoUrl = mock(() => Promise.resolve(null));
 const mockFindCodebaseByDefaultCwd = mock(() => Promise.resolve(null));
+const mockListCodebases = mock(() => Promise.resolve([]));
 const mockFindCodebaseByName = mock(() => Promise.resolve(null));
 const mockUpdateCodebase = mock(() => Promise.resolve());
 const mockCreateProjectSourceSymlink = mock((): Promise<void> => Promise.resolve());
@@ -40,6 +46,7 @@ mock.module('../db/codebases', () => ({
   updateCodebaseCommands: mockUpdateCodebaseCommands,
   findCodebaseByRepoUrl: mockFindCodebaseByRepoUrl,
   findCodebaseByDefaultCwd: mockFindCodebaseByDefaultCwd,
+  listCodebases: mockListCodebases,
   findCodebaseByName: mockFindCodebaseByName,
   updateCodebase: mockUpdateCodebase,
 }));
@@ -183,12 +190,97 @@ function makeCodebase(
     default_cwd: '/home/test/.archon/workspaces/owner/repo/source',
     default_branch: null,
     ai_assistant_type: 'claude',
+    kind: 'repo',
     commands: {},
     created_at: new Date(),
     updated_at: new Date(),
     ...overrides,
   };
 }
+
+function makeResolverDeps(
+  overrides: Partial<CodebaseCheckoutResolverDeps> = {}
+): CodebaseCheckoutResolverDeps {
+  return {
+    findCodebaseByDefaultCwd: async () => null,
+    listCodebases: async () => [],
+    getCanonicalRepoPath: async path => path,
+    getGitCheckoutIdentity: async path => ({
+      gitDir: `${path}/.git`,
+      commonGitDir: `${path}/.git`,
+      linkedWorktree: false,
+    }),
+    ...overrides,
+  };
+}
+
+describe('findCodebaseForCheckoutPath', () => {
+  const cwd = '/workspace/external-linked';
+  const commonGitDir = '/metadata/repository';
+
+  function externalLinkedError(): gitUtils.CanonicalRepoPathUnavailableError {
+    return new gitUtils.CanonicalRepoPathUnavailableError(cwd, commonGitDir);
+  }
+
+  test('matches an external linked worktree to its uniquely registered Git repository', async () => {
+    const registered = makeCodebase({ default_cwd: '/workspace/primary' }) as Codebase;
+    const separateClone = makeCodebase({
+      id: 'separate-clone',
+      default_cwd: '/workspace/separate-clone',
+    }) as Codebase;
+    const deps = makeResolverDeps({
+      getCanonicalRepoPath: async () => {
+        throw externalLinkedError();
+      },
+      listCodebases: async () => [registered, separateClone],
+      getGitCheckoutIdentity: async path => ({
+        gitDir: path === cwd ? `${commonGitDir}/worktrees/linked` : `${path}/.git`,
+        commonGitDir:
+          path === separateClone.default_cwd ? '/metadata/separate-clone' : commonGitDir,
+        linkedWorktree: path === cwd,
+      }),
+    });
+
+    await expect(findCodebaseForCheckoutPath(cwd, deps)).resolves.toBe(registered);
+  });
+
+  test('does not conflate a separate clone with the registered repository', async () => {
+    const registered = makeCodebase({ default_cwd: '/workspace/primary' }) as Codebase;
+    const deps = makeResolverDeps({
+      getCanonicalRepoPath: async () => {
+        throw externalLinkedError();
+      },
+      listCodebases: async () => [registered],
+      getGitCheckoutIdentity: async path => ({
+        gitDir: path === cwd ? `${commonGitDir}/worktrees/linked` : '/other/clone/.git',
+        commonGitDir: path === cwd ? commonGitDir : '/other/clone/.git',
+        linkedWorktree: path === cwd,
+      }),
+    });
+
+    await expect(findCodebaseForCheckoutPath(cwd, deps)).resolves.toBeNull();
+  });
+
+  test('rejects ambiguous registrations sharing one external Git directory', async () => {
+    const first = makeCodebase({ id: 'first', default_cwd: '/workspace/first' }) as Codebase;
+    const second = makeCodebase({ id: 'second', default_cwd: '/workspace/second' }) as Codebase;
+    const deps = makeResolverDeps({
+      getCanonicalRepoPath: async () => {
+        throw externalLinkedError();
+      },
+      listCodebases: async () => [first, second],
+      getGitCheckoutIdentity: async path => ({
+        gitDir: path === cwd ? `${commonGitDir}/worktrees/linked` : commonGitDir,
+        commonGitDir,
+        linkedWorktree: path === cwd,
+      }),
+    });
+
+    await expect(findCodebaseForCheckoutPath(cwd, deps)).rejects.toThrow(
+      'matches multiple registered codebases'
+    );
+  });
+});
 
 // ────────────────────────────────────────────────────────────────────────────
 describe('cloneRepository', () => {

--- a/packages/core/src/handlers/clone.ts
+++ b/packages/core/src/handlers/clone.ts
@@ -6,7 +6,7 @@ import { access, rm, stat, realpath } from 'fs/promises';
 import { join, basename, resolve } from 'path';
 import * as codebaseDb from '../db/codebases';
 import { sanitizeError } from '../utils/credential-sanitizer';
-import { execFileAsync } from '@archon/git';
+import { execFileAsync, getCanonicalRepoPath } from '@archon/git';
 import {
   expandTilde,
   getCommandFolderSearchPaths,
@@ -411,8 +411,16 @@ export async function registerRepository(localPath: string): Promise<RegisterRes
     throw new Error(`Path is not a git repository: ${localPath} (${(error as Error).message})`);
   }
 
-  // Check if already registered by path
-  const existing = await codebaseDb.findCodebaseByDefaultCwd(localPath);
+  // A linked worktree is another checkout of the same local repository, so its
+  // registered identity is owned by the primary checkout from its .git pointer.
+  // Ordinary clones return their own path unchanged and remain distinct (#1192).
+  let existing = await codebaseDb.findCodebaseByDefaultCwd(localPath);
+  if (!existing) {
+    const canonicalPath = await getCanonicalRepoPath(localPath);
+    if (canonicalPath !== localPath) {
+      existing = await codebaseDb.findCodebaseByDefaultCwd(canonicalPath);
+    }
+  }
   if (existing) {
     return {
       codebaseId: existing.id,

--- a/packages/core/src/handlers/clone.ts
+++ b/packages/core/src/handlers/clone.ts
@@ -6,7 +6,8 @@ import { access, rm, stat, realpath } from 'fs/promises';
 import { join, basename, resolve } from 'path';
 import * as codebaseDb from '../db/codebases';
 import { sanitizeError } from '../utils/credential-sanitizer';
-import { execFileAsync, getCanonicalRepoPath } from '@archon/git';
+import { execFileAsync } from '@archon/git';
+import { findCodebaseForCheckoutPath } from '../services/codebase-checkout-resolver';
 import {
   expandTilde,
   getCommandFolderSearchPaths,
@@ -411,16 +412,9 @@ export async function registerRepository(localPath: string): Promise<RegisterRes
     throw new Error(`Path is not a git repository: ${localPath} (${(error as Error).message})`);
   }
 
-  // A linked worktree is another checkout of the same local repository, so its
-  // registered identity is owned by the primary checkout from its .git pointer.
-  // Ordinary clones return their own path unchanged and remain distinct (#1192).
-  let existing = await codebaseDb.findCodebaseByDefaultCwd(localPath);
-  if (!existing) {
-    const canonicalPath = await getCanonicalRepoPath(localPath);
-    if (canonicalPath !== localPath) {
-      existing = await codebaseDb.findCodebaseByDefaultCwd(canonicalPath);
-    }
-  }
+  // Git's physical common directory proves linked-checkout ownership without
+  // conflating separate clones, remotes, names, or branches (#1192).
+  const existing = await findCodebaseForCheckoutPath(localPath);
   if (existing) {
     return {
       codebaseId: existing.id,

--- a/packages/core/src/services/codebase-checkout-resolver.ts
+++ b/packages/core/src/services/codebase-checkout-resolver.ts
@@ -1,0 +1,70 @@
+import type { Codebase } from '../types';
+import * as codebaseDb from '../db/codebases';
+import { resolve } from 'node:path';
+import {
+  CanonicalRepoPathUnavailableError,
+  getCanonicalRepoPath,
+  getGitCheckoutIdentity,
+  type GitCheckoutIdentity,
+} from '@archon/git';
+
+export interface CodebaseCheckoutResolverDeps {
+  findCodebaseByDefaultCwd: (cwd: string) => Promise<Codebase | null>;
+  listCodebases: () => Promise<readonly Codebase[]>;
+  getCanonicalRepoPath: (path: string) => Promise<string>;
+  getGitCheckoutIdentity: (path: string) => Promise<GitCheckoutIdentity>;
+}
+
+const defaultDeps: CodebaseCheckoutResolverDeps = {
+  findCodebaseByDefaultCwd: cwd => codebaseDb.findCodebaseByDefaultCwd(cwd),
+  listCodebases: () => codebaseDb.listCodebases(),
+  getCanonicalRepoPath: path => getCanonicalRepoPath(path),
+  getGitCheckoutIdentity: path => getGitCheckoutIdentity(path),
+};
+
+/**
+ * Resolve a checkout to an existing codebase without remote or branch inference.
+ *
+ * Exact registration wins. Normal linked worktrees then use their Git-proven
+ * primary checkout. A linked worktree backed by `--separate-git-dir` has no
+ * reverse primary-path pointer, so the final tier matches Git's exact common
+ * directory against registered repository checkouts and rejects ambiguity.
+ */
+export async function findCodebaseForCheckoutPath(
+  cwd: string,
+  deps: CodebaseCheckoutResolverDeps = defaultDeps
+): Promise<Codebase | null> {
+  const exact = await deps.findCodebaseByDefaultCwd(cwd);
+  if (exact) return exact;
+
+  try {
+    const canonicalCwd = await deps.getCanonicalRepoPath(cwd);
+    if (canonicalCwd === cwd) return null;
+    return await deps.findCodebaseByDefaultCwd(canonicalCwd);
+  } catch (error) {
+    if (!(error instanceof CanonicalRepoPathUnavailableError)) throw error;
+  }
+
+  const checkoutIdentity = await deps.getGitCheckoutIdentity(cwd);
+  const matches: Codebase[] = [];
+  for (const codebase of await deps.listCodebases()) {
+    if (codebase.kind === 'folder') continue;
+    try {
+      const registeredIdentity = await deps.getGitCheckoutIdentity(codebase.default_cwd);
+      if (resolve(registeredIdentity.commonGitDir) === resolve(checkoutIdentity.commonGitDir)) {
+        matches.push(codebase);
+      }
+    } catch {
+      // A stale registered path cannot own the live checkout identity.
+    }
+  }
+
+  if (matches.length > 1) {
+    const paths = matches.map(codebase => codebase.default_cwd).join(', ');
+    throw new Error(
+      `Checkout ${cwd} matches multiple registered codebases through Git directory ` +
+        `${checkoutIdentity.commonGitDir}: ${paths}. Register this exact checkout or remove the ambiguity.`
+    );
+  }
+  return matches[0] ?? null;
+}

--- a/packages/git/src/git.test.ts
+++ b/packages/git/src/git.test.ts
@@ -157,8 +157,21 @@ describe('git utilities', () => {
 
     test('extracts main repo path from worktree', async () => {
       await writeFile(join(testDir, '.git'), 'gitdir: /workspace/my-repo/.git/worktrees/issue-42');
-      const result = await git.getCanonicalRepoPath(testDir);
-      expect(result).toBe(repo('/workspace/my-repo'));
+      const execSpy = spyOn(git, 'execFileAsync')
+        .mockResolvedValueOnce({
+          stdout: '/workspace/my-repo/.git/worktrees/issue-42\n/workspace/my-repo/.git\n',
+          stderr: '',
+        })
+        .mockResolvedValueOnce({
+          stdout: 'worktree /workspace/my-repo\nHEAD abc123\nbranch refs/heads/main\n',
+          stderr: '',
+        });
+      try {
+        const result = await git.getCanonicalRepoPath(testDir);
+        expect(result).toBe(repo('/workspace/my-repo'));
+      } finally {
+        execSpy.mockRestore();
+      }
     });
 
     test('handles worktree path with nested directories', async () => {
@@ -166,20 +179,54 @@ describe('git utilities', () => {
         join(testDir, '.git'),
         'gitdir: /home/user/projects/my-app/.git/worktrees/feature-branch'
       );
-      const result = await git.getCanonicalRepoPath(testDir);
-      expect(result).toBe(repo('/home/user/projects/my-app'));
+      const execSpy = spyOn(git, 'execFileAsync')
+        .mockResolvedValueOnce({
+          stdout:
+            '/home/user/projects/my-app/.git/worktrees/feature-branch\n/home/user/projects/my-app/.git\n',
+          stderr: '',
+        })
+        .mockResolvedValueOnce({
+          stdout: 'worktree /home/user/projects/my-app\nHEAD abc123\n',
+          stderr: '',
+        });
+      try {
+        const result = await git.getCanonicalRepoPath(testDir);
+        expect(result).toBe(repo('/home/user/projects/my-app'));
+      } finally {
+        execSpy.mockRestore();
+      }
     });
 
     test('resolves a relative worktree pointer from the worktree root', async () => {
       await writeFile(join(testDir, '.git'), 'gitdir: ../primary/.git/worktrees/linked');
-      const result = await git.getCanonicalRepoPath(testDir);
-      expect(result).toBe(repo(resolve(testDir, '../primary')));
+      const primary = resolve(testDir, '../primary');
+      const execSpy = spyOn(git, 'execFileAsync')
+        .mockResolvedValueOnce({
+          stdout: `${primary}/.git/worktrees/linked\n${primary}/.git\n`,
+          stderr: '',
+        })
+        .mockResolvedValueOnce({ stdout: `worktree ${primary}\nHEAD abc123\n`, stderr: '' });
+      try {
+        const result = await git.getCanonicalRepoPath(testDir);
+        expect(result).toBe(repo(primary));
+      } finally {
+        execSpy.mockRestore();
+      }
     });
 
     test('keeps a submodule checkout as its own canonical repository', async () => {
       await writeFile(join(testDir, '.git'), 'gitdir: ../primary/.git/modules/vendor/module');
-      const result = await git.getCanonicalRepoPath(testDir);
-      expect(result).toBe(testDir);
+      const gitDir = resolve(testDir, '../primary/.git/modules/vendor/module');
+      const execSpy = spyOn(git, 'execFileAsync').mockResolvedValue({
+        stdout: `${gitDir}\n${gitDir}\n`,
+        stderr: '',
+      });
+      try {
+        const result = await git.getCanonicalRepoPath(testDir);
+        expect(result).toBe(testDir);
+      } finally {
+        execSpy.mockRestore();
+      }
     });
 
     test('keeps a submodule named under worktrees as its own canonical repository', async () => {
@@ -187,9 +234,39 @@ describe('git utilities', () => {
       await realMkdir(gitDir, { recursive: true });
       await writeFile(join(testDir, '.git'), `gitdir: ${gitDir}`);
 
-      const result = await git.getCanonicalRepoPath(testDir);
+      const execSpy = spyOn(git, 'execFileAsync').mockResolvedValue({
+        stdout: `${gitDir}\n${gitDir}\n`,
+        stderr: '',
+      });
+      try {
+        const result = await git.getCanonicalRepoPath(testDir);
+        expect(result).toBe(testDir);
+      } finally {
+        execSpy.mockRestore();
+      }
+    });
 
-      expect(result).toBe(testDir);
+    test('keeps a submodule inside a linked superproject as its own repository', async () => {
+      const commonGitDir = join(
+        testDir,
+        'super',
+        '.git',
+        'worktrees',
+        'linked-super',
+        'modules',
+        'vendor',
+        'module'
+      );
+      await writeFile(join(testDir, '.git'), `gitdir: ${commonGitDir}`);
+      const execSpy = spyOn(git, 'execFileAsync').mockResolvedValue({
+        stdout: `${commonGitDir}\n${commonGitDir}\n`,
+        stderr: '',
+      });
+      try {
+        await expect(git.getCanonicalRepoPath(testDir)).resolves.toBe(testDir);
+      } finally {
+        execSpy.mockRestore();
+      }
     });
 
     test('resolves a linked submodule worktree to the primary submodule checkout', async () => {
@@ -198,10 +275,14 @@ describe('git utilities', () => {
       await realMkdir(linkedGitDir, { recursive: true });
       await writeFile(join(linkedGitDir, 'commondir'), '../..\n');
       await writeFile(join(testDir, '.git'), `gitdir: ${linkedGitDir}`);
-      const execSpy = spyOn(git, 'execFileAsync').mockResolvedValue({
-        stdout: '../../../../vendor/module\n',
-        stderr: '',
-      });
+      const primaryCheckout = resolve(commonGitDir, '../../../../vendor/module');
+      const execSpy = spyOn(git, 'execFileAsync')
+        .mockResolvedValueOnce({
+          stdout: `${linkedGitDir}\n${commonGitDir}\n`,
+          stderr: '',
+        })
+        .mockResolvedValueOnce({ stdout: `worktree ${commonGitDir}\nHEAD abc123\n`, stderr: '' })
+        .mockResolvedValueOnce({ stdout: '../../../../vendor/module\n', stderr: '' });
 
       try {
         const result = await git.getCanonicalRepoPath(testDir);
@@ -213,7 +294,63 @@ describe('git utilities', () => {
           '--get',
           'core.worktree',
         ]);
-        expect(result).toBe(repo(resolve(commonGitDir, '../../../../vendor/module')));
+        expect(result).toBe(repo(primaryCheckout));
+      } finally {
+        execSpy.mockRestore();
+      }
+    });
+
+    test('resolves a linked submodule worktree inside a linked superproject', async () => {
+      const commonGitDir = join(
+        testDir,
+        'super',
+        '.git',
+        'worktrees',
+        'linked-super',
+        'modules',
+        'vendor',
+        'module'
+      );
+      const linkedGitDir = join(commonGitDir, 'worktrees', 'linked-module');
+      const primaryCheckout = join(testDir, 'linked-super', 'vendor', 'module');
+      await writeFile(join(testDir, '.git'), `gitdir: ${linkedGitDir}`);
+      const execSpy = spyOn(git, 'execFileAsync')
+        .mockResolvedValueOnce({ stdout: `${linkedGitDir}\n${commonGitDir}\n`, stderr: '' })
+        .mockResolvedValueOnce({ stdout: `worktree ${commonGitDir}\nHEAD abc123\n`, stderr: '' })
+        .mockResolvedValueOnce({ stdout: `${primaryCheckout}\n`, stderr: '' });
+      try {
+        await expect(git.getCanonicalRepoPath(testDir)).resolves.toBe(repo(primaryCheckout));
+      } finally {
+        execSpy.mockRestore();
+      }
+    });
+
+    test('keeps a primary checkout with an external Git directory', async () => {
+      const externalGitDir = join(testDir, 'metadata');
+      await writeFile(join(testDir, '.git'), `gitdir: ${externalGitDir}`);
+      const execSpy = spyOn(git, 'execFileAsync').mockResolvedValue({
+        stdout: `${externalGitDir}\n${externalGitDir}\n`,
+        stderr: '',
+      });
+      try {
+        await expect(git.getCanonicalRepoPath(testDir)).resolves.toBe(testDir);
+      } finally {
+        execSpy.mockRestore();
+      }
+    });
+
+    test('reports when an external Git directory cannot reveal the primary checkout', async () => {
+      const commonGitDir = join(testDir, 'metadata');
+      const linkedGitDir = join(commonGitDir, 'worktrees', 'linked');
+      await writeFile(join(testDir, '.git'), `gitdir: ${linkedGitDir}`);
+      const execSpy = spyOn(git, 'execFileAsync')
+        .mockResolvedValueOnce({ stdout: `${linkedGitDir}\n${commonGitDir}\n`, stderr: '' })
+        .mockResolvedValueOnce({ stdout: `worktree ${commonGitDir}\nHEAD abc123\n`, stderr: '' })
+        .mockRejectedValueOnce(new Error('core.worktree is unset'));
+      try {
+        await expect(git.getCanonicalRepoPath(testDir)).rejects.toBeInstanceOf(
+          git.CanonicalRepoPathUnavailableError
+        );
       } finally {
         execSpy.mockRestore();
       }
@@ -2821,14 +2958,19 @@ branch refs/heads/feature/auth
         'gitdir: /some/unusual/path/without/expected/structure'
       );
       mockLogger.error.mockClear();
+      const execSpy = spyOn(git, 'execFileAsync').mockRejectedValue(new Error('invalid gitdir'));
 
-      await expect(git.getCanonicalRepoPath(testDir)).rejects.toThrow(
-        'Cannot determine canonical repo path from worktree'
-      );
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        expect.objectContaining({ path: testDir }),
-        'canonical_path_regex_failed'
-      );
+      try {
+        await expect(git.getCanonicalRepoPath(testDir)).rejects.toThrow(
+          'Cannot determine canonical repo path from worktree'
+        );
+        expect(mockLogger.error).toHaveBeenCalledWith(
+          expect.objectContaining({ path: testDir }),
+          'canonical_path_resolution_failed'
+        );
+      } finally {
+        execSpy.mockRestore();
+      }
     });
   });
 
@@ -2838,24 +2980,50 @@ branch refs/heads/feature/auth
         join(testDir, '.git'),
         'gitdir: /workspace/my-repo/.git/worktrees/issue-42\n'
       );
+      const execSpy = spyOn(git, 'execFileAsync')
+        .mockResolvedValueOnce({
+          stdout: '/workspace/my-repo/.git/worktrees/issue-42\n/workspace/my-repo/.git\n',
+          stderr: '',
+        })
+        .mockResolvedValueOnce({
+          stdout: '/workspace/my-repo/.git\n/workspace/my-repo/.git\n',
+          stderr: '',
+        });
 
-      await expect(
-        git.verifyWorktreeOwnership(
-          git.toWorktreePath(testDir),
-          git.toRepoPath('/workspace/my-repo')
-        )
-      ).resolves.toBeUndefined();
+      try {
+        await expect(
+          git.verifyWorktreeOwnership(
+            git.toWorktreePath(testDir),
+            git.toRepoPath('/workspace/my-repo')
+          )
+        ).resolves.toBeUndefined();
+      } finally {
+        execSpy.mockRestore();
+      }
     });
 
     test('throws with "belongs to a different clone" when gitdir points elsewhere', async () => {
       await writeFile(join(testDir, '.git'), 'gitdir: /other/clone/.git/worktrees/issue-42\n');
+      const execSpy = spyOn(git, 'execFileAsync')
+        .mockResolvedValueOnce({
+          stdout: '/other/clone/.git/worktrees/issue-42\n/other/clone/.git\n',
+          stderr: '',
+        })
+        .mockResolvedValueOnce({
+          stdout: '/workspace/my-repo/.git\n/workspace/my-repo/.git\n',
+          stderr: '',
+        });
 
-      await expect(
-        git.verifyWorktreeOwnership(
-          git.toWorktreePath(testDir),
-          git.toRepoPath('/workspace/my-repo')
-        )
-      ).rejects.toThrow(/belongs to a different clone \(\/other\/clone\)/);
+      try {
+        await expect(
+          git.verifyWorktreeOwnership(
+            git.toWorktreePath(testDir),
+            git.toRepoPath('/workspace/my-repo')
+          )
+        ).rejects.toThrow(/belongs to a different clone \(\/other\/clone\/\.git\)/);
+      } finally {
+        execSpy.mockRestore();
+      }
     });
 
     test('normalizes trailing slashes in both paths', async () => {
@@ -2863,13 +3031,26 @@ branch refs/heads/feature/auth
         join(testDir, '.git'),
         'gitdir: /workspace/my-repo/.git/worktrees/issue-42\n'
       );
+      const execSpy = spyOn(git, 'execFileAsync')
+        .mockResolvedValueOnce({
+          stdout: '/workspace/my-repo/.git/worktrees/issue-42/\n/workspace/my-repo/.git/\n',
+          stderr: '',
+        })
+        .mockResolvedValueOnce({
+          stdout: '/workspace/my-repo/.git\n/workspace/my-repo/.git\n',
+          stderr: '',
+        });
 
-      await expect(
-        git.verifyWorktreeOwnership(
-          git.toWorktreePath(testDir),
-          git.toRepoPath('/workspace/my-repo/')
-        )
-      ).resolves.toBeUndefined();
+      try {
+        await expect(
+          git.verifyWorktreeOwnership(
+            git.toWorktreePath(testDir),
+            git.toRepoPath('/workspace/my-repo/')
+          )
+        ).resolves.toBeUndefined();
+      } finally {
+        execSpy.mockRestore();
+      }
     });
 
     test('throws EISDIR when .git is a directory (full checkout at path)', async () => {
@@ -2914,13 +3095,27 @@ branch refs/heads/feature/auth
         join(testDir, '.git'),
         'gitdir: /workspace/my-repo/.git/modules/vendor/submodule\n'
       );
+      const execSpy = spyOn(git, 'execFileAsync')
+        .mockResolvedValueOnce({
+          stdout:
+            '/workspace/my-repo/.git/modules/vendor/submodule\n/workspace/my-repo/.git/modules/vendor/submodule\n',
+          stderr: '',
+        })
+        .mockResolvedValueOnce({
+          stdout: '/workspace/my-repo/.git\n/workspace/my-repo/.git\n',
+          stderr: '',
+        });
 
-      await expect(
-        git.verifyWorktreeOwnership(
-          git.toWorktreePath(testDir),
-          git.toRepoPath('/workspace/my-repo')
-        )
-      ).rejects.toThrow(/not a git-worktree reference/);
+      try {
+        await expect(
+          git.verifyWorktreeOwnership(
+            git.toWorktreePath(testDir),
+            git.toRepoPath('/workspace/my-repo')
+          )
+        ).rejects.toThrow(/not a git-worktree reference/);
+      } finally {
+        execSpy.mockRestore();
+      }
     });
 
     test('resolves for a matching linked submodule worktree pointer', async () => {
@@ -2930,14 +3125,32 @@ branch refs/heads/feature/auth
       await realMkdir(linkedGitDir, { recursive: true });
       await writeFile(join(linkedGitDir, 'commondir'), '../..\n');
       await writeFile(join(testDir, '.git'), `gitdir: ${linkedGitDir}\n`);
-      const execSpy = spyOn(git, 'execFileAsync').mockResolvedValue({
-        stdout: '../../../../vendor/module\n',
-        stderr: '',
-      });
+      const execSpy = spyOn(git, 'execFileAsync')
+        .mockResolvedValueOnce({ stdout: `${linkedGitDir}\n${commonGitDir}\n`, stderr: '' })
+        .mockResolvedValueOnce({ stdout: `${commonGitDir}\n${commonGitDir}\n`, stderr: '' });
 
       try {
         await expect(
           git.verifyWorktreeOwnership(git.toWorktreePath(testDir), git.toRepoPath(primaryCheckout))
+        ).resolves.toBeUndefined();
+      } finally {
+        execSpy.mockRestore();
+      }
+    });
+
+    test('resolves for a linked worktree backed by an external Git directory', async () => {
+      const commonGitDir = join(testDir, 'metadata');
+      const linkedGitDir = join(commonGitDir, 'worktrees', 'linked');
+      await writeFile(join(testDir, '.git'), `gitdir: ${linkedGitDir}\n`);
+      const execSpy = spyOn(git, 'execFileAsync')
+        .mockResolvedValueOnce({ stdout: `${linkedGitDir}\n${commonGitDir}\n`, stderr: '' })
+        .mockResolvedValueOnce({ stdout: `${commonGitDir}\n${commonGitDir}\n`, stderr: '' });
+      try {
+        await expect(
+          git.verifyWorktreeOwnership(
+            git.toWorktreePath(testDir),
+            git.toRepoPath(join(testDir, 'primary'))
+          )
         ).resolves.toBeUndefined();
       } finally {
         execSpy.mockRestore();

--- a/packages/git/src/git.test.ts
+++ b/packages/git/src/git.test.ts
@@ -181,6 +181,30 @@ describe('git utilities', () => {
       const result = await git.getCanonicalRepoPath(testDir);
       expect(result).toBe(testDir);
     });
+
+    test('resolves a linked submodule worktree to the primary submodule checkout', async () => {
+      const commonGitDir = '/workspace/super/.git/modules/vendor/module';
+      await writeFile(join(testDir, '.git'), `gitdir: ${commonGitDir}/worktrees/linked`);
+      const execSpy = spyOn(git, 'execFileAsync').mockResolvedValue({
+        stdout: '../../../../vendor/module\n',
+        stderr: '',
+      });
+
+      try {
+        const result = await git.getCanonicalRepoPath(testDir);
+
+        expect(execSpy).toHaveBeenCalledWith('git', [
+          '--git-dir',
+          commonGitDir,
+          'config',
+          '--get',
+          'core.worktree',
+        ]);
+        expect(result).toBe(repo(resolve(commonGitDir, '../../../../vendor/module')));
+      } finally {
+        execSpy.mockRestore();
+      }
+    });
   });
 
   describe('getWorktreeBase', () => {

--- a/packages/git/src/git.test.ts
+++ b/packages/git/src/git.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, beforeEach, afterEach, mock, spyOn, type Mock } from 'bun:test';
 import { writeFile, mkdir as realMkdir, rm } from 'fs/promises';
-import { join } from 'path';
+import { join, resolve } from 'path';
 import { tmpdir, homedir } from 'os';
 // Loaded BEFORE mock.module replaces the module in the registry, so these are
 // the REAL identity validators — the mock re-exports them (no drift possible).
@@ -168,6 +168,18 @@ describe('git utilities', () => {
       );
       const result = await git.getCanonicalRepoPath(testDir);
       expect(result).toBe(repo('/home/user/projects/my-app'));
+    });
+
+    test('resolves a relative worktree pointer from the worktree root', async () => {
+      await writeFile(join(testDir, '.git'), 'gitdir: ../primary/.git/worktrees/linked');
+      const result = await git.getCanonicalRepoPath(testDir);
+      expect(result).toBe(repo(resolve(testDir, '../primary')));
+    });
+
+    test('keeps a submodule checkout as its own canonical repository', async () => {
+      await writeFile(join(testDir, '.git'), 'gitdir: ../primary/.git/modules/vendor/module');
+      const result = await git.getCanonicalRepoPath(testDir);
+      expect(result).toBe(testDir);
     });
   });
 

--- a/packages/git/src/git.test.ts
+++ b/packages/git/src/git.test.ts
@@ -182,9 +182,22 @@ describe('git utilities', () => {
       expect(result).toBe(testDir);
     });
 
+    test('keeps a submodule named under worktrees as its own canonical repository', async () => {
+      const gitDir = join(testDir, 'primary', '.git', 'modules', 'vendor', 'worktrees', 'module');
+      await realMkdir(gitDir, { recursive: true });
+      await writeFile(join(testDir, '.git'), `gitdir: ${gitDir}`);
+
+      const result = await git.getCanonicalRepoPath(testDir);
+
+      expect(result).toBe(testDir);
+    });
+
     test('resolves a linked submodule worktree to the primary submodule checkout', async () => {
-      const commonGitDir = '/workspace/super/.git/modules/vendor/module';
-      await writeFile(join(testDir, '.git'), `gitdir: ${commonGitDir}/worktrees/linked`);
+      const commonGitDir = join(testDir, 'super', '.git', 'modules', 'vendor', 'module');
+      const linkedGitDir = join(commonGitDir, 'worktrees', 'linked');
+      await realMkdir(linkedGitDir, { recursive: true });
+      await writeFile(join(linkedGitDir, 'commondir'), '../..\n');
+      await writeFile(join(testDir, '.git'), `gitdir: ${linkedGitDir}`);
       const execSpy = spyOn(git, 'execFileAsync').mockResolvedValue({
         stdout: '../../../../vendor/module\n',
         stderr: '',
@@ -2908,6 +2921,27 @@ branch refs/heads/feature/auth
           git.toRepoPath('/workspace/my-repo')
         )
       ).rejects.toThrow(/not a git-worktree reference/);
+    });
+
+    test('resolves for a matching linked submodule worktree pointer', async () => {
+      const commonGitDir = join(testDir, 'super', '.git', 'modules', 'vendor', 'module');
+      const linkedGitDir = join(commonGitDir, 'worktrees', 'linked');
+      const primaryCheckout = resolve(commonGitDir, '../../../../vendor/module');
+      await realMkdir(linkedGitDir, { recursive: true });
+      await writeFile(join(linkedGitDir, 'commondir'), '../..\n');
+      await writeFile(join(testDir, '.git'), `gitdir: ${linkedGitDir}\n`);
+      const execSpy = spyOn(git, 'execFileAsync').mockResolvedValue({
+        stdout: '../../../../vendor/module\n',
+        stderr: '',
+      });
+
+      try {
+        await expect(
+          git.verifyWorktreeOwnership(git.toWorktreePath(testDir), git.toRepoPath(primaryCheckout))
+        ).resolves.toBeUndefined();
+      } finally {
+        execSpy.mockRestore();
+      }
     });
 
     test('throws on corrupted .git content (no gitdir prefix)', async () => {

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -25,9 +25,11 @@ export {
   isWorktreePath,
   removeWorktree,
   getCanonicalRepoPath,
+  getGitCheckoutIdentity,
+  CanonicalRepoPathUnavailableError,
   verifyWorktreeOwnership,
 } from './worktree';
-export type { WorktreeLayout, WorktreeBaseOverride } from './worktree';
+export type { WorktreeLayout, WorktreeBaseOverride, GitCheckoutIdentity } from './worktree';
 
 // Branch operations
 export {

--- a/packages/git/src/worktree.ts
+++ b/packages/git/src/worktree.ts
@@ -294,68 +294,90 @@ export async function removeWorktree(
   });
 }
 
-type GitDirPointer =
-  | { kind: 'linked-worktree'; primaryCheckout: RepoPath }
-  | { kind: 'submodule' }
-  | { kind: 'invalid' };
+export interface GitCheckoutIdentity {
+  gitDir: string;
+  commonGitDir: string;
+  linkedWorktree: boolean;
+}
 
-// A submodule path may itself contain `worktrees/<name>`. Git's commondir
-// metadata, rather than that path shape, proves whether it is a linked worktree.
-async function decodeGitDirPointer(path: string, content: string): Promise<GitDirPointer> {
-  if (!content.startsWith('gitdir:')) return { kind: 'invalid' };
+export class CanonicalRepoPathUnavailableError extends Error {
+  constructor(
+    readonly checkoutPath: string,
+    readonly commonGitDir: string
+  ) {
+    super(
+      `Cannot determine the primary checkout for linked worktree at ${checkoutPath}. ` +
+        `Git uses external directory ${commonGitDir}, which does not record the primary checkout path.`
+    );
+    this.name = 'CanonicalRepoPathUnavailableError';
+  }
+}
 
-  const pointer = content.slice('gitdir:'.length).trim();
-  const gitDir = isAbsolute(pointer) ? pointer : resolve(path, pointer);
-  const worktreeMatch = /^(.*)[\\/]\.git[\\/]worktrees[\\/]/.exec(gitDir);
-  if (worktreeMatch) {
-    return { kind: 'linked-worktree', primaryCheckout: toRepoPath(worktreeMatch[1]) };
+/**
+ * Return Git's physical repository identity for a checkout.
+ *
+ * `--git-dir` and `--git-common-dir` are equal for independent checkouts and
+ * differ for linked worktrees. This avoids rebuilding valid Git layouts from
+ * pathname conventions (`.git/modules`, linked-superproject modules, or an
+ * external `--separate-git-dir`).
+ */
+export async function getGitCheckoutIdentity(path: string): Promise<GitCheckoutIdentity> {
+  const { stdout } = await execFileAsync('git', [
+    '-C',
+    path,
+    'rev-parse',
+    '--path-format=absolute',
+    '--git-dir',
+    '--git-common-dir',
+  ]);
+  const [gitDir, commonGitDir] = stdout.split(/\r?\n/).filter(line => line.length > 0);
+  if (!gitDir || !commonGitDir) {
+    throw new Error(`Git returned incomplete repository identity for ${path}`);
+  }
+  return {
+    gitDir,
+    commonGitDir,
+    linkedWorktree: resolve(gitDir) !== resolve(commonGitDir),
+  };
+}
+
+async function resolvePrimaryCheckout(
+  path: string,
+  identity: GitCheckoutIdentity
+): Promise<RepoPath> {
+  const { stdout: worktreeList } = await execFileAsync('git', [
+    '--git-dir',
+    identity.commonGitDir,
+    'worktree',
+    'list',
+    '--porcelain',
+  ]);
+  const firstWorktree = /^worktree (.+)$/m.exec(worktreeList)?.[1];
+  if (firstWorktree && resolve(firstWorktree) !== resolve(identity.commonGitDir)) {
+    return toRepoPath(firstWorktree);
   }
 
-  if (!/(?:^|[\\/])\.git[\\/]modules[\\/]/.test(gitDir)) {
-    return { kind: 'invalid' };
-  }
-
-  let commonDirPointer: string;
-  try {
-    commonDirPointer = (await readFile(join(gitDir, 'commondir'), 'utf-8')).trim();
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      return { kind: 'submodule' };
-    }
-    throw error;
-  }
-
-  if (!commonDirPointer) {
-    throw new Error(`Git returned an empty commondir for linked submodule worktree at ${path}`);
-  }
-
-  const commonGitDir = isAbsolute(commonDirPointer)
-    ? commonDirPointer
-    : resolve(gitDir, commonDirPointer);
   try {
     const { stdout } = await execFileAsync('git', [
       '--git-dir',
-      commonGitDir,
+      identity.commonGitDir,
       'config',
       '--get',
       'core.worktree',
     ]);
     const primaryCheckout = stdout.trim();
     if (primaryCheckout) {
-      return {
-        kind: 'linked-worktree',
-        primaryCheckout: toRepoPath(
-          isAbsolute(primaryCheckout) ? primaryCheckout : resolve(commonGitDir, primaryCheckout)
-        ),
-      };
+      return toRepoPath(
+        isAbsolute(primaryCheckout)
+          ? primaryCheckout
+          : resolve(identity.commonGitDir, primaryCheckout)
+      );
     }
-  } catch (error) {
-    getLog().error({ path, commonGitDir, err: error as Error }, 'submodule_worktree_path_failed');
-    throw new Error(
-      `Cannot determine primary checkout for linked submodule worktree at ${path}: ${(error as Error).message}`
-    );
+  } catch {
+    // External Git directories do not record a reverse pointer to their primary
+    // checkout. Registered-codebase lookup can still match their common Git dir.
   }
-  throw new Error(`Git returned an empty core.worktree for linked submodule worktree at ${path}`);
+  throw new CanonicalRepoPathUnavailableError(path, identity.commonGitDir);
 }
 
 /**
@@ -364,21 +386,18 @@ async function decodeGitDirPointer(path: string, content: string): Promise<GitDi
  */
 export async function getCanonicalRepoPath(path: string): Promise<RepoPath> {
   if (await isWorktreePath(path)) {
-    // Read .git file to find main repo
-    const gitPath = join(path, '.git');
-    const content = await readFile(gitPath, 'utf-8');
-    const pointer = await decodeGitDirPointer(path, content);
-    if (pointer.kind === 'linked-worktree') return pointer.primaryCheckout;
-    if (pointer.kind === 'submodule') return toRepoPath(path);
-    // A gitdir file that identifies neither a worktree nor a submodule is malformed here.
-    getLog().error(
-      { path, gitContentPrefix: content.substring(0, 120) },
-      'canonical_path_regex_failed'
-    );
-    throw new Error(
-      `Cannot determine canonical repo path from worktree at ${path}. ` +
-        `Unexpected .git file format: ${content.substring(0, 80)}`
-    );
+    try {
+      const identity = await getGitCheckoutIdentity(path);
+      if (!identity.linkedWorktree) return toRepoPath(path);
+      return await resolvePrimaryCheckout(path, identity);
+    } catch (error) {
+      if (error instanceof CanonicalRepoPathUnavailableError) throw error;
+      getLog().error({ path, err: error as Error }, 'canonical_path_resolution_failed');
+      throw new Error(
+        `Cannot determine canonical repo path from worktree at ${path}: ${(error as Error).message}`,
+        { cause: error }
+      );
+    }
   }
   return toRepoPath(path);
 }
@@ -392,10 +411,8 @@ export async function getCanonicalRepoPath(path: string): Promise<RepoPath> {
  * worktree. This is intentionally strict — a permissive fallback here
  * would re-introduce the cross-checkout bug this guard exists to prevent.
  *
- * Paths are normalized with `resolve()` before comparison to handle trailing
- * slashes and relative components. Symlinked paths (where canonical vs
- * registered paths differ by symlink resolution) are not equated — callers
- * should register codebases with consistent path forms.
+ * Git's common-directory paths are normalized with `resolve()` before
+ * comparison to handle trailing slashes and relative components.
  *
  * Error classification (surfaced via `classifyIsolationError` in
  * `@archon/isolation/errors.ts`):
@@ -437,21 +454,36 @@ export async function verifyWorktreeOwnership(
     throw wrap(`Cannot verify worktree ownership at ${worktreePath}: ${err.message}`);
   }
 
-  const pointer = await decodeGitDirPointer(worktreePath, gitContent);
-  if (pointer.kind !== 'linked-worktree') {
+  if (!gitContent.startsWith('gitdir:')) {
+    throw new Error(`Cannot adopt ${worktreePath}: .git pointer is not a git-worktree reference.`);
+  }
+
+  let worktreeIdentity: GitCheckoutIdentity;
+  let expectedIdentity: GitCheckoutIdentity;
+  try {
+    [worktreeIdentity, expectedIdentity] = await Promise.all([
+      getGitCheckoutIdentity(worktreePath),
+      getGitCheckoutIdentity(expectedRepo),
+    ]);
+  } catch (error) {
+    throw new Error(
+      `Cannot verify worktree ownership at ${worktreePath}: ${(error as Error).message}`,
+      {
+        cause: error,
+      }
+    );
+  }
+  if (!worktreeIdentity.linkedWorktree) {
     // Not a git-worktree pointer (e.g., submodule pointer, or malformed).
     // We cannot confirm this is our worktree, so refuse adoption.
     throw new Error(`Cannot adopt ${worktreePath}: .git pointer is not a git-worktree reference.`);
   }
 
-  // Compare on resolved paths (normalizes trailing slashes and relative
-  // components) but display the decoded path without applying `resolve()`.
-  // On Windows, resolving a POSIX-style gitdir would prepend a drive letter
-  // and make the error message misleading.
-  const existingRepo = pointer.primaryCheckout;
-  if (resolve(existingRepo) !== resolve(expectedRepo)) {
+  // Compare resolved common-directory paths: the primary checkout and every
+  // linked worktree share this Git identity, while separate clones differ.
+  if (resolve(worktreeIdentity.commonGitDir) !== resolve(expectedIdentity.commonGitDir)) {
     throw new Error(
-      `Worktree at ${worktreePath} belongs to a different clone (${existingRepo}). ` +
+      `Worktree at ${worktreePath} belongs to a different clone (${worktreeIdentity.commonGitDir}). ` +
         'Remove it from that clone or use a different codebase registration.'
     );
   }

--- a/packages/git/src/worktree.ts
+++ b/packages/git/src/worktree.ts
@@ -310,6 +310,37 @@ export async function getCanonicalRepoPath(path: string): Promise<RepoPath> {
     if (match) {
       return toRepoPath(match[1]);
     }
+    const linkedSubmoduleMatch =
+      /^(.*[\\/]\.git[\\/]modules[\\/].*)[\\/]worktrees[\\/][^\\/]+$/.exec(gitDir);
+    if (linkedSubmoduleMatch) {
+      const commonGitDir = linkedSubmoduleMatch[1];
+      try {
+        const { stdout } = await execFileAsync('git', [
+          '--git-dir',
+          commonGitDir,
+          'config',
+          '--get',
+          'core.worktree',
+        ]);
+        const primaryCheckout = stdout.trim();
+        if (primaryCheckout) {
+          return toRepoPath(
+            isAbsolute(primaryCheckout) ? primaryCheckout : resolve(commonGitDir, primaryCheckout)
+          );
+        }
+      } catch (error) {
+        getLog().error(
+          { path, commonGitDir, err: error as Error },
+          'submodule_worktree_path_failed'
+        );
+        throw new Error(
+          `Cannot determine primary checkout for linked submodule worktree at ${path}: ${(error as Error).message}`
+        );
+      }
+      throw new Error(
+        `Git returned an empty core.worktree for linked submodule worktree at ${path}`
+      );
+    }
     // Submodules also use a gitdir file, but they are independent checkout
     // roots rather than linked worktrees of the containing repository.
     if (/(?:^|[\\/])\.git[\\/]modules[\\/]/.test(gitDir)) {

--- a/packages/git/src/worktree.ts
+++ b/packages/git/src/worktree.ts
@@ -294,6 +294,70 @@ export async function removeWorktree(
   });
 }
 
+type GitDirPointer =
+  | { kind: 'linked-worktree'; primaryCheckout: RepoPath }
+  | { kind: 'submodule' }
+  | { kind: 'invalid' };
+
+// A submodule path may itself contain `worktrees/<name>`. Git's commondir
+// metadata, rather than that path shape, proves whether it is a linked worktree.
+async function decodeGitDirPointer(path: string, content: string): Promise<GitDirPointer> {
+  if (!content.startsWith('gitdir:')) return { kind: 'invalid' };
+
+  const pointer = content.slice('gitdir:'.length).trim();
+  const gitDir = isAbsolute(pointer) ? pointer : resolve(path, pointer);
+  const worktreeMatch = /^(.*)[\\/]\.git[\\/]worktrees[\\/]/.exec(gitDir);
+  if (worktreeMatch) {
+    return { kind: 'linked-worktree', primaryCheckout: toRepoPath(worktreeMatch[1]) };
+  }
+
+  if (!/(?:^|[\\/])\.git[\\/]modules[\\/]/.test(gitDir)) {
+    return { kind: 'invalid' };
+  }
+
+  let commonDirPointer: string;
+  try {
+    commonDirPointer = (await readFile(join(gitDir, 'commondir'), 'utf-8')).trim();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { kind: 'submodule' };
+    }
+    throw error;
+  }
+
+  if (!commonDirPointer) {
+    throw new Error(`Git returned an empty commondir for linked submodule worktree at ${path}`);
+  }
+
+  const commonGitDir = isAbsolute(commonDirPointer)
+    ? commonDirPointer
+    : resolve(gitDir, commonDirPointer);
+  try {
+    const { stdout } = await execFileAsync('git', [
+      '--git-dir',
+      commonGitDir,
+      'config',
+      '--get',
+      'core.worktree',
+    ]);
+    const primaryCheckout = stdout.trim();
+    if (primaryCheckout) {
+      return {
+        kind: 'linked-worktree',
+        primaryCheckout: toRepoPath(
+          isAbsolute(primaryCheckout) ? primaryCheckout : resolve(commonGitDir, primaryCheckout)
+        ),
+      };
+    }
+  } catch (error) {
+    getLog().error({ path, commonGitDir, err: error as Error }, 'submodule_worktree_path_failed');
+    throw new Error(
+      `Cannot determine primary checkout for linked submodule worktree at ${path}: ${(error as Error).message}`
+    );
+  }
+  throw new Error(`Git returned an empty core.worktree for linked submodule worktree at ${path}`);
+}
+
 /**
  * Get canonical repo path from a worktree path
  * If already canonical, returns the same path
@@ -303,50 +367,10 @@ export async function getCanonicalRepoPath(path: string): Promise<RepoPath> {
     // Read .git file to find main repo
     const gitPath = join(path, '.git');
     const content = await readFile(gitPath, 'utf-8');
-    // Git may store an absolute pointer or one relative to the worktree root.
-    const pointer = content.slice('gitdir:'.length).trim();
-    const gitDir = isAbsolute(pointer) ? pointer : resolve(path, pointer);
-    const match = /^(.*)[\\/]\.git[\\/]worktrees[\\/]/.exec(gitDir);
-    if (match) {
-      return toRepoPath(match[1]);
-    }
-    const linkedSubmoduleMatch =
-      /^(.*[\\/]\.git[\\/]modules[\\/].*)[\\/]worktrees[\\/][^\\/]+$/.exec(gitDir);
-    if (linkedSubmoduleMatch) {
-      const commonGitDir = linkedSubmoduleMatch[1];
-      try {
-        const { stdout } = await execFileAsync('git', [
-          '--git-dir',
-          commonGitDir,
-          'config',
-          '--get',
-          'core.worktree',
-        ]);
-        const primaryCheckout = stdout.trim();
-        if (primaryCheckout) {
-          return toRepoPath(
-            isAbsolute(primaryCheckout) ? primaryCheckout : resolve(commonGitDir, primaryCheckout)
-          );
-        }
-      } catch (error) {
-        getLog().error(
-          { path, commonGitDir, err: error as Error },
-          'submodule_worktree_path_failed'
-        );
-        throw new Error(
-          `Cannot determine primary checkout for linked submodule worktree at ${path}: ${(error as Error).message}`
-        );
-      }
-      throw new Error(
-        `Git returned an empty core.worktree for linked submodule worktree at ${path}`
-      );
-    }
-    // Submodules also use a gitdir file, but they are independent checkout
-    // roots rather than linked worktrees of the containing repository.
-    if (/(?:^|[\\/])\.git[\\/]modules[\\/]/.test(gitDir)) {
-      return toRepoPath(path);
-    }
-    // Worktree detected but regex didn't match - this is a real problem
+    const pointer = await decodeGitDirPointer(path, content);
+    if (pointer.kind === 'linked-worktree') return pointer.primaryCheckout;
+    if (pointer.kind === 'submodule') return toRepoPath(path);
+    // A gitdir file that identifies neither a worktree nor a submodule is malformed here.
     getLog().error(
       { path, gitContentPrefix: content.substring(0, 120) },
       'canonical_path_regex_failed'
@@ -413,23 +437,21 @@ export async function verifyWorktreeOwnership(
     throw wrap(`Cannot verify worktree ownership at ${worktreePath}: ${err.message}`);
   }
 
-  // gitdir: /path/to/repo/.git/worktrees/branch-name
-  const match = /gitdir: (.+)\/\.git\/worktrees\//.exec(gitContent);
-  if (!match) {
+  const pointer = await decodeGitDirPointer(worktreePath, gitContent);
+  if (pointer.kind !== 'linked-worktree') {
     // Not a git-worktree pointer (e.g., submodule pointer, or malformed).
     // We cannot confirm this is our worktree, so refuse adoption.
     throw new Error(`Cannot adopt ${worktreePath}: .git pointer is not a git-worktree reference.`);
   }
 
   // Compare on resolved paths (normalizes trailing slashes and relative
-  // components) but display the raw path from the .git pointer so the user
-  // sees the value they'd recognize. On Windows, `resolve()` would prepend
-  // a drive letter to the POSIX-style gitdir, making the error message
-  // misleading and causing platform-specific test breakage.
-  const existingRepoRaw = match[1];
-  if (resolve(existingRepoRaw) !== resolve(expectedRepo)) {
+  // components) but display the decoded path without applying `resolve()`.
+  // On Windows, resolving a POSIX-style gitdir would prepend a drive letter
+  // and make the error message misleading.
+  const existingRepo = pointer.primaryCheckout;
+  if (resolve(existingRepo) !== resolve(expectedRepo)) {
     throw new Error(
-      `Worktree at ${worktreePath} belongs to a different clone (${existingRepoRaw}). ` +
+      `Worktree at ${worktreePath} belongs to a different clone (${existingRepo}). ` +
         'Remove it from that clone or use a different codebase registration.'
     );
   }

--- a/packages/git/src/worktree.ts
+++ b/packages/git/src/worktree.ts
@@ -1,5 +1,5 @@
 import { readFile, access } from 'fs/promises';
-import { join, resolve } from 'path';
+import { isAbsolute, join, resolve } from 'path';
 import {
   createLogger,
   getArchonWorkspacesPath,
@@ -303,10 +303,17 @@ export async function getCanonicalRepoPath(path: string): Promise<RepoPath> {
     // Read .git file to find main repo
     const gitPath = join(path, '.git');
     const content = await readFile(gitPath, 'utf-8');
-    // gitdir: /path/to/repo/.git/worktrees/branch-name
-    const match = /gitdir: (.+)\/\.git\/worktrees\//.exec(content);
+    // Git may store an absolute pointer or one relative to the worktree root.
+    const pointer = content.slice('gitdir:'.length).trim();
+    const gitDir = isAbsolute(pointer) ? pointer : resolve(path, pointer);
+    const match = /^(.*)[\\/]\.git[\\/]worktrees[\\/]/.exec(gitDir);
     if (match) {
       return toRepoPath(match[1]);
+    }
+    // Submodules also use a gitdir file, but they are independent checkout
+    // roots rather than linked worktrees of the containing repository.
+    if (/(?:^|[\\/])\.git[\\/]modules[\\/]/.test(gitDir)) {
+      return toRepoPath(path);
     }
     // Worktree detected but regex didn't match - this is a real problem
     getLog().error(

--- a/packages/isolation/src/providers/worktree.test.ts
+++ b/packages/isolation/src/providers/worktree.test.ts
@@ -91,6 +91,7 @@ describe('WorktreeProvider', () => {
   let listWorktreesSpy: Mock<typeof git.listWorktrees>;
   let findWorktreeByBranchSpy: Mock<typeof git.findWorktreeByBranch>;
   let getCanonicalRepoPathSpy: Mock<typeof git.getCanonicalRepoPath>;
+  let verifyWorktreeOwnershipSpy: Mock<typeof git.verifyWorktreeOwnership>;
 
   beforeEach(() => {
     mockConfigLoader = async (): Promise<{ baseBranch: git.BranchName }> => ({
@@ -103,6 +104,7 @@ describe('WorktreeProvider', () => {
     listWorktreesSpy = spyOn(git, 'listWorktrees');
     findWorktreeByBranchSpy = spyOn(git, 'findWorktreeByBranch');
     getCanonicalRepoPathSpy = spyOn(git, 'getCanonicalRepoPath');
+    verifyWorktreeOwnershipSpy = spyOn(git, 'verifyWorktreeOwnership');
     getDefaultBranchSpy = spyOn(git, 'getDefaultBranch');
     getDefaultRemoteSpy = spyOn(git, 'getDefaultRemote');
     syncWorkspaceSpy = spyOn(git, 'syncWorkspace');
@@ -114,6 +116,7 @@ describe('WorktreeProvider', () => {
     listWorktreesSpy.mockResolvedValue([]);
     findWorktreeByBranchSpy.mockResolvedValue(null);
     getCanonicalRepoPathSpy.mockImplementation(async path => git.toRepoPath(path));
+    verifyWorktreeOwnershipSpy.mockResolvedValue(undefined);
     // Most paths exist by default (directoryExists checks for destroy etc.),
     // but .gitmodules is absent by default — most repos don't use submodules,
     // and default-on submodule init must skip cleanly in that case.
@@ -149,6 +152,7 @@ describe('WorktreeProvider', () => {
     listWorktreesSpy.mockRestore();
     findWorktreeByBranchSpy.mockRestore();
     getCanonicalRepoPathSpy.mockRestore();
+    verifyWorktreeOwnershipSpy.mockRestore();
     getDefaultBranchSpy.mockRestore();
     getDefaultRemoteSpy.mockRestore();
     syncWorkspaceSpy.mockRestore();
@@ -586,6 +590,9 @@ describe('WorktreeProvider', () => {
     test('throws when worktree belongs to different repo root (cross-checkout)', async () => {
       worktreeExistsSpy.mockResolvedValue(true);
       mockReadFile.mockResolvedValue('gitdir: /different/repo/.git/worktrees/archon/issue-42\n');
+      verifyWorktreeOwnershipSpy.mockRejectedValueOnce(
+        new Error('Worktree belongs to a different clone (/different/repo/.git).')
+      );
 
       await expect(provider.create(baseRequest)).rejects.toThrow(/belongs to a different clone/);
     });
@@ -595,6 +602,9 @@ describe('WorktreeProvider', () => {
       const eisdirError = new Error('EISDIR') as NodeJS.ErrnoException;
       eisdirError.code = 'EISDIR';
       mockReadFile.mockRejectedValue(eisdirError);
+      verifyWorktreeOwnershipSpy.mockRejectedValueOnce(
+        new Error('path contains a full git checkout')
+      );
 
       await expect(provider.create(baseRequest)).rejects.toThrow(
         /path contains a full git checkout/
@@ -606,6 +616,9 @@ describe('WorktreeProvider', () => {
       const eaccesError = new Error('EACCES: permission denied') as NodeJS.ErrnoException;
       eaccesError.code = 'EACCES';
       mockReadFile.mockRejectedValue(eaccesError);
+      verifyWorktreeOwnershipSpy.mockRejectedValueOnce(
+        new Error('Cannot verify worktree ownership: permission denied')
+      );
 
       await expect(provider.create(baseRequest)).rejects.toThrow(
         /Cannot verify worktree ownership/
@@ -619,6 +632,9 @@ describe('WorktreeProvider', () => {
       mockReadFile
         .mockResolvedValueOnce('gitdir: /workspace/repo/.git/modules/submodule-name\n')
         .mockRejectedValueOnce(enoentError);
+      verifyWorktreeOwnershipSpy.mockRejectedValueOnce(
+        new Error('.git pointer is not a git-worktree reference')
+      );
 
       await expect(provider.create(baseRequest)).rejects.toThrow(/not a git-worktree reference/);
     });
@@ -689,6 +705,9 @@ describe('WorktreeProvider', () => {
       );
       // .git points to a different clone
       mockReadFile.mockResolvedValue('gitdir: /other/clone/.git/worktrees/feature-auth\n');
+      verifyWorktreeOwnershipSpy.mockRejectedValueOnce(
+        new Error('Worktree belongs to a different clone (/other/clone/.git).')
+      );
 
       await expect(provider.create(request)).rejects.toThrow(/belongs to a different clone/);
     });

--- a/packages/isolation/src/providers/worktree.test.ts
+++ b/packages/isolation/src/providers/worktree.test.ts
@@ -1218,6 +1218,21 @@ describe('WorktreeProvider', () => {
       );
     });
 
+    test('uses an external-git-dir linked checkout as its own removal anchor', async () => {
+      const worktreePath = git.toWorktreePath('/workspace/external-linked');
+      getCanonicalRepoPathSpy.mockRejectedValue(
+        new git.CanonicalRepoPathUnavailableError(worktreePath, '/metadata/repository')
+      );
+
+      await provider.destroy(worktreePath);
+
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        expect.arrayContaining(['-C', worktreePath, 'worktree', 'remove', worktreePath]),
+        expect.any(Object)
+      );
+    });
+
     test('uses force flag when specified', async () => {
       const worktreePath = git.toWorktreePath('/workspace/worktrees/repo/issue-42');
 
@@ -1627,6 +1642,22 @@ describe('WorktreeProvider', () => {
       expect(result?.branchName).toBe(git.toBranchName('issue-42'));
     });
 
+    test('queries an external-git-dir linked checkout from its exact path', async () => {
+      const worktreePath = git.toWorktreePath('/workspace/external-linked');
+      worktreeExistsSpy.mockResolvedValue(true);
+      getCanonicalRepoPathSpy.mockRejectedValue(
+        new git.CanonicalRepoPathUnavailableError(worktreePath, '/metadata/repository')
+      );
+      listWorktreesSpy.mockResolvedValue([
+        { path: worktreePath, branch: git.toBranchName('external-linked') },
+      ]);
+
+      const result = await provider.get(worktreePath);
+
+      expect(result?.workingPath).toBe(worktreePath);
+      expect(listWorktreesSpy).toHaveBeenCalledWith(worktreePath);
+    });
+
     test('re-throws errors from getCanonicalRepoPath with logging', async () => {
       worktreeExistsSpy.mockResolvedValue(true);
       getCanonicalRepoPathSpy.mockRejectedValue(new Error('Permission denied'));
@@ -1726,6 +1757,23 @@ describe('WorktreeProvider', () => {
       expect(result?.provider).toBe('worktree');
       expect(result?.branchName).toBe(git.toBranchName('feature/auth'));
       expect(result?.metadata).toHaveProperty('adopted', true);
+    });
+
+    test('adopts an external-git-dir linked checkout from its exact path', async () => {
+      const worktreePath = git.toWorktreePath('/workspace/external-linked');
+      worktreeExistsSpy.mockResolvedValue(true);
+      getCanonicalRepoPathSpy.mockRejectedValue(
+        new git.CanonicalRepoPathUnavailableError(worktreePath, '/metadata/repository')
+      );
+      listWorktreesSpy.mockResolvedValue([
+        { path: worktreePath, branch: git.toBranchName('external-linked') },
+      ]);
+
+      const result = await provider.adopt(worktreePath);
+
+      expect(result?.workingPath).toBe(worktreePath);
+      expect(result?.metadata).toHaveProperty('adopted', true);
+      expect(listWorktreesSpy).toHaveBeenCalledWith(worktreePath);
     });
 
     test('returns null for non-existent path', async () => {

--- a/packages/isolation/src/providers/worktree.test.ts
+++ b/packages/isolation/src/providers/worktree.test.ts
@@ -614,7 +614,11 @@ describe('WorktreeProvider', () => {
 
     test('throws when .git pointer is not a git-worktree reference (e.g., submodule)', async () => {
       worktreeExistsSpy.mockResolvedValue(true);
-      mockReadFile.mockResolvedValue('gitdir: /workspace/repo/.git/modules/submodule-name\n');
+      const enoentError = new Error('ENOENT') as NodeJS.ErrnoException;
+      enoentError.code = 'ENOENT';
+      mockReadFile
+        .mockResolvedValueOnce('gitdir: /workspace/repo/.git/modules/submodule-name\n')
+        .mockRejectedValueOnce(enoentError);
 
       await expect(provider.create(baseRequest)).rejects.toThrow(/not a git-worktree reference/);
     });

--- a/packages/isolation/src/providers/worktree.test.ts
+++ b/packages/isolation/src/providers/worktree.test.ts
@@ -1218,19 +1218,35 @@ describe('WorktreeProvider', () => {
       );
     });
 
-    test('uses an external-git-dir linked checkout as its own removal anchor', async () => {
+    test('keeps a durable external Git directory anchor after removing its linked checkout', async () => {
       const worktreePath = git.toWorktreePath('/workspace/external-linked');
+      const branchName = git.toBranchName('external-linked');
       getCanonicalRepoPathSpy.mockRejectedValue(
         new git.CanonicalRepoPathUnavailableError(worktreePath, '/metadata/repository')
       );
 
-      await provider.destroy(worktreePath);
+      const result = await provider.destroy(worktreePath, {
+        branchName,
+        deleteRemoteBranch: true,
+      });
 
       expect(execSpy).toHaveBeenCalledWith(
         'git',
-        expect.arrayContaining(['-C', worktreePath, 'worktree', 'remove', worktreePath]),
+        expect.arrayContaining(['-C', '/metadata/repository', 'worktree', 'remove', worktreePath]),
         expect.any(Object)
       );
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        ['-C', '/metadata/repository', 'branch', '-D', branchName],
+        expect.any(Object)
+      );
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        ['-C', '/metadata/repository', 'push', 'origin', '--delete', branchName],
+        expect.any(Object)
+      );
+      expect(result.branchDeleted).toBe(true);
+      expect(result.remoteBranchDeleted).toBe(true);
     });
 
     test('uses force flag when specified', async () => {

--- a/packages/isolation/src/providers/worktree.test.ts
+++ b/packages/isolation/src/providers/worktree.test.ts
@@ -1218,7 +1218,7 @@ describe('WorktreeProvider', () => {
       );
     });
 
-    test('keeps a durable external Git directory anchor after removing its linked checkout', async () => {
+    test('keeps a durable external Git directory anchor when the linked checkout is supplied', async () => {
       const worktreePath = git.toWorktreePath('/workspace/external-linked');
       const branchName = git.toBranchName('external-linked');
       getCanonicalRepoPathSpy.mockRejectedValue(
@@ -1227,6 +1227,7 @@ describe('WorktreeProvider', () => {
 
       const result = await provider.destroy(worktreePath, {
         branchName,
+        canonicalRepoPath: git.toRepoPath(worktreePath),
         deleteRemoteBranch: true,
       });
 

--- a/packages/isolation/src/providers/worktree.ts
+++ b/packages/isolation/src/providers/worktree.ts
@@ -24,6 +24,7 @@ import {
   toRepoPath,
   toWorktreePath,
   toBranchName,
+  CanonicalRepoPathUnavailableError,
 } from '@archon/git';
 import type { WorktreeBaseOverride } from '@archon/git';
 import { getArchonWorkspacesPath } from '@archon/paths';
@@ -47,6 +48,24 @@ let cachedLog: ReturnType<typeof createLogger> | undefined;
 function getLog(): ReturnType<typeof createLogger> {
   if (!cachedLog) cachedLog = createLogger('isolation.worktree');
   return cachedLog;
+}
+
+/**
+ * Resolve the checkout from which Git worktree commands should run.
+ *
+ * External `--separate-git-dir` repositories do not record a reverse path to
+ * their primary checkout. Their linked checkouts are still valid command
+ * anchors, so retain the exact path only for that typed Git limitation.
+ */
+async function getGitCommandAnchor(path: string): Promise<RepoPath> {
+  try {
+    return await getCanonicalRepoPath(path);
+  } catch (error) {
+    if (error instanceof CanonicalRepoPathUnavailableError) {
+      return toRepoPath(path);
+    }
+    throw error;
+  }
 }
 
 /**
@@ -212,7 +231,7 @@ export class WorktreeProvider implements IIsolationProvider {
     if (options?.canonicalRepoPath) {
       repoPath = options.canonicalRepoPath;
     } else if (pathExists) {
-      repoPath = await getCanonicalRepoPath(worktreePath);
+      repoPath = await getGitCommandAnchor(worktreePath);
     } else {
       // Path doesn't exist and no canonicalRepoPath provided - can't clean up branch
       // This is expected when worktree was already fully cleaned up externally
@@ -432,7 +451,7 @@ export class WorktreeProvider implements IIsolationProvider {
     let repoPath: RepoPath;
     let worktrees: WorktreeInfo[];
     try {
-      repoPath = await getCanonicalRepoPath(worktreePath);
+      repoPath = await getGitCommandAnchor(worktreePath);
       worktrees = await listWorktrees(repoPath);
     } catch (error) {
       getLog().error({ err: error, worktreePath }, 'worktree_query_failed');
@@ -498,7 +517,7 @@ export class WorktreeProvider implements IIsolationProvider {
     let repoPath: RepoPath;
     let worktrees: WorktreeInfo[];
     try {
-      repoPath = await getCanonicalRepoPath(path);
+      repoPath = await getGitCommandAnchor(path);
       worktrees = await listWorktrees(repoPath);
     } catch (error) {
       const err = error as Error;

--- a/packages/isolation/src/providers/worktree.ts
+++ b/packages/isolation/src/providers/worktree.ts
@@ -51,18 +51,29 @@ function getLog(): ReturnType<typeof createLogger> {
 }
 
 /**
- * Resolve the checkout from which Git worktree commands should run.
+ * Resolve the anchors from which Git worktree commands should run.
  *
  * External `--separate-git-dir` repositories do not record a reverse path to
- * their primary checkout. Their linked checkouts are still valid command
- * anchors, so retain the exact path only for that typed Git limitation.
+ * their primary checkout. The exact linked checkout is valid while it exists;
+ * its common Git directory remains usable after that checkout is removed.
  */
-async function getGitCommandAnchor(path: string): Promise<RepoPath> {
+interface GitCommandAnchors {
+  active: RepoPath;
+  durable: RepoPath;
+}
+
+async function getGitCommandAnchors(path: string): Promise<GitCommandAnchors> {
   try {
-    return await getCanonicalRepoPath(path);
+    const canonicalPath = await getCanonicalRepoPath(path);
+    return { active: canonicalPath, durable: canonicalPath };
   } catch (error) {
     if (error instanceof CanonicalRepoPathUnavailableError) {
-      return toRepoPath(path);
+      return {
+        active: toRepoPath(path),
+        // The exact checkout may be removed by destroy(), while Git's common
+        // directory remains a valid anchor for prune and branch cleanup.
+        durable: toRepoPath(error.commonGitDir),
+      };
     }
     throw error;
   }
@@ -231,7 +242,7 @@ export class WorktreeProvider implements IIsolationProvider {
     if (options?.canonicalRepoPath) {
       repoPath = options.canonicalRepoPath;
     } else if (pathExists) {
-      repoPath = await getGitCommandAnchor(worktreePath);
+      repoPath = (await getGitCommandAnchors(worktreePath)).durable;
     } else {
       // Path doesn't exist and no canonicalRepoPath provided - can't clean up branch
       // This is expected when worktree was already fully cleaned up externally
@@ -451,7 +462,7 @@ export class WorktreeProvider implements IIsolationProvider {
     let repoPath: RepoPath;
     let worktrees: WorktreeInfo[];
     try {
-      repoPath = await getGitCommandAnchor(worktreePath);
+      repoPath = (await getGitCommandAnchors(worktreePath)).active;
       worktrees = await listWorktrees(repoPath);
     } catch (error) {
       getLog().error({ err: error, worktreePath }, 'worktree_query_failed');
@@ -517,7 +528,7 @@ export class WorktreeProvider implements IIsolationProvider {
     let repoPath: RepoPath;
     let worktrees: WorktreeInfo[];
     try {
-      repoPath = await getGitCommandAnchor(path);
+      repoPath = (await getGitCommandAnchors(path)).active;
       worktrees = await listWorktrees(repoPath);
     } catch (error) {
       const err = error as Error;

--- a/packages/isolation/src/providers/worktree.ts
+++ b/packages/isolation/src/providers/worktree.ts
@@ -240,7 +240,7 @@ export class WorktreeProvider implements IIsolationProvider {
     // Get canonical repo path - use provided path or derive from worktree
     let repoPath: string;
     if (options?.canonicalRepoPath) {
-      repoPath = options.canonicalRepoPath;
+      repoPath = (await getGitCommandAnchors(options.canonicalRepoPath)).durable;
     } else if (pathExists) {
       repoPath = (await getGitCommandAnchors(worktreePath)).durable;
     } else {

--- a/packages/isolation/src/resolver.test.ts
+++ b/packages/isolation/src/resolver.test.ts
@@ -1162,6 +1162,39 @@ describe('IsolationResolver', () => {
   // become a `blocked` result; unknown errors propagate as crashes.
   // -------------------------------------------------------------------------
   describe('canonical path resolution failure handling', () => {
+    test('uses an exact registered external-git-dir checkout as the worktree anchor', async () => {
+      const defaultCwd = '/workspace/external-linked';
+      getCanonicalSpy.mockRejectedValue(
+        new git.CanonicalRepoPathUnavailableError(defaultCwd, '/metadata/repository')
+      );
+      const createSpy = mock(
+        async (_request: IsolationRequest): Promise<IsolatedEnvironment> => ({
+          id: '/worktrees/new-branch',
+          provider: 'worktree',
+          workingPath: '/worktrees/new-branch',
+          branchName: git.toBranchName('new-branch'),
+          status: 'active',
+          createdAt: new Date(),
+          metadata: { adopted: false },
+        })
+      );
+      const resolver = createResolver({
+        provider: { ...makeMockProvider(), create: createSpy },
+      });
+
+      const result = await resolver.resolve({
+        existingEnvId: null,
+        codebase: { ...defaultCodebase, defaultCwd },
+        hints: { workflowType: 'issue', workflowId: '42' },
+        platformType: 'web',
+      });
+
+      expect(result.status).toBe('resolved');
+      expect(createSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ canonicalRepoPath: defaultCwd })
+      );
+    });
+
     test('known infrastructure error returns blocked with classified user message', async () => {
       const eaccesError = new Error('EACCES: permission denied') as NodeJS.ErrnoException;
       eaccesError.code = 'EACCES';

--- a/packages/isolation/src/resolver.ts
+++ b/packages/isolation/src/resolver.ts
@@ -15,6 +15,8 @@ import {
   toBranchName,
   isAncestorOf,
   verifyWorktreeOwnership,
+  CanonicalRepoPathUnavailableError,
+  toRepoPath,
 } from '@archon/git';
 import type { RepoPath, BranchName, WorktreePath } from '@archon/git';
 
@@ -133,7 +135,7 @@ export class IsolationResolver {
     const workflowType: IsolationWorkflowType = hints?.workflowType ?? 'thread';
     const workflowId = hints?.workflowId ?? '';
 
-    // Compute canonical repo path once — paths 3-6 all need it either for
+    // Compute the Git command anchor once — paths 3-6 all need it either for
     // ownership verification (cross-clone guard) or for worktree creation.
     // Mirror createNewEnvironment's contract: known infrastructure failures
     // (permission denied, ENOENT, malformed worktree pointer, etc.) become
@@ -144,29 +146,37 @@ export class IsolationResolver {
     try {
       canonicalPath = await getCanonicalRepoPath(codebase.defaultCwd);
     } catch (error) {
-      const err = error instanceof Error ? error : new Error(String(error));
-      getLog().error(
-        {
-          err,
-          errorType: err.constructor.name,
-          codebaseId: codebase.id,
-          defaultCwd: codebase.defaultCwd,
-        },
-        'isolation.canonical_repo_path_resolution_failed'
-      );
+      // A registered checkout backed by `--separate-git-dir` is already the
+      // authoritative path, but Git has no reverse pointer from its linked
+      // worktree metadata to a primary checkout. Git worktree operations are
+      // valid from that registered linked checkout, so retain it as the anchor.
+      if (error instanceof CanonicalRepoPathUnavailableError) {
+        canonicalPath = toRepoPath(codebase.defaultCwd);
+      } else {
+        const err = error instanceof Error ? error : new Error(String(error));
+        getLog().error(
+          {
+            err,
+            errorType: err.constructor.name,
+            codebaseId: codebase.id,
+            defaultCwd: codebase.defaultCwd,
+          },
+          'isolation.canonical_repo_path_resolution_failed'
+        );
 
-      if (!isKnownIsolationError(err)) {
-        throw err;
+        if (!isKnownIsolationError(err)) {
+          throw err;
+        }
+
+        const userMessage = classifyIsolationError(err);
+        return {
+          status: 'blocked',
+          reason: 'creation_failed',
+          userMessage:
+            userMessage +
+            ' Execution blocked to prevent changes to shared codebase. Please resolve the issue and try again.',
+        };
       }
-
-      const userMessage = classifyIsolationError(err);
-      return {
-        status: 'blocked',
-        reason: 'creation_failed',
-        userMessage:
-          userMessage +
-          ' Execution blocked to prevent changes to shared codebase. Please resolve the issue and try again.',
-      };
     }
 
     // 3. Check for existing environment with same workflow

--- a/packages/isolation/src/types.ts
+++ b/packages/isolation/src/types.ts
@@ -41,15 +41,17 @@ interface IsolationRequestBase {
   codebaseName?: string;
 
   /**
-   * Absolute, resolved filesystem path to the main repository checkout.
+   * Absolute, resolved filesystem path to a registered repository checkout.
    *
    * "Canonical" means the real path with symlinks resolved and `~` expanded
    * (e.g., `/home/user/.archon/workspaces/owner/repo/source`). This must
-   * point to the primary git checkout, not a worktree, because git worktree
-   * operations (add, remove, list) must be executed from the main repo.
+   * This normally points to the primary checkout. A repository created with
+   * `--separate-git-dir` does not record a reverse primary-checkout path, so an
+   * exactly registered linked checkout is also a valid Git worktree-operation
+   * anchor.
    *
-   * Use `getCanonicalRepoPath()` to resolve any path (including worktree
-   * paths) back to the canonical repo path.
+   * Use `getCanonicalRepoPath()` when Git can resolve a primary checkout; keep
+   * an exact registered checkout when it returns its typed unavailable result.
    */
   canonicalRepoPath: RepoPath;
 


### PR DESCRIPTION
## Problem and outcome

A workflow started from a linked Git worktree missed the already registered repository. Default isolation then failed on the valid project source symlink, while non-isolated runs silently forked into an unregistered `_cwd` storage identity.

- **Outcome:** Linked worktrees now launch, list, and resolve short run IDs under the registered Git repository identity.
- **Invariant:** Checkouts share identity only when Git reports the same physical common directory; remote, name, branch, and default-branch equality are not identity.
- **Boundaries:** Exact registrations win. Separate clones, plain submodules, folder projects, and unregistered directories remain distinct. #1192 and #2593/#2595 remain out of scope.

## Review guidance

- **Feedback requested:** Correctness of Git common-directory identity and the external-Git-dir ambiguity boundary.
- **Start here:** `packages/git/src/worktree.ts` for checkout identity, then `packages/core/src/services/codebase-checkout-resolver.ts` for registered-codebase resolution.
- **Review order:** Git primitive → core registration → CLI consumers → isolation ownership → focused regressions.
- **Risk:** `git init --separate-git-dir` has no reverse primary-checkout path. That fallback scans registered repositories for the exact common Git directory and throws when more than one matches.

## Solution

`getGitCheckoutIdentity` asks Git for absolute `--git-dir` and `--git-common-dir` values. Ordinary linked worktrees resolve their primary checkout through Git's worktree inventory; linked submodule worktrees use Git's `core.worktree`; independent checkouts return themselves. A linked checkout backed by an external Git directory produces a typed “primary unavailable” result, allowing the shared codebase resolver to recover only a unique registered checkout with the same common directory.

Registration, `workflow runs`, and every short-ID consumer now use that exact-first resolver. Worktree adoption compares the same Git common-directory identity. When an exact external-Git-dir linked checkout has no reverse primary path, isolation retains that checkout as the active anchor for creation, lookup, and adoption, while its common Git directory remains the durable cleanup anchor after removal. This removes `.git` pathname grammar while preserving the linked checkout as the workflow discovery and execution cwd.

## Behavior change

| | Before | After |
|---|---|---|
| **Linked registered checkout** | Could fail registration or silently use global/`_cwd` scope. | Reuses the registered codebase before mutation and retains project scope. |
| **Nested submodule layouts** | Valid linked-superproject paths could collapse into the superproject or fail ownership. | Plain submodules stay independent; their linked worktrees resolve to them. |
| **External Git directory** | Valid primary and linked checkouts could throw. | Primary stays independent; a linked checkout recovers a unique matching registration or fails on ambiguity. |

## Validation

- `cd packages/git && bun test src/git.test.ts` — 191 passed, 0 failed.
- `cd packages/core && bun test src/handlers/clone.test.ts` — 78 passed, 0 failed.
- `cd packages/cli && bun test src/commands/workflow.test.ts` — 237 passed, 0 failed.
- `cd packages/isolation && bun run test` — resolver, provider, error, factory, worktree-copy, PR-state, backend, and container suites passed.
- Package type checks for Git, core, and CLI — exit 0.
- Disposable real-Git linked-superproject/submodule fixture — plain submodule stayed independent, linked submodule worktree resolved to it, ownership passed; exit 0.
- Disposable real `git init --separate-git-dir` fixture — primary stayed independent, linked checkout returned the typed unavailable result, unique registered common-dir lookup recovered the codebase; exit 0.
- Real issue worktree registration and `workflow runs --json` — registered primary codebase returned and `scopeFallback: false`; exit 0.
- `bun run validate` — generated checks, type-check, lint, format, install tests, package-isolated tests, and script tests passed; exit 0.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | No migration. Historical runs retain their write-once `output_root`; new linked-worktree runs receive the registered codebase. | No schema or persisted-state change. |
| Rollout / rollback | Code-only identity lookup; reverting restores prior behavior without data cleanup. | Diff is limited to Git identity, existing consumers, and tests. |
| Failure behavior | Ambiguous external-Git-dir registrations fail explicitly; stale registrations are ignored; genuinely unregistered paths retain existing behavior. | Resolver regressions cover unique, separate-clone, and ambiguous cases. |

## Links

- Closes #2613
- Plan: https://github.com/coleam00/Archon/issues/2613#issuecomment-5340662560

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow recognition for linked Git worktrees, including run-ID lookup and event handling.
  * Reused the primary checkout when registering linked worktrees, preventing duplicate codebase records.
  * Improved repository path resolution for linked submodules, relative worktree paths, and external Git directories.
  * Preserved separate handling for standalone submodule checkouts and separate clones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
