### PR TITLE
fix(cli): install nested marketplace Skills

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,7 @@ my-workflow/
 │   └── helper.md
 ├── scripts/           # → installed to .archon/scripts/
 │   └── analyze.ts
-└── skills/            # → installed to .archon/skills/
+└── skills/            # → installed to .claude/skills/
     └── my-skill/
 ```
 

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -2,7 +2,15 @@
  * Tests for workflow commands
  */
 import { describe, it, expect, beforeEach, afterEach, spyOn, mock, jest } from 'bun:test';
-import { appendFileSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { WorkflowEmitterEvent } from '@archon/workflows/event-emitter';
@@ -25,6 +33,7 @@ import {
   workflowEventEmitCommand,
   workflowCleanupCommand,
   workflowResetSessionsCommand,
+  workflowInstallCommand,
   buildDetachedRunCmd,
   maybePrintTierNotice,
   resolveContainerBackendConfig,
@@ -169,8 +178,10 @@ class MockCanonicalRepoPathUnavailableError extends Error {
   }
 }
 
+let mockFindRepoRoot: string | null = null;
+
 mock.module('@archon/git', () => ({
-  findRepoRoot: mock(() => Promise.resolve(null)),
+  findRepoRoot: mock(() => Promise.resolve(mockFindRepoRoot)),
   getCanonicalRepoPath: mock((path: string) => Promise.resolve(path)),
   getGitCheckoutIdentity: mock((path: string) =>
     Promise.resolve({
@@ -6927,5 +6938,129 @@ describe('resolveContainerBackendConfig', () => {
   it('rejects a non-integer / non-positive pidsLimit', () => {
     expect(() => resolveContainerBackendConfig({ pidsLimit: 10.5 })).toThrow(/positive integer/);
     expect(() => resolveContainerBackendConfig({ pidsLimit: 0 })).toThrow(/positive integer/);
+  });
+});
+
+describe('workflowInstallCommand directory packages', () => {
+  const sha = 'a'.repeat(40);
+  const sourceRoot = 'integrations/archon/public-x-research';
+  let repoRoot: string;
+  let fetchSpy: ReturnType<typeof spyOn>;
+  let consoleSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    repoRoot = mkdtempSync(join(tmpdir(), 'archon-marketplace-install-'));
+    mockFindRepoRoot = repoRoot;
+    consoleSpy = spyOn(console, 'log').mockImplementation(() => {});
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(
+      (input: RequestInfo | URL): Promise<Response> => {
+        const url = String(input);
+        if (url === 'https://archon.diy/workflows.json') {
+          return Promise.resolve(
+            Response.json([
+              {
+                slug: 'public-x-research',
+                name: 'Public X Research',
+                author: 'kriptoburak',
+                description: 'Build a cited brief from bounded public X data.',
+                sourceUrl: `https://github.com/kriptoburak/xquik-dev-x-twitter-scraper/tree/${sha}/${sourceRoot}`,
+                sha,
+                tags: ['automation'],
+                archonVersionCompat: '>=0.9.0',
+              },
+            ])
+          );
+        }
+        if (url.includes(`/contents/${sourceRoot}?ref=${sha}`)) {
+          return Promise.resolve(
+            Response.json([
+              {
+                name: 'public-x-research.yaml',
+                type: 'file',
+                download_url: null,
+                path: `${sourceRoot}/public-x-research.yaml`,
+              },
+              {
+                name: 'skills',
+                type: 'dir',
+                download_url: null,
+                path: `${sourceRoot}/skills`,
+              },
+            ])
+          );
+        }
+        if (url.includes(`/contents/${sourceRoot}/skills?ref=${sha}`)) {
+          return Promise.resolve(
+            Response.json([
+              {
+                name: 'xquik-social-research',
+                type: 'dir',
+                download_url: null,
+                path: `${sourceRoot}/skills/xquik-social-research`,
+              },
+              {
+                name: '..',
+                type: 'dir',
+                download_url: null,
+                path: 'outside',
+              },
+            ])
+          );
+        }
+        if (url.includes(`/contents/${sourceRoot}/skills/xquik-social-research?ref=${sha}`)) {
+          return Promise.resolve(
+            Response.json([
+              {
+                name: 'SKILL.md',
+                type: 'file',
+                download_url: null,
+                path: `${sourceRoot}/skills/xquik-social-research/SKILL.md`,
+              },
+            ])
+          );
+        }
+        if (url.endsWith(`${sourceRoot}/public-x-research.yaml`)) {
+          return Promise.resolve(new Response('name: public-x-research\nnodes: []\n'));
+        }
+        if (url.endsWith(`${sourceRoot}/skills/xquik-social-research/SKILL.md`)) {
+          return Promise.resolve(new Response('# Xquik social research\n'));
+        }
+        return Promise.resolve(new Response('not found', { status: 404 }));
+      }
+    );
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    consoleSpy.mockRestore();
+    mockFindRepoRoot = null;
+    rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it('preserves nested Skill paths from a directory package', async () => {
+    await workflowInstallCommand('public-x-research', repoRoot);
+
+    expect(readFileSync(join(repoRoot, '.archon/workflows/public-x-research.yaml'), 'utf8')).toBe(
+      'name: public-x-research\nnodes: []\n'
+    );
+    expect(
+      readFileSync(join(repoRoot, '.claude/skills/xquik-social-research/SKILL.md'), 'utf8')
+    ).toBe('# Xquik social research\n');
+    expect(fetchSpy.mock.calls.some(([input]) => String(input).includes('/contents/outside'))).toBe(
+      false
+    );
+  });
+
+  it('preserves an existing nested file unless force is set', async () => {
+    const skillPath = join(repoRoot, '.claude/skills/xquik-social-research/SKILL.md');
+    mkdirSync(join(skillPath, '..'), { recursive: true });
+    writeFileSync(skillPath, 'local skill\n');
+
+    await workflowInstallCommand('public-x-research', repoRoot);
+    expect(readFileSync(skillPath, 'utf8')).toBe('local skill\n');
+
+    await workflowInstallCommand('public-x-research', repoRoot, true);
+    expect(readFileSync(skillPath, 'utf8')).toBe('# Xquik social research\n');
+    expect(existsSync(join(repoRoot, '.claude/skills/xquik-social-research'))).toBe(true);
   });
 });

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -35,7 +35,7 @@ import {
   readTierNoticeState,
   markTierNoticeShown,
 } from '@archon/paths';
-import { isAbsolute, join } from 'node:path';
+import { dirname, isAbsolute, join } from 'node:path';
 import { mkdirSync, openSync, closeSync, readFileSync, writeSync } from 'node:fs';
 import { spawn, type ChildProcess } from 'node:child_process';
 import { createWorkflowDeps } from '@archon/core/workflows/store-adapter';
@@ -3261,6 +3261,11 @@ interface GitHubContentItem {
   path: string;
 }
 
+interface GitHubDirectoryFile {
+  sourcePath: string;
+  relativePath: string[];
+}
+
 /** Fetch directory listing from GitHub Contents API at a pinned SHA. */
 async function fetchGitHubDirectory(
   owner: string,
@@ -3284,6 +3289,36 @@ async function fetchGitHubDirectory(
     throw new Error(`Expected directory listing from ${url}, got a single file`);
   }
   return data as GitHubContentItem[];
+}
+
+/** Recursively collect safe files while preserving their source-relative paths. */
+async function fetchGitHubDirectoryFiles(
+  owner: string,
+  repo: string,
+  path: string,
+  sha: string,
+  relativePath: string[] = []
+): Promise<GitHubDirectoryFile[]> {
+  const items = await fetchGitHubDirectory(owner, repo, path, sha);
+  const files: GitHubDirectoryFile[] = [];
+
+  for (const item of items) {
+    if (!isSafePathComponent(item.name)) {
+      console.log(`  Skipped (unsafe path component): ${item.name}`);
+      continue;
+    }
+
+    const itemRelativePath = [...relativePath, item.name];
+    if (item.type === 'file') {
+      files.push({ sourcePath: item.path, relativePath: itemRelativePath });
+    } else if (item.type === 'dir') {
+      files.push(
+        ...(await fetchGitHubDirectoryFiles(owner, repo, item.path, sha, itemRelativePath))
+      );
+    }
+  }
+
+  return files;
 }
 
 /** Download a file from raw.githubusercontent.com at a pinned SHA. */
@@ -3426,32 +3461,28 @@ async function installDirectory(
       continue;
     }
 
-    const subItems = await fetchGitHubDirectory(owner, repo, subdir.path, entry.sha);
-    const files = subItems.filter(f => f.type === 'file');
+    const files = await fetchGitHubDirectoryFiles(owner, repo, subdir.path, entry.sha);
 
     let targetDir: string;
     if (subdir.name === 'commands') {
       targetDir = join(archonDir, 'commands');
     } else if (subdir.name === 'scripts') {
       targetDir = join(archonDir, 'scripts');
+    } else if (subdir.name === 'skills') {
+      targetDir = join(dirname(archonDir), '.claude', 'skills');
     } else {
-      // Other subdirs (e.g. skills) go under .archon/<dirname>
+      // Other supporting directories retain their name under .archon/.
       targetDir = join(archonDir, subdir.name);
     }
 
-    mkdirSync(targetDir, { recursive: true });
-
     for (const file of files) {
-      if (!isSafePathComponent(file.name)) {
-        console.log(`  Skipped (unsafe filename): ${file.name}`);
-        continue;
-      }
-      const destFile = join(targetDir, file.name);
+      const destFile = join(targetDir, ...file.relativePath);
       if (existsSync(destFile) && !force) {
         console.log(`  Skipped (exists): ${destFile}`);
         continue;
       }
-      const content = await downloadRawFile(owner, repo, file.path, entry.sha);
+      mkdirSync(dirname(destFile), { recursive: true });
+      const content = await downloadRawFile(owner, repo, file.sourcePath, entry.sha);
       writeFileSync(destFile, content);
       console.log(`  Installed: ${destFile}`);
       installedCount++;

--- a/packages/docs-web/src/data/marketplace.ts
+++ b/packages/docs-web/src/data/marketplace.ts
@@ -215,4 +215,16 @@ export const marketplaceEntries: MarketplaceEntry[] = [
     tags: ['automation', 'development'],
     archonVersionCompat: '>=0.5.0',
   },
+  {
+    slug: 'public-x-research',
+    name: 'Public X Research',
+    author: 'kriptoburak',
+    description:
+      'Search bounded public X or Twitter data and produce a cited Markdown brief. Preserves source IDs, links, timestamps, and research limits through an environment-backed Xquik MCP connection.',
+    sourceUrl:
+      'https://github.com/kriptoburak/xquik-dev-x-twitter-scraper/tree/18794ff416d8881e9f553000e102eb963ce6d89f/integrations/archon/public-x-research',
+    sha: '18794ff416d8881e9f553000e102eb963ce6d89f',
+    tags: ['automation'],
+    archonVersionCompat: '>=0.9.0',
+  },
 ];


### PR DESCRIPTION
## Problem and outcome

Directory marketplace packages document nested `skills/<name>/` folders, but the installer discarded every nested file and wrote Skills to an undiscoverable path. This left valid workflows installed but unable to resolve their declared Skills.

- **Outcome:** Directory packages preserve nested files, and Skills install under the project `.claude/skills/` root used by current providers.
- **Invariant:** Every destination component remains validated, pinned to the declared SHA, and protected from overwrite unless `--force` is set.
- **Scope boundary:** Single-file installation and workflow execution semantics do not change.
- **Root cause:** `installDirectory()` filtered each supporting directory to immediate files and mapped `skills/` to `.archon/skills/`.

## Review guidance

- **Feedback requested:** Installer correctness, path safety, and the marketplace package convention.
- **Start here:** `packages/cli/src/commands/workflow.ts:3294` because it owns recursive collection and safe relative paths.
- **Review order:** `workflow.ts`, its regression tests, the marketplace entry, then the contribution guide.
- **Lower-attention areas:** The marketplace record and one-line documentation mapping are checked by marketplace lint and the full validation gate.
- **Known risk or uncertainty:** None.

## Solution

`fetchGitHubDirectoryFiles()` walks directory entries recursively while rejecting unsafe path components at every level. `installDirectory()` preserves each safe relative path, creates parent directories, and retains existing per-file `--force` behavior. The `skills/` convention now targets the repository `.claude/skills/` directory, which matches Archon provider resolution.

The marketplace entry uses a real directory package that exercises the repaired path. Its SHA-pinned workflow performs bounded public X or Twitter research through Xquik MCP, keeps source metadata, and renders a cited Markdown brief. It permits public reads only and keeps the API key as an environment reference.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Nested package files were silently omitted; Skills went to `.archon/skills/`. | Nested files retain their paths; Skills install to `.claude/skills/<name>/`. |
| **Failure behavior** | Declared Skills remained unresolved after a reported successful install. | Unsafe components are skipped, existing files are preserved, and valid Skills resolve from the documented root. |

## Validation

- `bun test packages/cli/src/commands/workflow.test.ts` - 241 passed, 0 failed. Covers nested installation, unsafe components, existing files, and `--force`.
- `bun run packages/docs-web/scripts/lint-marketplace.ts` - all 15 entries and pinned sources passed.
- `bun run validate` - generated-file checks, type checks, lint, formatting, installer tests, all package tests, and script tests passed.
- `node --test tests/archon-workflow.test.mjs` in the pinned source repository - 4 passed, 0 failed.
- Isolated `archon validate workflows public-x-research` - 1 valid workflow, 0 errors.
- Isolated dry run with default stubs and code execution - preflight and renderer completed without provider or network calls.
- **Not verified:** A live authenticated MCP request. Validation avoids consuming user credentials or calling a live provider.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | Existing single-file workflows are unchanged. Directory packages can now install their documented nested resources. | `packages/cli/src/commands/workflow.test.ts:6944` |
| Security / permissions / data | Every destination component is validated. The source is SHA-pinned. The example workflow allows bounded public reads only. | `packages/cli/src/commands/workflow.ts:3305`, source commit `18794ff416d8881e9f553000e102eb963ce6d89f` |
| Rollout / rollback | Ships with the next CLI and marketplace deployment; reverting this commit restores prior behavior. | Single commit with no migration or persistent state change. |
| Documentation / communication | The contribution guide now names the provider-discoverable Skill destination. | `CONTRIBUTING.md:94` |

## Links

- Closes #2664

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the Public X Research marketplace workflow, which produces cited Markdown briefs from bounded public X/Twitter data.
  - Marketplace directory installations now support nested files and folders while preserving their structure.
  - Workflow skills are installed under `.claude/skills/`, with other supporting files retaining their relative locations.

- **Bug Fixes**
  - Unsafe path components are excluded during installation.
  - Existing files are preserved by default and can be replaced when forced.

- **Documentation**
  - Updated marketplace directory structure guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->