### PR TITLE
feat(workflows): reusable blocks can repeat inside loop groups

### DIFF
--- a/packages/docs-web/src/content/docs/book/quick-reference.md
+++ b/packages/docs-web/src/content/docs/book/quick-reference.md
@@ -219,7 +219,7 @@ per iteration (see [Cross-Node Loops](/guides/loop-nodes/#cross-node-loops-with-
 
 | Field | Required | Type | Description |
 |-------|----------|------|-------------|
-| `nodes` | Yes | node[] | Sub-DAG body re-run in full each iteration. Any node type, including nested `loop_group`. `depends_on` is body-scoped; body ids must not shadow outer ids |
+| `nodes` | Yes | node[] | Sub-DAG body re-run in full each iteration. Executable nodes, `include:`, and nested `loop_group` are supported; runtime `workflow:` sub-runs are not. `depends_on` is body-scoped; body ids must not shadow outer ids |
 | `until` | One channel required | string | Completion signal — checked in the body's terminal-node output. Omit it for a deterministic group |
 | `max_iterations` | Yes | number | Maximum iterations before the node fails |
 | `fresh_context` | No | boolean | `true` starts fresh body AI sessions each iteration (default: false — sessions continue) |

--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -1039,14 +1039,15 @@ the workflow that owns the run is.
 
 Expansion happens at **load time (discovery)**, before the workflow ever runs. By the time
 the executor sees the DAG there are no include nodes left — the inlined nodes are ordinary
-top-level nodes, so runs, events, resume, and approvals all behave exactly as if you had
-written the nodes by hand. There is no separate child run.
+executable nodes in the include's containing scope, so runs, events, resume, and approvals all
+behave exactly as if you had written the nodes by hand. A top-level include produces top-level
+nodes; an include in a `loop_group` body produces body-local nodes. There is no separate child run.
 
-- **Namespacing.** Each included node `n` becomes a top-level node with id
-  `<includeId>__<n.id>` (double underscore). Including `archon-review-block` under
-  `id: review` yields `review__verify-pr-base`, `review__sync`, `review__implement-fixes`,
-  and so on. These namespaced ids are what appear in the event stream and in
-  `archon workflow get <id>`.
+- **Namespacing.** Each included node `n` receives id `<includeId>__<n.id>` (double
+  underscore) within that scope. Including `archon-review-block` under `id: review` yields
+  `review__verify-pr-base`, `review__sync`, `review__implement-fixes`, and so on. These
+  namespaced ids are what appear in the event stream and in `archon workflow get <id>`;
+  body-local events additionally carry their enclosing group prefix.
 - **Edges and command bodies.** Internal `depends_on` edges and `$id.output` references are
   rewired to the namespaced ids automatically. This includes named `command:` and
   `loop.command` files: discovery resolves their bodies and compiles them into the flat DAG

--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -1067,6 +1067,13 @@ written the nodes by hand. There is no separate child run.
   has multiple leaf nodes.
 - **Output.** `$<includeId>.output` in another node resolves to the block's primary sink.
   In the example, `$review.output` is the output of the block's `implement-fixes` node.
+- **Inside a `loop_group` body.** An include expands inside that sealed body at load time.
+  Its nodes keep the usual `<includeId>__<nodeId>` names, then the loop runtime prefixes
+  persisted step names with the group id (for example `fix-loop.review__synthesize`). Every
+  iteration re-runs the expanded nodes exactly like equivalent inline body nodes. The group's
+  `until_bash` can read `$<includeId>.output` and expansion binds it to the block's declared
+  `returns:` node. A `workflow:` node is different — it creates a child run at runtime and
+  remains unsupported inside a loop-group body.
 
 ### Passing values into an included block
 
@@ -1154,9 +1161,9 @@ in the child's run metadata.
   implementation detail.
 - **Literal targets only.** `include:` takes a literal workflow name — no
   `include: $something` and no cross-repo includes.
-- **Not inside a `loop_group` body.** An include node nested in a `loop_group` body is
-  rejected at load time — and so is a `workflow:` node, which surprises people in both
-  directions. Neither keyword may appear in a loop-group body today.
+- **No child runs inside a `loop_group` body.** A `workflow:` node remains unsupported there;
+  use `include:` when the reusable nodes should participate in the same run and repeat as
+  part of the group's static body.
 - **Depth-capped and cycle-checked.** Includes may nest up to 3 levels deep; cycles
   (`A` includes `B` includes `A`) and over-deep chains are load errors that drop only the
   offending workflow — other workflows still load.

--- a/packages/docs-web/src/content/docs/guides/loop-nodes.md
+++ b/packages/docs-web/src/content/docs/guides/loop-nodes.md
@@ -648,16 +648,37 @@ nodes:
 - The body is **sealed**: a body node's `depends_on` may only reference sibling
   body nodes, not outer-DAG nodes. Outer context is still reachable via `$nodeId.output`
   refs in body prompts.
-- Loop-control events (skip, trigger-rule, `when:` evaluations) are namespaced
-  `{groupId}.{nodeId}` in the event log. Body node **lifecycle** events
-  (`node_started`/`node_completed`/`node_failed`, tool events) currently use the
-  raw body-node id — a known v1 limitation, so expect repeated step names across
-  iterations in the event log.
+- Loop-control and body lifecycle events use the namespaced step name
+  `{groupId}.{nodeId}` in the persisted event log, with the iteration recorded in
+  event data. Nested groups compose the prefix.
 - A body node that **fails** fails the whole group immediately with that node's
   error (no further iterations run) — same semantics as a failed node in a
   top-level DAG.
 - `$fix-loop.output` (visible to the outer DAG) is the **final iteration's
   terminal-node output**.
+
+### Reusing a block in the body
+
+`include:` is valid in a `loop_group` body. Discovery expands the block before the run starts,
+so each iteration executes ordinary namespaced body nodes — there is no child run or
+runtime-resolved graph:
+
+```yaml
+- id: converge
+  loop_group:
+    until_bash: test "$review.output.ready" = true
+    max_iterations: 5
+    nodes:
+      - id: review
+        include: reusable-review
+        with:
+          request: $INPUTS.request
+```
+
+The block's `returns:` node supplies `$review.output`, including in `until_bash`. Internal
+dependencies, inputs, gates, and namespacing behave the same as for a top-level include. A
+`workflow:` node still cannot appear in a group body because it creates a separately governed
+runtime sub-run rather than static composition.
 
 ### Cross-iteration references: `$LOOP_PREV`
 

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -16158,6 +16158,76 @@ describe('executeDagWorkflow -- loop_group node', () => {
     expect(result).toContain('iteration 2 final result');
   });
 
+  it('re-executes a load-time included body block on every loop_group iteration (#2623)', async () => {
+    let callCount = 0;
+    mockSendQueryDag.mockImplementation(async function* () {
+      callCount++;
+      yield {
+        type: 'assistant',
+        content: callCount === 1 ? 'iteration 1 still working' : 'iteration 2 DONE',
+      };
+      yield { type: 'result', sessionId: `included-body-${callCount}` };
+    });
+
+    const block = workflowDefinitionSchema.parse({
+      name: 'review-block',
+      description: 'Reusable loop body',
+      returns: 'review',
+      nodes: [{ id: 'review', prompt: 'review this iteration' }],
+    });
+    const parent = workflowDefinitionSchema.parse({
+      name: 'included-loop-group',
+      description: 'Repeats a composed block',
+      nodes: [
+        {
+          id: 'group',
+          loop_group: {
+            until: 'DONE',
+            max_iterations: 3,
+            nodes: [{ id: 'pass', include: 'review-block' }],
+          },
+        },
+      ],
+    });
+    const { workflows, errors } = expandWorkflowIncludes(
+      new Map([
+        [block.name, block],
+        [parent.name, parent],
+      ])
+    );
+    expect(errors).toHaveLength(0);
+    const expanded = workflows.get(parent.name);
+    expect(expanded).toBeDefined();
+    if (!expanded) throw new Error('expected expanded workflow');
+
+    const store = createMockStore();
+    const result = await executeDagWorkflow(
+      createMockDeps(store),
+      createMockPlatform(),
+      'conv-lg',
+      testDir,
+      expanded,
+      makeWorkflowRun('dag-loopgroup-included'),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    expect(callCount).toBe(2);
+    expect(result).toContain('iteration 2 DONE');
+    const bodyCompletions = store.createWorkflowEvent.mock.calls
+      .map(([event]) => event)
+      .filter(
+        event => event.event_type === 'node_completed' && event.step_name === 'group.pass__review'
+      );
+    expect(bodyCompletions.map(event => event.data?.iteration)).toEqual([1, 2]);
+  });
+
   it('runs a command-backed loop node inside a loop_group body with namespaced lifecycle events', async () => {
     // A `loop:` body node may use `loop.command` like any top-level loop. The
     // command body must reach the AI, and the loop's persisted lifecycle events

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -99,8 +99,11 @@ import { parseWorkflow } from './loader';
 import { expandWorkflowIncludes } from './include-expander';
 import {
   COMPILED_LOOP_COMMAND,
+  COMPOSED_NODE,
+  readComposedMeta,
   type CompiledLoopCommand,
   type LoopWithCompiledCommand,
+  type NodeWithComposedMeta,
 } from './compiled-command';
 import { OutputRefError } from './output-ref';
 import type { WorkflowDeps, IWorkflowPlatform, WorkflowConfig } from './deps';
@@ -17108,6 +17111,78 @@ describe('executeDagWorkflow -- loop_group node', () => {
       ''
     );
     expect('cancel' in cancelNode && cancelNode.cancel).toBe("stopping: it's done");
+  });
+
+  it('EDGE H (#2623): resolves namespaced $LOOP_PREV across AI config and compiled loop prompts', () => {
+    const prev = new Map<string, NodeOutput>([
+      ['block__review', makeOutput('completed', 'PRIOR', undefined)],
+    ]);
+    const ref = '$LOOP_PREV.block__review.output';
+
+    const aiNode = applyLoopPrevToBodyNode(
+      {
+        id: 'use',
+        prompt: `main=${ref}`,
+        systemPrompt: `system=${ref}`,
+        agents: {
+          helper: {
+            description: `description=${ref}`,
+            prompt: `agent=${ref}`,
+          },
+        },
+        depends_on: [],
+      } as DagNode,
+      prev,
+      ''
+    );
+
+    expect('prompt' in aiNode && aiNode.prompt).toBe('main=PRIOR');
+    expect(aiNode.systemPrompt).toBe('system=PRIOR');
+    expect(aiNode.agents?.helper?.description).toBe('description=PRIOR');
+    expect(aiNode.agents?.helper?.prompt).toBe('agent=PRIOR');
+
+    const commandLoop = dagNodeSchema.parse({
+      id: 'repeat',
+      loop: { command: 'review-command', until: 'DONE', max_iterations: 2 },
+      depends_on: [],
+    });
+    if (!('loop' in commandLoop)) throw new Error('expected loop node');
+    (commandLoop.loop as typeof commandLoop.loop & LoopWithCompiledCommand)[COMPILED_LOOP_COMMAND] =
+      { prompt: `compiled=${ref}` };
+
+    const substitutedLoop = applyLoopPrevToBodyNode(commandLoop, prev, '');
+    if (!('loop' in substitutedLoop)) throw new Error('expected substituted loop node');
+    const compiled = (
+      substitutedLoop.loop as typeof substitutedLoop.loop & LoopWithCompiledCommand
+    )[COMPILED_LOOP_COMMAND];
+    expect(compiled?.prompt).toBe('compiled=PRIOR');
+
+    const gate = dagNodeSchema.parse({
+      id: 'gate',
+      approval: {
+        message: `approve=${ref}`,
+        on_reject: { prompt: `retry=${ref}` },
+      },
+      depends_on: [],
+    });
+    const substitutedGate = applyLoopPrevToBodyNode(gate, prev, '');
+    if (!('approval' in substitutedGate) || substitutedGate.approval === undefined)
+      throw new Error('expected approval node');
+    expect(substitutedGate.approval.message).toBe('approve=PRIOR');
+    expect(substitutedGate.approval.on_reject?.prompt).toBe('retry=PRIOR');
+
+    const script = dagNodeSchema.parse({
+      id: 'script',
+      script: 'console.log(process.env.INPUTS_PREVIOUS)',
+      runtime: 'bun',
+      depends_on: [],
+    });
+    (script as DagNode & NodeWithComposedMeta)[COMPOSED_NODE] = {
+      origin: 'review-block',
+      inputs: { previous: ref },
+    };
+    const substitutedScript = applyLoopPrevToBodyNode(script, prev, '');
+    expect(readComposedMeta(substitutedScript)?.inputs).toEqual({ previous: 'PRIOR' });
   });
 
   it('EDGE H: never splices $LOOP_USER_INPUT into a script body — env delivery only (#2115)', () => {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -16231,6 +16231,97 @@ describe('executeDagWorkflow -- loop_group node', () => {
     expect(bodyCompletions.map(event => event.data?.iteration)).toEqual([1, 2]);
   });
 
+  it('resolves an included inner body previous output in nested loop_group until_bash (#2623)', async () => {
+    // This runs the authored include through real load-time expansion before executing the
+    // nested groups. The inner gate combines three scopes: its included body's previous
+    // iteration, that body's current output, and the enclosing group's previous iteration.
+    // Apostrophes in every carried value make unsafe shell interpolation fail visibly.
+    const outerCounter = join(testDir, 'nested-until-outer-counter');
+    const outerCounterRef = `"${outerCounter.replace(/\\/g, '/')}"`;
+
+    const block = workflowDefinitionSchema.parse({
+      name: 'nested-check-block',
+      description: 'Reusable nested loop check',
+      returns: 'check',
+      nodes: [{ id: 'check', bash: `echo "inner's ready"` }],
+    });
+    const parent = workflowDefinitionSchema.parse({
+      name: 'nested-included-loop-group',
+      description: 'Repeats an included block inside nested groups',
+      nodes: [
+        {
+          id: 'outer',
+          loop_group: {
+            max_iterations: 2,
+            until_bash:
+              `test $seed.output = "outer's second" && ` + `test $inner.output = "inner's ready"`,
+            nodes: [
+              {
+                id: 'seed',
+                bash:
+                  `if [ -f ${outerCounterRef} ]; then echo "outer's second"; ` +
+                  `else touch ${outerCounterRef}; echo "outer's first"; fi`,
+              },
+              {
+                id: 'inner',
+                loop_group: {
+                  max_iterations: 2,
+                  until_bash:
+                    `test $LOOP_PREV.pass__check.output = "inner's ready" && ` +
+                    `test $pass.output = "inner's ready" && ` +
+                    `{ test -z $LOOP_PREV.seed.output || ` +
+                    `test $LOOP_PREV.seed.output = "outer's first"; }`,
+                  nodes: [{ id: 'pass', include: 'nested-check-block' }],
+                },
+                depends_on: ['seed'],
+              },
+            ],
+          },
+        },
+      ],
+    });
+    const { workflows, errors } = expandWorkflowIncludes(
+      new Map([
+        [block.name, block],
+        [parent.name, parent],
+      ])
+    );
+    expect(errors).toHaveLength(0);
+    const expanded = workflows.get(parent.name);
+    expect(expanded).toBeDefined();
+    if (!expanded) throw new Error('expected expanded workflow');
+
+    const store = createMockStore();
+    const result = await executeDagWorkflow(
+      createMockDeps(store),
+      createMockPlatform(),
+      'conv-lg',
+      testDir,
+      expanded,
+      makeWorkflowRun('dag-nested-loopgroup-included-prev'),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    // Each outer iteration runs two inner iterations: inner iteration 1 sees an empty
+    // previous snapshot, while iteration 2 sees the prior included-node output. The outer
+    // repeats once, proving its own previous `seed` output remains outer-scoped.
+    expect(result).toContain("inner's ready");
+    const includedCompletions = store.createWorkflowEvent.mock.calls
+      .map(([event]) => event)
+      .filter(
+        event =>
+          event.event_type === 'node_completed' && event.step_name === 'outer.inner.pass__check'
+      );
+    expect(includedCompletions.map(event => event.data?.iteration)).toEqual([1, 2, 1, 2]);
+  });
+
   it('runs a command-backed loop node inside a loop_group body with namespaced lifecycle events', async () => {
     // A `loop:` body node may use `loop.command` like any top-level loop. The
     // command body must reach the AI, and the loop's persisted lifecycle events

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -16269,8 +16269,10 @@ describe('executeDagWorkflow -- loop_group node', () => {
                   until_bash:
                     `test $LOOP_PREV.pass__check.output = "inner's ready" && ` +
                     `test $pass.output = "inner's ready" && ` +
-                    `{ test -z $LOOP_PREV.seed.output || ` +
-                    `test $LOOP_PREV.seed.output = "outer's first"; }`,
+                    `{ { test $seed.output = "outer's first" && ` +
+                    `test -z $LOOP_PREV.seed.output; } || ` +
+                    `{ test $seed.output = "outer's second" && ` +
+                    `test $LOOP_PREV.seed.output = "outer's first"; }; }`,
                   nodes: [{ id: 'pass', include: 'nested-check-block' }],
                 },
                 depends_on: ['seed'],

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -3872,8 +3872,22 @@ async function executeLoopGroupNode(
       // to the caller instead of being swallowed by the per-iteration catch.
       const groupBashPath = resolveBashPath();
       try {
-        const { prompt: bashPrompt } = substituteWorkflowVariables(
+        // Resolve this group's own cross-iteration refs against the snapshot captured
+        // before its body ran. `loopPrevOutputs` now contains the CURRENT iteration, so
+        // using it here would collapse `$LOOP_PREV` into `$node.output` semantics. Only
+        // direct body ids belong to this scope; refs owned by an enclosing group were
+        // already resolved while preparing this nested group, and descendant ids are not
+        // present in this group's per-iteration output map.
+        const prevResolvedBash = substituteLoopPrevRefs(
           group.until_bash,
+          prevSnapshot,
+          true,
+          logDir,
+          directBodyIds,
+          directBodyIds
+        );
+        const { prompt: bashPrompt } = substituteWorkflowVariables(
+          prevResolvedBash,
           workflowRun.id,
           workflowRun.user_message,
           artifactsDir,
@@ -4249,10 +4263,9 @@ export function applyLoopPrevToBodyNode(
     // (in knownBodyIds but not directBodyIds) is left intact (return match) for the inner
     // group's own pass, while a ref to an OUTER-direct id resolves here at the outer
     // granularity and a true typo still throws. The inner group's own executeLoopGroupNode
-    // computes fresh sets when it runs, so inner-owned refs resolve at the inner iteration
-    // granularity. The inner group's until_bash is shell-bound and only ever substituted
-    // here for OUTER-loop refs (a nested group's own until_bash cannot reference its own body
-    // via $LOOP_PREV — executeLoopGroupNode does not re-run this pass on the group's until_bash).
+    // computes fresh sets when it runs, so inner-owned refs in both body nodes and its
+    // completion script resolve at the inner iteration granularity. This outer pass still
+    // resolves enclosing-group refs in the nested until_bash before that inner execution.
     return {
       ...substitutedNode,
       loop_group: {

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -89,8 +89,10 @@ import { buildTruncationMarker } from './utils/output-truncation';
 import { writeNodeArtifact, readNodeArtifacts } from './artifacts-index';
 import {
   COMPILED_LOOP_COMMAND,
+  COMPOSED_NODE,
   readComposedMeta,
   type LoopWithCompiledCommand,
+  type NodeWithComposedMeta,
 } from './compiled-command';
 import { assistantModelDefaults, resolveNodeModel } from './node-model-resolution';
 import {
@@ -4135,9 +4137,10 @@ async function executeLoopGroupNode(
  * that uses the run's user_message — not the loop's per-iteration user input — so
  * $LOOP_USER_INPUT must be resolved here, at the loop-group level).
  *
- * Only prompt-bearing fields are substituted in v1; `when:` conditions are NOT (they use
- * evaluateCondition, which does not call substituteLoopPrevRefs). Body authors who need
- * cross-iteration gating should branch on prompt content, not `when:`.
+ * Prompt-bearing fields include node prompts, AI configuration, and load-time compiled loop
+ * command prompts. `when:` conditions are NOT substituted (they use evaluateCondition, which
+ * does not call substituteLoopPrevRefs). Body authors who need cross-iteration gating should
+ * branch on prompt content, not `when:`.
  *
  * `knownBodyIds` (transitive body-id set) and `directBodyIds` (this group's immediate body
  * ids) are threaded UNCHANGED into every substituteLoopPrevRefs call AND into the
@@ -4182,25 +4185,65 @@ export function applyLoopPrevToBodyNode(
     const userInputForField = escapedForBash ? shellQuote(loopUserInput) : loopUserInput;
     return prevResolved.replace(/\$LOOP_USER_INPUT/g, userInputForField);
   };
-  if (isLoopNode(node)) {
+  // AI configuration is live prompt text too. Resolve it in this same per-iteration pass
+  // before the ordinary workflow-variable/node-output pass runs in `runLayers`, otherwise
+  // a namespaced `$LOOP_PREV` inside an included block reaches the provider literally.
+  const substitutedNode: DagNode = {
+    ...node,
+    ...(node.systemPrompt !== undefined ? { systemPrompt: sub(node.systemPrompt) } : {}),
+    ...(node.agents !== undefined
+      ? {
+          agents: Object.fromEntries(
+            Object.entries(node.agents).map(([id, agent]) => [
+              id,
+              {
+                ...agent,
+                description: sub(agent.description),
+                prompt: sub(agent.prompt),
+              },
+            ])
+          ),
+        }
+      : {}),
+  };
+  const composedMeta = readComposedMeta(node);
+  if (composedMeta?.inputs !== undefined) {
+    (substitutedNode as DagNode & NodeWithComposedMeta)[COMPOSED_NODE] = {
+      ...composedMeta,
+      inputs: Object.fromEntries(
+        Object.entries(composedMeta.inputs).map(([name, value]) => [name, sub(value)])
+      ),
+    };
+  }
+
+  if (isLoopNode(substitutedNode)) {
     // until_bash is shell-bound: an unresolved $LOOP_PREV would silently degrade to an
     // (empty) shell variable expansion inside bash -c.
+    const loop = {
+      ...substitutedNode.loop,
+      ...(substitutedNode.loop.prompt !== undefined
+        ? { prompt: sub(substitutedNode.loop.prompt) }
+        : {}),
+      ...(substitutedNode.loop.until_bash !== undefined
+        ? { until_bash: sub(substitutedNode.loop.until_bash, true) }
+        : {}),
+    };
+    const compiled = (
+      substitutedNode.loop as typeof substitutedNode.loop & LoopWithCompiledCommand
+    )[COMPILED_LOOP_COMMAND];
+    if (compiled?.prompt !== undefined) {
+      (loop as typeof loop & LoopWithCompiledCommand)[COMPILED_LOOP_COMMAND] = {
+        prompt: sub(compiled.prompt),
+      };
+    }
     return {
-      ...node,
+      ...substitutedNode,
       loop: {
-        ...node.loop,
-        // A command-backed loop has no inline prompt to substitute — its prompt text
-        // is loaded from the command file inside executeLoopNode. Group-level
-        // $LOOP_PREV.<bodyId>.output refs are resolved only in YAML fields (this
-        // pass); they are not scanned inside command-file bodies.
-        ...(node.loop.prompt !== undefined ? { prompt: sub(node.loop.prompt) } : {}),
-        ...(node.loop.until_bash !== undefined
-          ? { until_bash: sub(node.loop.until_bash, true) }
-          : {}),
+        ...loop,
       },
     };
   }
-  if (isLoopGroupNode(node)) {
+  if (isLoopGroupNode(substitutedNode)) {
     // Nested loop_group: recurse into the body. `knownBodyIds`/`directBodyIds` are the OUTER
     // group's sets, threaded UNCHANGED — so during this OUTER pass a ref to an inner-owned id
     // (in knownBodyIds but not directBodyIds) is left intact (return match) for the inner
@@ -4211,13 +4254,13 @@ export function applyLoopPrevToBodyNode(
     // here for OUTER-loop refs (a nested group's own until_bash cannot reference its own body
     // via $LOOP_PREV — executeLoopGroupNode does not re-run this pass on the group's until_bash).
     return {
-      ...node,
+      ...substitutedNode,
       loop_group: {
-        ...node.loop_group,
-        ...(node.loop_group.until_bash !== undefined
-          ? { until_bash: sub(node.loop_group.until_bash, true) }
+        ...substitutedNode.loop_group,
+        ...(substitutedNode.loop_group.until_bash !== undefined
+          ? { until_bash: sub(substitutedNode.loop_group.until_bash, true) }
           : {}),
-        nodes: node.loop_group.nodes.map(n =>
+        nodes: substitutedNode.loop_group.nodes.map(n =>
           applyLoopPrevToBodyNode(
             n,
             loopPrevOutputs,
@@ -4230,22 +4273,39 @@ export function applyLoopPrevToBodyNode(
       },
     };
   }
-  if (isApprovalNode(node)) {
-    return { ...node, approval: { ...node.approval, message: sub(node.approval.message) } };
+  if (isApprovalNode(substitutedNode)) {
+    return {
+      ...substitutedNode,
+      approval: {
+        ...substitutedNode.approval,
+        message: sub(substitutedNode.approval.message),
+        ...(substitutedNode.approval.on_reject !== undefined
+          ? {
+              on_reject: {
+                ...substitutedNode.approval.on_reject,
+                prompt: sub(substitutedNode.approval.on_reject.prompt),
+              },
+            }
+          : {}),
+      },
+    };
   }
-  if (isBashNode(node)) return { ...node, bash: sub(node.bash, true) };
+  if (isBashNode(substitutedNode))
+    return { ...substitutedNode, bash: sub(substitutedNode.bash, true) };
   // Scripts never pass through a shell (execFile argv) — bash-quoting would inject
   // literal quote artifacts into TS/Python source. $LOOP_PREV.* refs are spliced raw
   // (mirroring executeScriptNode's substituteNodeOutputRefs(..., false)); $LOOP_USER_INPUT
   // is skipped here (skipUserInput) and delivered via env by executeScriptNode (#2115).
-  if (isScriptNode(node)) return { ...node, script: sub(node.script, false, true) };
+  if (isScriptNode(substitutedNode))
+    return { ...substitutedNode, script: sub(substitutedNode.script, false, true) };
   // Cancel reason is display text, never executed — mirrors the normal-path default.
-  if (isCancelNode(node)) return { ...node, cancel: sub(node.cancel) };
-  if ('command' in node && typeof node.command === 'string')
-    return { ...node, command: sub(node.command) };
-  if ('prompt' in node && typeof node.prompt === 'string')
-    return { ...node, prompt: sub(node.prompt) };
-  return node;
+  if (isCancelNode(substitutedNode))
+    return { ...substitutedNode, cancel: sub(substitutedNode.cancel) };
+  if ('command' in substitutedNode && typeof substitutedNode.command === 'string')
+    return { ...substitutedNode, command: sub(substitutedNode.command) };
+  if ('prompt' in substitutedNode && typeof substitutedNode.prompt === 'string')
+    return { ...substitutedNode, prompt: sub(substitutedNode.prompt) };
+  return substitutedNode;
 }
 
 /**

--- a/packages/workflows/src/include-expander.test.ts
+++ b/packages/workflows/src/include-expander.test.ts
@@ -1417,6 +1417,152 @@ describe('expandWorkflowIncludes — determinism', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Includes inside loop_group bodies (#2623)
+// ---------------------------------------------------------------------------
+
+describe('expandWorkflowIncludes — loop_group body composition (#2623)', () => {
+  test('expands a body include in local scope and binds completion to its declared return', () => {
+    const block: WorkflowDefinition = {
+      ...wf('review-block', [
+        {
+          id: 'decide',
+          prompt: 'review $INPUTS.context',
+          output_format: {
+            type: 'object',
+            properties: { done: { type: 'boolean' } },
+            required: ['done'],
+          },
+        },
+        {
+          id: 'cleanup',
+          bash: 'echo $LOOP_PREV.decide.output.done',
+          depends_on: ['decide'],
+        },
+      ]),
+      inputs: { context: { required: true } },
+      returns: 'decide',
+      requires: ['github'],
+    };
+    const parent = wf('parent', [
+      {
+        id: 'group',
+        loop_group: {
+          until_bash: 'test "$review.output.done" = true',
+          max_iterations: 3,
+          nodes: [
+            { id: 'seed', bash: 'echo context' },
+            {
+              id: 'review',
+              include: 'review-block',
+              depends_on: ['seed'],
+              with: { context: '$seed.output' },
+            },
+            {
+              id: 'consume',
+              prompt: 'done=$review.output.done',
+              depends_on: ['review'],
+            },
+          ],
+        },
+      },
+    ]);
+
+    const { workflows, errors } = expandWorkflowIncludes(mapOf(block, parent));
+
+    expect(errors).toHaveLength(0);
+    const expanded = workflows.get('parent')!;
+    const group = nodeById(expanded, 'group');
+    expect(group?.loop_group?.nodes.map(node => node.id)).toEqual([
+      'seed',
+      'review__decide',
+      'review__cleanup',
+      'consume',
+    ]);
+    expect(group?.loop_group?.nodes.some(node => 'include' in node)).toBe(false);
+    expect(group?.loop_group?.until_bash).toBe('test "$review__decide.output.done" = true');
+
+    const decide = group?.loop_group?.nodes.find(node => node.id === 'review__decide');
+    const cleanup = group?.loop_group?.nodes.find(node => node.id === 'review__cleanup');
+    const consume = group?.loop_group?.nodes.find(node => node.id === 'consume');
+    expect(decide?.depends_on).toEqual(['seed']);
+    expect(cleanup?.depends_on).toEqual(['review__decide']);
+    expect(cleanup && 'bash' in cleanup ? cleanup.bash : '').toBe(
+      'echo $LOOP_PREV.review__decide.output.done'
+    );
+    expect(consume?.depends_on).toEqual(['review__cleanup']);
+    expect(consume && 'prompt' in consume ? consume.prompt : '').toBe(
+      'done=$review__decide.output.done'
+    );
+    expect(decide && 'prompt' in decide ? decide.prompt : '').toBe('review $seed.output');
+    expect(composedOrigin(decide)).toBe('review-block');
+    expect(composedInputs(decide)).toEqual({ context: '$seed.output' });
+    expect(expanded.requires).toEqual(['github']);
+  });
+
+  test('expands independent includes in nested loop_group scopes without leaking directives', () => {
+    const block = wf('block', [{ id: 'work', prompt: 'work' }]);
+    const parent = wf('parent', [
+      {
+        id: 'outer',
+        loop_group: {
+          until_bash: 'true',
+          max_iterations: 1,
+          nodes: [
+            { id: 'first', include: 'block' },
+            { id: 'second', include: 'block', depends_on: ['first'] },
+            {
+              id: 'inner',
+              loop_group: {
+                until_bash: 'test -n "$third.output"',
+                max_iterations: 1,
+                nodes: [{ id: 'third', include: 'block' }],
+              },
+              depends_on: ['second'],
+            },
+          ],
+        },
+      },
+    ]);
+
+    const { workflows, errors } = expandWorkflowIncludes(mapOf(block, parent));
+
+    expect(errors).toHaveLength(0);
+    const outer = nodeById(workflows.get('parent')!, 'outer');
+    expect(outer?.loop_group?.nodes.map(node => node.id)).toEqual([
+      'first__work',
+      'second__work',
+      'inner',
+    ]);
+    expect(outer?.loop_group?.nodes.find(node => node.id === 'second__work')?.depends_on).toEqual([
+      'first__work',
+    ]);
+    const inner = outer?.loop_group?.nodes.find(node => node.id === 'inner');
+    expect(inner?.loop_group?.nodes.map(node => node.id)).toEqual(['third__work']);
+    expect(inner?.loop_group?.until_bash).toBe('test -n "$third__work.output"');
+  });
+
+  test('fails the owning workflow when a body include target is unknown', () => {
+    const parent = wf('parent', [
+      {
+        id: 'group',
+        loop_group: {
+          until_bash: 'true',
+          max_iterations: 1,
+          nodes: [{ id: 'missing', include: 'does-not-exist' }],
+        },
+      },
+    ]);
+
+    const { workflows, errors } = expandWorkflowIncludes(mapOf(parent));
+
+    expect(workflows.has('parent')).toBe(false);
+    expect(errors.find(error => error.filename === 'parent')?.error).toContain(
+      "Node 'missing': include target 'does-not-exist' not found"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // returns: + declared inputs: (#2470)
 // ---------------------------------------------------------------------------
 

--- a/packages/workflows/src/include-expander.test.ts
+++ b/packages/workflows/src/include-expander.test.ts
@@ -1459,7 +1459,7 @@ describe('expandWorkflowIncludes — loop_group body composition (#2623)', () =>
             },
             {
               id: 'consume',
-              prompt: 'done=$review.output.done',
+              prompt: 'done=$review.output.done previous=$LOOP_PREV.review.output',
               depends_on: ['review'],
             },
           ],
@@ -1491,7 +1491,7 @@ describe('expandWorkflowIncludes — loop_group body composition (#2623)', () =>
     );
     expect(consume?.depends_on).toEqual(['review__cleanup']);
     expect(consume && 'prompt' in consume ? consume.prompt : '').toBe(
-      'done=$review__decide.output.done'
+      'done=$review__decide.output.done previous=$LOOP_PREV.review.output'
     );
     expect(decide && 'prompt' in decide ? decide.prompt : '').toBe('review $seed.output');
     expect(composedOrigin(decide)).toBe('review-block');

--- a/packages/workflows/src/include-expander.ts
+++ b/packages/workflows/src/include-expander.ts
@@ -377,10 +377,11 @@ function collapseWorkflowScope(raw: WorkflowDefinition): WorkflowDefinition {
 function rewriteNodeOutputRefs(
   node: DagNode,
   renameOutputRef: (id: string) => string,
-  expandDependency: (id: string) => string[]
+  expandDependency: (id: string) => string[],
+  renameLoopPrevRef: (id: string) => string
 ): void {
   const code = (text: string): string =>
-    applyLoopPrevOutputRefRename(applyOutputRefRename(text, renameOutputRef), renameOutputRef);
+    applyLoopPrevOutputRefRename(applyOutputRefRename(text, renameOutputRef), renameLoopPrevRef);
   const whenExpr = (text: string): string => applyWhenRefRename(text, renameOutputRef);
 
   if (node.when !== undefined) node.when = whenExpr(node.when);
@@ -421,7 +422,7 @@ function rewriteNodeOutputRefs(
       node.loop_group.until_bash = code(node.loop_group.until_bash);
     }
     for (const body of node.loop_group.nodes) {
-      rewriteNodeOutputRefs(body, renameOutputRef, expandDependency);
+      rewriteNodeOutputRefs(body, renameOutputRef, expandDependency, renameLoopPrevRef);
     }
   } else if (isApprovalNode(node)) {
     node.approval.message = code(node.approval.message);
@@ -703,7 +704,7 @@ function inlineInclude(
     // Rewrite child-internal refs before inserting caller values. This ordering is
     // load-bearing: a caller ref such as `$gather.output` must remain parent-scoped even
     // when the included block also has a node named `gather`.
-    rewriteNodeOutputRefs(clone, rename, id => [rename(id)]);
+    rewriteNodeOutputRefs(clone, rename, id => [rename(id)], rename);
     applyInputsMacro(clone, resolvedInputs, missingInputs, includeNode);
     // Stamped AFTER both passes, for the same reason the caller's values are inserted
     // after the rename: these are the CALLER's strings, so they stay parent-scoped here
@@ -1002,8 +1003,7 @@ export function expandWorkflowIncludes(
     stack: string[]
   ): ExpandedNodeList {
     const expandedNodes: DagNode[] = [];
-    const sinksByIncludeId = new Map<string, string[]>();
-    const primarySinkByIncludeId = new Map<string, string>();
+    const includesById = new Map<string, ExpandedInclude>();
     const includedRequirements: WorkflowRequirement[] = [];
 
     for (const node of nodes) {
@@ -1020,8 +1020,7 @@ export function expandWorkflowIncludes(
         warnDroppedWorkflowLevelFields(node, child);
         includedRequirements.push(...(child.requires ?? []));
         const inlined = inlineInclude(node, child, commandContents ?? new Map());
-        sinksByIncludeId.set(node.id, inlined.sinks);
-        primarySinkByIncludeId.set(node.id, inlined.primarySink);
+        includesById.set(node.id, inlined);
         expandedNodes.push(...inlined.namespaced);
         continue;
       }
@@ -1059,13 +1058,16 @@ export function expandWorkflowIncludes(
     // Rewrite only aliases owned by this list. `rewriteNodeOutputRefs` deliberately
     // recurses into nested loop_group bodies because their text may read enclosing
     // outputs, while their sealed depends_on edges remain local to their own list.
-    const renameIncludeRef = (id: string): string => primarySinkByIncludeId.get(id) ?? id;
-    const expandIncludeDependency = (id: string): string[] => sinksByIncludeId.get(id) ?? [id];
+    const renameIncludeRef = (id: string): string => includesById.get(id)?.primarySink ?? id;
+    const expandIncludeDependency = (id: string): string[] => includesById.get(id)?.sinks ?? [id];
     for (const node of expandedNodes) {
       if (node.depends_on !== undefined) {
         node.depends_on = node.depends_on.flatMap(expandIncludeDependency);
       }
-      rewriteNodeOutputRefs(node, renameIncludeRef, expandIncludeDependency);
+      // `$include.output` is a current-iteration composition alias. It deliberately does
+      // not create a parallel `$LOOP_PREV.<includeId>` grammar: previous-iteration refs
+      // continue to name only the executable body ids produced by `inlineInclude()`.
+      rewriteNodeOutputRefs(node, renameIncludeRef, expandIncludeDependency, id => id);
     }
 
     return { nodes: expandedNodes, includedRequirements, renameIncludeRef };

--- a/packages/workflows/src/include-expander.ts
+++ b/packages/workflows/src/include-expander.ts
@@ -108,6 +108,13 @@ export const INCLUDE_MAX_DEPTH = 3;
 const OUTPUT_REF_PATTERN = /\$([a-zA-Z_][a-zA-Z0-9_-]*)\.output/g;
 
 /**
+ * Cross-iteration body refs use the same executable node ids, under a distinct prefix.
+ * When a reusable block is inlined into a loop_group body, its authored sibling ids must
+ * follow the same namespace rewrite as current-iteration `$id.output` refs.
+ */
+const LOOP_PREV_OUTPUT_REF_PATTERN = /\$LOOP_PREV\.([a-zA-Z_][a-zA-Z0-9_-]*)\.output/g;
+
+/**
  * `when:`-only ref pattern. The condition grammar (condition-evaluator.ts) additionally
  * accepts the SHORTHAND `$id.field` form (equivalent to `$id.output.field`) alongside
  * `$id.output` / `$id.output.field`. So in a `when:` a bare `$id` followed by `.` and a
@@ -129,6 +136,13 @@ function applyOutputRefRename(text: string, rename: (id: string) => string): str
   return text.replace(OUTPUT_REF_PATTERN, (match, id: string) => {
     const renamed = rename(id);
     return renamed === id ? match : `$${renamed}.output`;
+  });
+}
+
+function applyLoopPrevOutputRefRename(text: string, rename: (id: string) => string): string {
+  return text.replace(LOOP_PREV_OUTPUT_REF_PATTERN, (match, id: string) => {
+    const renamed = rename(id);
+    return renamed === id ? match : `$LOOP_PREV.${renamed}.output`;
   });
 }
 
@@ -365,7 +379,8 @@ function rewriteNodeOutputRefs(
   renameOutputRef: (id: string) => string,
   expandDependency: (id: string) => string[]
 ): void {
-  const code = (text: string): string => applyOutputRefRename(text, renameOutputRef);
+  const code = (text: string): string =>
+    applyLoopPrevOutputRefRename(applyOutputRefRename(text, renameOutputRef), renameOutputRef);
   const whenExpr = (text: string): string => applyWhenRefRename(text, renameOutputRef);
 
   if (node.when !== undefined) node.when = whenExpr(node.when);
@@ -970,6 +985,92 @@ export function expandWorkflowIncludes(
   const failed = new Set<string>();
   const errors: WorkflowLoadError[] = [];
 
+  interface ExpandedNodeList {
+    nodes: DagNode[];
+    includedRequirements: WorkflowRequirement[];
+    renameIncludeRef: (id: string) => string;
+  }
+
+  /**
+   * Expand one statically scoped node list. The workflow's top-level DAG and every
+   * loop_group body each own an independent include-id namespace: dependencies and
+   * `$include.output` refs bind only to directives in that list.
+   */
+  function expandNodeList(
+    nodes: DagNode[],
+    workflowName: string,
+    stack: string[]
+  ): ExpandedNodeList {
+    const expandedNodes: DagNode[] = [];
+    const sinksByIncludeId = new Map<string, string[]>();
+    const primarySinkByIncludeId = new Map<string, string>();
+    const includedRequirements: WorkflowRequirement[] = [];
+
+    for (const node of nodes) {
+      if (isIncludeNode(node)) {
+        let child: WorkflowDefinition;
+        try {
+          child = expandOne(node.include, [...stack, workflowName]);
+        } catch (e) {
+          if (e instanceof IncludeExpansionError) {
+            throw new IncludeExpansionError(`Node '${node.id}': ${e.message}`);
+          }
+          throw e;
+        }
+        warnDroppedWorkflowLevelFields(node, child);
+        includedRequirements.push(...(child.requires ?? []));
+        const inlined = inlineInclude(node, child, commandContents ?? new Map());
+        sinksByIncludeId.set(node.id, inlined.sinks);
+        primarySinkByIncludeId.set(node.id, inlined.primarySink);
+        expandedNodes.push(...inlined.namespaced);
+        continue;
+      }
+
+      if (isLoopGroupNode(node)) {
+        const body = expandNodeList(node.loop_group.nodes, workflowName, stack);
+        includedRequirements.push(...body.includedRequirements);
+        expandedNodes.push({
+          ...node,
+          loop_group: {
+            ...node.loop_group,
+            // The completion script runs against THIS body's output map. Rebind an
+            // authored `$include.output` to the included workflow's declared return,
+            // just as refs on ordinary sibling body nodes are rebound below.
+            ...(node.loop_group.until_bash !== undefined
+              ? {
+                  until_bash: applyOutputRefRename(
+                    node.loop_group.until_bash,
+                    body.renameIncludeRef
+                  ),
+                }
+              : {}),
+            nodes: body.nodes,
+          },
+        });
+        continue;
+      }
+
+      // Already a private clone — `collapseWorkflowScope` cloned every node before
+      // writing this workflow's config onto it, so the second pass below can mutate
+      // it without reaching the raw parsed definition discovery still holds.
+      expandedNodes.push(node);
+    }
+
+    // Rewrite only aliases owned by this list. `rewriteNodeOutputRefs` deliberately
+    // recurses into nested loop_group bodies because their text may read enclosing
+    // outputs, while their sealed depends_on edges remain local to their own list.
+    const renameIncludeRef = (id: string): string => primarySinkByIncludeId.get(id) ?? id;
+    const expandIncludeDependency = (id: string): string[] => sinksByIncludeId.get(id) ?? [id];
+    for (const node of expandedNodes) {
+      if (node.depends_on !== undefined) {
+        node.depends_on = node.depends_on.flatMap(expandIncludeDependency);
+      }
+      rewriteNodeOutputRefs(node, renameIncludeRef, expandIncludeDependency);
+    }
+
+    return { nodes: expandedNodes, includedRequirements, renameIncludeRef };
+  }
+
   function expandOne(name: string, stack: string[]): WorkflowDefinition {
     // Cycle + depth are checked BEFORE the memo so a node memoized via a shallow path
     // can never mask a too-deep or cyclic reference reaching it via a longer path.
@@ -999,61 +1100,20 @@ export function expandWorkflowIncludes(
     // cloned now, deliberately: the alternative is a workflow that behaves differently
     // depending on whether it happens to contain an `include:`.
     const collapsed = collapseWorkflowScope(raw);
-
-    if (!collapsed.nodes.some(isIncludeNode)) {
-      memo.set(name, collapsed);
-      return collapsed;
-    }
-
-    const newNodes: DagNode[] = [];
-    const sinksByIncludeId = new Map<string, string[]>();
-    const primarySinkByIncludeId = new Map<string, string>();
     // Capability requirements union UPWARD (#1764): a composed workflow's `requires:` is
     // a fact about what its nodes need, not a choice the composing run makes. Dropping it
     // turned a clean pre-cost refusal into a mid-run failure inside a block the parent
     // cannot inspect. A union can only make a run refuse EARLIER.
-    const requires: WorkflowRequirement[] = [...(collapsed.requires ?? [])];
-
-    for (const node of collapsed.nodes) {
-      if (isIncludeNode(node)) {
-        let child: WorkflowDefinition;
-        try {
-          child = expandOne(node.include, [...stack, name]);
-        } catch (e) {
-          if (e instanceof IncludeExpansionError) {
-            throw new IncludeExpansionError(`Node '${node.id}': ${e.message}`);
-          }
-          throw e;
-        }
-        warnDroppedWorkflowLevelFields(node, child);
-        requires.push(...(child.requires ?? []));
-        const inlined = inlineInclude(node, child, commandContents ?? new Map());
-        sinksByIncludeId.set(node.id, inlined.sinks);
-        primarySinkByIncludeId.set(node.id, inlined.primarySink);
-        newNodes.push(...inlined.namespaced);
-      } else {
-        // Already a private clone — `collapseWorkflowScope` cloned every node before
-        // writing this workflow's config onto it, so the second pass below can mutate
-        // it without reaching the raw parsed definition discovery still holds.
-        newNodes.push(node);
-      }
-    }
-
-    // Second pass — rewrite references to include ids across every node:
-    //   (a) depends_on entries equal to an include id → that include's sink list
-    //   (b) $includeId.output → $<primarySink>.output
-    const renameIncludeRef = (id: string): string => primarySinkByIncludeId.get(id) ?? id;
-    const expandIncludeDependency = (id: string): string[] => sinksByIncludeId.get(id) ?? [id];
-    for (const node of newNodes) {
-      if (node.depends_on !== undefined) {
-        node.depends_on = node.depends_on.flatMap(expandIncludeDependency);
-      }
-      rewriteNodeOutputRefs(node, renameIncludeRef, expandIncludeDependency);
-    }
+    const expanded = expandNodeList(collapsed.nodes, name, stack);
+    const requires: WorkflowRequirement[] = [
+      ...(collapsed.requires ?? []),
+      ...expanded.includedRequirements,
+    ];
 
     // Re-validate the fully-flattened DAG. Catches a namespaced id colliding with a
-    // hand-written node, cycles introduced by edge rewiring, and unknown deps.
-    const structureError = validateDagStructure(newNodes);
+    // hand-written node, cycles introduced by edge rewiring, unknown deps, and the
+    // equivalent failures inside every recursively expanded loop_group body.
+    const structureError = validateDagStructure(expanded.nodes);
     if (structureError) {
       throw new IncludeExpansionError(structureError);
     }
@@ -1061,12 +1121,14 @@ export function expandWorkflowIncludes(
     const dedupedRequires = [...new Set(requires)];
     const result: WorkflowDefinition = {
       ...collapsed,
-      nodes: newNodes,
+      nodes: expanded.nodes,
       // `returns:` may name an include directive that no longer exists after flattening.
       // Rebind it to the same primary sink used for `$includeId.output`; ordinary node ids
       // pass through unchanged. Without this, a nested reusable workflow can finish with a
       // dangling return id even though every node-level reference was rewritten correctly.
-      ...(collapsed.returns !== undefined ? { returns: renameIncludeRef(collapsed.returns) } : {}),
+      ...(collapsed.returns !== undefined
+        ? { returns: expanded.renameIncludeRef(collapsed.returns) }
+        : {}),
       ...(dedupedRequires.length > 0 ? { requires: dedupedRequires } : {}),
     };
     memo.set(name, result);

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -35,7 +35,7 @@ clearRegistry();
 registerBuiltinProviders();
 
 import { discoverWorkflows, discoverWorkflowsWithConfig } from './workflow-discovery';
-import { isBashNode, isCancelNode, isLoopNode } from './schemas';
+import { isBashNode, isCancelNode, isLoopGroupNode, isLoopNode } from './schemas';
 import { parseWorkflow } from './loader';
 import { COMPILED_LOOP_COMMAND, type LoopWithCompiledCommand } from './compiled-command';
 import { workflowDefinitionSchema } from './schemas/workflow';
@@ -4624,31 +4624,75 @@ nodes:
       expect(finish?.depends_on).toEqual(['sub__second']);
     });
 
-    it('should reject an include node inside a loop_group body', async () => {
+    it('should expand an include node inside a loop_group body', async () => {
       const workflowDir = join(testDir, '.archon', 'workflows');
       await mkdir(workflowDir, { recursive: true });
 
       await writeFile(
+        join(workflowDir, 'block.yaml'),
+        `
+name: block
+description: Reusable review block
+returns: decide
+nodes:
+  - id: decide
+    prompt: Decide whether the work is done
+    output_format:
+      type: object
+      properties:
+        done:
+          type: boolean
+      required: [done]
+  - id: cleanup
+    bash: echo cleanup
+    depends_on: [decide]
+`
+      );
+      await writeFile(
         join(workflowDir, 'include-in-loop-group.yaml'),
         `
 name: include-in-loop-group
-description: Include nested in a loop_group body (rejected in v1)
+description: Include nested in a loop_group body
 nodes:
   - id: grp
     loop_group:
-      until: DONE
+      until_bash: test "$review.output.done" = true
       max_iterations: 3
       nodes:
-        - id: bad
+        - id: setup
+          bash: echo setup
+        - id: review
           include: block
+          depends_on: [setup]
+        - id: summarize
+          prompt: result=$review.output.done
+          depends_on: [review]
 `
       );
 
       const result = await discoverWorkflows(testDir, { loadDefaults: false });
-      const err = result.errors.find(e => e.filename === 'include-in-loop-group.yaml');
-      expect(err).toBeDefined();
-      expect(err?.error).toContain('loop_group');
-      expect(err?.error).toContain("'include' is not supported");
+      expect(result.errors.filter(e => e.filename === 'include-in-loop-group.yaml')).toHaveLength(
+        0
+      );
+      const workflow = result.workflows.find(
+        entry => entry.workflow.name === 'include-in-loop-group'
+      )?.workflow;
+      expect(workflow).toBeDefined();
+      const group = workflow?.nodes.find(node => node.id === 'grp');
+      expect(group && isLoopGroupNode(group)).toBe(true);
+      if (!group || !isLoopGroupNode(group)) throw new Error('expected loop_group');
+      expect(group.loop_group.nodes.map(node => node.id)).toEqual([
+        'setup',
+        'review__decide',
+        'review__cleanup',
+        'summarize',
+      ]);
+      expect(group.loop_group.nodes.some(node => 'include' in node)).toBe(false);
+      expect(group.loop_group.until_bash).toBe('test "$review__decide.output.done" = true');
+      expect(group.loop_group.nodes.find(node => node.id === 'summarize')).toMatchObject({
+        prompt: 'result=$review__decide.output.done',
+        depends_on: ['review__cleanup'],
+      });
     });
 
     it('should error two files that declare the same workflow name', async () => {

--- a/packages/workflows/src/loader.ts
+++ b/packages/workflows/src/loader.ts
@@ -687,13 +687,6 @@ export function validateDagStructure(
   // list and treat each loop_group as one outer node.
   for (const node of nodes) {
     if (isLoopGroupNode(node)) {
-      // `include` inside a loop_group body is rejected in v1 (bounds the interaction
-      // surface — see the plan's NOT Building). An include is a load-time inlining
-      // directive; nesting it inside a per-iteration sub-DAG body is not yet supported.
-      const includeInBody = node.loop_group.nodes.find(isIncludeNode);
-      if (includeInBody) {
-        return `loop_group '${node.id}' body: 'include' is not supported inside a loop_group body`;
-      }
       // `workflow:` (sub-run) inside a loop_group body is rejected (bounds the
       // interaction surface — see the plan's NOT Building). This wholesale rejection
       // also covers a fan-out (`fan_out:`) workflow node in a loop_group body (slice 2,

--- a/packages/workflows/src/workflow-discovery-command-scan.test.ts
+++ b/packages/workflows/src/workflow-discovery-command-scan.test.ts
@@ -15,7 +15,7 @@ afterEach(async () => {
 });
 
 describe('discoverWorkflows — nested included command compilation', () => {
-  test('pre-resolves a command block included directly inside a loop_group body', async () => {
+  test('pre-resolves a command block included below nested loop_group bodies', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'archon-workflow-discovery-'));
     tempDirectories.push(cwd);
     const workflowDir = join(cwd, '.archon', 'workflows');
@@ -38,14 +38,29 @@ describe('discoverWorkflows — nested included command compilation', () => {
       join(workflowDir, 'parent.yaml'),
       JSON.stringify({
         name: 'parent',
-        description: 'Includes a command block inside a group body',
+        description: 'Includes a command block inside nested group bodies',
         nodes: [
           {
             id: 'group',
             loop_group: {
               until: 'DONE',
               max_iterations: 1,
-              nodes: [{ id: 'block', include: 'command-block', with: { context: 'iteration' } }],
+              nodes: [
+                {
+                  id: 'inner',
+                  loop_group: {
+                    until: 'DONE',
+                    max_iterations: 1,
+                    nodes: [
+                      {
+                        id: 'block',
+                        include: 'command-block',
+                        with: { context: 'iteration' },
+                      },
+                    ],
+                  },
+                },
+              ],
             },
           },
         ],
@@ -60,7 +75,10 @@ describe('discoverWorkflows — nested included command compilation', () => {
     const group = parent?.nodes.find(node => node.id === 'group');
     expect(group && isLoopGroupNode(group)).toBe(true);
     if (!group || !isLoopGroupNode(group)) throw new Error('expected loop_group');
-    expect(group.loop_group.nodes).toEqual([
+    const inner = group.loop_group.nodes.find(node => node.id === 'inner');
+    expect(inner && isLoopGroupNode(inner)).toBe(true);
+    if (!inner || !isLoopGroupNode(inner)) throw new Error('expected nested loop_group');
+    expect(inner.loop_group.nodes).toEqual([
       expect.objectContaining({
         id: 'block__review',
         prompt: 'Review iteration and emit DONE.',

--- a/packages/workflows/src/workflow-discovery-command-scan.test.ts
+++ b/packages/workflows/src/workflow-discovery-command-scan.test.ts
@@ -4,6 +4,7 @@ import { join } from 'path';
 import { afterEach, describe, expect, test } from 'bun:test';
 import { discoverWorkflows } from './workflow-discovery';
 import { COMPILED_LOOP_COMMAND, type LoopWithCompiledCommand } from './compiled-command';
+import { isLoopGroupNode } from './schemas';
 
 const tempDirectories: string[] = [];
 
@@ -14,6 +15,59 @@ afterEach(async () => {
 });
 
 describe('discoverWorkflows — nested included command compilation', () => {
+  test('pre-resolves a command block included directly inside a loop_group body', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'archon-workflow-discovery-'));
+    tempDirectories.push(cwd);
+    const workflowDir = join(cwd, '.archon', 'workflows');
+    const commandDir = join(cwd, '.archon', 'commands');
+    await Promise.all([
+      mkdir(workflowDir, { recursive: true }),
+      mkdir(commandDir, { recursive: true }),
+    ]);
+
+    await writeFile(
+      join(workflowDir, 'block.yaml'),
+      JSON.stringify({
+        name: 'command-block',
+        description: 'Command-backed loop body block',
+        inputs: { context: { required: true } },
+        nodes: [{ id: 'review', command: 'body-review' }],
+      })
+    );
+    await writeFile(
+      join(workflowDir, 'parent.yaml'),
+      JSON.stringify({
+        name: 'parent',
+        description: 'Includes a command block inside a group body',
+        nodes: [
+          {
+            id: 'group',
+            loop_group: {
+              until: 'DONE',
+              max_iterations: 1,
+              nodes: [{ id: 'block', include: 'command-block', with: { context: 'iteration' } }],
+            },
+          },
+        ],
+      })
+    );
+    await writeFile(join(commandDir, 'body-review.md'), 'Review $INPUTS.context and emit DONE.');
+
+    const result = await discoverWorkflows(cwd, { loadDefaults: false });
+
+    expect(result.errors.filter(error => error.filename === 'parent.yaml')).toHaveLength(0);
+    const parent = result.workflows.find(item => item.workflow.name === 'parent')?.workflow;
+    const group = parent?.nodes.find(node => node.id === 'group');
+    expect(group && isLoopGroupNode(group)).toBe(true);
+    if (!group || !isLoopGroupNode(group)) throw new Error('expected loop_group');
+    expect(group.loop_group.nodes).toEqual([
+      expect.objectContaining({
+        id: 'block__review',
+        prompt: 'Review iteration and emit DONE.',
+      }),
+    ]);
+  });
+
   test('pre-resolves and compiles loop_group command files before include expansion', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'archon-workflow-discovery-'));
     tempDirectories.push(cwd);

--- a/packages/workflows/src/workflow-discovery.ts
+++ b/packages/workflows/src/workflow-discovery.ts
@@ -25,8 +25,9 @@ import type {
   WorkflowWithSource,
   WorkflowSource,
   DeclaredWorkflowConfig,
+  DagNode,
 } from './schemas';
-import { isIncludeNode } from './schemas';
+import { isIncludeNode, isLoopGroupNode } from './schemas';
 import * as archonPaths from '@archon/paths';
 import {
   BUNDLED_WORKFLOWS,
@@ -511,14 +512,17 @@ async function resolveIncludeBlockCommandContents(
   config: CommandScanConfig
 ): Promise<Map<string, IncludeCommandContent>> {
   const targetNames = new Set<string>();
-  const visit = (workflow: WorkflowDefinition): void => {
-    for (const node of workflow.nodes) {
-      if (isIncludeNode(node) && !targetNames.has(node.include)) {
-        targetNames.add(node.include);
-        const target = byName.get(node.include);
-        if (target) visit(target);
-      }
+  const visitNodes = (nodes: readonly DagNode[]): void => {
+    for (const node of nodes) {
+      if (isLoopGroupNode(node)) visitNodes(node.loop_group.nodes);
+      if (!isIncludeNode(node) || targetNames.has(node.include)) continue;
+      targetNames.add(node.include);
+      const target = byName.get(node.include);
+      if (target) visit(target);
     }
+  };
+  const visit = (workflow: WorkflowDefinition): void => {
+    visitNodes(workflow.nodes);
   };
   for (const workflow of byName.values()) visit(workflow);
 


### PR DESCRIPTION
## Problem and outcome

Reusable blocks could not participate in iterative review/fix workflows because the loader rejected `include:` inside a `loop_group` body. Authors had to duplicate the block or manually unroll a fixed number of rounds.

- **Outcome:** A block included in a group body expands during discovery and its ordinary namespaced nodes execute on every group iteration.
- **Invariant:** Successful discovery leaves no `include:` directive at any depth; the executor still receives a fully resolved static graph.
- **Scope boundary:** This adds no YAML syntax or runtime composition. `workflow:` sub-runs remain unsupported inside group bodies, and the unmerged #2627 consumer is not part of this change.
- **Root cause:** The recursive schema accepted the shape, but validation explicitly rejected it; after removing that guard, both include expansion and command-target discovery were still limited to the top-level node list.

## Review guidance

- **Feedback requested:** Correctness of nested scope ownership, include output/dependency rewrites, and preservation of the load-time-only composition boundary.
- **Start here:** `packages/workflows/src/include-expander.ts:985` — the existing one-include primitive is now orchestrated recursively for each static node-list scope.
- **Review order:** `include-expander.ts`, `workflow-discovery.ts`, `loader.ts`, then the focused expansion/discovery/executor fixtures.
- **Lower-attention areas:** The documentation mirrors behavior covered by the discovery and executor tests.
- **Known risk or uncertainty:** None.

## Solution

The existing include transform now runs for the workflow DAG and recursively for every `loop_group` body. Each node-list owns its include dependency and declared-return aliases, included requirements flow upward, group `until_bash` references bind to the included block's declared return, and block-internal `$LOOP_PREV` references follow executable-node namespacing. Command-backed targets are also found recursively before expansion.

The executor is unchanged: expanded block nodes remain inside the group body and use the same iteration, event, session, artifact, and accounting paths as equivalent inline nodes. This follows the Workflow Language Constitution by resolving composition completely at load time.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | A `loop_group` body containing `include:` was omitted with a load error. | Discovery expands the block in place and every iteration re-runs its namespaced executable nodes. |
| **Failure behavior** | All body includes failed before expansion. | Invalid targets, inputs, commands, collisions, cycles, and depth still fail during discovery; valid includes load. |

## Validation

- `cd packages/workflows && bun test src/loader.test.ts src/include-expander.test.ts` — 376 passed — proves nested expansion, local aliases, declared-return completion, requirements, inputs, and fail-closed loading.
- `cd packages/workflows && bun test src/workflow-discovery-command-scan.test.ts` — 5 passed — proves command-backed body blocks materialize during real discovery.
- `cd packages/workflows && bun test src/dag-executor.test.ts` — 518 passed — proves expanded block nodes repeat under the existing group runtime and persist ordinary namespaced iteration events.
- `cd packages/workflows && bun test src/state-migration.test.ts src/dry-run.test.ts` — 64 passed — proves the static expanded graph remains compatible with dry-run and state paths.
- `bun --filter @archon/workflows type-check` — passed.
- `bun run validate` — passed in full.
- **Not verified:** Nothing material; discovery, runtime, dry-run, types, lint, formatting, builds, and the complete repository test gate are covered.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | Existing top-level includes and inline group bodies retain their behavior; no data migration is required. | Full repository validation and existing composition/loop suites pass. |
| Rollout / rollback | The change is confined to load-time discovery and is safely reversible by restoring the explicit rejection. | No schema or executor changes. |
| Documentation / communication | Authoring and loop guides now document body includes, static expansion, namespacing, returns, and the sub-run boundary. | `packages/docs-web/src/content/docs/guides/authoring-workflows.md`, `packages/docs-web/src/content/docs/guides/loop-nodes.md` |

## Links

- Closes #2623
- Plan: https://github.com/coleam00/Archon/issues/2623#issuecomment-5342889982


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for expanding and executing included workflow nodes inside loop groups.
  * Included nodes are namespaced, rerun on each iteration, and can provide loop completion outputs.
  * Nested loop groups and lifecycle events now use consistent namespaced step names.
  * Workflow discovery resolves included commands within loop groups.
  * Expanded loop iteration references across prompts, approvals, scripts, and composed inputs.

* **Bug Fixes**
  * Corrected dependency and output reference wiring for included nodes across loop iterations.

* **Documentation**
  * Updated loop group guidance and clarified that nested runtime workflow sub-runs remain unsupported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->