### PR TITLE
fix(lint): running validate with a nested worktree no longer fails

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -19,6 +19,11 @@ sessions/
 api_sessions/
 workspace/
 
+# Nested git worktrees (separate checkouts, formatted on their own branch)
+worktrees/
+.worktrees/
+.claude/worktrees/
+
 # Lock files (auto-generated)
 package-lock.json
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,7 +14,10 @@ export default tseslint.config(
       '.agents/examples/**',
       'packages/docs-web/**',
       'workspace/**',
+      // Nested git worktrees are separate checkouts that lint on their own branch.
+      // Their files are outside every tsconfig project here, so typed rules crash on them.
       'worktrees/**',
+      '.worktrees/**',
       '.claude/worktrees/**',
       '.claude/skills/**',
       '.archon/**', // User workflow/script/command content — not in any tsconfig project


### PR DESCRIPTION
## Problem and outcome

`bun run validate` fails from the main checkout whenever a git worktree exists under `.worktrees/`, which is where the worktree tooling puts isolated checkouts. ESLint walks into that nested checkout and aborts the entire lint step on the first file outside every tsconfig project here, and Prettier separately reports that checkout's files as unformatted. Nothing in the repository is actually wrong, so the failure is pure noise that blocks the pre-PR gate for anyone who keeps a worktree there.

- **Outcome:** `bun run lint` and `bun run format:check` ignore nested git worktrees, so `bun run validate` passes from the main checkout while one is present.
- **Invariant:** These paths hold foreign checkouts that lint and format on their own branch. Neither tool should ever descend into them, and no tracked file lives under them.
- **Scope boundary:** Ignore lists only. No rule, parser, tsconfig, or formatting option changed, and no repository file was reformatted.
- **Root cause:** ESLint's ignore list already covered `worktrees/**` and `.claude/worktrees/**` but never `.worktrees/**`, the location actually in use. Prettier's ignore list covered none of the three, so it had the same latent hole in all of them.

## Review guidance

- **Feedback requested:** Whether covering all three worktree locations in both tools is the right breadth, rather than only the `.worktrees/**` path that fails today.
- **Start here:** `eslint.config.mjs:17` — the global ignores array is the only thing standing between the linter and a nested checkout.
- **Review order:** `eslint.config.mjs`, then `.prettierignore`.
- **Lower-attention areas:** None; the diff is eight added lines across two files.
- **Known risk or uncertainty:** None. `git ls-files` returns nothing under `worktrees/`, `.worktrees/`, or `.claude/worktrees/`, so these patterns cannot shadow a tracked file.

## Solution

ESLint gains `.worktrees/**` alongside the two worktree paths it already ignored, with a comment recording why: the files are outside every tsconfig project, so the type-checked rules do not merely report on them, they throw and take the whole run down.

Prettier gains all three paths. It had no worktree exclusion at all, so `worktrees/` and `.claude/worktrees/` were the same bug waiting for someone to use those directories. Fixing only the path that fails today would leave two known holes behind, and the two ignore lists are easier to reason about when they agree on what a foreign checkout is.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | With a worktree under `.worktrees/`, `validate` fails at the lint step and again at `format:check`. | `validate` passes; nested checkouts are skipped by both tools. |
| **Failure behavior** | ESLint aborted the whole run with a `getParserServices` rule-loading error naming a file in the nested checkout, which reads as a config break rather than a stray directory. | No abort. Genuine lint and format failures in the repository itself still fail the gate. |

## Validation

- Reproduced first on `dev` at `4bdde52a` with `.worktrees/fix-codex-config-compat` present: `bun x eslint . --cache --max-warnings 0` aborted with `Error while loading rule '@typescript-eslint/await-thenable'` on `.worktrees/fix-codex-config-compat/.archon/scripts/__tests__/fixtures/benign/clean-fetch.ts`, and `bun x prettier --check .` reported 16 unformatted files, all of them inside that worktree and none tracked by this repository.
- Confirmed the diagnosis before changing anything: `bun x eslint . --cache --max-warnings 0 --ignore-pattern '.worktrees/**'` exited 0 on the unmodified config, isolating the cause to the missing ignore.
- `bun run lint --max-warnings 0` — exit 0 — with the same worktree still on disk.
- `bun run format:check` — "All matched files use Prettier code style!" — same conditions.
- `bun run validate` — exit 0 — all generated-file checks, type-check across every package, lint, format, installer tests, and 7638 passing tests with 0 failures.
- `git ls-files` over `worktrees/`, `.worktrees/`, and `.claude/worktrees/` returns nothing, proving the new patterns exclude no tracked file.
- **Not verified:** Nothing material. The change is inert to CI, which checks out a single working tree and so has no nested worktree to ignore either way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated formatting and linting exclusions to ignore nested Git worktree directories.
  * Added documentation clarifying that these directories are separate checkouts and are not part of the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->