### PR TITLE
feat(workflows): scaffold sparse dry-run fixtures

### DIFF
--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -35,6 +35,8 @@ describe('CLI help output', () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('--dry-run');
     expect(result.stdout).toContain('--stubs <path>');
+    expect(result.stdout).toContain('--stubs-init <path>');
+    expect(result.stdout).toContain('--default-stubs');
     expect(result.stdout).toContain('--exec-code');
     expect(result.stdout).toContain('--pause-at-gates');
   });
@@ -185,6 +187,8 @@ describe('CLI argument parsing', () => {
         force: { type: 'boolean' },
         'dry-run': { type: 'boolean' },
         stubs: { type: 'string' },
+        'stubs-init': { type: 'string' },
+        'default-stubs': { type: 'boolean' },
         'exec-code': { type: 'boolean' },
         'pause-at-gates': { type: 'boolean' },
       },
@@ -324,12 +328,17 @@ describe('CLI argument parsing', () => {
         '--dry-run',
         '--stubs',
         'fixtures.yaml',
+        '--stubs-init',
+        'generated.yaml',
+        '--default-stubs',
         '--exec-code',
         '--pause-at-gates',
       ]);
 
       expect(result.values['dry-run']).toBe(true);
       expect(result.values.stubs).toBe('fixtures.yaml');
+      expect(result.values['stubs-init']).toBe('generated.yaml');
+      expect(result.values['default-stubs']).toBe(true);
       expect(result.values['exec-code']).toBe(true);
       expect(result.values['pause-at-gates']).toBe(true);
     });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -162,6 +162,8 @@ Options:
   --resume                   Resume the most recent failed or paused run of the workflow (mutually exclusive with --branch)
   --dry-run                  Simulate workflow DAG control flow without creating a run or contacting a provider
   --stubs <path>             YAML node-output map for --dry-run
+  --stubs-init <path>        Write a complete dry-run stub scaffold and exit
+  --default-stubs            Fill missing reached nodes with validated placeholders during --dry-run
   --exec-code                Execute trusted bash/script nodes during --dry-run (default: require stubs)
   --pause-at-gates           Stop a dry-run at approval gates instead of auto-approving
   --spawn                    Open setup wizard in a new terminal window (for setup command)
@@ -318,6 +320,8 @@ async function main(): Promise<number> {
         full: { type: 'boolean' },
         'dry-run': { type: 'boolean' },
         stubs: { type: 'string' },
+        'stubs-init': { type: 'string' },
+        'default-stubs': { type: 'boolean' },
         'exec-code': { type: 'boolean' },
         'pause-at-gates': { type: 'boolean' },
         // Repeatable: `--input a=1 --input b=2` yields ['a=1', 'b=2'] (#2554).
@@ -350,6 +354,8 @@ async function main(): Promise<number> {
   const detachFlag = values.detach as boolean | undefined;
   const dryRunFlag = values['dry-run'] as boolean | undefined;
   const stubsPath = values.stubs as string | undefined;
+  const stubsInitPath = values['stubs-init'] as string | undefined;
+  const defaultStubsFlag = values['default-stubs'] as boolean | undefined;
   const execCodeFlag = values['exec-code'] as boolean | undefined;
   const pauseAtGatesFlag = values['pause-at-gates'] as boolean | undefined;
   // Handle help flag
@@ -605,6 +611,8 @@ async function main(): Promise<number> {
               json: jsonFlag,
               dryRun: dryRunFlag,
               stubsPath,
+              stubsInitPath,
+              defaultStubs: defaultStubsFlag,
               execCode: execCodeFlag,
               pauseAtGates: pauseAtGatesFlag,
               // Raw `name=value` assignments; parsed at the invocation gate (#2554).

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -626,10 +626,18 @@ describe('workflowRunCommand — dry-run', () => {
 
   it('rejects dry-run-only and incompatible lifecycle flags', async () => {
     await expect(
+      workflowRunCommand('/test/path', 'plan', '', { stubsPath: 'fixtures.yaml' })
+    ).rejects.toThrow('--stubs requires --dry-run');
+
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'plan' }, 'project')],
+      errors: [],
+    });
+    await expect(
       workflowRunCommand('/test/path', 'plan', '', { stubsInitPath: 'fixtures.yaml' })
     ).rejects.toThrow('--stubs-init requires --dry-run');
 
-    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
     (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
       workflows: [makeTestWorkflowWithSource({ name: 'plan' }, 'project')],
       errors: [],

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -122,6 +122,7 @@ mock.module('@archon/workflows/executor', () => ({
 }));
 mock.module('@archon/workflows/dry-run', () => ({
   loadDryRunStubs: mock(() => Promise.resolve({ node: 'stubbed output' })),
+  writeDryRunStubScaffold: mock(() => Promise.resolve({ first: 'TODO', second: 'TODO' })),
   dryRunWorkflow: mock(() =>
     Promise.resolve({
       workflow: 'plan',
@@ -517,6 +518,7 @@ describe('workflowRunCommand — dry-run', () => {
     const dryRun = await import('@archon/workflows/dry-run');
     (executeWorkflow as ReturnType<typeof mock>).mockClear();
     (dryRun.loadDryRunStubs as ReturnType<typeof mock>).mockClear();
+    (dryRun.writeDryRunStubScaffold as ReturnType<typeof mock>).mockClear();
     (dryRun.dryRunWorkflow as ReturnType<typeof mock>).mockClear();
     (dryRun.formatDryRunTrace as ReturnType<typeof mock>).mockClear();
     (dryRun.dryRunWorkflow as ReturnType<typeof mock>).mockResolvedValue({
@@ -546,6 +548,7 @@ describe('workflowRunCommand — dry-run', () => {
     await workflowRunCommand('/test/path', 'plan', 'hello', {
       dryRun: true,
       stubsPath: 'fixtures.yaml',
+      defaultStubs: true,
       execCode: true,
       pauseAtGates: true,
       json: true,
@@ -556,6 +559,7 @@ describe('workflowRunCommand — dry-run', () => {
       expect.objectContaining({
         userMessage: 'hello',
         cwd: '/test/path',
+        defaultStubs: true,
         execCode: true,
         pauseAtGates: true,
       })
@@ -567,6 +571,30 @@ describe('workflowRunCommand — dry-run', () => {
       outcome: 'completed',
     });
     expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  it('writes a scaffold from the discovered workflow and exits before simulation', async () => {
+    const { executeWorkflow } = await import('@archon/workflows/executor');
+    const dryRun = await import('@archon/workflows/dry-run');
+
+    await workflowRunCommand('/test/path', 'plan', '', {
+      dryRun: true,
+      stubsInitPath: 'fixtures/generated.yaml',
+      json: true,
+    });
+
+    expect(dryRun.writeDryRunStubScaffold).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'plan' }),
+      join('/test/path', 'fixtures/generated.yaml')
+    );
+    expect(dryRun.loadDryRunStubs).not.toHaveBeenCalled();
+    expect(dryRun.dryRunWorkflow).not.toHaveBeenCalled();
+    expect(executeWorkflow).not.toHaveBeenCalled();
+    expect(JSON.parse(firstJsonPayload(stdoutSpy))).toEqual({
+      workflow: 'plan',
+      stubsPath: join('/test/path', 'fixtures/generated.yaml'),
+      nodeCount: 2,
+    });
   });
 
   it('writes the human trace through guaranteed stdout delivery', async () => {
@@ -598,8 +626,8 @@ describe('workflowRunCommand — dry-run', () => {
 
   it('rejects dry-run-only and incompatible lifecycle flags', async () => {
     await expect(
-      workflowRunCommand('/test/path', 'plan', '', { stubsPath: 'fixtures.yaml' })
-    ).rejects.toThrow('--stubs requires --dry-run');
+      workflowRunCommand('/test/path', 'plan', '', { stubsInitPath: 'fixtures.yaml' })
+    ).rejects.toThrow('--stubs-init requires --dry-run');
 
     const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
     (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
@@ -607,8 +635,39 @@ describe('workflowRunCommand — dry-run', () => {
       errors: [],
     });
     await expect(
+      workflowRunCommand('/test/path', 'plan', '', { defaultStubs: true })
+    ).rejects.toThrow('--default-stubs requires --dry-run');
+
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'plan' }, 'project')],
+      errors: [],
+    });
+    await expect(
       workflowRunCommand('/test/path', 'plan', '', { dryRun: true, detach: true })
     ).rejects.toThrow('--dry-run cannot be combined with --detach');
+  });
+
+  it('rejects scaffold mode combined with simulation stub options', async () => {
+    await expect(
+      workflowRunCommand('/test/path', 'plan', '', {
+        dryRun: true,
+        stubsInitPath: 'generated.yaml',
+        stubsPath: 'overrides.yaml',
+      })
+    ).rejects.toThrow('--stubs-init cannot be combined with --stubs');
+
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'plan' }, 'project')],
+      errors: [],
+    });
+    await expect(
+      workflowRunCommand('/test/path', 'plan', '', {
+        dryRun: true,
+        stubsInitPath: 'generated.yaml',
+        defaultStubs: true,
+      })
+    ).rejects.toThrow('--stubs-init cannot be combined with --default-stubs');
   });
 
   it('emits failure JSON before returning a nonzero-worthy error', async () => {

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -48,7 +48,12 @@ import {
   resolveTopLevelInputs,
 } from '@archon/workflows/utils/workflow-requirements';
 import { parseInputAssignments } from '@archon/workflows/workflow-inputs';
-import { dryRunWorkflow, formatDryRunTrace, loadDryRunStubs } from '@archon/workflows/dry-run';
+import {
+  dryRunWorkflow,
+  formatDryRunTrace,
+  loadDryRunStubs,
+  writeDryRunStubScaffold,
+} from '@archon/workflows/dry-run';
 import {
   getWorkflowEventEmitter,
   type WorkflowEmitterEvent,
@@ -220,6 +225,10 @@ export interface WorkflowRunOptions {
   dryRun?: boolean;
   /** YAML mapping of node ids to scalar or structured simulated outputs. */
   stubsPath?: string;
+  /** Write a complete YAML stub scaffold for the discovered workflow and exit. */
+  stubsInitPath?: string;
+  /** Fill reached nodes missing from the supplied stub map with validated placeholders. */
+  defaultStubs?: boolean;
   /** Execute reachable bash/script nodes locally instead of requiring stubs. */
   execCode?: boolean;
   /** Stop at the first approval gate instead of auto-approving it. */
@@ -955,6 +964,8 @@ export async function workflowRunCommand(
 
   const dryRunOnlyOptions = [
     ['--stubs', options.stubsPath !== undefined],
+    ['--stubs-init', options.stubsInitPath !== undefined],
+    ['--default-stubs', options.defaultStubs === true],
     ['--exec-code', options.execCode === true],
     ['--pause-at-gates', options.pauseAtGates === true],
   ] as const;
@@ -978,6 +989,12 @@ export async function workflowRunCommand(
     if (incompatibleFlag) {
       throw new Error(`--dry-run cannot be combined with ${incompatibleFlag}.`);
     }
+    if (options.stubsInitPath !== undefined && options.stubsPath !== undefined) {
+      throw new Error('--stubs-init cannot be combined with --stubs.');
+    }
+    if (options.stubsInitPath !== undefined && options.defaultStubs) {
+      throw new Error('--stubs-init cannot be combined with --default-stubs.');
+    }
 
     // The IDENTICAL invocation gate a real run passes through below (#2610): parse
     // `--input name=value`, validate against the declared `inputs:` contract, and fail
@@ -994,6 +1011,23 @@ export async function workflowRunCommand(
         ? options.stubsPath
         : join(effectiveDiscoveryCwd, options.stubsPath)
       : undefined;
+    const stubsInitPath = options.stubsInitPath
+      ? isAbsolute(options.stubsInitPath)
+        ? options.stubsInitPath
+        : join(effectiveDiscoveryCwd, options.stubsInitPath)
+      : undefined;
+    if (stubsInitPath !== undefined) {
+      const scaffold = await writeDryRunStubScaffold(workflow, stubsInitPath);
+      const nodeCount = Object.keys(scaffold).length;
+      if (options.json) {
+        await writeJsonLine({ workflow: workflow.name, stubsPath: stubsInitPath, nodeCount });
+      } else {
+        await writeStdout(
+          `Created dry-run stub scaffold for ${workflow.name}: ${stubsInitPath} (${String(nodeCount)} nodes)\n`
+        );
+      }
+      return;
+    }
     const stubs = await loadDryRunStubs(stubsPath);
     // The install's config + AI profile are what make the per-node provider/model report
     // match a real run — tier keywords and `@alias` refs resolve through the same profile
@@ -1011,6 +1045,7 @@ export async function workflowRunCommand(
       stubs,
       ...(dryRunInputs ? { inputs: dryRunInputs } : {}),
       execCode: options.execCode,
+      defaultStubs: options.defaultStubs,
       pauseAtGates: options.pauseAtGates,
       config: dryRunConfig,
       aiProfile: buildAiProfile(dryRunConfig.assistant, {

--- a/packages/docs-web/src/content/docs/reference/cli.md
+++ b/packages/docs-web/src/content/docs/reference/cli.md
@@ -226,6 +226,8 @@ Note that a real `run` emits a JSON payload **only** under `--detach`. Without i
 | `--detach` | Run in a detached background child and return immediately. The child does all the work; find it later with `workflow runs`/`workflow get`. Child stdout/stderr is captured to `~/.archon/logs/detached-run-<id>.log`. Combine with `--json` for a machine-readable ack. |
 | `--dry-run` | Simulate deterministic DAG control flow in memory. Creates no run, worktree, session, event, artifact, or provider request. |
 | `--stubs <path>` | YAML mapping of node ids to scalar or structured outputs for `--dry-run`. Relative paths resolve from `--cwd`. |
+| `--stubs-init <path>` | Write a complete stub scaffold for the expanded workflow and exit. Refuses to overwrite an existing file. Relative paths resolve from `--cwd`. |
+| `--default-stubs` | Fill reachable nodes omitted from `--stubs` with schema-valid placeholders. Explicit stubs still win; without this flag, missing reachable stubs remain an error. |
 | `--exec-code` | During `--dry-run`, execute trusted `bash:`/`script:` nodes locally instead of requiring stubs. Default is no code execution. |
 | `--pause-at-gates` | During `--dry-run`, stop at the first approval gate instead of auto-approving it. |
 
@@ -249,7 +251,20 @@ archon workflow run triage --cwd /path/to/repo \
   --dry-run --stubs stubs.yaml --json | jq '.trace, .outcome'
 ```
 
-The stub file must contain one YAML mapping. Each value is either a string or an object. Object stubs are preserved as structured output, so downstream `$classify.output.severity` references behave like live structured producers. A reachable AI, bash, or script node without a stub fails the simulation and appears in `missingStubs`; stubs for unknown or unreachable nodes appear in `unusedStubs`. Whole-output references retain their normal lenient behavior, while invalid strict `$node.output.field` references fail the consuming node exactly as they do in a real run. See [Node Output References](/reference/variables/#node-output-references).
+Generate a starting fixture when a composed workflow has many nodes, then keep only the values that drive the path you want to test:
+
+```bash
+archon workflow run deliver --cwd /path/to/repo \
+  --dry-run --stubs-init fixtures/deliver.yaml
+
+# After editing the load-bearing values in the generated YAML:
+archon workflow run deliver --cwd /path/to/repo \
+  --dry-run --stubs fixtures/deliver.yaml --default-stubs
+```
+
+The scaffold is derived from the already-expanded workflow, so included top-level nodes use their flattened ids (for example, `review__classify`). Structured `output_format` values are emitted as YAML objects with native booleans, numbers, arrays, and nested required properties. Loop completion fields are generated as `true`. If Archon cannot prove that a generated value satisfies its JSON Schema, scaffold generation fails before creating the file.
+
+The stub file must contain one YAML mapping. Each value is either a string or an object. Object stubs are preserved as structured output, so downstream `$classify.output.severity` references behave like live structured producers. Strict coverage remains the default: a reachable AI, bash, or script node without a stub fails the simulation and appears in `missingStubs`. Add `--default-stubs` to fill only omitted reachable nodes with the same schema-aware placeholders used by scaffold generation; explicit values always take precedence. Supplied stubs for unknown or unreachable nodes appear in `unusedStubs`, while generated placeholders do not. Whole-output references retain their normal lenient behavior, while invalid strict `$node.output.field` references fail the consuming node exactly as they do in a real run. See [Node Output References](/reference/variables/#node-output-references).
 
 A workflow's declared `inputs:` resolve exactly as in a real run: omitted inputs take their declared `default:`, `--input name=value` binds a value (visible in the trace's resolved text), and a missing **required** input or an **undeclared** name fails at the invocation gate with the same errors a real run gives — before any trace output. With `--exec-code`, bash and script nodes also receive the run-level inputs as the same `INPUTS_<UPPER_SNAKE>` environment variables a real run delivers (a composed block's own inputs for named scripts are a real-run-only channel).
 

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -8,6 +8,7 @@
     ".": "./src/index.ts",
     "./types": "./src/types.ts",
     "./effort": "./src/shared/effort.ts",
+    "./structured-output": "./src/shared/structured-output.ts",
     "./claude/provider": "./src/claude/provider.ts",
     "./claude/config": "./src/claude/config.ts",
     "./claude/binary-resolver": "./src/claude/binary-resolver.ts",

--- a/packages/workflows/src/dry-run.test.ts
+++ b/packages/workflows/src/dry-run.test.ts
@@ -3,7 +3,13 @@ import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync 
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { makeTestComposedWorkflow, makeTestWorkflow } from './test-utils';
-import { dryRunWorkflow, formatDryRunTrace, loadDryRunStubs } from './dry-run';
+import {
+  createDryRunStubScaffold,
+  dryRunWorkflow,
+  formatDryRunTrace,
+  loadDryRunStubs,
+  writeDryRunStubScaffold,
+} from './dry-run';
 import type { DryRunResolution } from './dry-run';
 import { buildAiProfile } from './model-validation';
 import { resolveWorkflowModelScope } from './node-model-resolution';
@@ -84,6 +90,201 @@ describe('loadDryRunStubs', () => {
     await expect(loadDryRunStubs(temporaryFile('node: 42\n'))).rejects.toThrow(
       'Invalid dry-run stub file'
     );
+  });
+});
+
+describe('dry-run stub scaffolding and sparse defaults (#2624)', () => {
+  test('writes YAML-native schema placeholders for flattened and loop-group node ids', async () => {
+    const block = makeTestWorkflow({
+      name: 'review-block',
+      nodes: [
+        {
+          id: 'classify',
+          prompt: 'classify',
+          output_format: {
+            type: 'object',
+            properties: {
+              kind: { type: 'string', enum: ['bug', 'feature'] },
+              summary: { type: 'string', minLength: 5 },
+              ready: { type: 'boolean' },
+              score: { type: 'number', minimum: 2 },
+              labels: { type: 'array', minItems: 1, items: { type: 'string' } },
+              meta: {
+                type: 'object',
+                properties: { reviewed: { type: 'boolean' } },
+                required: ['reviewed'],
+              },
+            },
+            required: ['kind', 'summary', 'ready', 'score', 'labels', 'meta'],
+          },
+        },
+        {
+          id: 'group',
+          loop_group: {
+            until: 'TODO',
+            max_iterations: 2,
+            nodes: [
+              { id: 'draft', prompt: 'draft' },
+              { id: 'finish', prompt: 'finish', depends_on: ['draft'] },
+            ],
+          },
+          depends_on: ['classify'],
+        },
+      ],
+    });
+    const parent = makeTestWorkflow({
+      name: 'parent',
+      nodes: [
+        { id: 'review', include: 'review-block' },
+        { id: 'approve', approval: { message: 'approve' }, depends_on: ['review'] },
+        { id: 'stop', cancel: 'stop', depends_on: ['approve'] },
+      ],
+    });
+    const workflow = makeTestComposedWorkflow([block, parent], 'parent');
+    const directory = mkdtempSync(join(tmpdir(), 'archon-dry-run-scaffold-'));
+    temporaryDirectories.push(directory);
+    const path = join(directory, 'fixtures', 'stubs.yaml');
+
+    const written = await writeDryRunStubScaffold(workflow, path);
+    const loaded = await loadDryRunStubs(path);
+
+    expect(loaded).toEqual(written);
+    expect(Object.keys(loaded).sort()).toEqual(['draft', 'finish', 'review__classify']);
+    expect(loaded.review__classify).toEqual({
+      kind: 'bug',
+      summary: 'TTTTT',
+      ready: false,
+      score: 2,
+      labels: ['TODO'],
+      meta: { reviewed: false },
+    });
+    expect(await Bun.file(path).text()).toContain('ready: false');
+    await expect(writeDryRunStubScaffold(workflow, path)).rejects.toThrow(
+      'stub scaffold already exists'
+    );
+  });
+
+  test('does not leave a partial file when a placeholder cannot satisfy the schema', async () => {
+    const workflow = makeTestWorkflow({
+      name: 'unsupported-placeholder',
+      nodes: [
+        {
+          id: 'strict',
+          prompt: 'strict',
+          output_format: {
+            type: 'object',
+            properties: { code: { type: 'string', pattern: '^OK$' } },
+            required: ['code'],
+          },
+        },
+      ],
+    });
+    const directory = mkdtempSync(join(tmpdir(), 'archon-dry-run-scaffold-fail-'));
+    temporaryDirectories.push(directory);
+    const path = join(directory, 'stubs.yaml');
+
+    await expect(writeDryRunStubScaffold(workflow, path)).rejects.toThrow(
+      "Cannot generate schema-valid dry-run stub for node 'strict'"
+    );
+    expect(existsSync(path)).toBe(false);
+  });
+
+  test('completes a 36-node composition with only three load-bearing overrides', async () => {
+    const blockNodes = [
+      {
+        id: 'gate',
+        prompt: 'gate',
+        output_format: {
+          type: 'object',
+          properties: { verdict: { type: 'string', enum: ['go', 'stop'] } },
+          required: ['verdict'],
+        },
+      },
+      ...Array.from({ length: 11 }, (_, index) => ({
+        id: `step-${String(index + 1)}`,
+        prompt: `step ${String(index + 1)}`,
+        depends_on: [index === 0 ? 'gate' : `step-${String(index)}`],
+        ...(index === 0 ? { when: "$gate.output.verdict == 'go'" } : {}),
+      })),
+    ];
+    const block = makeTestWorkflow({ name: 'large-block', nodes: blockNodes });
+    const parent = makeTestWorkflow({
+      name: 'large-parent',
+      nodes: ['one', 'two', 'three'].map(id => ({ id, include: 'large-block' })),
+    });
+    const workflow = makeTestComposedWorkflow([block, parent], 'large-parent');
+    expect(workflow.nodes).toHaveLength(36);
+    const stubs = {
+      one__gate: { verdict: 'go' },
+      two__gate: { verdict: 'stop' },
+      three__gate: { verdict: 'go' },
+      never_reached: 'unused',
+    };
+
+    const sparse = await dryRunWorkflow({
+      workflow,
+      userMessage: '',
+      cwd: process.cwd(),
+      stubs,
+      defaultStubs: true,
+    });
+    const strict = await dryRunWorkflow({
+      workflow,
+      userMessage: '',
+      cwd: process.cwd(),
+      stubs,
+    });
+
+    expect(sparse.outcome).toBe('completed');
+    expect(sparse.missingStubs).toEqual([]);
+    expect(sparse.unusedStubs).toEqual(['never_reached']);
+    expect(sparse.trace.find(entry => entry.nodeId === 'one__step-1')?.state).toBe('stubbed');
+    expect(sparse.trace.find(entry => entry.nodeId === 'two__step-1')?.state).toBe('skipped');
+    expect(strict.outcome).toBe('failed');
+    expect(strict.missingStubs).toEqual(['one__step-1', 'three__step-1']);
+  });
+
+  test('defaults loops to completion and still executes code under execCode', async () => {
+    const workflow = makeTestWorkflow({
+      name: 'default-loop-stubs',
+      nodes: [
+        { id: 'signal', loop: { prompt: 'work', until: 'DONE', max_iterations: 2 } },
+        {
+          id: 'field',
+          loop: { prompt: 'work', until_field: 'done', max_iterations: 2 },
+          output_format: {
+            type: 'object',
+            properties: { done: { type: 'boolean' } },
+            required: ['done'],
+          },
+          depends_on: ['signal'],
+        },
+        { id: 'code', bash: 'printf live', depends_on: ['field'] },
+      ],
+    });
+
+    const scaffold = createDryRunStubScaffold(workflow);
+    const result = await dryRunWorkflow({
+      workflow,
+      userMessage: '',
+      cwd: process.cwd(),
+      defaultStubs: true,
+      execCode: true,
+    });
+
+    expect(scaffold).toEqual({ signal: 'DONE', field: { done: true }, code: 'TODO' });
+    expect(result.outcome).toBe('completed');
+    expect(result.trace.find(entry => entry.nodeId === 'signal')?.reason).toContain(
+      'completion signal'
+    );
+    expect(result.trace.find(entry => entry.nodeId === 'field')?.reason).toContain(
+      "'done' is true"
+    );
+    expect(result.trace.find(entry => entry.nodeId === 'code')).toMatchObject({
+      state: 'completed',
+      reason: 'executed locally',
+      output: 'live',
+    });
   });
 });
 

--- a/packages/workflows/src/dry-run.test.ts
+++ b/packages/workflows/src/dry-run.test.ts
@@ -204,13 +204,17 @@ describe('dry-run stub scaffolding and sparse defaults (#2624)', () => {
         { id: 'second', loop_group: body() },
       ],
     });
+    const directory = mkdtempSync(join(tmpdir(), 'archon-dry-run-scaffold-keys-'));
+    temporaryDirectories.push(directory);
+    const path = join(directory, 'stubs.yaml');
 
-    const scaffold = createDryRunStubScaffold(workflow);
+    const scaffold = await writeDryRunStubScaffold(workflow, path);
+    const loaded = await loadDryRunStubs(path);
     const strict = await dryRunWorkflow({
       workflow,
       userMessage: '',
       cwd: process.cwd(),
-      stubs: scaffold,
+      stubs: loaded,
     });
     const sparse = await dryRunWorkflow({
       workflow,
@@ -222,11 +226,51 @@ describe('dry-run stub scaffolding and sparse defaults (#2624)', () => {
     expect(Object.keys(scaffold).sort()).toEqual(['__proto__', 'constructor', 'shared']);
     expect(scaffold.__proto__).toBe('TODO');
     expect(Object.getOwnPropertyDescriptor(scaffold, 'constructor')?.value).toBe('TODO');
+    expect(Object.hasOwn(loaded, '__proto__')).toBe(true);
+    expect(loaded.__proto__).toBe('TODO');
     expect(strict.outcome).toBe('completed');
     expect(strict.unusedStubs).toEqual([]);
     expect(sparse.outcome).toBe('completed');
     expect(sparse.trace.find(entry => entry.nodeId === '__proto__')?.output).toBe('TODO');
     expect(sparse.trace.filter(entry => entry.nodeId === 'shared')).toHaveLength(2);
+  });
+
+  test('selects a retained candidate after collecting every shared-key consumer', async () => {
+    const body = (values: string[]) => ({
+      until_bash: 'true',
+      max_iterations: 1,
+      nodes: [
+        {
+          id: 'shared',
+          prompt: 'work',
+          output_format: {
+            type: 'object',
+            properties: { kind: { type: 'string', enum: values } },
+            required: ['kind'],
+          },
+        },
+      ],
+    });
+    const workflow = makeTestWorkflow({
+      name: 'retained-shared-candidate',
+      nodes: [
+        { id: 'first', loop_group: body(['A', 'B']) },
+        { id: 'second', loop_group: body(['B', 'A', 'C']) },
+        { id: 'third', loop_group: body(['C', 'B']) },
+      ],
+    });
+
+    const scaffold = createDryRunStubScaffold(workflow);
+    const result = await dryRunWorkflow({
+      workflow,
+      userMessage: '',
+      cwd: process.cwd(),
+      stubs: scaffold,
+    });
+
+    expect(scaffold.shared).toEqual({ kind: 'B' });
+    expect(result.outcome).toBe('completed');
+    expect(result.unusedStubs).toEqual([]);
   });
 
   test('rejects only genuinely incompatible nodes sharing one raw stub key', () => {

--- a/packages/workflows/src/dry-run.test.ts
+++ b/packages/workflows/src/dry-run.test.ts
@@ -189,6 +189,114 @@ describe('dry-run stub scaffolding and sparse defaults (#2624)', () => {
     expect(existsSync(path)).toBe(false);
   });
 
+  test('owns prototype-named keys and coalesces compatible loop-body keys', async () => {
+    const body = () => ({
+      until: 'TODO',
+      max_iterations: 1,
+      nodes: [{ id: 'shared', prompt: 'work' }],
+    });
+    const workflow = makeTestWorkflow({
+      name: 'shared-stub-keys',
+      nodes: [
+        { id: '__proto__', prompt: 'prototype' },
+        { id: 'constructor', prompt: 'constructor' },
+        { id: 'first', loop_group: body() },
+        { id: 'second', loop_group: body() },
+      ],
+    });
+
+    const scaffold = createDryRunStubScaffold(workflow);
+    const strict = await dryRunWorkflow({
+      workflow,
+      userMessage: '',
+      cwd: process.cwd(),
+      stubs: scaffold,
+    });
+    const sparse = await dryRunWorkflow({
+      workflow,
+      userMessage: '',
+      cwd: process.cwd(),
+      defaultStubs: true,
+    });
+
+    expect(Object.keys(scaffold).sort()).toEqual(['__proto__', 'constructor', 'shared']);
+    expect(scaffold.__proto__).toBe('TODO');
+    expect(Object.getOwnPropertyDescriptor(scaffold, 'constructor')?.value).toBe('TODO');
+    expect(strict.outcome).toBe('completed');
+    expect(strict.unusedStubs).toEqual([]);
+    expect(sparse.outcome).toBe('completed');
+    expect(sparse.trace.find(entry => entry.nodeId === '__proto__')?.output).toBe('TODO');
+    expect(sparse.trace.filter(entry => entry.nodeId === 'shared')).toHaveLength(2);
+  });
+
+  test('rejects only genuinely incompatible nodes sharing one raw stub key', () => {
+    const body = (only: string) => ({
+      until: 'TODO',
+      max_iterations: 1,
+      nodes: [
+        {
+          id: 'shared',
+          prompt: 'work',
+          output_format: {
+            type: 'object',
+            properties: { kind: { type: 'string', enum: [only] } },
+            required: ['kind'],
+          },
+        },
+      ],
+    });
+    const workflow = makeTestWorkflow({
+      name: 'incompatible-stub-keys',
+      nodes: [
+        { id: 'first', loop_group: body('first') },
+        { id: 'second', loop_group: body('second') },
+      ],
+    });
+
+    expect(() => createDryRunStubScaffold(workflow)).toThrow(
+      "nodes sharing stub key 'shared' require incompatible values"
+    );
+  });
+
+  test('fails closed on asynchronous output schemas without an unhandled rejection', async () => {
+    const workflow = makeTestWorkflow({
+      name: 'async-schema',
+      nodes: [
+        {
+          id: 'strict',
+          prompt: 'strict',
+          output_format: {
+            $async: true,
+            type: 'object',
+            properties: { code: { type: 'string' } },
+            required: ['code'],
+          },
+        },
+      ],
+    });
+    const directory = mkdtempSync(join(tmpdir(), 'archon-dry-run-scaffold-async-'));
+    temporaryDirectories.push(directory);
+    const path = join(directory, 'stubs.yaml');
+
+    await expect(writeDryRunStubScaffold(workflow, path)).rejects.toThrow(
+      'asynchronous output_format schemas are unsupported'
+    );
+    const sparse = await dryRunWorkflow({
+      workflow,
+      userMessage: '',
+      cwd: process.cwd(),
+      defaultStubs: true,
+    });
+
+    expect(existsSync(path)).toBe(false);
+    expect(sparse.outcome).toBe('failed');
+    expect(sparse.trace[0]).toMatchObject({
+      nodeId: 'strict',
+      state: 'failed',
+      reason: expect.stringContaining('asynchronous output_format schemas are unsupported'),
+    });
+  });
+
   test('completes a 36-node composition with only three load-bearing overrides', async () => {
     const blockNodes = [
       {

--- a/packages/workflows/src/dry-run.ts
+++ b/packages/workflows/src/dry-run.ts
@@ -2,9 +2,10 @@
 import { z } from '@hono/zod-openapi';
 import { execFileAsync, resolveBashPath } from '@archon/git';
 import { createLogger, getArchonTempPath } from '@archon/paths';
+import { validateStructuredOutput } from '@archon/providers/structured-output';
 import { randomUUID } from 'node:crypto';
-import { mkdir, rm } from 'node:fs/promises';
-import { join } from 'node:path';
+import { mkdir, open, rm } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
 import {
   buildTopologicalLayers,
   checkComposedBlockBoundaries,
@@ -59,6 +60,139 @@ export const dryRunStubValueSchema = z.union([z.string(), z.record(z.string(), z
 export const dryRunStubsSchema = z.record(z.string(), dryRunStubValueSchema);
 export type DryRunStubValue = z.infer<typeof dryRunStubValueSchema>;
 export type DryRunStubs = z.infer<typeof dryRunStubsSchema>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function schemaPlaceholder(schema: unknown): unknown {
+  if (!isRecord(schema)) return 'TODO';
+
+  if ('const' in schema) return structuredClone(schema.const);
+  if ('default' in schema) return structuredClone(schema.default);
+  if (Array.isArray(schema.enum) && schema.enum.length > 0) {
+    return structuredClone(schema.enum[0]);
+  }
+
+  switch (schema.type) {
+    case 'object': {
+      const properties = isRecord(schema.properties) ? schema.properties : {};
+      const required = Array.isArray(schema.required)
+        ? schema.required.filter((name): name is string => typeof name === 'string')
+        : [];
+      return Object.fromEntries(required.map(name => [name, schemaPlaceholder(properties[name])]));
+    }
+    case 'array': {
+      const minItems =
+        typeof schema.minItems === 'number' && Number.isInteger(schema.minItems)
+          ? Math.max(0, schema.minItems)
+          : 0;
+      return Array.from({ length: minItems }, () => schemaPlaceholder(schema.items));
+    }
+    case 'boolean':
+      return false;
+    case 'integer':
+      return typeof schema.minimum === 'number' ? Math.ceil(schema.minimum) : 0;
+    case 'number':
+      return typeof schema.minimum === 'number' ? schema.minimum : 0;
+    case 'null':
+      return null;
+    case 'string': {
+      const minLength =
+        typeof schema.minLength === 'number' && Number.isInteger(schema.minLength)
+          ? Math.max(0, schema.minLength)
+          : 0;
+      return minLength > 4 ? 'T'.repeat(minLength) : 'TODO';
+    }
+    default:
+      return 'TODO';
+  }
+}
+
+function generatedStubFor(node: DagNode): DryRunStubValue {
+  if (node.output_format === undefined) {
+    return isLoopNode(node) && node.loop.until !== undefined ? node.loop.until : 'TODO';
+  }
+
+  const value = schemaPlaceholder(node.output_format);
+  if (!isRecord(value)) {
+    throw new Error(
+      `Cannot generate dry-run stub for node '${node.id}': output_format must produce an object value`
+    );
+  }
+  if (isLoopNode(node) && node.loop.until_field !== undefined) {
+    value[node.loop.until_field] = true;
+  }
+
+  let compileError: string | undefined;
+  const validation = validateStructuredOutput(value, node.output_format, message => {
+    compileError = message;
+  });
+  if (compileError !== undefined) {
+    throw new Error(
+      `Cannot generate dry-run stub for node '${node.id}': output_format could not be compiled (${compileError})`
+    );
+  }
+  if (!validation.valid) {
+    throw new Error(
+      `Cannot generate schema-valid dry-run stub for node '${node.id}': ${validation.errors.join('; ')}`
+    );
+  }
+  return value;
+}
+
+function collectsStub(node: DagNode): boolean {
+  return !(
+    isApprovalNode(node) ||
+    isCancelNode(node) ||
+    isIncludeNode(node) ||
+    isWorkflowNode(node) ||
+    isLoopGroupNode(node)
+  );
+}
+
+/** Build the complete static stub map for an already-expanded workflow definition. */
+export function createDryRunStubScaffold(workflow: WorkflowDefinition): DryRunStubs {
+  const stubs: DryRunStubs = {};
+  const visit = (nodes: readonly DagNode[]): void => {
+    for (const node of nodes) {
+      if (collectsStub(node)) {
+        if (stubs[node.id] !== undefined) {
+          throw new Error(
+            `Cannot generate dry-run scaffold: multiple nodes use stub key '${node.id}'`
+          );
+        }
+        stubs[node.id] = generatedStubFor(node);
+      }
+      if (isLoopGroupNode(node)) visit(node.loop_group.nodes);
+    }
+  };
+  visit(workflow.nodes);
+  return stubs;
+}
+
+/** Write a scaffold without ever overwriting an existing fixture. */
+export async function writeDryRunStubScaffold(
+  workflow: WorkflowDefinition,
+  path: string
+): Promise<DryRunStubs> {
+  const stubs = createDryRunStubScaffold(workflow);
+  await mkdir(dirname(path), { recursive: true });
+  let handle;
+  try {
+    handle = await open(path, 'wx');
+    await handle.writeFile(Bun.YAML.stringify(stubs));
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err.code === 'EEXIST') {
+      throw new Error(`Dry-run stub scaffold already exists: ${path}`);
+    }
+    throw error;
+  } finally {
+    await handle?.close();
+  }
+  return stubs;
+}
 
 const dryRunNodeTypeSchema = z.enum([
   'command',
@@ -225,6 +359,7 @@ interface DryRunContext {
   artifactsDir: string;
   stateDir: string;
   execCode: boolean;
+  defaultStubs: boolean;
   pauseAtGates: boolean;
   trace: DryRunTraceEntry[];
   consumedStubs: Set<string>;
@@ -426,8 +561,14 @@ async function executeCodeNode(
 
 function stubFor(node: DagNode, ctx: DryRunContext): DryRunStubValue | undefined {
   const stub = ctx.stubs[node.id];
-  if (stub !== undefined) ctx.consumedStubs.add(node.id);
-  return stub;
+  if (stub !== undefined) {
+    ctx.consumedStubs.add(node.id);
+    return stub;
+  }
+  if (ctx.defaultStubs && !((isBashNode(node) || isScriptNode(node)) && ctx.execCode)) {
+    return generatedStubFor(node);
+  }
+  return undefined;
 }
 
 /** The completion channels a simulated loop may declare. */
@@ -818,6 +959,8 @@ export async function dryRunWorkflow(options: {
    */
   inputs?: Record<string, string>;
   execCode?: boolean;
+  /** Fill reached nodes without explicit stubs using schema-valid deterministic placeholders. */
+  defaultStubs?: boolean;
   pauseAtGates?: boolean;
   /**
    * The install's resolved config and AI profile. Supplying them is what makes the
@@ -843,6 +986,7 @@ export async function dryRunWorkflow(options: {
     artifactsDir: join(tempRoot, 'artifacts'),
     stateDir: join(tempRoot, 'state'),
     execCode: options.execCode ?? false,
+    defaultStubs: options.defaultStubs ?? false,
     pauseAtGates: options.pauseAtGates ?? false,
     trace: [],
     consumedStubs: new Set<string>(),

--- a/packages/workflows/src/dry-run.ts
+++ b/packages/workflows/src/dry-run.ts
@@ -57,8 +57,35 @@ function getLog(): ReturnType<typeof createLogger> {
 }
 
 export const dryRunStubValueSchema = z.union([z.string(), z.record(z.string(), z.unknown())]);
-export const dryRunStubsSchema = z.record(z.string(), dryRunStubValueSchema);
 export type DryRunStubValue = z.infer<typeof dryRunStubValueSchema>;
+export const dryRunStubsSchema = z.unknown().transform((value, ctx) => {
+  if (!isRecord(value)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'expected a mapping of node ids to outputs',
+    });
+    return z.NEVER;
+  }
+
+  const entries: [string, DryRunStubValue][] = [];
+  let invalid = false;
+  for (const [id, candidate] of Object.entries(value)) {
+    const result = dryRunStubValueSchema.safeParse(candidate);
+    if (!result.success) {
+      invalid = true;
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [id],
+        message: result.error.issues.map(issue => issue.message).join('; '),
+      });
+      continue;
+    }
+    // Validation establishes the union; retaining the raw value preserves own keys
+    // such as `__proto__` across the YAML → Zod boundary.
+    entries.push([id, candidate as DryRunStubValue]);
+  }
+  return invalid ? z.NEVER : Object.fromEntries(entries);
+});
 export type DryRunStubs = z.infer<typeof dryRunStubsSchema>;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -170,32 +197,36 @@ function collectsStub(node: DagNode): boolean {
 
 /** Build the complete static stub map for an already-expanded workflow definition. */
 export function createDryRunStubScaffold(workflow: WorkflowDefinition): DryRunStubs {
-  const stubs = new Map<string, { value: DryRunStubValue; consumers: DagNode[] }>();
+  const stubs = new Map<string, { candidates: DryRunStubValue[]; consumers: DagNode[] }>();
   const visit = (nodes: readonly DagNode[]): void => {
     for (const node of nodes) {
       if (collectsStub(node)) {
         const generated = generatedStubFor(node);
         const existing = stubs.get(node.id);
         if (existing === undefined) {
-          stubs.set(node.id, { value: generated, consumers: [node] });
+          stubs.set(node.id, { candidates: [generated], consumers: [node] });
         } else {
-          const consumers = [...existing.consumers, node];
-          const value = [existing.value, generated].find(candidate =>
-            consumers.every(consumer => stubSatisfiesNode(consumer, candidate))
-          );
-          if (value === undefined) {
-            throw new Error(
-              `Cannot generate dry-run scaffold: nodes sharing stub key '${node.id}' require incompatible values`
-            );
-          }
-          stubs.set(node.id, { value, consumers });
+          existing.candidates.push(generated);
+          existing.consumers.push(node);
         }
       }
       if (isLoopGroupNode(node)) visit(node.loop_group.nodes);
     }
   };
   visit(workflow.nodes);
-  return Object.fromEntries([...stubs].map(([id, entry]) => [id, entry.value]));
+  return Object.fromEntries(
+    [...stubs].map(([id, entry]) => {
+      const value = entry.candidates.find(candidate =>
+        entry.consumers.every(consumer => stubSatisfiesNode(consumer, candidate))
+      );
+      if (value === undefined) {
+        throw new Error(
+          `Cannot generate dry-run scaffold: nodes sharing stub key '${id}' require incompatible values`
+        );
+      }
+      return [id, value];
+    })
+  );
 }
 
 /** Write a scaffold without ever overwriting an existing fixture. */

--- a/packages/workflows/src/dry-run.ts
+++ b/packages/workflows/src/dry-run.ts
@@ -113,6 +113,11 @@ function generatedStubFor(node: DagNode): DryRunStubValue {
   if (node.output_format === undefined) {
     return isLoopNode(node) && node.loop.until !== undefined ? node.loop.until : 'TODO';
   }
+  if (node.output_format.$async === true) {
+    throw new Error(
+      `Cannot generate dry-run stub for node '${node.id}': asynchronous output_format schemas are unsupported`
+    );
+  }
 
   const value = schemaPlaceholder(node.output_format);
   if (!isRecord(value)) {
@@ -141,6 +146,18 @@ function generatedStubFor(node: DagNode): DryRunStubValue {
   return value;
 }
 
+function stubSatisfiesNode(node: DagNode, stub: DryRunStubValue): boolean {
+  if (node.output_format !== undefined) {
+    if (!isRecord(stub)) return false;
+    const validation = validateStructuredOutput(stub, node.output_format);
+    if (!validation.valid) return false;
+  }
+  if (isLoopNode(node)) {
+    return loopIterationCompletes(node.loop, completedOutput(node, stub)).kind !== 'incomplete';
+  }
+  return true;
+}
+
 function collectsStub(node: DagNode): boolean {
   return !(
     isApprovalNode(node) ||
@@ -153,22 +170,32 @@ function collectsStub(node: DagNode): boolean {
 
 /** Build the complete static stub map for an already-expanded workflow definition. */
 export function createDryRunStubScaffold(workflow: WorkflowDefinition): DryRunStubs {
-  const stubs: DryRunStubs = {};
+  const stubs = new Map<string, { value: DryRunStubValue; consumers: DagNode[] }>();
   const visit = (nodes: readonly DagNode[]): void => {
     for (const node of nodes) {
       if (collectsStub(node)) {
-        if (stubs[node.id] !== undefined) {
-          throw new Error(
-            `Cannot generate dry-run scaffold: multiple nodes use stub key '${node.id}'`
+        const generated = generatedStubFor(node);
+        const existing = stubs.get(node.id);
+        if (existing === undefined) {
+          stubs.set(node.id, { value: generated, consumers: [node] });
+        } else {
+          const consumers = [...existing.consumers, node];
+          const value = [existing.value, generated].find(candidate =>
+            consumers.every(consumer => stubSatisfiesNode(consumer, candidate))
           );
+          if (value === undefined) {
+            throw new Error(
+              `Cannot generate dry-run scaffold: nodes sharing stub key '${node.id}' require incompatible values`
+            );
+          }
+          stubs.set(node.id, { value, consumers });
         }
-        stubs[node.id] = generatedStubFor(node);
       }
       if (isLoopGroupNode(node)) visit(node.loop_group.nodes);
     }
   };
   visit(workflow.nodes);
-  return stubs;
+  return Object.fromEntries([...stubs].map(([id, entry]) => [id, entry.value]));
 }
 
 /** Write a scaffold without ever overwriting an existing fixture. */
@@ -560,10 +587,9 @@ async function executeCodeNode(
 }
 
 function stubFor(node: DagNode, ctx: DryRunContext): DryRunStubValue | undefined {
-  const stub = ctx.stubs[node.id];
-  if (stub !== undefined) {
+  if (Object.hasOwn(ctx.stubs, node.id)) {
     ctx.consumedStubs.add(node.id);
-    return stub;
+    return ctx.stubs[node.id];
   }
   if (ctx.defaultStubs && !((isBashNode(node) || isScriptNode(node)) && ctx.execCode)) {
     return generatedStubFor(node);


### PR DESCRIPTION
## Problem and outcome

Large composed workflows currently require an explicit stub for every reachable flattened node, so a dry-run fixture can become dozens of boilerplate entries even when only a few values drive routing.

- **Outcome:** `--stubs-init <path>` writes a complete schema-aware fixture, while `--default-stubs` lets a dry run supply only load-bearing overrides.
- **Invariant:** Explicit stubs always win, generated structured values validate against `output_format`, and strict missing-stub coverage remains the default.
- **Scope boundary:** Explicit stub validation, workflow YAML, and web/API surfaces are unchanged.

## Review guidance

- **Feedback requested:** Correctness of placeholder generation, composed/loop stub keys, and strict compatibility.
- **Start here:** `packages/workflows/src/dry-run.ts:112` — owns the shared schema-valid placeholder contract used by scaffolding and sparse simulation.
- **Review order:** `dry-run.ts`, `dry-run.test.ts`, CLI wiring/tests, then the CLI reference.
- **Lower-attention areas:** CLI parser/help additions are mechanical and covered by `cli.test.ts`.
- **Known risk or uncertainty:** JSON Schema constructs the deterministic generator cannot satisfy fail closed instead of producing an invalid fixture.

## Solution

One workflow-owned primitive derives deterministic placeholders from required schema fields and validates structured values with the same Ajv helper used by live structured output. Scaffold generation walks the already-expanded workflow, including loop-group bodies, and refuses to overwrite an existing file. Sparse simulation calls that same primitive only when an explicit reached-node stub is absent; explicit values remain the only entries counted as consumed or unused.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Every reachable runnable node needed an explicit stub. | Strict mode is unchanged; `--default-stubs` fills omitted reached nodes, and `--stubs-init` creates a complete starting fixture. |
| **Failure behavior** | Missing reached nodes failed the dry run. | They still fail by default; scaffold generation also fails before file creation when a valid structured placeholder cannot be proven. |

## Validation

- `bun run validate` — passed all generated checks, workspace type checks, zero-warning lint, formatting, installer tests, package tests, and script tests.
- `cd packages/workflows && bun test src/dry-run.test.ts` — 47 passed; covers a 36-node composition with three overrides, flattened/include ids, loop bodies, schema-shaped YAML, loop completion, and overwrite refusal.
- `cd packages/cli && bun test src/commands/workflow.test.ts` — 235 passed; covers CLI handoff, output, compatibility, and flag conflicts.
- Repository discovery plus scaffold generation — all 63 discovered workflows generated successfully with zero load errors.
- **Not verified:** The unmerged #2627 dogfood workflow itself; focused repository fixtures prove the same engine contract without making it a dependency.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | No migration. Strict coverage remains the default and sparse behavior is opt-in. | `packages/workflows/src/dry-run.test.ts` |
| Rollout / rollback | CLI-only additive behavior; reverting this PR restores the prior strict-only surface. | Complete diff |
| Documentation / communication | CLI flags, scaffold flow, placeholder semantics, and failure behavior are documented. | `packages/docs-web/src/content/docs/reference/cli.md` |

## Links

- Closes #2624
- Plan: https://github.com/coleam00/Archon/issues/2624#issuecomment-5341987144


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dry-run options to generate stub scaffolds and provide schema-valid default stubs.
  * Scaffold generation supports human-readable and JSON output, prevents overwriting existing files, and exits before workflow execution.
  * Dry-run results now include structured output, loop completion details, and missing or unused stub information.
* **Bug Fixes**
  * Improved handling of shared keys, falsy values, asynchronous schemas, and local code execution.
  * Added validation for incompatible stub options.
* **Documentation**
  * Expanded CLI guidance for stub generation, defaults, coverage, and output behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->