### PR TITLE
fix(workflows): preserve loop-group raw output on resume

### DIFF
--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -4792,6 +4792,12 @@ nodes:
 describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
   let testDir: string;
 
+  type PersistedEvent = {
+    event_type: string;
+    step_name?: string;
+    data?: Record<string, unknown>;
+  };
+
   beforeEach(async () => {
     testDir = join(
       tmpdir(),
@@ -4823,6 +4829,78 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       // ignore cleanup errors
     }
   });
+
+  function rawLoopGroupWorkflow(field: 'note' | 'status'): WorkflowDefinition {
+    return {
+      name: `raw-loop-group-${field}`,
+      description: 'Raw loop-group resume parity fixture',
+      nodes: [
+        dagNodeSchema.parse({
+          id: 'group',
+          output_format: {
+            type: 'object',
+            properties: { status: { type: 'string' } },
+            required: ['status'],
+          },
+          loop_group: {
+            until_bash: 'exit 0',
+            max_iterations: 1,
+            fresh_context: false,
+            nodes: [{ id: 'emit', bash: `printf '%s' '{"note":"hi"}'` }],
+          },
+        }),
+        dagNodeSchema.parse({
+          id: 'consumer',
+          prompt: `whole=[$group.output]\nfield=[$group.output.${field}]`,
+          depends_on: ['group'],
+        }),
+      ],
+    };
+  }
+
+  async function runRawLoopGroupWorkflow(
+    field: 'note' | 'status',
+    runId: string,
+    priorCompletedNodes?: Map<string, string>
+  ): Promise<{
+    prompt: string | undefined;
+    result: string | undefined;
+    events: PersistedEvent[];
+  }> {
+    let prompt: string | undefined;
+    mockSendQueryDag.mockClear();
+    mockSendQueryDag.mockImplementation(async function* (resolvedPrompt: string) {
+      prompt = resolvedPrompt;
+      yield { type: 'assistant', content: 'consumer completed' };
+      yield { type: 'result', sessionId: `${runId}-session` };
+    });
+
+    const store = createMockStore();
+    const result = await executeDagWorkflow(
+      createMockDeps(store),
+      createMockPlatform(),
+      'conv-resume',
+      testDir,
+      rawLoopGroupWorkflow(field),
+      makeWorkflowRun(runId),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      priorCompletedNodes
+    );
+
+    const events = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls.map(
+      (call: unknown[]) => call[0] as PersistedEvent
+    );
+    return { prompt, result, events };
+  }
 
   it('skips nodes that appear in priorCompletedNodes', async () => {
     const store = createMockStore();
@@ -5200,6 +5278,63 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       { input: 0, output: 0 }
     );
     expect(eventTokenTotal).toEqual({ input: 100, output: 10 });
+  });
+
+  it('keeps raw loop_group output schemaless on resume for a present undeclared field', async () => {
+    const rawOutput = '{"note":"hi"}';
+    const fresh = await runRawLoopGroupWorkflow('note', 'raw-group-present-fresh');
+    const resumed = await runRawLoopGroupWorkflow(
+      'note',
+      'raw-group-present-resumed',
+      new Map([['group', rawOutput]])
+    );
+
+    expect(fresh.prompt).toBe(`whole=[${rawOutput}]\nfield=[hi]`);
+    expect(resumed.prompt).toBe(fresh.prompt);
+    expect(fresh.result).toBe('consumer completed');
+    expect(resumed.result).toBe(fresh.result);
+
+    const freshGroup = fresh.events.find(
+      event => event.event_type === 'node_completed' && event.step_name === 'group'
+    );
+    const resumedGroup = resumed.events.find(
+      event => event.event_type === 'node_skipped_prior_success' && event.step_name === 'group'
+    );
+    expect(freshGroup?.data?.node_output).toBe(rawOutput);
+    expect(resumedGroup?.data?.node_output).toBe(freshGroup?.data?.node_output);
+  });
+
+  it('keeps an absent loop_group JSON field missing on fresh execution and resume', async () => {
+    const rawOutput = '{"note":"hi"}';
+    const fresh = await runRawLoopGroupWorkflow('status', 'raw-group-absent-fresh');
+    const resumed = await runRawLoopGroupWorkflow(
+      'status',
+      'raw-group-absent-resumed',
+      new Map([['group', rawOutput]])
+    );
+
+    expect(fresh.prompt).toBeUndefined();
+    expect(resumed.prompt).toBeUndefined();
+    expect(fresh.result).toBeUndefined();
+    expect(resumed.result).toBeUndefined();
+
+    const freshFailure = fresh.events.find(
+      event => event.event_type === 'node_failed' && event.step_name === 'consumer'
+    );
+    const resumedFailure = resumed.events.find(
+      event => event.event_type === 'node_failed' && event.step_name === 'consumer'
+    );
+    expect(freshFailure?.data?.error).toContain('JSON output has no such key');
+    expect(resumedFailure?.data?.error).toBe(freshFailure?.data?.error);
+
+    const freshGroup = fresh.events.find(
+      event => event.event_type === 'node_completed' && event.step_name === 'group'
+    );
+    const resumedGroup = resumed.events.find(
+      event => event.event_type === 'node_skipped_prior_success' && event.step_name === 'group'
+    );
+    expect(freshGroup?.data?.node_output).toBe(rawOutput);
+    expect(resumedGroup?.data?.node_output).toBe(freshGroup?.data?.node_output);
   });
 
   // #2091: on resume, prior completed nodes are rehydrated from text only, so the

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -5337,6 +5337,63 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     expect(resumedGroup?.data?.node_output).toBe(freshGroup?.data?.node_output);
   });
 
+  it('keeps a structured loop declared-field contract on resume', async () => {
+    const store = createMockStore();
+    let capturedPrompt = '';
+    mockSendQueryDag.mockClear();
+    mockSendQueryDag.mockImplementation(async function* (prompt: string) {
+      capturedPrompt = prompt;
+      yield { type: 'assistant', content: 'consumer completed' };
+      yield { type: 'result', sessionId: 'structured-loop-resume-session' };
+    });
+
+    await executeDagWorkflow(
+      createMockDeps(store),
+      createMockPlatform(),
+      'conv-resume',
+      testDir,
+      {
+        name: 'structured-loop-resume',
+        nodes: [
+          {
+            id: 'iterate',
+            output_format: {
+              type: 'object',
+              properties: { done: { type: 'boolean' }, note: { type: 'string' } },
+              required: ['done'],
+            },
+            loop: {
+              prompt: 'iterate',
+              until_field: 'done',
+              max_iterations: 1,
+              fresh_context: false,
+            },
+          },
+          {
+            id: 'consumer',
+            prompt: 'note=[$iterate.output.note]',
+            depends_on: ['iterate'],
+          },
+        ],
+      },
+      makeWorkflowRun('structured-loop-resume'),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      new Map([['iterate', '{"done":true}']])
+    );
+
+    expect(mockSendQueryDag).toHaveBeenCalledTimes(1);
+    expect(capturedPrompt).toBe('note=[]');
+  });
+
   // #2091: on resume, prior completed nodes are rehydrated from text only, so the
   // producer's output_format field set must be re-derived from the loaded definition —
   // otherwise the strict `$node.output.field` contract downgrades to the schemaless

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -8835,13 +8835,14 @@ export async function executeDagWorkflow(
       const node = nodesById.get(nodeId);
       // Nodes flagged always_run re-execute on resume — leave them for fresh output.
       if (node?.always_run) continue;
-      // Re-derive the producer's declared field set from the loaded definition so the
-      // strict `$node.output.field` contract (output-ref.ts) is invariant across fresh
-      // vs resumed runs. The resume snapshot rehydrates text only, so without
-      // this a declared-optional-absent field would throw instead of resolving to ''
-      // and an undeclared key would resolve instead of throwing (#2091). Mirrors the
-      // fresh-completion capture above.
-      const declaredFields = declaredFieldsFromSchema(node?.output_format);
+      // Re-derive a schema-capable producer's declared field set from the loaded
+      // definition so its strict `$node.output.field` contract survives resume (#2091).
+      // A loop_group is the exception: its output_format is ignored and fresh completion
+      // exposes the final body output as raw text, so resumed output must stay raw too.
+      const declaredFields =
+        node !== undefined && !isLoopGroupNode(node)
+          ? declaredFieldsFromSchema(node.output_format)
+          : undefined;
       nodeOutputs.set(nodeId, {
         state: 'completed',
         output,

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -2277,6 +2277,50 @@ nodes:
       }
     });
 
+    it('warns that output_format is ignored on a loop_group', async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+
+      await writeFile(
+        join(workflowDir, 'loop-group-structured.yaml'),
+        `
+name: loop-group-structured
+description: Group with an unsupported structured output declaration
+nodes:
+  - id: iterate
+    provider: claude
+    model: claude-opus-4-6
+    output_format:
+      type: object
+      properties:
+        done:
+          type: boolean
+      required: [done]
+    loop_group:
+      until_bash: exit 0
+      max_iterations: 1
+      nodes:
+        - id: work
+          bash: echo done
+`
+      );
+
+      mockLogger.warn.mockClear();
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      expect(result.errors).toHaveLength(0);
+      expect(result.workflows).toHaveLength(1);
+      expect(isLoopGroupNode(result.workflows[0].workflow.nodes[0])).toBe(true);
+
+      const aiFieldWarnings = mockLogger.warn.mock.calls.filter(
+        call => typeof call[1] === 'string' && call[1].includes('ai_fields_ignored')
+      );
+      expect(aiFieldWarnings).toHaveLength(1);
+      const warnedFields = (aiFieldWarnings[0][0] as { fields: string[] }).fields;
+      expect(warnedFields).toContain('output_format');
+      expect(warnedFields).not.toContain('model');
+      expect(warnedFields).not.toContain('provider');
+    });
+
     it('should NOT warn about pi: on loop nodes and should preserve it (#2133)', async () => {
       const workflowDir = join(testDir, '.archon', 'workflows');
       await mkdir(workflowDir, { recursive: true });


### PR DESCRIPTION
## Problem and outcome

A completed `loop_group` exposes its final body output as raw text, but resume reconstruction was attaching the group's ignored `output_format` as a declared-field contract. The same stored JSON bytes therefore resolved fields differently depending on whether the downstream node ran fresh or after resume.

- **Outcome:** Byte-identical loop-group output now resolves identically fresh and resumed, including present undeclared fields and absent fields named only by the unsupported group schema.
- **Invariant:** A `loop_group` keeps one raw output boundary; resume must not invent a structured-output channel that fresh execution never produced.
- **Scope boundary:** Schema-capable prompt, command, loop, and workflow producers retain their existing strict resume reconstruction. Persistence, schemas, and YAML syntax are unchanged.
- **Root cause:** Generic resume prepopulation derived declared fields from every loaded node's `output_format`, including `loop_group`, even though fresh group completion ignores that field.

## Review guidance

- **Feedback requested:** Correctness of the raw-producer exception and fresh/resume regression coverage.
- **Start here:** `packages/workflows/src/dag-executor.ts:8838` — the typed discriminator keeps only loop-group resume output schemaless.
- **Review order:** Resume reconstruction, paired executor regressions, then the loader warning assertion.
- **Lower-attention areas:** Test fixture setup; it uses existing executor and discovery paths without production abstractions.
- **Known risk or uncertainty:** None within the stable workflow definition. Immutable workflow source across resume is separately designed in #2646.

## Solution

Resume prepopulation now uses the existing `isLoopGroupNode` discriminator to skip declared-field derivation for groups while preserving #2091 behavior for every schema-capable producer. Paired executor tests run the same raw JSON workflow fresh and from a byte-identical prior-success snapshot: an undeclared present field resolves on both paths, while a declared-but-absent field fails with the same missing-key error on both paths. A companion structured-loop resume test protects the neighboring schema-capable producer contract. Discovery coverage also pins the existing warning that group-level `output_format` is ignored.

## Behavior change

| | Before | After |
|---|---|---|
| **Present undeclared JSON field** | Resolved fresh; rejected after resume as outside the unsupported schema | Resolves to the same value fresh and resumed |
| **Absent field declared only on the group** | Failed fresh; resolved empty after resume | Fails with the same missing-key error fresh and resumed |

## Validation

- Pre-fix focused regression — both acceptance tests failed in the opposite fresh/resume directions described above.
- `cd packages/workflows && bun test src/dag-executor.test.ts` — 530 passed, 0 failed, 1,391 assertions.
- `cd packages/workflows && bun test src/loader.test.ts` — 284 passed, 0 failed, 762 assertions.
- `bun --filter @archon/workflows type-check` — passed.
- `bun run validate` — passed generated checks, all package type-checks, zero-warning lint, formatting, installer tests, package-isolated tests, and script tests.
- **Not verified:** Nothing material within #2587's stable-definition contract; workflow-source immutability across resume is tracked by #2646.

## Links

- Closes #2587
- Closes #2585
- Related #2563
- Related #2646
- Plan: https://github.com/coleam00/Archon/issues/2587#issuecomment-5352191988


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workflow resume behavior so loop-group outputs remain consistent with fresh executions.
  * Preserved available undeclared output fields during resumed runs and consistently handled fields that are missing.
  * Ensured optional structured outputs resolve consistently when values are unavailable.
  * Ignored unsupported output formatting for loop groups while allowing valid workflow configurations to load successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->