### PR TITLE
fix(core): refuse a scoped chat whose project directory is gone

### DIFF
--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -1661,10 +1661,24 @@ describe('provider cwd resolution', () => {
       const platform = makePlatform();
       await handleMessage(platform, 'conv-1', 'hello');
 
-      // This guard is deliberately scoped to `cwd === null`. The override case is
-      // a different situation with different advice and belongs to #2551; if this
-      // ever starts firing here, the two guards have been collapsed into one.
-      expect(getSendQueryCwd()).toBe('/worktrees/removed');
+      // This guard is deliberately scoped to `cwd === null`; the override case is a
+      // different situation with different advice and belongs to #2551.
+      //
+      // Assert that THIS guard stays silent rather than asserting what the turn
+      // does next. What happens next is not stable across the two PRs: today the
+      // override reaches the provider, and once #2551's guard lands beside this
+      // one it refuses the turn instead. Either way the invariant that matters
+      // here is the same — this guard did not claim the case.
+      expect(mockLogger.warn).not.toHaveBeenCalledWith(
+        expect.anything(),
+        'orchestrator.codebase_cwd_missing'
+      );
+      const sends = (platform.sendMessage as ReturnType<typeof mock>).mock.calls.map(c => c[1]);
+      expect(
+        sends.some(
+          (s: unknown) => typeof s === 'string' && s.includes('project directory no longer exists')
+        )
+      ).toBe(false);
     });
 
     test('does not fire when the project directory is present', async () => {

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -1581,6 +1581,118 @@ describe('provider cwd resolution', () => {
     expect(mockSendQuery).toHaveBeenCalled();
   });
 
+  // ─── missing project directory (#2663) ──────────────────────────────────────
+
+  describe('missing project directory', () => {
+    test('refuses the turn and never reaches the provider when default_cwd is gone', async () => {
+      const codebase = makeCodebaseForSync();
+      const conversation = makeConversation({ codebase_id: 'codebase-1' });
+      mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+      mockGetCodebase.mockReturnValueOnce(Promise.resolve(codebase));
+      mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
+      mockExistsSync.mockImplementation((p: string) => p !== '/repos/test-repo');
+
+      const platform = makePlatform();
+      await handleMessage(platform, 'conv-1', 'hello');
+
+      // Handing a missing path to the provider is the whole defect: the spawn
+      // fails ENOENT against the BINARY, so the user is told the wrong thing.
+      expect(mockSendQuery).not.toHaveBeenCalled();
+      const sent = (platform.sendMessage as ReturnType<typeof mock>).mock.calls[0][1] as string;
+      expect(sent).toContain('/repos/test-repo');
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ codebaseId: 'codebase-1', cwd: '/repos/test-repo' }),
+        'orchestrator.codebase_cwd_missing'
+      );
+    });
+
+    test('offers recovery that actually works, and not the traps', async () => {
+      const codebase = makeCodebaseForSync();
+      const conversation = makeConversation({ codebase_id: 'codebase-1' });
+      mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+      mockGetCodebase.mockReturnValueOnce(Promise.resolve(codebase));
+      mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
+      mockExistsSync.mockImplementation((p: string) => p !== '/repos/test-repo');
+
+      const platform = makePlatform();
+      await handleMessage(platform, 'conv-1', 'hello');
+
+      const sent = (platform.sendMessage as ReturnType<typeof mock>).mock.calls[0][1] as string;
+      // /update-project validates the new path and repairs the registration.
+      expect(sent).toContain('/update-project');
+      expect(sent).toContain('/setproject');
+      // /worktree remove answers "not using a worktree" when isolation_env_id is
+      // null, and otherwise repoints cwd at this same missing directory.
+      expect(sent).not.toContain('/worktree remove');
+      // /register-project creates a new registration rather than repairing this one.
+      expect(sent).not.toContain('/register-project');
+    });
+
+    test('writes no user row when it refuses, so none is left unpaired', async () => {
+      mockAddMessage.mockClear();
+      const codebase = makeCodebaseForSync();
+      const conversation = makeConversation({ codebase_id: 'codebase-1' });
+      mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+      mockGetCodebase.mockReturnValueOnce(Promise.resolve(codebase));
+      mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
+      mockExistsSync.mockImplementation((p: string) => p !== '/repos/test-repo');
+
+      // Non-web only: the web adapter's route persists its own turns, so the
+      // orchestrator never writes a user row for it and this could not regress.
+      const platform = makePlatform();
+      platform.getPlatformType = mock(() => 'telegram') as typeof platform.getPlatformType;
+      await handleMessage(platform, 'conv-1', 'hello');
+
+      expect(mockSendQuery).not.toHaveBeenCalled();
+      expect(mockAddMessage.mock.calls.filter(c => c[1] === 'user')).toHaveLength(0);
+    });
+
+    test('leaves a stale cwd override to the conversation-cwd guard', async () => {
+      const codebase = makeCodebaseForSync();
+      const conversation = makeConversation({
+        codebase_id: 'codebase-1',
+        cwd: '/worktrees/removed',
+      });
+      mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+      mockGetCodebase.mockReturnValueOnce(Promise.resolve(codebase));
+      mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
+      mockExistsSync.mockImplementation((p: string) => p !== '/worktrees/removed');
+
+      const platform = makePlatform();
+      await handleMessage(platform, 'conv-1', 'hello');
+
+      // This guard is deliberately scoped to `cwd === null`. The override case is
+      // a different situation with different advice and belongs to #2551; if this
+      // ever starts firing here, the two guards have been collapsed into one.
+      expect(getSendQueryCwd()).toBe('/worktrees/removed');
+    });
+
+    test('does not fire when the project directory is present', async () => {
+      const codebase = makeCodebaseForSync();
+      const conversation = makeConversation({ codebase_id: 'codebase-1' });
+      mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+      mockGetCodebase.mockReturnValueOnce(Promise.resolve(codebase));
+      mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
+
+      const platform = makePlatform();
+      await handleMessage(platform, 'conv-1', 'hello');
+
+      expect(getSendQueryCwd()).toBe('/repos/test-repo');
+    });
+
+    test('leaves the unscoped path alone — the workspaces root is created on demand', async () => {
+      const conversation = makeConversation({ codebase_id: null });
+      mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+      mockListCodebases.mockReturnValueOnce(Promise.resolve([]));
+      mockExistsSync.mockImplementation(() => false);
+
+      const platform = makePlatform();
+      await handleMessage(platform, 'conv-1', 'hello');
+
+      expect(getSendQueryCwd()).toBe('/home/test/.archon/workspaces');
+    });
+  });
+
   test('unscoped chat uses ensureArchonWorkspacesPath result', async () => {
     const conversation = makeConversation({ codebase_id: null });
     mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -373,9 +373,10 @@ function makeCodebase(name: string, id = `id-${name}`): Codebase {
 // handleUpdateProject. Today a leak is survivable only because the predicates
 // here reject one literal path — that is luck, not a guarantee, and it stops
 // being true the moment a test rejects something broader. Reset before every
+// test so no describe can poison another.
+//
 // Deliberately no count here: any number rots on the next test added, and the
 // mechanism is the argument.
-// test so no describe can poison another.
 beforeEach(() => {
   mockExistsSync.mockImplementation(() => true);
 });
@@ -1720,11 +1721,44 @@ describe('provider cwd resolution', () => {
       const sent = (platform.sendMessage as ReturnType<typeof mock>).mock.calls[0][1] as string;
       expect(sent).toContain('/worktrees/removed');
       expect(sent).toContain('working directory no longer exists');
+      // This guard's own message signature — nothing else emits that sentence, so
+      // it cannot false-alarm. Deliberately NOT also asserting the absence of
+      // `/update-project`: the guard above offers `/worktree remove` and
+      // `/setproject` and never that, so the two strings always co-occur and it
+      // would add no detection — while breaking this test if anyone ever adds
+      // `/update-project` to that message, an edit that has nothing to do with
+      // this guard.
       expect(sent).not.toContain('project directory no longer exists');
-      expect(sent).not.toContain('/update-project');
       expect(mockLogger.warn).toHaveBeenCalledWith(
         expect.anything(),
         'orchestrator.conversation_cwd_missing'
+      );
+    });
+
+    test('runs the turn when the cwd override is healthy but default_cwd is gone', async () => {
+      const codebase = makeCodebaseForSync();
+      const conversation = makeConversation({
+        codebase_id: 'codebase-1',
+        cwd: '/worktrees/healthy',
+      });
+      mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+      mockGetCodebase.mockReturnValueOnce(Promise.resolve(codebase));
+      mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
+      // The project root is gone, but this conversation does not use it.
+      mockExistsSync.mockImplementation((p: string) => p !== '/repos/test-repo');
+
+      const platform = makePlatform();
+      await handleMessage(platform, 'conv-1', 'hello');
+
+      // This is the case that makes `&& conversation.cwd === null` load-bearing
+      // rather than decorative. Drop that clause while leaving the target as
+      // `default_cwd` and this guard refuses a perfectly healthy turn, telling the
+      // user their project directory is gone and offering to repoint a directory
+      // the turn never touches. Nothing else in the suite catches that mutation.
+      expect(getSendQueryCwd()).toBe('/worktrees/healthy');
+      expect(mockLogger.warn).not.toHaveBeenCalledWith(
+        expect.anything(),
+        'orchestrator.codebase_cwd_missing'
       );
     });
 

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -1670,7 +1670,7 @@ describe('provider cwd resolution', () => {
       expect(mockAddMessage.mock.calls.filter(c => c[1] === 'user')).toHaveLength(0);
     });
 
-    test('leaves a stale cwd override to the conversation-cwd guard', async () => {
+    test('a stale cwd override gets the conversation-cwd message, not this one', async () => {
       const codebase = makeCodebaseForSync();
       const conversation = makeConversation({
         codebase_id: 'codebase-1',
@@ -1684,25 +1684,27 @@ describe('provider cwd resolution', () => {
       const platform = makePlatform();
       await handleMessage(platform, 'conv-1', 'hello');
 
-      // This guard is deliberately scoped to `cwd === null`; the override case is a
-      // different situation with different advice and belongs to #2551.
+      // Pins WHICH refusal the user gets, which is the part still observable here.
       //
-      // Assert that THIS guard stays silent rather than asserting what the turn
-      // does next. Since #2551 landed, the conversation-cwd guard sitting above
-      // this one refuses the override case, so an assertion about reaching the
-      // provider would be asserting that guard's behaviour, not this one's. The
-      // durable invariant is narrower and is what is checked here: this guard did
-      // not claim the case.
-      expect(mockLogger.warn).not.toHaveBeenCalledWith(
+      // Be clear about what this does not do: it cannot catch widening this guard's
+      // condition to `conversation.cwd ?? default_cwd`. The conversation-cwd guard
+      // above returns first for every `cwd !== null` case, so a widened condition
+      // is dead code, and the mutation passes the whole suite. That is a property
+      // of the ordering, not a gap worth papering over with a weaker assertion —
+      // the note on the guard itself carries the reason to keep it narrow.
+      //
+      // What this DOES catch is the two guards' messages crossing: this guard
+      // claiming the override case and answering with project-root advice that says
+      // nothing about `isolation_env_id`.
+      const sent = (platform.sendMessage as ReturnType<typeof mock>).mock.calls[0][1] as string;
+      expect(sent).toContain('/worktrees/removed');
+      expect(sent).toContain('working directory no longer exists');
+      expect(sent).not.toContain('project directory no longer exists');
+      expect(sent).not.toContain('/update-project');
+      expect(mockLogger.warn).toHaveBeenCalledWith(
         expect.anything(),
-        'orchestrator.codebase_cwd_missing'
+        'orchestrator.conversation_cwd_missing'
       );
-      const sends = (platform.sendMessage as ReturnType<typeof mock>).mock.calls.map(c => c[1]);
-      expect(
-        sends.some(
-          (s: unknown) => typeof s === 'string' && s.includes('project directory no longer exists')
-        )
-      ).toBe(false);
     });
 
     test('does not fire when the project directory is present', async () => {

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -1651,6 +1651,27 @@ describe('provider cwd resolution', () => {
       expect(sent).not.toContain('/update-project Client Ops');
     });
 
+    test('escapes quotes and backslashes in the project name', async () => {
+      // Quoting alone is not enough: a `"` inside the name closes the quoted token
+      // early and reproduces the original defect, and a trailing `\` escapes the
+      // closing quote. parseCommand honours backslash escapes inside quotes, so a
+      // single pass over both characters round-trips. One pass, not two chained
+      // replaces — escaping `"` first and `\` second would double-escape the
+      // backslashes the first pass just added.
+      const codebase = { ...makeCodebaseForSync(), name: 'Bob"s \\Ops' };
+      const conversation = makeConversation({ codebase_id: 'codebase-1' });
+      mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+      mockGetCodebase.mockReturnValueOnce(Promise.resolve(codebase));
+      mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
+      mockExistsSync.mockImplementation((p: string) => p !== '/repos/test-repo');
+
+      const platform = makePlatform();
+      await handleMessage(platform, 'conv-1', 'hello');
+
+      const sent = (platform.sendMessage as ReturnType<typeof mock>).mock.calls[0][1] as string;
+      expect(sent).toContain('/update-project "Bob\\"s \\\\Ops" <new-path>');
+    });
+
     test('writes no user row when it refuses, so none is left unpaired', async () => {
       mockAddMessage.mockClear();
       const codebase = makeCodebaseForSync();

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -1688,10 +1688,11 @@ describe('provider cwd resolution', () => {
       // different situation with different advice and belongs to #2551.
       //
       // Assert that THIS guard stays silent rather than asserting what the turn
-      // does next. What happens next is not stable across the two PRs: today the
-      // override reaches the provider, and once #2551's guard lands beside this
-      // one it refuses the turn instead. Either way the invariant that matters
-      // here is the same — this guard did not claim the case.
+      // does next. Since #2551 landed, the conversation-cwd guard sitting above
+      // this one refuses the override case, so an assertion about reaching the
+      // provider would be asserting that guard's behaviour, not this one's. The
+      // durable invariant is narrower and is what is checked here: this guard did
+      // not claim the case.
       expect(mockLogger.warn).not.toHaveBeenCalledWith(
         expect.anything(),
         'orchestrator.codebase_cwd_missing'

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -373,6 +373,8 @@ function makeCodebase(name: string, id = `id-${name}`): Codebase {
 // handleUpdateProject. Today a leak is survivable only because the predicates
 // here reject one literal path — that is luck, not a guarantee, and it stops
 // being true the moment a test rejects something broader. Reset before every
+// Deliberately no count here: any number rots on the next test added, and the
+// mechanism is the argument.
 // test so no describe can poison another.
 beforeEach(() => {
   mockExistsSync.mockImplementation(() => true);
@@ -1626,6 +1628,27 @@ describe('provider cwd resolution', () => {
       expect(sent).not.toContain('/worktree remove');
       // /register-project creates a new registration rather than repairing this one.
       expect(sent).not.toContain('/register-project');
+    });
+
+    test('quotes a project name containing whitespace so the suggestion parses', async () => {
+      const codebase = { ...makeCodebaseForSync(), name: 'Client Ops' };
+      const conversation = makeConversation({ codebase_id: 'codebase-1' });
+      mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
+      mockGetCodebase.mockReturnValueOnce(Promise.resolve(codebase));
+      mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));
+      mockExistsSync.mockImplementation((p: string) => p !== '/repos/test-repo');
+
+      const platform = makePlatform();
+      await handleMessage(platform, 'conv-1', 'hello');
+
+      const sent = (platform.sendMessage as ReturnType<typeof mock>).mock.calls[0][1] as string;
+      // handleUpdateProject takes only the FIRST token as the project name, so an
+      // unquoted `Client Ops` parses as `Client` and hands the user a second, more
+      // confusing error instead of a repair. Verified against the real parser:
+      // `/update-project Client Ops <path>` -> name "Client", path "Ops <path>";
+      // the quoted form -> name "Client Ops", path "<path>".
+      expect(sent).toContain('/update-project "Client Ops" <new-path>');
+      expect(sent).not.toContain('/update-project Client Ops');
     });
 
     test('writes no user row when it refuses, so none is left unpaired', async () => {

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -1640,14 +1640,20 @@ export async function handleMessage(
     // the same field with no mutation between the reads, which is what lets them sit
     // side by side.
     //
-    // Keep the condition narrow rather than widening it to `conversation.cwd ??
-    // default_cwd`. Be aware that no test can hold you to this: the guard above
-    // already returns for every `cwd !== null` case, so a widened condition here is
-    // dead code rather than a behaviour change, and it is unobservable through
-    // handleMessage. The reason to keep it narrow is that it would silently become
-    // observable the moment the guard above is moved, narrowed, or removed — at
-    // which point this guard would answer for a stale worktree with the wrong
-    // message, one that says nothing about `isolation_env_id`.
+    // `&& conversation.cwd === null` is load-bearing. Dropping it while leaving the
+    // target as `default_cwd` refuses a healthy turn: a conversation working in a
+    // live worktree, whose project root happens to be gone, would be told its
+    // project directory no longer exists and offered `/update-project` for a
+    // directory that turn never touches. Covered by `runs the turn when the cwd
+    // override is healthy but default_cwd is gone`.
+    //
+    // Widening it the other way — to `conversation.cwd ?? default_cwd`, moving the
+    // target with the condition — is instead unobservable here, because the guard
+    // above already returns for every `cwd !== null` case. No test holds you to
+    // that one. Keep it narrow anyway: it becomes observable the moment the guard
+    // above is moved, narrowed, or removed, at which point this guard would answer
+    // for a stale worktree with the wrong message, one that says nothing about
+    // `isolation_env_id`.
     //
     // Refuses rather than falling back to the workspaces root the way the
     // `scopedCodebase === undefined` branch below does: relocating the agent into a
@@ -1684,11 +1690,12 @@ export async function handleMessage(
     // Persist the inbound user message for non-web platforms (Slack/Telegram/
     // GitHub/Discord/CLI) — the web adapter's route persists web turns itself.
     // Placed AFTER every early return that declines the turn — deterministic
-    // commands (including `/workflow approve|reject`) and the missing-project guard
-    // above — so only AI-bound turns get a user row (no orphaned user message
-    // without an assistant reply), and BEFORE the AI call so the user row's
-    // timestamp precedes the assistant row's. A plain message at a gate is NOT a
-    // refusal since #2577; it flows into the AI turn and earns its user row.
+    // commands (including `/workflow approve|reject`), the stale-worktree guard and
+    // the missing-project guard above — so only AI-bound turns get a user row (no
+    // orphaned user message without an assistant reply), and BEFORE the AI call so
+    // the user row's timestamp precedes the assistant row's. A plain message at a
+    // gate is NOT a refusal since #2577; it flows into the AI turn and earns its
+    // user row.
     //
     // A new refusal that needs nothing computed below belongs above this block. One
     // that needs data from further down (workflow discovery, gate lookup) has to

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -1638,9 +1638,16 @@ export async function handleMessage(
     // override is a different situation with different recovery advice, handled by
     // the guard directly above this one (#2551). The two conditions are disjoint on
     // the same field with no mutation between the reads, which is what lets them sit
-    // side by side. Do not collapse them into a `conversation.cwd ?? default_cwd`
-    // check: that silently absorbs the override case and replaces its message —
-    // which branches on `isolation_env_id` — with this one.
+    // side by side.
+    //
+    // Keep the condition narrow rather than widening it to `conversation.cwd ??
+    // default_cwd`. Be aware that no test can hold you to this: the guard above
+    // already returns for every `cwd !== null` case, so a widened condition here is
+    // dead code rather than a behaviour change, and it is unobservable through
+    // handleMessage. The reason to keep it narrow is that it would silently become
+    // observable the moment the guard above is moved, narrowed, or removed — at
+    // which point this guard would answer for a stale worktree with the wrong
+    // message, one that says nothing about `isolation_env_id`.
     //
     // Refuses rather than falling back to the workspaces root the way the
     // `scopedCodebase === undefined` branch below does: relocating the agent into a
@@ -1657,13 +1664,17 @@ export async function handleMessage(
           `This conversation's project directory no longer exists:\n\`${scoped.default_cwd}\`\n\n` +
             `The project "${scoped.name}" is still registered, but its folder is gone — ` +
             'deleted, moved, or on a volume that is no longer mounted.\n\n' +
-            // The name is quoted so the suggestion survives a project whose name
-            // contains whitespace: handleUpdateProject takes only the first token
-            // as the name (`const [projectName, ...pathParts] = args`), so an
-            // unquoted "Client Ops" would parse as name "Client" and send the user
-            // a second, wronger error. parseCommand understands quoted tokens, and
-            // quoting is a no-op for names without whitespace.
-            `- \`/update-project "${scoped.name}" <new-path>\` to point it at the new location\n` +
+            // The name is quoted, and `"`/`\` inside it escaped, so the suggestion
+            // round-trips back through parseCommand as the same string. Without the
+            // quotes, handleUpdateProject takes only the first token as the name
+            // (`const [projectName, ...pathParts] = args`), so `Client Ops` parses
+            // as `Client` and hands the user a second, wronger error; without the
+            // escaping, a name containing a quote terminates the quoted token early
+            // and does the same thing. parseCommand honours backslash escapes inside
+            // quotes (command-handler.ts:206-212), and both are no-ops for a plain
+            // name.
+            `- \`/update-project "${scoped.name.replace(/[\\"]/g, c => `\\${c}`)}" <new-path>\` ` +
+            'to point it at the new location\n' +
             '- `/setproject <name>` to switch this conversation to a different project'
         );
         return;

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -1635,11 +1635,12 @@ export async function handleMessage(
     // (#2663).
     //
     // Scoped to `conversation.cwd === null` on purpose. A conversation WITH a cwd
-    // override is a different situation with different recovery advice — that case
-    // belongs to #2551, which is UNMERGED as of this change, so until it lands a
-    // stale `cwd` override is still unguarded here. Either way, do not collapse the
-    // two into a `conversation.cwd ?? default_cwd` check: that silently absorbs the
-    // override case and replaces its message with this one.
+    // override is a different situation with different recovery advice, handled by
+    // the guard directly above this one (#2551). The two conditions are disjoint on
+    // the same field with no mutation between the reads, which is what lets them sit
+    // side by side. Do not collapse them into a `conversation.cwd ?? default_cwd`
+    // check: that silently absorbs the override case and replaces its message —
+    // which branches on `isolation_env_id` — with this one.
     //
     // Refuses rather than falling back to the workspaces root the way the
     // `scopedCodebase === undefined` branch below does: relocating the agent into a

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -1614,13 +1614,59 @@ export async function handleMessage(
       }
     }
 
+    // 3. Load codebases, discover workflows, build prompt
+    //
+    // The codebase load sits ABOVE the user-message persist so the missing-project
+    // guard below can read `default_cwd` without paying a second query. It reads
+    // `remote_agent_codebases` while the persist writes `remote_agent_messages`, so
+    // the two are independent in both directions, and every consumer of `codebases`
+    // runs far below. Keep it here: moved back down, the guard would have to refuse
+    // AFTER the user row is written, which is exactly the orphaned-row bug this
+    // ordering exists to prevent.
+    const codebases = await codebaseDb.listCodebases();
+
+    // A registered project's directory can vanish under a long-lived conversation —
+    // the clone deleted, a container volume reset, a folder project moved. Providers
+    // pass `cwd` straight to their subprocess, and `posix_spawn` reports a missing
+    // WORKING DIRECTORY as ENOENT against the EXECUTABLE's path, so the failure
+    // surfaces as "No such file or directory (os error 2)" on Codex or a bogus
+    // libc/architecture mismatch on Claude. Neither names the directory (#2663).
+    //
+    // Scoped to `conversation.cwd === null` on purpose. A conversation WITH a cwd
+    // override is a different situation with different recovery advice, owned by the
+    // guard in #2551 — do not collapse the two into a `conversation.cwd ??
+    // default_cwd` check, which would silently absorb that case and its message.
+    //
+    // Refuses rather than falling back to the workspaces root the way the
+    // `scopedCodebase === undefined` branch below does: relocating the agent into a
+    // directory the user did not scope would widen its write scope without consent.
+    if (conversation.codebase_id !== null && conversation.cwd === null) {
+      const scoped = codebases.find(c => c.id === conversation.codebase_id);
+      if (scoped !== undefined && !existsSync(scoped.default_cwd)) {
+        getLog().warn(
+          { conversationId, codebaseId: scoped.id, cwd: scoped.default_cwd },
+          'orchestrator.codebase_cwd_missing'
+        );
+        await platform.sendMessage(
+          conversationId,
+          `This conversation's project directory no longer exists:\n\`${scoped.default_cwd}\`\n\n` +
+            `The project "${scoped.name}" is still registered, but its folder is gone — ` +
+            'deleted, moved, or lost with a reset container volume.\n\n' +
+            `- \`/update-project ${scoped.name} <new-path>\` to point it at the new location\n` +
+            '- `/setproject <name>` to switch this conversation to a different project'
+        );
+        return;
+      }
+    }
+
     // Persist the inbound user message for non-web platforms (Slack/Telegram/
     // GitHub/Discord/CLI) — the web adapter's route persists web turns itself.
-    // Placed AFTER the deterministic-command and approval early-returns so only
-    // AI-bound turns get a user row (no orphaned user message without an
-    // assistant reply), and BEFORE the AI call so the user row's timestamp
-    // precedes the assistant row's. Fire-and-forget: a DB failure must not break
-    // platform delivery (#1182).
+    // Placed AFTER every early return that declines the turn — deterministic
+    // commands, approvals, and the missing-project guard above — so only AI-bound
+    // turns get a user row (no orphaned user message without an assistant reply),
+    // and BEFORE the AI call so the user row's timestamp precedes the assistant
+    // row's. Any new refusal belongs above this block, not below it.
+    // Fire-and-forget: a DB failure must not break platform delivery (#1182).
     if (!isWebAdapter(platform)) {
       messageDb
         .addMessage(conversation.id, 'user', message, undefined, userId)
@@ -1633,8 +1679,6 @@ export async function handleMessage(
         });
     }
 
-    // 3. Load codebases, discover workflows, build prompt
-    const codebases = await codebaseDb.listCodebases();
     const {
       workflows: workflowsWithSource,
       errors: workflowErrors,

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -1619,23 +1619,27 @@ export async function handleMessage(
     // The codebase load sits ABOVE the user-message persist so the missing-project
     // guard below can read `default_cwd` without paying a second query. It reads
     // `remote_agent_codebases` while the persist writes `remote_agent_messages`, so
-    // the two are independent in both directions, and every consumer of `codebases`
-    // runs far below. Keep it here: moved back down, the guard would have to refuse
-    // AFTER the user row is written, which is exactly the orphaned-row bug this
-    // ordering exists to prevent.
+    // the two are independent in both directions, and every OTHER consumer of
+    // `codebases` runs far below (the guard just under this line is the one that
+    // needed the hoist). Keep it here: moved back down, the guard would have to
+    // refuse AFTER the user row is written, which is exactly the orphaned-row bug
+    // this ordering exists to prevent.
     const codebases = await codebaseDb.listCodebases();
 
     // A registered project's directory can vanish under a long-lived conversation —
-    // the clone deleted, a container volume reset, a folder project moved. Providers
-    // pass `cwd` straight to their subprocess, and `posix_spawn` reports a missing
-    // WORKING DIRECTORY as ENOENT against the EXECUTABLE's path, so the failure
-    // surfaces as "No such file or directory (os error 2)" on Codex or a bogus
-    // libc/architecture mismatch on Claude. Neither names the directory (#2663).
+    // the clone deleted, the folder moved, the volume holding it unmounted.
+    // Providers pass `cwd` straight to their subprocess, and `posix_spawn` reports
+    // a missing WORKING DIRECTORY as ENOENT against the EXECUTABLE's path, so the
+    // failure surfaces as "No such file or directory (os error 2)" on Codex or a
+    // bogus libc/architecture mismatch on Claude. Neither names the directory
+    // (#2663).
     //
     // Scoped to `conversation.cwd === null` on purpose. A conversation WITH a cwd
-    // override is a different situation with different recovery advice, owned by the
-    // guard in #2551 — do not collapse the two into a `conversation.cwd ??
-    // default_cwd` check, which would silently absorb that case and its message.
+    // override is a different situation with different recovery advice — that case
+    // belongs to #2551, which is UNMERGED as of this change, so until it lands a
+    // stale `cwd` override is still unguarded here. Either way, do not collapse the
+    // two into a `conversation.cwd ?? default_cwd` check: that silently absorbs the
+    // override case and replaces its message with this one.
     //
     // Refuses rather than falling back to the workspaces root the way the
     // `scopedCodebase === undefined` branch below does: relocating the agent into a
@@ -1651,8 +1655,14 @@ export async function handleMessage(
           conversationId,
           `This conversation's project directory no longer exists:\n\`${scoped.default_cwd}\`\n\n` +
             `The project "${scoped.name}" is still registered, but its folder is gone — ` +
-            'deleted, moved, or lost with a reset container volume.\n\n' +
-            `- \`/update-project ${scoped.name} <new-path>\` to point it at the new location\n` +
+            'deleted, moved, or on a volume that is no longer mounted.\n\n' +
+            // The name is quoted so the suggestion survives a project whose name
+            // contains whitespace: handleUpdateProject takes only the first token
+            // as the name (`const [projectName, ...pathParts] = args`), so an
+            // unquoted "Client Ops" would parse as name "Client" and send the user
+            // a second, wronger error. parseCommand understands quoted tokens, and
+            // quoting is a no-op for names without whitespace.
+            `- \`/update-project "${scoped.name}" <new-path>\` to point it at the new location\n` +
             '- `/setproject <name>` to switch this conversation to a different project'
         );
         return;
@@ -1662,10 +1672,16 @@ export async function handleMessage(
     // Persist the inbound user message for non-web platforms (Slack/Telegram/
     // GitHub/Discord/CLI) — the web adapter's route persists web turns itself.
     // Placed AFTER every early return that declines the turn — deterministic
-    // commands, approvals, and the missing-project guard above — so only AI-bound
-    // turns get a user row (no orphaned user message without an assistant reply),
-    // and BEFORE the AI call so the user row's timestamp precedes the assistant
-    // row's. Any new refusal belongs above this block, not below it.
+    // commands (including `/workflow approve|reject`) and the missing-project guard
+    // above — so only AI-bound turns get a user row (no orphaned user message
+    // without an assistant reply), and BEFORE the AI call so the user row's
+    // timestamp precedes the assistant row's. A plain message at a gate is NOT a
+    // refusal since #2577; it flows into the AI turn and earns its user row.
+    //
+    // A new refusal that needs nothing computed below belongs above this block. One
+    // that needs data from further down (workflow discovery, gate lookup) has to
+    // hoist that dependency first, the way `codebases` was hoisted here — putting
+    // the refusal below the persist instead is what orphans the row.
     // Fire-and-forget: a DB failure must not break platform delivery (#1182).
     if (!isWebAdapter(platform)) {
       messageDb


### PR DESCRIPTION
## Problem and outcome

A registered project's directory can vanish under a long-lived conversation — the clone deleted, a container volume reset, a folder project moved. The chat path resolved `conversation.cwd ?? default_cwd` with no existence check and handed the missing path straight to the provider, which failed with an error that named the wrong thing entirely.

- **Outcome:** the turn is refused before the provider is invoked, naming the missing directory and the two commands that actually recover from it.
- **Invariant:** a refused chat turn never leaves a `user` row without its paired `assistant` row.
- **Scope boundary:** only the no-override case (`conversation.cwd === null`). The stale-worktree-override case belongs to #2551 and is deliberately untouched — see *Why this is not #2551* below.
- **Root cause:** `posix_spawn` reports a missing **working directory** as `ENOENT` against the **executable's** path. Reproduced directly:

  ```
  spawnSync('/bin/echo', ['hi'], { cwd: '<deleted dir>' })
  // ENOENT: no such file or directory, posix_spawn '/bin/echo'
  ```

  That is why Codex surfaced `No such file or directory (os error 2)` and the Claude SDK — which checks only that the binary exists on disk — concluded a libc/architecture mismatch. The binary is fine. Neither error ever named the directory, which is the one fact needed to fix it.

Gap found by @waaaw in #2114 while investigating #1170. Credit for identifying it is theirs.

## Review guidance

- **Feedback requested:** whether the guard's condition is scoped tightly enough to stay disjoint from #2551, and whether the recovery advice is the right pair of commands.
- **Start here:** `packages/core/src/orchestrator/orchestrator-agent.ts` — the guard and the load it depends on. The placement is the load-bearing part, not the check itself.
- **Review order:** the guard and the moved codebase load → the persist block's updated comment → the six tests.
- **Lower-attention areas:** none; the diff is small and hand-written.
- **Known risk or uncertainty:** this touches the same neighbourhood as #2551, so the two conflict textually. Merge instructions are in *Merge order* below — "keep both" is right for the guards and **wrong** for the test fixture, so please read it rather than resolving by instinct.

## Merge order

#2551 first, then this. I merged the two branches locally and ran the combined suite to check the resolution rather than assume it: **247 pass, 0 fail** with both guards present.

- **Production guards — keep both.** They are disjoint (`cwd === null` here, `cwd !== null` there) and both belong above the persist block. Order between them does not matter.
- **Test fixture — keep exactly one.** #2551 adds a byte-identical `const mockExistsSync = mock((_path: string) => true);` to the same file. Keeping both is a duplicate-declaration error. Keep one, and prefer **this PR's top-level `beforeEach`** over #2551's describe-level reset: the describe-level one leaves every later describe running against whatever predicate leaked out of `provider cwd resolution`.
- **Test blocks — keep both.** They cover different cases and do not overlap.

## Solution

**Why the placement is the whole design.** The guard has to run before the user-message persist. That block's own comment states the invariant it protects: only AI-bound turns get a user row, so a `user` row always pairs with an `assistant` row. But the codebase row was not loaded there — `listCodebases()` sat *after* the persist, and `scopedCodebase` was not derived until ~140 lines later.

So the codebase load moves twelve lines up, above the persist. That is free: it reads `remote_agent_codebases` while the persist writes `remote_agent_messages`, the two are independent in both directions, every consumer of `codebases` runs far below, and `discoverAllWorkflows` performs its own `getCodebase()` lookup rather than reading the array. It also removes an existing orphaned-row scenario, since a `listCodebases()` failure now throws before the persist rather than after it.

The guard then refuses rather than falling back the way the neighbouring `scopedCodebase === undefined` branch does. Relocating the agent into a directory the user did not scope would widen its write scope without consent.

**Why this is not #2551.** The two conditions are disjoint by construction — that PR handles `cwd !== null`, this one handles `cwd === null` — so neither subsumes the other, and this PR cannot close that PR's half of the defect. They also need different messages, which is the substantive reason to keep them apart: #2551 tells the user their isolated worktree was removed and to run `/worktree remove`. That advice is false here. With `isolation_env_id` null the command returns *"This conversation is not using a worktree."*, and otherwise it repoints `cwd` at this same missing directory. The repo already documents that trap. This message suggests `/update-project`, which validates the new path and repairs the registration, and `/setproject`, which always works. Tests pin both the suggestions and the omissions so the advice cannot rot into the wrong commands.

Collapsing the two guards into one `conversation.cwd ?? default_cwd` check would silently absorb #2551's case and its message. The condition is commented as load-bearing for that reason.

The project name is quoted in the `/update-project` suggestion. `handleUpdateProject` takes only the first whitespace-separated token as the name, so for a project registered as `Client Ops` an unquoted suggestion parses as name `Client` and hands the user a second, more confusing error instead of a repair — verified against the real parser. Quoting is a no-op for names without whitespace.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | A chat message against a deleted project directory returns `No such file or directory (os error 2)` (Codex) or a libc/architecture error naming the Claude binary | The turn is refused, naming the missing directory and the project, with `/update-project` and `/setproject` as recovery |
| **Failure behavior** | Provider spawns into a nonexistent directory; the operator investigates the binary | Fails before the provider, logged as `orchestrator.codebase_cwd_missing` with `conversationId`, `codebaseId`, and `cwd` |

## Validation

- `bun run validate` — **exit code 0** — run as its own command with its real exit code captured, never piped. Proves generated-file checks, type-check, lint at `--max-warnings 0`, format, and the full per-package suite.
- `bun test src/orchestrator/orchestrator-agent.test.ts` (from `packages/core`) — 243 pass / 0 fail — seven new tests covering the refusal, the recovery advice and its omissions, quoting a project name that contains whitespace, the no-orphaned-row invariant, disjointness from #2551, the happy path, and the untouched unscoped path.
- Combined with #2551 (branches merged locally, conflict resolved as described under *Merge order*) — 247 pass / 0 fail.
- **The invariant test was observed failing, not just passing.** With the guard moved below the persist block, `writes no user row when it refuses` failed with `Expected length: 0, Received length: 1` while its sibling assertion `expect(mockSendQuery).not.toHaveBeenCalled()` still passed — isolating the orphaned row and nothing else. Only that one test broke; the other five stayed green. This is the exact defect that made the earlier attempt in #2114 unsuitable, so it is worth having a test that provably catches it.
- Root cause reproduced directly with `child_process.spawnSync` against a deleted directory (transcript above).
- **Not verified:** no end-to-end run against a live Codex install with a genuinely deleted project directory. The refusal is decided at the orchestrator seam and is covered there; everything below it is a pass-through for `sendMessage`.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | None. No schema change and no new state. A directory that exists behaves exactly as before. | Happy-path test asserts the unchanged `default_cwd` dispatch |
| Rollout / rollback | Fully reversible: one guard, one moved line, one test-fixture change, single commit. | 2 files |
| Observability | A stale project now emits `orchestrator.codebase_cwd_missing` instead of being indistinguishable from a provider crash. | The guard |

### One note for reviewers of this file

The shared `existsSync` mock is now reset in a top-level `beforeEach`. That is required by this change rather than tidying: 21 tests in the file scope a codebase and only 2 set `cwd`, which puts the rest inside this guard's condition. A leaked `false` predicate would refuse those turns and make them assert against the wrong thing, silently. The existing describe-level save/restore in `paused approval gate routing` was left alone — it is now redundant but harmless, and that file is being edited by other PRs.

## Links

- Closes #2663
- Depends on #2551 — merge that first. This complements it and does not substitute for it; landing this alone leaves the stale-worktree-override case open.
- Related #2114 — the closed draft where @waaaw found this gap
- Related #1170 — closed as fixed by `ensureArchonWorkspacesPath`, which covered only the unscoped half


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project recovery commands so project names containing spaces, quotes, or backslashes are handled correctly.
  * Added clearer refusal messaging and warnings when a conversation’s working directory is unavailable.
  * Prevented project-directory recovery advice from appearing in unrelated stale working-directory scenarios.

* **Tests**
  * Updated coverage to verify user-facing messages and warnings for missing conversation directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->