### PR TITLE
fix(web): keep streaming run logs pinned to the tail

### DIFF
--- a/packages/web/src/experiments/console/routes/RunDetailPage.tsx
+++ b/packages/web/src/experiments/console/routes/RunDetailPage.tsx
@@ -123,11 +123,26 @@ export function RunDetailPage(): ReactElement {
   const [selectedNodeId, setSelectedNodeId] = useState<string>(() => readNodeFilter());
 
   // Hoisted above any early returns so the hook order stays stable.
-  const scrollToNode = useCallback((nodeId: string): void => {
-    const el = document.getElementById(`node-transition-${nodeId}`);
-    if (el !== null) {
-      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    }
+  const scrollToNode = useCallback((nodeId: string): boolean => {
+    const scroller = scrollRef.current;
+    const target = document.getElementById(`node-transition-${nodeId}`);
+    if (scroller === null || target === null) return false;
+
+    const scrollerRect = scroller.getBoundingClientRect();
+    const targetRect = target.getBoundingClientRect();
+    const centeredTop =
+      scroller.scrollTop +
+      targetRect.top +
+      targetRect.height / 2 -
+      (scrollerRect.top + scroller.clientHeight / 2);
+    const destination = Math.min(
+      scroller.scrollHeight - scroller.clientHeight,
+      Math.max(0, centeredTop)
+    );
+    const willMove = Math.abs(destination - scroller.scrollTop) > 1;
+
+    target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    return willMove;
   }, []);
 
   // `Project | null` / `RunDetailView | null` rather than the `as unknown as T`
@@ -222,9 +237,16 @@ export function RunDetailPage(): ReactElement {
   const [atBottom, setAtBottom] = useState(true);
   const pendingNodeIdRef = useRef<string | null>(null);
 
+  const finishNodeReveal = useCallback((nodeId: string): void => {
+    if (pendingNodeIdRef.current !== nodeId) return;
+    pendingNodeIdRef.current = null;
+    lastBottomRef.current = false;
+    setAtBottom(false);
+  }, []);
+
   // Bind the observer to the conditional content node so it survives loading and
   // Log remounts. A Graph-selected node takes precedence over the mount's normal
-  // tail position and keeps follow disabled until the user reaches the tail again.
+  // tail position and keeps follow disabled until its reveal settles.
   const contentRef = useCallback(
     (node: HTMLDivElement | null): (() => void) | undefined => {
       if (node === null) return undefined;
@@ -244,7 +266,7 @@ export function RunDetailPage(): ReactElement {
       if (pendingNodeId !== null) {
         requestAnimationFrame(() => {
           if (pendingNodeIdRef.current !== pendingNodeId) return;
-          scrollToNode(pendingNodeId);
+          if (!scrollToNode(pendingNodeId)) finishNodeReveal(pendingNodeId);
         });
       }
 
@@ -252,7 +274,7 @@ export function RunDetailPage(): ReactElement {
         observer.disconnect();
       };
     },
-    [scrollToNode]
+    [finishNodeReveal, scrollToNode]
   );
 
   const handleScroll = useCallback((): void => {
@@ -265,11 +287,9 @@ export function RunDetailPage(): ReactElement {
   }, []);
 
   const handleScrollEnd = useCallback((): void => {
-    if (pendingNodeIdRef.current === null) return;
-    pendingNodeIdRef.current = null;
-    lastBottomRef.current = false;
-    setAtBottom(false);
-  }, []);
+    const pendingNodeId = pendingNodeIdRef.current;
+    if (pendingNodeId !== null) finishNodeReveal(pendingNodeId);
+  }, [finishNodeReveal]);
 
   const scrollToBottom = useCallback((): void => {
     const el = scrollRef.current;

--- a/packages/web/src/experiments/console/routes/RunDetailPage.tsx
+++ b/packages/web/src/experiments/console/routes/RunDetailPage.tsx
@@ -56,6 +56,8 @@ const TOGGLE_KEYS = {
   node: 'archon.console.runNodeFilter',
 } as const;
 
+const NEAR_BOTTOM_PX = 120;
+
 function readToggle(key: string, defaultOn: boolean): boolean {
   try {
     const stored = localStorage.getItem(key);
@@ -214,20 +216,61 @@ export function RunDetailPage(): ReactElement {
     }
   }, [detail, nodeOptions, selectedNodeId]);
 
-  // Auto-scroll to bottom on new content IF user is already near the bottom.
+  // Follow intent belongs to user navigation, not post-render geometry. Content
+  // growth can make a pinned viewport look detached before an effect measures it.
   const lastBottomRef = useRef(true);
-  useEffect(() => {
+  const [atBottom, setAtBottom] = useState(true);
+  const pendingNodeIdRef = useRef<string | null>(null);
+  const observerRef = useRef<ResizeObserver | null>(null);
+
+  // Bind the observer to the conditional content node so it survives loading and
+  // Log remounts. A Graph-selected node takes precedence over the mount's normal
+  // tail position and keeps follow disabled until the user reaches the tail again.
+  const contentRef = useCallback(
+    (node: HTMLDivElement | null): void => {
+      observerRef.current?.disconnect();
+      observerRef.current = null;
+      if (node === null) return;
+
+      const pendingNodeId = pendingNodeIdRef.current;
+      const followTail = pendingNodeId === null;
+      lastBottomRef.current = followTail;
+      setAtBottom(followTail);
+
+      const observer = new ResizeObserver(() => {
+        if (!lastBottomRef.current) return;
+        const el = scrollRef.current;
+        if (el !== null) el.scrollTop = el.scrollHeight;
+      });
+      observer.observe(node);
+      observerRef.current = observer;
+
+      if (pendingNodeId !== null) {
+        requestAnimationFrame(() => {
+          if (pendingNodeIdRef.current !== pendingNodeId) return;
+          pendingNodeIdRef.current = null;
+          scrollToNode(pendingNodeId);
+        });
+      }
+    },
+    [scrollToNode]
+  );
+
+  const handleScroll = useCallback((): void => {
     const el = scrollRef.current;
     if (el === null) return;
-    // Near-bottom heuristic: within 120px of the end.
-    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 120;
-    lastBottomRef.current = atBottom;
-  });
-  useEffect(() => {
+    const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < NEAR_BOTTOM_PX;
+    lastBottomRef.current = nearBottom;
+    setAtBottom(nearBottom);
+  }, []);
+
+  const scrollToBottom = useCallback((): void => {
     const el = scrollRef.current;
-    if (el === null || !lastBottomRef.current) return;
+    if (el === null) return;
+    lastBottomRef.current = true;
+    setAtBottom(true);
     el.scrollTop = el.scrollHeight;
-  }, [messages?.length, detail?.events.length]);
+  }, []);
 
   // Keymap bindings: hoisted above early returns so the hook order is stable
   // across all render paths (loading, error, ready).
@@ -382,46 +425,59 @@ export function RunDetailPage(): ReactElement {
 
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
           {view === 'log' ? (
-            <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto">
-              <div className="w-full px-6">
-                <div className="sticky top-0 z-10 -mx-6 bg-surface px-6">{toolbar}</div>
+            <div className="relative min-h-0 flex-1">
+              <div ref={scrollRef} onScroll={handleScroll} className="h-full overflow-y-auto">
+                <div ref={contentRef} className="w-full px-6">
+                  <div className="sticky top-0 z-10 -mx-6 bg-surface px-6">{toolbar}</div>
 
-                <div className="py-4">
-                  <RunStartedLine run={run} />
+                  <div className="py-4">
+                    <RunStartedLine run={run} />
 
-                  <div className="mt-2">
-                    <RunStream
-                      messages={messageList}
-                      events={events}
-                      showToolCalls={showToolCalls}
-                      showSystem={showSystem}
-                      selectedNodeId={selectedNodeId}
-                    />
-                  </div>
-
-                  <RunFinishedLine run={run} />
-
-                  {run.status === 'paused' &&
-                  run.approval !== null &&
-                  run.approval !== undefined ? (
-                    <div className="mt-6 rounded border border-warning/30 bg-warning/[0.04] p-4">
-                      <div className="mb-2 flex items-center gap-2">
-                        <span
-                          aria-hidden
-                          className="h-2 w-2 animate-pulse rounded-full bg-warning"
-                        />
-                        <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-warning">
-                          Waiting for approval
-                        </span>
-                      </div>
-                      <ApprovalContext run={run} />
-                      <div className="mt-2">
-                        <ApprovalPanel run={run} />
-                      </div>
+                    <div className="mt-2">
+                      <RunStream
+                        messages={messageList}
+                        events={events}
+                        showToolCalls={showToolCalls}
+                        showSystem={showSystem}
+                        selectedNodeId={selectedNodeId}
+                      />
                     </div>
-                  ) : null}
+
+                    <RunFinishedLine run={run} />
+
+                    {run.status === 'paused' &&
+                    run.approval !== null &&
+                    run.approval !== undefined ? (
+                      <div className="mt-6 rounded border border-warning/30 bg-warning/[0.04] p-4">
+                        <div className="mb-2 flex items-center gap-2">
+                          <span
+                            aria-hidden
+                            className="h-2 w-2 animate-pulse rounded-full bg-warning"
+                          />
+                          <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-warning">
+                            Waiting for approval
+                          </span>
+                        </div>
+                        <ApprovalContext run={run} />
+                        <div className="mt-2">
+                          <ApprovalPanel run={run} />
+                        </div>
+                      </div>
+                    ) : null}
+                  </div>
                 </div>
               </div>
+              {!atBottom ? (
+                <button
+                  type="button"
+                  onClick={scrollToBottom}
+                  aria-label="Jump to bottom"
+                  className="absolute bottom-3 left-1/2 flex -translate-x-1/2 items-center gap-1 rounded-full border border-border bg-surface-elevated px-3 py-1 text-[11px] text-text-secondary shadow-md transition-colors hover:text-text-primary"
+                >
+                  <span aria-hidden>↓</span>
+                  Jump to bottom
+                </button>
+              ) : null}
             </div>
           ) : view === 'graph' ? (
             <>
@@ -432,12 +488,9 @@ export function RunDetailPage(): ReactElement {
                   projectCwd={project.path}
                   events={events}
                   onNodeSelect={(nodeId): void => {
+                    pendingNodeIdRef.current = nodeId;
                     setView('log');
                     writeView('log');
-                    // Defer scroll until the log view has mounted.
-                    requestAnimationFrame(() => {
-                      scrollToNode(nodeId);
-                    });
                   }}
                 />
               ) : (

--- a/packages/web/src/experiments/console/routes/RunDetailPage.tsx
+++ b/packages/web/src/experiments/console/routes/RunDetailPage.tsx
@@ -221,16 +221,13 @@ export function RunDetailPage(): ReactElement {
   const lastBottomRef = useRef(true);
   const [atBottom, setAtBottom] = useState(true);
   const pendingNodeIdRef = useRef<string | null>(null);
-  const observerRef = useRef<ResizeObserver | null>(null);
 
   // Bind the observer to the conditional content node so it survives loading and
   // Log remounts. A Graph-selected node takes precedence over the mount's normal
   // tail position and keeps follow disabled until the user reaches the tail again.
   const contentRef = useCallback(
-    (node: HTMLDivElement | null): void => {
-      observerRef.current?.disconnect();
-      observerRef.current = null;
-      if (node === null) return;
+    (node: HTMLDivElement | null): (() => void) | undefined => {
+      if (node === null) return undefined;
 
       const pendingNodeId = pendingNodeIdRef.current;
       const followTail = pendingNodeId === null;
@@ -243,20 +240,23 @@ export function RunDetailPage(): ReactElement {
         if (el !== null) el.scrollTop = el.scrollHeight;
       });
       observer.observe(node);
-      observerRef.current = observer;
 
       if (pendingNodeId !== null) {
         requestAnimationFrame(() => {
           if (pendingNodeIdRef.current !== pendingNodeId) return;
-          pendingNodeIdRef.current = null;
           scrollToNode(pendingNodeId);
         });
       }
+
+      return () => {
+        observer.disconnect();
+      };
     },
     [scrollToNode]
   );
 
   const handleScroll = useCallback((): void => {
+    if (pendingNodeIdRef.current !== null) return;
     const el = scrollRef.current;
     if (el === null) return;
     const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < NEAR_BOTTOM_PX;
@@ -264,9 +264,17 @@ export function RunDetailPage(): ReactElement {
     setAtBottom(nearBottom);
   }, []);
 
+  const handleScrollEnd = useCallback((): void => {
+    if (pendingNodeIdRef.current === null) return;
+    pendingNodeIdRef.current = null;
+    lastBottomRef.current = false;
+    setAtBottom(false);
+  }, []);
+
   const scrollToBottom = useCallback((): void => {
     const el = scrollRef.current;
     if (el === null) return;
+    pendingNodeIdRef.current = null;
     lastBottomRef.current = true;
     setAtBottom(true);
     el.scrollTop = el.scrollHeight;
@@ -426,7 +434,12 @@ export function RunDetailPage(): ReactElement {
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
           {view === 'log' ? (
             <div className="relative min-h-0 flex-1">
-              <div ref={scrollRef} onScroll={handleScroll} className="h-full overflow-y-auto">
+              <div
+                ref={scrollRef}
+                onScroll={handleScroll}
+                onScrollEnd={handleScrollEnd}
+                className="h-full overflow-y-auto"
+              >
                 <div ref={contentRef} className="w-full px-6">
                   <div className="sticky top-0 z-10 -mx-6 bg-surface px-6">{toolbar}</div>
 


### PR DESCRIPTION
## Problem and outcome

The console run log only reacted to message/event count changes, so streamed growth inside an existing entry could leave the newest output below the viewport. The earlier contributor implementation in #1946 established the right observer-based behavior, but its initial tail snap could overwrite a Graph-selected node after the Log view remounted.

- **Outcome:** Active and completed logs open at the tail; rendered height growth stays visible while pinned; scrolling away exposes a jump-to-bottom control; Graph node selection remains at the selected node.
- **Invariant:** Ordinary Log mounts default to the tail, 120 px or more from the end is detached, and an explicit Graph destination overrides mount-time, observer, and programmatic reveal scroll behavior until the reveal settles. It then remains detached until the operator repins.
- **Scope boundary:** This changes only `RunDetailPage`. ChatPage/shared-hook extraction remains in #1974, and the unrelated Windows symlink tests from #1946 are not included.
- **Root cause:** Scroll intent was inferred from post-growth geometry and follow was triggered only by array lengths. Adding observed height growth without coordinating the existing Graph-to-Log destination created competing scroll writers.

## Review guidance

- **Feedback requested:** Scroll-intent ownership, callback-ref lifecycle, and Graph-to-Log destination precedence.
- **Start here:** `packages/web/src/experiments/console/routes/RunDetailPage.tsx` — the observer, pending destination, reveal guard, detach threshold, and explicit repin are owned together here.
- **Review order:** Follow state and callback ref, Log container/pill, then the Graph selection handoff.
- **Lower-attention areas:** The JSX indentation around the existing log content is mechanical; the diff is one file and the full repository gate passed.
- **Known risk or uncertainty:** None. Browser verification covers conditional mount, initial observer delivery, smooth reveal events, actual wheel input, and the exact threshold boundary.

## Solution

This carries forward Leex's useful `ResizeObserver`, follow-intent state, 120 px threshold, and jump-to-bottom work from #1946. The observer is attached through a React 19 callback ref and returns its own cleanup, so its lifetime follows the conditionally mounted content rather than data-effect dependencies.

`RunDetailPage` records a Graph-selected node before switching views. The Log mount sees that destination, keeps tail following disabled, and ignores scroll events generated by the smooth reveal. When a moving reveal ends, the guard is released while the log stays detached; a geometry precheck releases it immediately when the destination cannot move and would emit no `scrollend`. Later operator scrolling or the jump control can repin it. Ordinary mounts still start pinned. This keeps the complete policy local to the page while the behavior stabilizes before #1974's shared-hook work.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Existing-entry growth could fall below the viewport; scrolling away had no visible recovery control. | Height growth follows while pinned; scroll-up detaches; the pill repins and resumes following. |
| **Graph navigation** | The existing node reveal worked alone, but the naïve observer port could later snap to the tail. | A pending node destination wins the Log remount, observer delivery, and its own programmatic scroll events. |

## Validation

- `bun install --frozen-lockfile && bun run validate` — passed all generated checks, type checks, zero-warning lint, format, installer checks, package tests, and root script tests on final head `393a6736`.
- `bun --filter @archon/web build` — passed; Vite produced the production bundle.
- Headless Chrome against the real dev route and an isolated tall-run database copy — active cold load landed at distance 0; +240 px existing-entry growth stayed at distance 0; a real -500 px wheel detached; detached +260 px growth preserved `scrollTop`; the pill repinned and later +220 px growth followed.
- Browser boundary check — distance 119 hid the pill; distance 120 showed it.
- Browser Graph-to-Log checks — selecting non-final `code-review` centered it to 0.25 px at `scrollTop=636`; +280 px later growth kept `scrollTop=636`. Selecting final `report` settled only 46 px from the tail with the pill visible; +280 px growth kept its `scrollTop=19387`. A later real downward wheel repinned, and +220 px growth followed.
- Browser no-op Graph check — selecting already-positioned first node `extract-pr-number` remained at `scrollTop=0`; the no-movement path released its guard without waiting for an event the browser does not emit. A later real wheel repinned, and +220 px growth followed.
- Browser completed-run check — fresh cold load landed at distance 0 with no jump button.
- Exact-base scope check — both Windows test files remain byte-identical to `d9364a3f`; only `RunDetailPage.tsx` changed.
- **Not verified:** Nothing material; all requested route-level scroll states and the repository gate were exercised on the corrected head.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | No data, API, config, or migration changes. The existing strict `< 120` policy and centered node reveal are preserved. | One-page merge-base diff. |
| Rollout / rollback | Revert the three delivery commits to restore the prior count-keyed behavior. | Commits `93a4c1c8`, `8065535a`, and `393a6736`. |
| Documentation / communication | The visible control is self-explanatory; contributor provenance and later shared-hook work are linked below. | #1946 and #1974. |

## Links

- Supersedes #1946
- Related #1945
- Related #1974


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Log views stay pinned to the latest entries as content grows without disrupting manual scrolling.
  * Added a “Jump to bottom” control when viewing earlier log entries.
  * Selecting a graph node automatically scrolls to its corresponding log entry once available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->