### PR TITLE
fix(workflows): preserve nested include input bindings

### DIFF
--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -1275,13 +1275,14 @@ surfaces it rewrites. That makes the right-hand form work and the left-hand form
 
 ```yaml
 when: "$probe.output == '$INPUTS.mode'"   # ✅ becomes  $probe.output == 'fast'
-when: "$INPUTS.mode == 'fast'"            # ❌ becomes  fast == 'fast'  → unparseable
+when: "$INPUTS.mode == 'fast'"            # ❌ would become  fast == 'fast'
 ```
 
-The second is not a condition any more, so the node is skipped with an unparseable-`when:`
-warning at run time. The left-hand form is a `workflow:`/direct-run feature: those callers
-resolve `$INPUTS` at evaluation time, while an included block is inlined into the caller's
-own run and has no input scope left to resolve against.
+The second would no longer be a condition, so include expansion rejects it at load time and
+shows both the authored and rewritten expressions instead of allowing a runtime skip. The
+left-hand form is a `workflow:`/direct-run feature: those callers resolve `$INPUTS` at
+evaluation time, while an included block is inlined into the caller's own run and has no
+input scope left to resolve against.
 :::
 
 ### Running a workflow that declares inputs

--- a/packages/workflows/src/dry-run.test.ts
+++ b/packages/workflows/src/dry-run.test.ts
@@ -819,6 +819,53 @@ describe('dryRunWorkflow — declared inputs (#2610)', () => {
     expect(result.trace[0]?.resolvedText).toBe('Work on ship it');
   });
 
+  test('uses the input-bound compiled prompt for a nested included loop command', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'archon-dry-run-nested-inputs-'));
+    temporaryDirectories.push(cwd);
+    mkdirSync(join(cwd, '.archon', 'commands'), { recursive: true });
+    // The raw source keeps the middle workflow's input name. Loading it at simulation time
+    // reproduces #2629; the expanded node's compiled prompt has already rebound that name.
+    writeFileSync(join(cwd, '.archon', 'commands', 'loop-impl.md'), 'Raw $INPUTS.work');
+
+    const implement = makeTestWorkflow({
+      name: 'implement',
+      inputs: { work: { required: true } },
+      nodes: [
+        { id: 'implement', loop: { command: 'loop-impl', until: 'DONE', max_iterations: 1 } },
+      ],
+    });
+    const deliver = makeTestWorkflow({
+      name: 'deliver',
+      inputs: { work: { required: true } },
+      nodes: [{ id: 'impl', include: 'implement', with: { work: '$INPUTS.work' } }],
+    });
+    const fix = makeTestWorkflow({
+      name: 'fix',
+      inputs: { target: { required: true } },
+      nodes: [{ id: 'deliver', include: 'deliver', with: { work: 'Fix $INPUTS.target' } }],
+    });
+    const { workflows, errors } = expandWorkflowIncludes(
+      new Map([
+        ['implement', implement],
+        ['deliver', deliver],
+        ['fix', fix],
+      ]),
+      new Map([['loop-impl', 'Work on $INPUTS.work']])
+    );
+    expect(errors).toHaveLength(0);
+
+    const result = await dryRunWorkflow({
+      workflow: workflows.get('fix')!,
+      userMessage: '',
+      cwd,
+      stubs: { deliver__impl__implement: '<promise>DONE</promise>' },
+      inputs: { target: 'issue 2629' },
+    });
+
+    expect(result.outcome).toBe('completed');
+    expect(result.trace[0]?.resolvedText).toBe('Work on Fix issue 2629');
+  });
+
   test('when: conditions branch on the effective input map', async () => {
     const workflow = makeTestWorkflow({
       name: 'inputs-when',

--- a/packages/workflows/src/dry-run.ts
+++ b/packages/workflows/src/dry-run.ts
@@ -12,6 +12,7 @@ import {
   substituteNodeOutputRefs,
 } from './dag-executor';
 import { evaluateCondition } from './condition-evaluator';
+import { COMPILED_LOOP_COMMAND, type LoopWithCompiledCommand } from './compiled-command';
 import { declaredFieldsFromSchema } from './output-ref';
 import { discoverScriptsForCwd } from './script-discovery';
 import {
@@ -514,7 +515,29 @@ async function simulateLoop(
 ): Promise<void> {
   if (!isLoopNode(node)) return;
   let previous = '';
-  const template = node.loop.prompt ?? (await loadDryRunCommand(ctx.cwd, node.loop.command ?? ''));
+  let template: string;
+  if (node.loop.prompt !== undefined) {
+    template = node.loop.prompt;
+  } else {
+    const command = node.loop.command ?? '';
+    const compiled = (node.loop as typeof node.loop & LoopWithCompiledCommand)[
+      COMPILED_LOOP_COMMAND
+    ];
+    const hasCompiledError = compiled !== undefined && typeof compiled.error === 'string';
+    const hasCompiledPrompt = compiled !== undefined && typeof compiled.prompt === 'string';
+    if (hasCompiledError && !hasCompiledPrompt) {
+      throw new Error(compiled.error);
+    }
+    if (hasCompiledPrompt && !hasCompiledError) {
+      template = compiled.prompt;
+    } else if (compiled !== undefined) {
+      throw new Error(
+        `Loop node '${node.id}' has malformed compiled command metadata for '${command}' — expected exactly one string prompt or error.`
+      );
+    } else {
+      template = await loadDryRunCommand(ctx.cwd, command);
+    }
+  }
   let resolvedText = template;
   for (let current = 1; current <= node.loop.max_iterations; current++) {
     resolvedText = resolveText(template, ctx, outputs, false, previous);

--- a/packages/workflows/src/include-expander.test.ts
+++ b/packages/workflows/src/include-expander.test.ts
@@ -460,6 +460,40 @@ describe('expandWorkflowIncludes — with input mapping', () => {
     expect(use && 'prompt' in use ? use.prompt : '').toBe('```\nliteral literal\n``` empty=[]');
   });
 
+  test('rejects a when expression made unparseable by input substitution', () => {
+    const block = wf('parameterized', [
+      { id: 'probe', bash: 'echo go' },
+      {
+        id: 'use',
+        prompt: 'work',
+        depends_on: ['probe'],
+        when: "$INPUTS.mode == 'fast' && $probe.output == 'go'",
+      },
+    ]);
+    block.inputs = { mode: { default: 'fast' } };
+    const parent = wf('parent', [{ id: 'review', include: 'parameterized' }]);
+
+    const { workflows, errors } = expandWorkflowIncludes(mapOf(block, parent));
+
+    expect(workflows.has('parent')).toBe(false);
+    const error = errors.find(candidate => candidate.filename === 'parent')?.error;
+    expect(error).toContain("Node 'review'");
+    expect(error).toContain("$INPUTS.mode == 'fast' && $review__probe.output == 'go'");
+    expect(error).toContain("fast == 'fast' && $review__probe.output == 'go'");
+    expect(error).toContain('right-hand side');
+  });
+
+  test('does not broaden the load error to an unchanged malformed when expression', () => {
+    const block = wf('parameterized', [{ id: 'use', prompt: 'work', when: 'not an atom' }]);
+    block.inputs = { mode: { default: 'fast' } };
+    const parent = wf('parent', [{ id: 'review', include: 'parameterized' }]);
+
+    const { workflows, errors } = expandWorkflowIncludes(mapOf(block, parent));
+
+    expect(errors).toHaveLength(0);
+    expect(nodeById(workflows.get('parent')!, 'review__use')?.when).toBe('not an atom');
+  });
+
   test('substitutes inputs across every other supported inline node surface', () => {
     const block = wf('parameterized', [
       { id: 'shell', bash: 'echo $INPUTS.value' },

--- a/packages/workflows/src/include-expander.ts
+++ b/packages/workflows/src/include-expander.ts
@@ -56,6 +56,7 @@ import {
 import { createLogger } from '@archon/paths';
 import { validateDagStructure } from './loader';
 import { resolveDeclaredInputs } from './workflow-inputs';
+import { parseWhenAtom, whenAtoms } from './when-atom';
 import {
   COMPILED_LOOP_COMMAND,
   COMPOSED_NODE,
@@ -457,7 +458,12 @@ function rewriteNodeOutputRefs(
  * takes include inputs but is NOT a runtime node-ref surface would reopen the #2476 gap;
  * it belongs in one of these two functions, not silently in this one alone.
  */
-function applyInputsMacro(node: DagNode, args: Record<string, string>, missing: Set<string>): void {
+function applyInputsMacro(
+  node: DagNode,
+  args: Record<string, string>,
+  missing: Set<string>,
+  includeNode: IncludeNode
+): void {
   const substitute = (text: string): string =>
     text.replace(INPUTS_REF, (match, name: string) => {
       // `Object.hasOwn` rather than a plain `args[name]` lookup: a bare index read reaches
@@ -473,7 +479,19 @@ function applyInputsMacro(node: DagNode, args: Record<string, string>, missing: 
       return value;
     });
 
-  if (node.when !== undefined) node.when = substitute(node.when);
+  const substituteWhen = (when: string): string => {
+    const expanded = substitute(when);
+    const wasParseable = whenAtoms(when).every(atom => parseWhenAtom(atom) !== null);
+    const isParseable = whenAtoms(expanded).every(atom => parseWhenAtom(atom) !== null);
+    if (expanded !== when && wasParseable && !isParseable) {
+      throw new IncludeExpansionError(
+        `Node '${includeNode.id}': input substitution made included node '${node.id}' field 'when' unparseable: "${when}" became "${expanded}". Put '$INPUTS.<name>' on the right-hand side of a comparison whose left-hand side is a node-output reference.`
+      );
+    }
+    return expanded;
+  };
+
+  if (node.when !== undefined) node.when = substituteWhen(node.when);
 
   // An inherited stamp's values may reference THIS level's inputs — `with: { plan:
   // '$INPUTS.topic' }` one file down. Without this walk the stamp keeps the literal
@@ -483,7 +501,7 @@ function applyInputsMacro(node: DagNode, args: Record<string, string>, missing: 
     for (const [key, value] of Object.entries(stamped)) stamped[key] = substitute(value);
   }
   for (const boundary of readComposedMeta(node)?.boundaries ?? []) {
-    if (boundary.when !== undefined) boundary.when = substitute(boundary.when);
+    if (boundary.when !== undefined) boundary.when = substituteWhen(boundary.when);
   }
 
   // Base AI-turn fields — valid on every AI node mode (command / prompt / loop_group), so
@@ -510,7 +528,7 @@ function applyInputsMacro(node: DagNode, args: Record<string, string>, missing: 
     if (node.loop_group.until_bash !== undefined) {
       node.loop_group.until_bash = substitute(node.loop_group.until_bash);
     }
-    for (const body of node.loop_group.nodes) applyInputsMacro(body, args, missing);
+    for (const body of node.loop_group.nodes) applyInputsMacro(body, args, missing, includeNode);
   } else if (isApprovalNode(node)) {
     node.approval.message = substitute(node.approval.message);
     if (node.approval.on_reject !== undefined) {
@@ -671,7 +689,7 @@ function inlineInclude(
     // load-bearing: a caller ref such as `$gather.output` must remain parent-scoped even
     // when the included block also has a node named `gather`.
     rewriteNodeOutputRefs(clone, rename, id => [rename(id)]);
-    applyInputsMacro(clone, resolvedInputs, missingInputs);
+    applyInputsMacro(clone, resolvedInputs, missingInputs, includeNode);
     // Stamped AFTER both passes, for the same reason the caller's values are inserted
     // after the rename: these are the CALLER's strings, so they stay parent-scoped here
     // and are walked by the next level out, not by this one. Each node gets its own copy


### PR DESCRIPTION
## Problem and outcome

Nested include chains could dry-run a command-backed loop from its raw command source after include expansion had already rebound the command's inputs, producing an `Unknown input` error that real execution did not share. Include input substitution could also turn an authored valid `when:` condition into invalid syntax and defer that mistake to a silent runtime skip.

- **Outcome:** Dry runs now use the same compiled, input-bound loop prompt as real execution, and include expansion reports a precise load error when substitution breaks a valid `when:` expression.
- **Invariant:** Included workflows remain a load-time flattened DAG; command compilation and the existing `when:` parser remain the authoritative primitives.
- **Scope boundary:** This does not add runtime input scopes to included nodes, change direct/sub-run input semantics, or extend the `when:` language.
- **Root cause:** Dry-run simulation reopened the raw loop command instead of consuming `COMPILED_LOOP_COMMAND`; `when:` input macros were substituted without checking whether the shared parser could still parse the result.

## Review guidance

- **Feedback requested:** Correctness at the include-expansion and dry-run/executor parity seams.
- **Start here:** `packages/workflows/src/dry-run.ts:510` — command-backed loop simulation now follows the executor's compiled-command precedence.
- **Review order:** `dry-run.ts`, `dry-run.test.ts`, `include-expander.ts`, `include-expander.test.ts`, then the authoring guide.
- **Lower-attention areas:** The documentation update only aligns the existing include-input warning with the new load-time failure behavior.
- **Known risk or uncertainty:** None.

## Solution

Dry-run loop simulation now prefers an inline prompt, then valid compiled command metadata, and only reloads a command when no compiled metadata exists—the same ownership boundary used by real execution. Include macro expansion reuses the shared `when:` atom parser before and after substitution and rejects only a changed valid-to-invalid expression, preserving the existing behavior for unrelated malformed author text.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | A nested included loop could fail only in dry-run because the raw command still referenced the child input name. | Dry-run executes the compiled prompt containing the fully rebound outer input. |
| **Failure behavior** | An include macro could create an unparseable `when:` and the node would be skipped later. | Include expansion fails with the include id, included node id, original expression, rewritten expression, and remediation. |

## Validation

- `bun run validate` — passed — generated artifacts, type-check, zero-warning lint, formatting, installer tests, all package tests, and script tests are green.
- `cd packages/workflows && bun test src/include-expander.test.ts` — 90 passed, 0 failed — covers valid-to-invalid substitution and the unchanged malformed-expression boundary.
- `cd packages/workflows && bun test src/dry-run.test.ts` — 43 passed, 0 failed — covers the three-level include chain with a command-backed loop.
- `cd packages/workflows && bun test src/condition-evaluator.test.ts` — 92 passed, 0 failed — confirms the shared condition grammar remains unchanged.
- **Not verified:** Nothing material; the regressions use focused repository fixtures and the complete repository validation is green.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | No data or YAML schema migration. Existing valid include conditions continue to expand; only substitutions that make a valid condition invalid now fail earlier. | `packages/workflows/src/include-expander.test.ts:463` |
| Rollout / rollback | Localized workflow-engine behavior with a single reversible commit. | `1fcd0075` |
| Documentation / communication | The authoring guide now documents the load-time rejection and retained right-hand-side form. | `packages/docs-web/src/content/docs/guides/authoring-workflows.md` |

## Links

- Closes #2629
- Closes #2580
- Plan: https://github.com/coleam00/Archon/issues/2629#issuecomment-5341433806
- Companion publication: https://github.com/coleam00/Archon/issues/2580#issuecomment-5341433990


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid conditions created during workflow input substitution are now detected when workflows load, with clearer error details.
  * Nested included workflows now resolve loop prompts and rebound inputs correctly during dry runs.
  * Malformed conditions that were already present are preserved unless input substitution makes them invalid.
* **Documentation**
  * Updated workflow authoring guidance to reflect stricter validation of input-based conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->