### PR TITLE
fix(workflows): retain loop artifacts per iteration

### DIFF
--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -887,7 +887,7 @@ When a node sets `output_type`, the executor writes a typed sidecar after the no
 - `$ARTIFACTS_DIR/nodes/<id>.md` — the node's output text
 - `$ARTIFACTS_DIR/nodes/<id>.meta.json` — metadata (`outputType`, `runId`, `producedAt`, `size`, and `sessionId` when available)
 
-For a node inside a `loop_group`, `<id>` is the namespaced producer identity and the filenames add `.iteration-<n>` (for example, `refine_draft.iteration-2.md`). Its metadata records `nodeId: "refine.draft"` and `iteration: 2`, preserving every iteration as a distinct governed output, including across an interactive resume. Top-level node filenames and metadata are unchanged.
+For a node inside a `loop_group`, `<id>` is the namespaced producer identity and the filenames add the full iteration coordinate as `.iteration-<outer>-...-<inner>`. For example, `refine_draft.iteration-2.md` records `nodeId: "refine.draft"` and `iterations: [2]`; a nested artifact such as `outer_inner_leaf.iteration-2-1.md` records `iterations: [2, 1]`. This preserves every execution as a distinct governed output, including across nested groups and interactive resume. Top-level node filenames and metadata are unchanged.
 
 This works on **every** node type (`bash`/`script` produce typed outputs too, just without a `sessionId`). The write is **best-effort** — if it fails, the node still succeeds and a warning is logged; the typed sidecar may simply be absent. `output_type` is an open set of labels (`plan`, `findings`, `code`, `summary`, …) — pick a convention and keep casing consistent, since lookup is case-sensitive.
 

--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -220,7 +220,7 @@ nodes:
 | `idle_timeout` | number | — | Kill node if idle for this many milliseconds |
 | `retry` | object | — | Per-node retry configuration. See [Retry Configuration](#retry-configuration) |
 | `always_run` | boolean | `false` | Opt out of resume caching: re-run this node on resume even if a prior run completed it. See [Opting Out of Resume Caching](#opting-out-of-resume-caching) |
-| `output_type` | string | — | Semantic label for this node's output (e.g. `'plan'`, `'findings'`, `'code'`). When set, the executor writes `$ARTIFACTS_DIR/nodes/<id>.md` + `<id>.meta.json` after the node completes (best-effort) so later nodes and runs can locate output by type instead of guessing filenames. See [The Artifact Chain](#the-artifact-chain) |
+| `output_type` | string | — | Semantic label for this node's output (e.g. `'plan'`, `'findings'`, `'code'`). When set, the executor writes `$ARTIFACTS_DIR/nodes/<id>.md` + `<id>.meta.json` after the node completes (best-effort) so later nodes and runs can locate output by type instead of guessing filenames. A `loop_group` body node retains a suffixed sidecar for each iteration. See [The Artifact Chain](#the-artifact-chain) |
 
 **AI node options** — apply to `command` and `prompt` nodes:
 
@@ -886,6 +886,8 @@ When a node sets `output_type`, the executor writes a typed sidecar after the no
 
 - `$ARTIFACTS_DIR/nodes/<id>.md` — the node's output text
 - `$ARTIFACTS_DIR/nodes/<id>.meta.json` — metadata (`outputType`, `runId`, `producedAt`, `size`, and `sessionId` when available)
+
+For a node inside a `loop_group`, `<id>` is the namespaced producer identity and the filenames add `.iteration-<n>` (for example, `refine_draft.iteration-2.md`). Its metadata records `nodeId: "refine.draft"` and `iteration: 2`, preserving every iteration as a distinct governed output, including across an interactive resume. Top-level node filenames and metadata are unchanged.
 
 This works on **every** node type (`bash`/`script` produce typed outputs too, just without a `sessionId`). The write is **best-effort** — if it fails, the node still succeeds and a warning is logged; the typed sidecar may simply be absent. `output_type` is an open set of labels (`plan`, `findings`, `code`, `summary`, …) — pick a convention and keep casing consistent, since lookup is case-sensitive.
 

--- a/packages/workflows/src/artifacts-index.test.ts
+++ b/packages/workflows/src/artifacts-index.test.ts
@@ -78,6 +78,46 @@ describe('artifacts-index', () => {
     expect(await readNodeArtifacts(dir)).toEqual([meta]);
   });
 
+  test('legacy scalar loop metadata remains readable and can be rewritten', async () => {
+    const nodesDir = join(dir, 'nodes');
+    await mkdir(nodesDir, { recursive: true });
+    await writeFile(join(nodesDir, 'refine_draft.iteration-2.md'), 'legacy draft', 'utf8');
+    await writeFile(
+      join(nodesDir, 'refine_draft.iteration-2.meta.json'),
+      JSON.stringify({
+        nodeId: 'refine.draft',
+        iteration: 2,
+        outputType: 'draft',
+        path: join('nodes', 'refine_draft.iteration-2.md'),
+        runId: 'r',
+        producedAt: '2026-06-03T00:00:00.000Z',
+        size: 12,
+      }),
+      'utf8'
+    );
+
+    expect(await readNodeArtifacts(dir)).toEqual([
+      expect.objectContaining({ nodeId: 'refine.draft', iterations: [2] }),
+    ]);
+
+    await expect(
+      writeNodeArtifact(
+        dir,
+        {
+          nodeId: 'refine.draft',
+          iterations: [2],
+          outputType: 'draft',
+          runId: 'r',
+          producedAt: '2026-06-03T01:00:00.000Z',
+        },
+        'current draft'
+      )
+    ).resolves.toMatchObject({ iterations: [2] });
+    expect(await readFile(join(nodesDir, 'refine_draft.iteration-2.md'), 'utf8')).toBe(
+      'current draft'
+    );
+  });
+
   test('readNodeArtifacts returns [] for a dir with no artifacts yet', async () => {
     expect(await readNodeArtifacts(dir)).toEqual([]);
   });

--- a/packages/workflows/src/artifacts-index.test.ts
+++ b/packages/workflows/src/artifacts-index.test.ts
@@ -54,12 +54,12 @@ describe('artifacts-index', () => {
     expect('sessionId' in meta).toBe(false);
   });
 
-  test('writeNodeArtifact includes a loop iteration in the artifact identity', async () => {
+  test('writeNodeArtifact includes a loop iteration coordinate in the artifact identity', async () => {
     const meta = await writeNodeArtifact(
       dir,
       {
         nodeId: 'refine.draft',
-        iteration: 2,
+        iterations: [2, 3],
         outputType: 'draft',
         runId: 'r',
         producedAt: '2026-06-03T00:00:00.000Z',
@@ -69,10 +69,10 @@ describe('artifacts-index', () => {
 
     expect(meta).toMatchObject({
       nodeId: 'refine.draft',
-      iteration: 2,
-      path: join('nodes', 'refine_draft.iteration-2.md'),
+      iterations: [2, 3],
+      path: join('nodes', 'refine_draft.iteration-2-3.md'),
     });
-    expect(await readFile(join(dir, 'nodes', 'refine_draft.iteration-2.md'), 'utf8')).toBe(
+    expect(await readFile(join(dir, 'nodes', 'refine_draft.iteration-2-3.md'), 'utf8')).toBe(
       'iteration two'
     );
     expect(await readNodeArtifacts(dir)).toEqual([meta]);

--- a/packages/workflows/src/artifacts-index.test.ts
+++ b/packages/workflows/src/artifacts-index.test.ts
@@ -54,6 +54,30 @@ describe('artifacts-index', () => {
     expect('sessionId' in meta).toBe(false);
   });
 
+  test('writeNodeArtifact includes a loop iteration in the artifact identity', async () => {
+    const meta = await writeNodeArtifact(
+      dir,
+      {
+        nodeId: 'refine.draft',
+        iteration: 2,
+        outputType: 'draft',
+        runId: 'r',
+        producedAt: '2026-06-03T00:00:00.000Z',
+      },
+      'iteration two'
+    );
+
+    expect(meta).toMatchObject({
+      nodeId: 'refine.draft',
+      iteration: 2,
+      path: join('nodes', 'refine_draft.iteration-2.md'),
+    });
+    expect(await readFile(join(dir, 'nodes', 'refine_draft.iteration-2.md'), 'utf8')).toBe(
+      'iteration two'
+    );
+    expect(await readNodeArtifacts(dir)).toEqual([meta]);
+  });
+
   test('readNodeArtifacts returns [] for a dir with no artifacts yet', async () => {
     expect(await readNodeArtifacts(dir)).toEqual([]);
   });

--- a/packages/workflows/src/artifacts-index.ts
+++ b/packages/workflows/src/artifacts-index.ts
@@ -3,6 +3,9 @@ import { join } from 'node:path';
 import { createLogger } from '@archon/paths';
 import { nodeArtifactSchema, type NodeArtifact } from './schemas/node-artifact';
 
+const artifactOwnerSchema = nodeArtifactSchema.pick({ nodeId: true, iterations: true });
+type ArtifactOwner = Pick<NodeArtifact, 'nodeId' | 'iterations'>;
+
 /** Lazy logger (deferred so test mocks can intercept createLogger). */
 let cachedLog: ReturnType<typeof createLogger> | undefined;
 function getLog(): ReturnType<typeof createLogger> {
@@ -28,36 +31,26 @@ function safeSegment(id: string): string {
  * `writeNodeArtifact` — a missing or corrupt prior file is treated as "no known
  * owner" so the write proceeds (and overwrites the unusable file).
  */
-async function readArtifactOwner(
-  metaPath: string
-): Promise<Pick<NodeArtifact, 'nodeId' | 'iteration'> | undefined> {
+async function readArtifactOwner(metaPath: string): Promise<ArtifactOwner | undefined> {
   try {
-    const parsed = JSON.parse(await readFile(metaPath, 'utf8')) as {
-      nodeId?: unknown;
-      iteration?: unknown;
-    };
-    if (typeof parsed.nodeId !== 'string') return undefined;
-    if (
-      parsed.iteration !== undefined &&
-      (!Number.isInteger(parsed.iteration) || (parsed.iteration as number) < 1)
-    ) {
-      return undefined;
-    }
-    return {
-      nodeId: parsed.nodeId,
-      ...(parsed.iteration !== undefined ? { iteration: parsed.iteration as number } : {}),
-    };
+    const parsed = artifactOwnerSchema.safeParse(JSON.parse(await readFile(metaPath, 'utf8')));
+    return parsed.success ? parsed.data : undefined;
   } catch {
     return undefined;
   }
 }
 
+function sameIterations(left: number[] | undefined, right: number[] | undefined): boolean {
+  if (left === undefined || right === undefined) return left === right;
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
 /**
  * Write a node's typed output artifact: the output text to `nodes/<id>.md`
- * and its metadata to `nodes/<id>.meta.json`. A loop_group body artifact adds
- * `.iteration-<n>` to both filenames. Per-producer files (no shared index): the
- * index is derived on read by globbing, so separate nodes and loop iterations
- * never overwrite one another's metadata.
+ * and its metadata to `nodes/<id>.meta.json`. A loop_group body artifact adds its
+ * full coordinate as `.iteration-<outer>-...-<inner>` to both filenames.
+ * Per-producer files (no shared index): the index is derived on read by globbing,
+ * so separate nodes and loop executions never overwrite one another's metadata.
  * Writes are issued sequentially after each layer settles — there is no in-run
  * write contention; the per-node layout is what isolates one node from the next.
  *
@@ -74,7 +67,9 @@ export async function writeNodeArtifact(
   await mkdir(nodesDir, { recursive: true });
   const safeId = safeSegment(params.nodeId);
   const artifactId =
-    params.iteration === undefined ? safeId : `${safeId}.iteration-${String(params.iteration)}`;
+    params.iterations === undefined
+      ? safeId
+      : `${safeId}.iteration-${params.iterations.map(String).join('-')}`;
   const metaPath = join(nodesDir, `${artifactId}.meta.json`);
 
   // Collision guard: producer identities are unique per workflow iteration, so
@@ -85,7 +80,8 @@ export async function writeNodeArtifact(
   const priorOwner = await readArtifactOwner(metaPath);
   if (
     priorOwner !== undefined &&
-    (priorOwner.nodeId !== params.nodeId || priorOwner.iteration !== params.iteration)
+    (priorOwner.nodeId !== params.nodeId ||
+      !sameIterations(priorOwner.iterations, params.iterations))
   ) {
     throw new Error(
       `node artifact id collision: '${params.nodeId}' and '${priorOwner.nodeId}' both map to filename segment '${artifactId}'`
@@ -96,7 +92,7 @@ export async function writeNodeArtifact(
   await writeFile(join(artifactsDir, relPath), outputText, 'utf8');
   const meta: NodeArtifact = {
     nodeId: params.nodeId,
-    ...(params.iteration !== undefined ? { iteration: params.iteration } : {}),
+    ...(params.iterations !== undefined ? { iterations: params.iterations } : {}),
     outputType: params.outputType,
     path: relPath,
     runId: params.runId,

--- a/packages/workflows/src/artifacts-index.ts
+++ b/packages/workflows/src/artifacts-index.ts
@@ -23,15 +23,30 @@ function safeSegment(id: string): string {
 }
 
 /**
- * Read the `nodeId` recorded in an existing `.meta.json`, or `undefined` if the
- * file is missing or unreadable. Used only by the collision guard in
+ * Read the producer identity recorded in an existing `.meta.json`, or `undefined`
+ * if the file is missing or unreadable. Used only by the collision guard in
  * `writeNodeArtifact` — a missing or corrupt prior file is treated as "no known
  * owner" so the write proceeds (and overwrites the unusable file).
  */
-async function readArtifactNodeId(metaPath: string): Promise<string | undefined> {
+async function readArtifactOwner(
+  metaPath: string
+): Promise<Pick<NodeArtifact, 'nodeId' | 'iteration'> | undefined> {
   try {
-    const parsed = JSON.parse(await readFile(metaPath, 'utf8')) as { nodeId?: unknown };
-    return typeof parsed.nodeId === 'string' ? parsed.nodeId : undefined;
+    const parsed = JSON.parse(await readFile(metaPath, 'utf8')) as {
+      nodeId?: unknown;
+      iteration?: unknown;
+    };
+    if (typeof parsed.nodeId !== 'string') return undefined;
+    if (
+      parsed.iteration !== undefined &&
+      (!Number.isInteger(parsed.iteration) || (parsed.iteration as number) < 1)
+    ) {
+      return undefined;
+    }
+    return {
+      nodeId: parsed.nodeId,
+      ...(parsed.iteration !== undefined ? { iteration: parsed.iteration as number } : {}),
+    };
   } catch {
     return undefined;
   }
@@ -39,9 +54,10 @@ async function readArtifactNodeId(metaPath: string): Promise<string | undefined>
 
 /**
  * Write a node's typed output artifact: the output text to `nodes/<id>.md`
- * and its metadata to `nodes/<id>.meta.json`. Per-node files (no shared index):
- * the index is derived on read by globbing, so a node's output is addressable by
- * id and separate nodes / separate runs never overwrite one another's metadata.
+ * and its metadata to `nodes/<id>.meta.json`. A loop_group body artifact adds
+ * `.iteration-<n>` to both filenames. Per-producer files (no shared index): the
+ * index is derived on read by globbing, so separate nodes and loop iterations
+ * never overwrite one another's metadata.
  * Writes are issued sequentially after each layer settles — there is no in-run
  * write contention; the per-node layout is what isolates one node from the next.
  *
@@ -57,24 +73,30 @@ export async function writeNodeArtifact(
   const nodesDir = join(artifactsDir, NODES_SUBDIR);
   await mkdir(nodesDir, { recursive: true });
   const safeId = safeSegment(params.nodeId);
-  const metaPath = join(nodesDir, `${safeId}.meta.json`);
+  const artifactId =
+    params.iteration === undefined ? safeId : `${safeId}.iteration-${String(params.iteration)}`;
+  const metaPath = join(nodesDir, `${artifactId}.meta.json`);
 
-  // Collision guard: node ids are unique per workflow, so an existing metadata
-  // file under this safe segment naming a *different* node means safeSegment()
-  // collapsed two distinct ids (e.g. `a.b` and `a_b`) onto one filename. Fail
+  // Collision guard: producer identities are unique per workflow iteration, so
+  // existing metadata naming a different producer means safeSegment() collapsed
+  // two distinct ids (e.g. `a.b` and `a_b`) onto one filename. Fail
   // loudly — the best-effort caller logs it — instead of silently overwriting the
   // first node's artifact. First writer wins; the second is logged, not lost-silent.
-  const priorNodeId = await readArtifactNodeId(metaPath);
-  if (priorNodeId !== undefined && priorNodeId !== params.nodeId) {
+  const priorOwner = await readArtifactOwner(metaPath);
+  if (
+    priorOwner !== undefined &&
+    (priorOwner.nodeId !== params.nodeId || priorOwner.iteration !== params.iteration)
+  ) {
     throw new Error(
-      `node artifact id collision: '${params.nodeId}' and '${priorNodeId}' both map to filename segment '${safeId}'`
+      `node artifact id collision: '${params.nodeId}' and '${priorOwner.nodeId}' both map to filename segment '${artifactId}'`
     );
   }
 
-  const relPath = join(NODES_SUBDIR, `${safeId}.md`);
+  const relPath = join(NODES_SUBDIR, `${artifactId}.md`);
   await writeFile(join(artifactsDir, relPath), outputText, 'utf8');
   const meta: NodeArtifact = {
     nodeId: params.nodeId,
+    ...(params.iteration !== undefined ? { iteration: params.iteration } : {}),
     outputType: params.outputType,
     path: relPath,
     runId: params.runId,

--- a/packages/workflows/src/artifacts-index.ts
+++ b/packages/workflows/src/artifacts-index.ts
@@ -6,6 +6,21 @@ import { nodeArtifactSchema, type NodeArtifact } from './schemas/node-artifact';
 const artifactOwnerSchema = nodeArtifactSchema.pick({ nodeId: true, iterations: true });
 type ArtifactOwner = Pick<NodeArtifact, 'nodeId' | 'iterations'>;
 
+/** Upgrade the persisted scalar coordinate written before nested loop support. */
+function normalizePersistedArtifact(value: unknown): unknown {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return value;
+  const artifact = value as Record<string, unknown>;
+  if (
+    artifact.iterations === undefined &&
+    typeof artifact.iteration === 'number' &&
+    Number.isInteger(artifact.iteration) &&
+    artifact.iteration > 0
+  ) {
+    return { ...artifact, iterations: [artifact.iteration] };
+  }
+  return value;
+}
+
 /** Lazy logger (deferred so test mocks can intercept createLogger). */
 let cachedLog: ReturnType<typeof createLogger> | undefined;
 function getLog(): ReturnType<typeof createLogger> {
@@ -33,7 +48,9 @@ function safeSegment(id: string): string {
  */
 async function readArtifactOwner(metaPath: string): Promise<ArtifactOwner | undefined> {
   try {
-    const parsed = artifactOwnerSchema.safeParse(JSON.parse(await readFile(metaPath, 'utf8')));
+    const parsed = artifactOwnerSchema.safeParse(
+      normalizePersistedArtifact(JSON.parse(await readFile(metaPath, 'utf8')))
+    );
     return parsed.success ? parsed.data : undefined;
   } catch {
     return undefined;
@@ -128,7 +145,9 @@ export async function readNodeArtifacts(artifactsDir: string): Promise<NodeArtif
     if (!file.endsWith('.meta.json')) continue;
     const full = join(nodesDir, file);
     try {
-      const parsed = nodeArtifactSchema.safeParse(JSON.parse(await readFile(full, 'utf8')));
+      const parsed = nodeArtifactSchema.safeParse(
+        normalizePersistedArtifact(JSON.parse(await readFile(full, 'utf8')))
+      );
       if (parsed.success) {
         out.push(parsed.data);
       } else {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -15227,6 +15227,152 @@ describe('executeDagWorkflow -- typed artifacts (output_type)', () => {
     }
     expect(wrote).toBe(false);
   });
+
+  it('loop_group body output_type preserves a namespaced artifact for every iteration', async () => {
+    let calls = 0;
+    mockSendQueryDag.mockImplementation(async function* () {
+      calls++;
+      const content = calls === 3 ? 'iteration 3\nDONE' : `iteration ${String(calls)}`;
+      yield { type: 'assistant', content };
+      yield { type: 'result', sessionId: `loop-session-${String(calls)}` };
+    });
+
+    const artifactsDir = join(testDir, 'artifacts');
+    await executeDagWorkflow(
+      createMockDeps(),
+      createMockPlatform(),
+      'conv-dag',
+      testDir,
+      {
+        name: 'typed-loop-body',
+        nodes: [
+          {
+            id: 'refine',
+            loop_group: {
+              until: 'DONE',
+              max_iterations: 3,
+              fresh_context: false,
+              nodes: [
+                { id: 'draft', prompt: 'produce a draft', output_type: 'draft', depends_on: [] },
+              ],
+            },
+          },
+        ],
+      },
+      makeWorkflowRun(),
+      'claude',
+      undefined,
+      artifactsDir,
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    expect(calls).toBe(3);
+    for (let iteration = 1; iteration <= 3; iteration++) {
+      const artifactId = `refine_draft.iteration-${String(iteration)}`;
+      expect(await readFile(join(artifactsDir, 'nodes', `${artifactId}.md`), 'utf8')).toBe(
+        iteration === 3 ? 'iteration 3\nDONE' : `iteration ${String(iteration)}`
+      );
+      const meta = JSON.parse(
+        await readFile(join(artifactsDir, 'nodes', `${artifactId}.meta.json`), 'utf8')
+      ) as Record<string, unknown>;
+      expect(meta).toMatchObject({
+        nodeId: 'refine.draft',
+        iteration,
+        outputType: 'draft',
+        path: join('nodes', `${artifactId}.md`),
+      });
+    }
+  });
+
+  it('loop_group resume leaves completed iteration artifacts unchanged', async () => {
+    const artifactsDir = join(testDir, 'artifacts');
+    const workflow = {
+      name: 'typed-loop-resume',
+      nodes: [
+        {
+          id: 'refine',
+          loop_group: {
+            until: 'APPROVED',
+            max_iterations: 3,
+            fresh_context: false,
+            interactive: true,
+            nodes: [
+              { id: 'draft', prompt: 'produce a draft', output_type: 'draft', depends_on: [] },
+            ],
+          },
+        },
+      ] as DagNode[],
+    };
+
+    mockSendQueryDag.mockImplementationOnce(async function* () {
+      yield { type: 'assistant', content: 'iteration 1 draft' };
+      yield { type: 'result', sessionId: 'loop-session-1' };
+    });
+    const firstDeps = createMockDeps();
+    await executeDagWorkflow(
+      firstDeps,
+      createMockPlatform(),
+      'conv-dag',
+      testDir,
+      workflow,
+      makeWorkflowRun(),
+      'claude',
+      undefined,
+      artifactsDir,
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+    const firstArtifactPath = join(artifactsDir, 'nodes', 'refine_draft.iteration-1.md');
+    const firstMetaPath = join(artifactsDir, 'nodes', 'refine_draft.iteration-1.meta.json');
+    const firstArtifact = await readFile(firstArtifactPath, 'utf8');
+    const firstMeta = await readFile(firstMetaPath, 'utf8');
+
+    mockSendQueryDag.mockImplementationOnce(async function* () {
+      yield { type: 'assistant', content: 'iteration 2 approved\nAPPROVED' };
+      yield { type: 'result', sessionId: 'loop-session-2' };
+    });
+    await executeDagWorkflow(
+      createMockDeps(),
+      createMockPlatform(),
+      'conv-dag',
+      testDir,
+      workflow,
+      makeWorkflowRun('dag-test-run-id', {
+        metadata: {
+          approval: {
+            type: 'interactive_loop',
+            nodeId: 'refine',
+            iteration: 1,
+            sessionId: 'loop-session-1',
+            sessionProvider: 'claude',
+            message: 'Review.',
+          },
+          loop_user_input: 'approved',
+        },
+      }),
+      'claude',
+      undefined,
+      artifactsDir,
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    expect(await readFile(firstArtifactPath, 'utf8')).toBe(firstArtifact);
+    expect(await readFile(firstMetaPath, 'utf8')).toBe(firstMeta);
+    expect(await readFile(join(artifactsDir, 'nodes', 'refine_draft.iteration-2.md'), 'utf8')).toBe(
+      'iteration 2 approved\nAPPROVED'
+    );
+  });
 });
 
 describe('executeDagWorkflow -- persist_session', () => {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -15281,7 +15281,89 @@ describe('executeDagWorkflow -- typed artifacts (output_type)', () => {
       ) as Record<string, unknown>;
       expect(meta).toMatchObject({
         nodeId: 'refine.draft',
-        iteration,
+        iterations: [iteration],
+        outputType: 'draft',
+        path: join('nodes', `${artifactId}.md`),
+      });
+    }
+  });
+
+  it('nested loop_group body output_type preserves the full iteration coordinate', async () => {
+    let calls = 0;
+    mockSendQueryDag.mockImplementation(async function* () {
+      calls++;
+      const content =
+        calls === 2
+          ? 'outer iteration 2, inner iteration 1\nINNER_DONE\nOUTER_DONE'
+          : 'outer iteration 1, inner iteration 1\nINNER_DONE';
+      yield { type: 'assistant', content };
+      yield { type: 'result', sessionId: `nested-loop-session-${String(calls)}` };
+    });
+
+    const artifactsDir = join(testDir, 'artifacts');
+    await executeDagWorkflow(
+      createMockDeps(),
+      createMockPlatform(),
+      'conv-dag',
+      testDir,
+      {
+        name: 'typed-nested-loop-body',
+        nodes: [
+          {
+            id: 'outer',
+            loop_group: {
+              until: 'OUTER_DONE',
+              max_iterations: 2,
+              fresh_context: true,
+              nodes: [
+                {
+                  id: 'inner',
+                  loop_group: {
+                    until: 'INNER_DONE',
+                    max_iterations: 1,
+                    fresh_context: true,
+                    nodes: [
+                      {
+                        id: 'leaf',
+                        prompt: 'produce nested output',
+                        output_type: 'draft',
+                        depends_on: [],
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      makeWorkflowRun(),
+      'claude',
+      undefined,
+      artifactsDir,
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    expect(calls).toBe(2);
+    for (let outerIteration = 1; outerIteration <= 2; outerIteration++) {
+      const artifactId = `outer_inner_leaf.iteration-${String(outerIteration)}-1`;
+      const expectedOutput =
+        outerIteration === 2
+          ? 'outer iteration 2, inner iteration 1\nINNER_DONE\nOUTER_DONE'
+          : 'outer iteration 1, inner iteration 1\nINNER_DONE';
+      expect(await readFile(join(artifactsDir, 'nodes', `${artifactId}.md`), 'utf8')).toBe(
+        expectedOutput
+      );
+      const meta = JSON.parse(
+        await readFile(join(artifactsDir, 'nodes', `${artifactId}.meta.json`), 'utf8')
+      ) as Record<string, unknown>;
+      expect(meta).toMatchObject({
+        nodeId: 'outer.inner.leaf',
+        iterations: [outerIteration, 1],
         outputType: 'draft',
         path: join('nodes', `${artifactId}.md`),
       });

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -15370,6 +15370,207 @@ describe('executeDagWorkflow -- typed artifacts (output_type)', () => {
     }
   });
 
+  it('three nested loop_groups preserve every artifact coordinate', async () => {
+    mockSendQueryDag.mockImplementationOnce(async function* () {
+      yield { type: 'assistant', content: 'LEVEL_3_DONE\nLEVEL_2_DONE\nLEVEL_1_DONE' };
+      yield { type: 'result', sessionId: 'three-level-session' };
+    });
+
+    const artifactsDir = join(testDir, 'artifacts');
+    await executeDagWorkflow(
+      createMockDeps(),
+      createMockPlatform(),
+      'conv-dag',
+      testDir,
+      {
+        name: 'typed-three-level-loop-body',
+        nodes: [
+          {
+            id: 'level1',
+            loop_group: {
+              until: 'LEVEL_1_DONE',
+              max_iterations: 1,
+              fresh_context: true,
+              nodes: [
+                {
+                  id: 'level2',
+                  loop_group: {
+                    until: 'LEVEL_2_DONE',
+                    max_iterations: 1,
+                    fresh_context: true,
+                    nodes: [
+                      {
+                        id: 'level3',
+                        loop_group: {
+                          until: 'LEVEL_3_DONE',
+                          max_iterations: 1,
+                          fresh_context: true,
+                          nodes: [
+                            {
+                              id: 'leaf',
+                              prompt: 'produce deeply nested output',
+                              output_type: 'draft',
+                              depends_on: [],
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      makeWorkflowRun(),
+      'claude',
+      undefined,
+      artifactsDir,
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    const artifactId = 'level1_level2_level3_leaf.iteration-1-1-1';
+    expect(await readFile(join(artifactsDir, 'nodes', `${artifactId}.md`), 'utf8')).toBe(
+      'LEVEL_3_DONE\nLEVEL_2_DONE\nLEVEL_1_DONE'
+    );
+    const meta = JSON.parse(
+      await readFile(join(artifactsDir, 'nodes', `${artifactId}.meta.json`), 'utf8')
+    ) as Record<string, unknown>;
+    expect(meta).toMatchObject({
+      nodeId: 'level1.level2.level3.leaf',
+      iterations: [1, 1, 1],
+      outputType: 'draft',
+      path: join('nodes', `${artifactId}.md`),
+    });
+  });
+
+  it('nested interactive loop_group resume preserves the enclosing iteration coordinate', async () => {
+    const artifactsDir = join(testDir, 'artifacts');
+    const workflow = {
+      name: 'typed-nested-interactive-resume',
+      nodes: [
+        {
+          id: 'outer',
+          loop_group: {
+            until: 'OUTER_DONE',
+            max_iterations: 2,
+            fresh_context: true,
+            nodes: [
+              {
+                id: 'inner',
+                loop_group: {
+                  until: 'INNER_DONE',
+                  max_iterations: 2,
+                  fresh_context: true,
+                  interactive: true,
+                  signal_completes: true,
+                  gate_message: 'Review inner output.',
+                  nodes: [
+                    {
+                      id: 'leaf',
+                      prompt: 'produce nested output',
+                      output_type: 'draft',
+                      depends_on: [],
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ] as DagNode[],
+    };
+
+    let status: WorkflowRun['status'] = 'running';
+    const firstStore = createMockStore();
+    firstStore.getWorkflowRunStatus.mockImplementation(async () => status);
+    firstStore.pauseWorkflowRun.mockImplementation(async () => {
+      status = 'paused';
+    });
+    mockSendQueryDag
+      .mockImplementationOnce(async function* () {
+        yield { type: 'assistant', content: 'outer iteration 1\nINNER_DONE' };
+        yield { type: 'result', sessionId: 'nested-resume-session-1' };
+      })
+      .mockImplementationOnce(async function* () {
+        yield { type: 'assistant', content: 'outer iteration 2, inner iteration 1' };
+        yield { type: 'result', sessionId: 'nested-resume-session-2' };
+      });
+
+    await executeDagWorkflow(
+      createMockDeps(firstStore),
+      createMockPlatform(),
+      'conv-dag',
+      testDir,
+      workflow,
+      makeWorkflowRun('nested-interactive-run'),
+      'claude',
+      undefined,
+      artifactsDir,
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    expect(mockSendQueryDag.mock.calls.length).toBe(2);
+    const pauseContext = firstStore.pauseWorkflowRun.mock.calls[0][1];
+    expect(pauseContext).toMatchObject({
+      type: 'interactive_loop',
+      nodeId: 'inner',
+      loopNodePath: 'outer.inner',
+      iteration: 1,
+      iterations: [2, 1],
+    });
+
+    mockSendQueryDag.mockImplementationOnce(async function* () {
+      yield {
+        type: 'assistant',
+        content: 'outer iteration 2, inner iteration 2\nINNER_DONE\nOUTER_DONE',
+      };
+      yield { type: 'result', sessionId: 'nested-resume-session-3' };
+    });
+    await executeDagWorkflow(
+      createMockDeps(),
+      createMockPlatform(),
+      'conv-dag',
+      testDir,
+      workflow,
+      makeWorkflowRun('nested-interactive-run', {
+        metadata: {
+          approval: pauseContext,
+          loop_user_input: 'approved',
+        },
+      }),
+      'claude',
+      undefined,
+      artifactsDir,
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    expect(mockSendQueryDag.mock.calls.length).toBe(3);
+    expect(
+      await readFile(join(artifactsDir, 'nodes', 'outer_inner_leaf.iteration-2-2.md'), 'utf8')
+    ).toContain('OUTER_DONE');
+    const resumedMeta = JSON.parse(
+      await readFile(
+        join(artifactsDir, 'nodes', 'outer_inner_leaf.iteration-2-2.meta.json'),
+        'utf8'
+      )
+    ) as Record<string, unknown>;
+    expect(resumedMeta.iterations).toEqual([2, 2]);
+  });
+
   it('loop_group resume leaves completed iteration artifacts unchanged', async () => {
     const artifactsDir = join(testDir, 'artifacts');
     const workflow = {

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -3570,6 +3570,8 @@ async function executeLoopGroupNode(
    *  could be omitted, silently handing the body an isolated Set and quietly undoing the
    *  de-duplication, with no compiler signal. */
   warnedProviderConflicts: Set<string>,
+  /** Iteration coordinate of enclosing loop_groups, outermost first. */
+  enclosingIterations: readonly number[],
   issueContext?: string,
   stepNamePrefix = '',
   execContext: ExecutionContext = { kind: 'host' },
@@ -3774,6 +3776,7 @@ async function executeLoopGroupNode(
       totalLoopIterations: 0,
       stepNamePrefix: bodyStepNamePrefix,
       iteration: i,
+      iterations: [...enclosingIterations, i],
       // Deliver this iteration's approval-gate free-text to body script: nodes via env
       // (never spliced into source — #2115); matches applyLoopPrevToBodyNode's skip.
       bodyLoopUserInput: userInputForIter,
@@ -7186,6 +7189,8 @@ interface RunLayersContext {
    * so multi-iteration runs are disaggregatable in the persisted event log (#2090).
    */
   iteration?: number;
+  /** Full loop_group coordinate, outermost first; omitted for the top-level DAG. */
+  iterations?: readonly number[];
   /**
    * Per-iteration `$LOOP_USER_INPUT` free-text for loop_group body `script:` nodes,
    * delivered into the subprocess as an env var (never spliced into TS/Python source —
@@ -7234,6 +7239,7 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
     priorCompletedNodes,
     stepNamePrefix,
     iteration,
+    iterations,
   } = ctx;
   // nodeOutputs + accumulators + lastSequentialSession are mutated in place on `ctx`.
 
@@ -7615,6 +7621,7 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
               ctx.nodeOutputs,
               config,
               ctx.warnedProviderConflicts,
+              ctx.iterations ?? [],
               issueContext,
               stepNamePrefix,
               execContext,
@@ -8073,10 +8080,10 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
         if (output.state === 'completed' && completedNode?.output_type) {
           const meta = {
             // A loop_group body node executes repeatedly, so its artifact identity
-            // includes the same composed group prefix as lifecycle events plus the
-            // current iteration. Top-level nodes keep their existing raw identity.
-            nodeId: iteration === undefined ? nodeId : stepNamePrefix + nodeId,
-            ...(iteration !== undefined ? { iteration } : {}),
+            // includes the composed group prefix and complete nested coordinate.
+            // Top-level nodes keep their existing raw identity.
+            nodeId: iterations === undefined ? nodeId : stepNamePrefix + nodeId,
+            ...(iterations !== undefined ? { iterations: [...iterations] } : {}),
             outputType: completedNode.output_type,
             runId: workflowRun.id,
             producedAt: new Date().toISOString(),

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -8072,7 +8072,11 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
         const completedNode = nodeById.get(nodeId);
         if (output.state === 'completed' && completedNode?.output_type) {
           const meta = {
-            nodeId,
+            // A loop_group body node executes repeatedly, so its artifact identity
+            // includes the same composed group prefix as lifecycle events plus the
+            // current iteration. Top-level nodes keep their existing raw identity.
+            nodeId: iteration === undefined ? nodeId : stepNamePrefix + nodeId,
+            ...(iteration !== undefined ? { iteration } : {}),
             outputType: completedNode.output_type,
             runId: workflowRun.id,
             producedAt: new Date().toISOString(),

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -3603,8 +3603,30 @@ async function executeLoopGroupNode(
   // Detect interactive loop resume (mirrors executeLoopNode).
   const rawApproval = workflowRun.metadata?.approval;
   const loopGateMeta = isApprovalContext(rawApproval) ? rawApproval : undefined;
-  const isLoopResume = loopGateMeta?.type === 'interactive_loop' && loopGateMeta.nodeId === node.id;
-  const startIteration = isLoopResume ? (loopGateMeta.iteration ?? 0) + 1 : 1;
+  const resumeIterations =
+    Array.isArray(loopGateMeta?.iterations) &&
+    loopGateMeta.iterations.every(iteration => Number.isInteger(iteration) && iteration > 0)
+      ? loopGateMeta.iterations
+      : undefined;
+  const isInteractiveResume = loopGateMeta?.type === 'interactive_loop';
+  // New pauses carry the complete path. The nodeId fallback preserves top-level and
+  // legacy resume behavior, whose metadata predates nested coordinates.
+  const isLoopResume =
+    isInteractiveResume &&
+    (loopGateMeta.loopNodePath !== undefined
+      ? loopGateMeta.loopNodePath === stepName
+      : loopGateMeta.nodeId === node.id);
+  const isEnclosingLoopResume =
+    isInteractiveResume &&
+    loopGateMeta.loopNodePath !== undefined &&
+    loopGateMeta.loopNodePath.startsWith(`${stepName}.`) &&
+    resumeIterations !== undefined;
+  const resumeIteration = resumeIterations?.[enclosingIterations.length];
+  const startIteration = isLoopResume
+    ? (resumeIteration ?? loopGateMeta.iteration ?? 0) + 1
+    : isEnclosingLoopResume
+      ? (resumeIteration ?? 1)
+      : 1;
   const loopGateRunMeta = (workflowRun.metadata ?? {}) as LoopGateRunMetadata;
   const loopUserInput = isLoopResume ? (loopGateRunMeta.loop_user_input ?? '') : '';
 
@@ -3803,6 +3825,18 @@ async function executeLoopGroupNode(
       loopTotalTokens = {
         input: (loopTotalTokens?.input ?? 0) + iterCtx.totalTokensIn,
         output: (loopTotalTokens?.output ?? 0) + iterCtx.totalTokensOut,
+      };
+    }
+    // A gate inside this group's body owns the pause. Stop every enclosing group at
+    // the same iteration; resume metadata will re-enter this coordinate and then the
+    // exact nested group will advance past its gated iteration.
+    if (postBodyStatus === 'paused') {
+      return {
+        state: 'completed',
+        output: lastIterationOutput,
+        costUsd: loopTotalCostUsd,
+        ...(loopTotalTokens !== undefined ? { tokens: loopTotalTokens } : {}),
+        loopIterations: i,
       };
     }
 
@@ -4088,6 +4122,8 @@ async function executeLoopGroupNode(
         message: honestMessage,
         type: 'interactive_loop',
         iteration: i,
+        loopNodePath: stepName,
+        iterations: [...enclosingIterations, i],
         // Persist the body's session cursor so a resumed fresh_context: false loop
         // continues the pre-pause conversation (restored into the cursor on resume).
         // The provider tag rides along so the restore never threads the session into

--- a/packages/workflows/src/schemas/dag-node.ts
+++ b/packages/workflows/src/schemas/dag-node.ts
@@ -262,9 +262,10 @@ export const dagNodeBaseSchema = z.object({
   // Declares the semantic type of this node's output (e.g. 'plan', 'findings',
   // 'code', 'summary' — an open set). When set, the executor writes a typed
   // sidecar artifact (`nodes/<id>.md` + `<id>.meta.json`) after the node
-  // completes, so other nodes and later runs can locate output by type instead
-  // of guessing filenames. Valid on every node type (bash/script produce typed
-  // outputs too) — not an AI-only field.
+  // completes; loop_group body nodes retain one suffixed sidecar per iteration.
+  // Other nodes and later runs can locate output by type instead of guessing
+  // filenames. Valid on every node type (bash/script produce typed outputs too)
+  // — not an AI-only field.
   output_type: z.string().min(1).optional(),
 });
 

--- a/packages/workflows/src/schemas/node-artifact.ts
+++ b/packages/workflows/src/schemas/node-artifact.ts
@@ -4,16 +4,16 @@ import { z } from '@hono/zod-openapi';
  * Metadata for a node's typed output artifact, written when a node declares
  * `output_type`. Persisted as `nodes/<id>.meta.json` alongside the output file
  * `nodes/<id>.md` inside the run's artifacts dir; loop_group body artifacts add
- * an iteration suffix. Other nodes and later runs can locate a prior output by
- * type instead of guessing filenames.
+ * their complete iteration coordinate as a suffix. Other nodes and later runs
+ * can locate a prior output by type instead of guessing filenames.
  *
  * Distinct from `artifactTypeSchema` (the workflow-event artifact kinds:
  * pr/commit/file_created/…) — this describes a node's on-disk output file.
  */
 export const nodeArtifactSchema = z.object({
   nodeId: z.string(),
-  /** 1-based loop_group iteration for a body-node artifact. Omitted for top-level nodes. */
-  iteration: z.number().int().positive().optional(),
+  /** 1-based iteration coordinate from outermost to innermost loop_group. */
+  iterations: z.array(z.number().int().positive()).min(1).optional(),
   outputType: z.string().min(1),
   /** Path to the output file, relative to the artifacts dir (e.g. `nodes/plan.md`). */
   path: z.string(),

--- a/packages/workflows/src/schemas/node-artifact.ts
+++ b/packages/workflows/src/schemas/node-artifact.ts
@@ -3,14 +3,17 @@ import { z } from '@hono/zod-openapi';
 /**
  * Metadata for a node's typed output artifact, written when a node declares
  * `output_type`. Persisted as `nodes/<id>.meta.json` alongside the output file
- * `nodes/<id>.md` inside the run's artifacts dir, so other nodes and later runs
- * can locate a prior output by type instead of guessing filenames.
+ * `nodes/<id>.md` inside the run's artifacts dir; loop_group body artifacts add
+ * an iteration suffix. Other nodes and later runs can locate a prior output by
+ * type instead of guessing filenames.
  *
  * Distinct from `artifactTypeSchema` (the workflow-event artifact kinds:
  * pr/commit/file_created/…) — this describes a node's on-disk output file.
  */
 export const nodeArtifactSchema = z.object({
   nodeId: z.string(),
+  /** 1-based loop_group iteration for a body-node artifact. Omitted for top-level nodes. */
+  iteration: z.number().int().positive().optional(),
   outputType: z.string().min(1),
   /** Path to the output file, relative to the artifacts dir (e.g. `nodes/plan.md`). */
   path: z.string(),

--- a/packages/workflows/src/schemas/workflow-run.ts
+++ b/packages/workflows/src/schemas/workflow-run.ts
@@ -228,6 +228,10 @@ export interface ApprovalContext {
   childRunId?: string;
   /** Current loop iteration when paused (interactive loops only). */
   iteration?: number;
+  /** Complete namespaced loop_group path for nested interactive-loop resume. */
+  loopNodePath?: string;
+  /** Complete loop_group coordinate at the gate, outermost first. */
+  iterations?: number[];
   /**
    * Session ID to restore on resume (interactive loops only). Gate pauses write an
    * EXPLICIT null (never omit the key) when there is no session to restore — same


### PR DESCRIPTION
## Problem and outcome

Loop-group body nodes that declare `output_type` wrote every iteration to the same typed-artifact sidecar, overwriting earlier work and making resumed runs lose iteration history. Each loop iteration now retains an independently addressable output and metadata record.

- **Outcome:** Loop-body typed artifacts use a namespaced producer identity and an iteration-specific filename, while top-level artifact paths remain unchanged.
- **Invariant:** Artifacts from completed loop iterations remain attributable to their group, body node, and 1-based iteration, including after an interactive resume.
- **Scope boundary:** This changes only the typed sidecars written for `output_type`; lifecycle events, loop execution, and top-level artifact contracts are unchanged.
- **Root cause:** The shared artifact writer received only the raw body-node ID, even though the executor already tracked the loop's composed prefix and iteration, so each iteration resolved to identical paths.

## Review guidance

- **Feedback requested:** Correctness of loop-body artifact identity and preservation across resume.
- **Start here:** `packages/workflows/src/dag-executor.ts:8072` — passes the existing composed loop identity and iteration into the artifact metadata at the shared completion funnel.
- **Review order:** `dag-executor.ts`, `artifacts-index.ts`, then the focused executor and writer regressions.
- **Lower-attention areas:** Documentation and schema comments describe the established artifact contract; no generated files changed.
- **Known risk or uncertainty:** None.

## Solution

The executor now identifies loop-body producers with the same composed group/body identity used for lifecycle events and records the 1-based iteration. The artifact writer incorporates that iteration only when present, producing separate `.iteration-<n>.md` and metadata sidecars. Its collision guard now treats the producer identity as the node ID plus optional iteration. This keeps the existing top-level filenames and best-effort write behavior intact.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Later loop iterations overwrite a body node's typed sidecar. | Every iteration retains its own namespaced typed sidecar and metadata. |
| **Failure behavior** | A resumed loop can silently replace an earlier iteration's audit artifact. | Earlier completed artifacts remain intact while later iterations write separate files. |

## Validation

- `bun test src/dag-executor.test.ts -t 'loop_group body output_type|loop_group resume leaves|node with output_type writes'` — passed (4 tests) — proves per-iteration retention and resume preservation.
- `bun test src/artifacts-index.test.ts` — passed (10 tests) — proves iteration-aware writer identity.
- `bun run type-check` in `packages/workflows` — passed.
- `bun --filter @archon/workflows test` — passed.
- `bun run validate` — passed after temporarily isolating and restoring an existing ignored workflow fixture that the packaging check misclassified; no fixture content changed.
- `git diff --check` — passed.
- **Not verified:** Nothing material; focused regression coverage and the full repository validation suite passed.

## Links

- Closes #2480


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Typed artifacts in loop groups now retain distinct files and metadata for each nested iteration.
  * Paused nested workflows can resume at the correct gate and iteration without reprocessing completed iterations.
  * Artifact metadata now records full loop-iteration coordinates.

* **Bug Fixes**
  * Prevented artifacts from different iterations or producers from overwriting one another.
  * Added compatibility for existing artifacts using legacy iteration metadata.

* **Documentation**
  * Clarified artifact naming and per-iteration output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->