### PR TITLE
fix(security): pin ws to a patched version for the Discord gateway socket

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -257,6 +257,7 @@
     "path-to-regexp": "^8.4.2",
     "qs": "^6.15.1",
     "test-exclude": "^7.0.1",
+    "ws": "^8.21.0",
   },
   "packages": {
     "@antfu/ni": ["@antfu/ni@25.0.0", "", { "dependencies": { "ansis": "^4.0.0", "fzf": "^0.5.2", "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" }, "bin": { "na": "bin/na.mjs", "ni": "bin/ni.mjs", "nr": "bin/nr.mjs", "nci": "bin/nci.mjs", "nlx": "bin/nlx.mjs", "nun": "bin/nun.mjs", "nup": "bin/nup.mjs" } }, "sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA=="],
@@ -2757,7 +2758,7 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+    "ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
 
     "wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "path-to-regexp": "^8.4.2",
     "qs": "^6.15.1",
     "flatted": "^3.4.2",
-    "@hono/node-server": "^1.19.13"
+    "@hono/node-server": "^1.19.13",
+    "ws": "^8.21.0"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.209",


### PR DESCRIPTION
## Problem and outcome

`ws` resolves to a single hoisted `8.19.0` across the whole tree, and two published advisories cover that version. `discord.js` uses `ws` for its live gateway WebSocket, so the high-severity memory-exhaustion DoS is reachable from remote frame traffic on any install running the Discord adapter.

| package | advisory | affected range | patched |
|---|---|---|---|
| `ws` | [GHSA-96hv-2xvq-fx4p](https://github.com/advisories/GHSA-96hv-2xvq-fx4p) (high) — memory exhaustion DoS from tiny fragments and data chunks | `>=8.0.0, <8.21.0` | `8.21.0` |
| `ws` | [GHSA-58qx-3vcg-4xpx](https://github.com/advisories/GHSA-58qx-3vcg-4xpx) (medium) — uninitialized memory disclosure | `>=8.0.0, <8.20.1` | `8.20.1` |

**Why Archon is exposed:** `discord.js@14.25.1` → `@discordjs/ws@1.2.3` → `ws@^8.17.0` is the gateway socket the Discord adapter holds open. `@slack/socket-mode@2.0.6` (`ws@^8`), `@google/genai` and `@mistralai/mistralai` (`ws@^8.18.0`) share the same hoisted resolution.

- **Outcome:** `ws` resolves to `8.21.3`; both advisories clear. Verified there is exactly one copy in the store — `node_modules/.bun/ws@8.21.3` is the only `ws@*` entry.
- **Invariant:** the override stays a caret, so patch releases keep flowing without another manual bump.
- **Scope boundary:** one dependency only. No other package, no `astro`/`sharp`/`better-auth`, no source change, no scanner config. The lockfile moves exactly one resolution.

## Review guidance

- **Feedback requested:** correctness of the exposure claim and the override scope.
- **Start here:** `package.json:71` — the single override line. Everything else follows from it.
- **Lower-attention areas:** `bun.lock` — two lines, both mechanical (the override entry and the `ws` resolution). Regenerate with `bun install` to confirm.
- **Known risk or uncertainty:** every consumer declares a caret range on `8.x` (`^8`, `^8.17.0`, `^8.18.0`), so `^8.21.0` sits inside all of them — this is an in-range patch bump, not a forced major. Deliberately a **flat** root override, which is safe here because `ws` has a single hoisted resolution; contrast `undici`, where a flat override would clobber a Pi-scoped pin and which is therefore excluded.

## Solution

One entry added to the existing root `overrides` block. `ws` is transitive-only — nothing in the workspace declares it directly — so an override is the only lever, and it is the same mechanism already used for `axios`, `qs`, `follow-redirects` and `path-to-regexp`.

Deliberately kept to one dependency so it is revertable by deleting one line, per the review shape agreed on #2253.

## Validation

- `bun run validate` — exit code `0` — full suite: generated-file checks, type-check across all 12 packages, ESLint at `--max-warnings 0`, Prettier, installer tests, and the per-package test suites including `@archon/adapters` (the Discord adapter's own tests).
- `rm -rf node_modules && bun install --frozen-lockfile` — clean, and `git status` shows no lockfile rewrite afterwards, so the committed lock is exactly what a fresh CI install produces.
- `ls node_modules/.bun | grep '^ws@'` → `ws@8.21.3`, single entry — proves the override took effect tree-wide with no duplicate `8.19.0` left behind.
- **Not verified:** no live Discord gateway smoke test. `ws` `8.19.0 → 8.21.3` is a patch-level bump within the range every consumer already declares, and the adapter test suite passes, so behavioral change is not expected.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Security / permissions / data | Closes a remotely reachable high-severity DoS on the Discord gateway socket. No new capability, network call, or permission. | Advisory table above |
| Rollout / rollback | Revert by deleting the `"ws"` line from `overrides` and re-running `bun install`. Blast radius is one transitive resolution. | `git show` — 4 lines across 2 files |

## Credit

The `ws` finding and its applicability analysis come from @DIZ-admin in #2253, which identified it among a larger set of dependency changes. This lands that finding on its own so it can be reviewed and reverted independently.

## Links

- Related #2253


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the WebSocket package configuration to use version 8.21.0 or later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->