### PR TITLE
fix(cli): install nested marketplace Skills

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,7 @@ my-workflow/
 │   └── helper.md
 ├── scripts/           # → installed to .archon/scripts/
 │   └── analyze.ts
-└── skills/            # → installed to .archon/skills/
+└── skills/            # → installed to .claude/skills/
     └── my-skill/
 ```
 

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -2,7 +2,15 @@
  * Tests for workflow commands
  */
 import { describe, it, expect, beforeEach, afterEach, spyOn, mock, jest } from 'bun:test';
-import { appendFileSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { WorkflowEmitterEvent } from '@archon/workflows/event-emitter';
@@ -26,12 +34,20 @@ import {
   workflowEventEmitCommand,
   workflowCleanupCommand,
   workflowResetSessionsCommand,
+  workflowInstallCommand,
   buildDetachedRunCmd,
   maybePrintTierNotice,
   resolveContainerBackendConfig,
   hasUnresolvedWriteback,
   buildNodeSummaries,
 } from './workflow';
+
+interface GitHubContentResponseFixture {
+  name: string;
+  type: 'file' | 'dir';
+  download_url: null;
+  path: string;
+}
 
 const mockLogger = {
   fatal: mock(() => undefined),
@@ -228,8 +244,10 @@ class MockCanonicalRepoPathUnavailableError extends Error {
   }
 }
 
+let mockFindRepoRoot: string | null = null;
+
 mock.module('@archon/git', () => ({
-  findRepoRoot: mock(() => Promise.resolve(null)),
+  findRepoRoot: mock(() => Promise.resolve(mockFindRepoRoot)),
   getCanonicalRepoPath: mock((path: string) => Promise.resolve(path)),
   getGitCheckoutIdentity: mock((path: string) =>
     Promise.resolve({
@@ -7896,5 +7914,232 @@ describe('resolveContainerBackendConfig', () => {
   it('rejects a non-integer / non-positive pidsLimit', () => {
     expect(() => resolveContainerBackendConfig({ pidsLimit: 10.5 })).toThrow(/positive integer/);
     expect(() => resolveContainerBackendConfig({ pidsLimit: 0 })).toThrow(/positive integer/);
+  });
+});
+
+describe('workflowInstallCommand directory packages', () => {
+  const sha = 'a'.repeat(40);
+  const sourceRoot = 'integrations/archon/public-x-research';
+  let repoRoot: string;
+  let fetchSpy: ReturnType<typeof spyOn>;
+  let consoleSpy: ReturnType<typeof spyOn>;
+  let directoryMode: 'normal' | 'deep' | 'wide' | 'oversized';
+
+  beforeEach(() => {
+    repoRoot = mkdtempSync(join(tmpdir(), 'archon-marketplace-install-'));
+    mockFindRepoRoot = repoRoot;
+    directoryMode = 'normal';
+    mockLogger.error.mockClear();
+    consoleSpy = spyOn(console, 'log').mockImplementation(() => {});
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(
+      (input: RequestInfo | URL): Promise<Response> => {
+        const url = String(input);
+        if (url === 'https://archon.diy/workflows.json') {
+          return Promise.resolve(
+            Response.json([
+              {
+                slug: 'public-x-research',
+                name: 'Public X Research',
+                author: 'kriptoburak',
+                description: 'Build a cited brief from bounded public X data.',
+                sourceUrl: `https://github.com/kriptoburak/xquik-dev-x-twitter-scraper/tree/${sha}/${sourceRoot}`,
+                sha,
+                tags: ['automation'],
+                archonVersionCompat: '>=0.9.0',
+              },
+            ])
+          );
+        }
+        if (url.includes(`/contents/${sourceRoot}?ref=${sha}`)) {
+          const supportingDirectories =
+            directoryMode === 'wide'
+              ? Array.from(
+                  { length: 50 },
+                  (_: unknown, index: number): GitHubContentResponseFixture => ({
+                    name: `support-${String(index)}`,
+                    type: 'dir',
+                    download_url: null,
+                    path: `${sourceRoot}/support-${String(index)}`,
+                  })
+                )
+              : [
+                  {
+                    name: 'skills',
+                    type: 'dir',
+                    download_url: null,
+                    path: `${sourceRoot}/skills`,
+                  },
+                ];
+          return Promise.resolve(
+            Response.json([
+              {
+                name: 'public-x-research.yaml',
+                type: 'file',
+                download_url: null,
+                path: `${sourceRoot}/public-x-research.yaml`,
+              },
+              ...supportingDirectories,
+            ])
+          );
+        }
+        if (directoryMode === 'wide' && url.includes(`/contents/${sourceRoot}/support-`)) {
+          return Promise.resolve(Response.json([]));
+        }
+        if (url.includes(`/contents/${sourceRoot}/skills?ref=${sha}`)) {
+          if (directoryMode === 'oversized') {
+            return Promise.resolve(
+              Response.json(
+                Array.from(
+                  { length: 1000 },
+                  (_: unknown, index: number): GitHubContentResponseFixture => ({
+                    name: `file-${String(index)}.md`,
+                    type: 'file',
+                    download_url: null,
+                    path: `${sourceRoot}/skills/file-${String(index)}.md`,
+                  })
+                )
+              )
+            );
+          }
+          return Promise.resolve(
+            Response.json([
+              {
+                name: 'xquik-social-research',
+                type: 'dir',
+                download_url: null,
+                path: `${sourceRoot}/skills/xquik-social-research`,
+              },
+              {
+                name: '..',
+                type: 'dir',
+                download_url: null,
+                path: 'outside',
+              },
+            ])
+          );
+        }
+        if (url.includes(`/contents/${sourceRoot}/skills/xquik-social-research?ref=${sha}`)) {
+          if (directoryMode === 'deep') {
+            return Promise.resolve(
+              Response.json([
+                {
+                  name: 'next',
+                  type: 'dir',
+                  download_url: null,
+                  path: `${sourceRoot}/skills/xquik-social-research/next`,
+                },
+              ])
+            );
+          }
+          return Promise.resolve(
+            Response.json([
+              {
+                name: 'SKILL.md',
+                type: 'file',
+                download_url: null,
+                path: `${sourceRoot}/skills/xquik-social-research/SKILL.md`,
+              },
+            ])
+          );
+        }
+        if (
+          directoryMode === 'deep' &&
+          url.includes(`/contents/${sourceRoot}/skills/xquik-social-research/`)
+        ) {
+          const path = url.split('/contents/')[1]?.split('?ref=')[0];
+          return Promise.resolve(
+            Response.json([
+              {
+                name: 'next',
+                type: 'dir',
+                download_url: null,
+                path: `${path}/next`,
+              },
+            ])
+          );
+        }
+        if (url.endsWith(`${sourceRoot}/public-x-research.yaml`)) {
+          return Promise.resolve(new Response('name: public-x-research\nnodes: []\n'));
+        }
+        if (url.endsWith(`${sourceRoot}/skills/xquik-social-research/SKILL.md`)) {
+          return Promise.resolve(new Response('# Xquik social research\n'));
+        }
+        return Promise.resolve(new Response('not found', { status: 404 }));
+      }
+    );
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    consoleSpy.mockRestore();
+    mockFindRepoRoot = null;
+    rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it('preserves nested Skill paths from a directory package', async () => {
+    await workflowInstallCommand('public-x-research', repoRoot);
+
+    expect(readFileSync(join(repoRoot, '.archon/workflows/public-x-research.yaml'), 'utf8')).toBe(
+      'name: public-x-research\nnodes: []\n'
+    );
+    expect(
+      readFileSync(join(repoRoot, '.claude/skills/xquik-social-research/SKILL.md'), 'utf8')
+    ).toBe('# Xquik social research\n');
+    expect(fetchSpy.mock.calls.some(([input]) => String(input).includes('/contents/outside'))).toBe(
+      false
+    );
+  });
+
+  it('preserves an existing nested file unless force is set', async () => {
+    const skillPath = join(repoRoot, '.claude/skills/xquik-social-research/SKILL.md');
+    mkdirSync(join(skillPath, '..'), { recursive: true });
+    writeFileSync(skillPath, 'local skill\n');
+
+    await workflowInstallCommand('public-x-research', repoRoot);
+    expect(readFileSync(skillPath, 'utf8')).toBe('local skill\n');
+
+    await workflowInstallCommand('public-x-research', repoRoot, true);
+    expect(readFileSync(skillPath, 'utf8')).toBe('# Xquik social research\n');
+    expect(existsSync(join(repoRoot, '.claude/skills/xquik-social-research'))).toBe(true);
+  });
+
+  it('rejects directory packages deeper than the traversal limit before writing', async () => {
+    directoryMode = 'deep';
+
+    await expect(workflowInstallCommand('public-x-research', repoRoot)).rejects.toThrow(
+      'maximum depth of 8'
+    );
+    expect(existsSync(join(repoRoot, '.archon/workflows/public-x-research.yaml'))).toBe(false);
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      {
+        error: 'GitHub directory package exceeds the maximum depth of 8',
+        errorType: 'Error',
+        err: expect.any(Error),
+        slug: 'public-x-research',
+      },
+      'cli.workflow_install_failed'
+    );
+  });
+
+  it('rejects directory packages beyond the request limit before writing', async () => {
+    directoryMode = 'wide';
+
+    await expect(workflowInstallCommand('public-x-research', repoRoot)).rejects.toThrow(
+      '50 request limit'
+    );
+    expect(existsSync(join(repoRoot, '.archon/workflows/public-x-research.yaml'))).toBe(false);
+  });
+
+  it('rejects a listing at the GitHub Contents API item limit before writing', async () => {
+    directoryMode = 'oversized';
+    const existingSkillPath = join(repoRoot, '.claude/skills/xquik-social-research/SKILL.md');
+    mkdirSync(join(existingSkillPath, '..'), { recursive: true });
+    writeFileSync(existingSkillPath, 'existing skill\n');
+
+    await expect(workflowInstallCommand('public-x-research', repoRoot)).rejects.toThrow(
+      '1000-item Contents API limit'
+    );
+    expect(readFileSync(existingSkillPath, 'utf8')).toBe('existing skill\n');
+    expect(existsSync(join(repoRoot, '.archon/workflows/public-x-research.yaml'))).toBe(false);
   });
 });

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -35,7 +35,7 @@ import {
   readTierNoticeState,
   markTierNoticeShown,
 } from '@archon/paths';
-import { isAbsolute, join } from 'node:path';
+import { dirname, isAbsolute, join } from 'node:path';
 import { mkdirSync, openSync, closeSync, readFileSync, writeSync } from 'node:fs';
 import { spawn, type ChildProcess } from 'node:child_process';
 import { createWorkflowDeps } from '@archon/core/workflows/store-adapter';
@@ -3774,6 +3774,19 @@ interface GitHubContentItem {
   path: string;
 }
 
+interface GitHubDirectoryFile {
+  sourcePath: string;
+  relativePath: string[];
+}
+
+interface GitHubDirectoryTraversal {
+  requests: number;
+}
+
+const MAX_GITHUB_DIRECTORY_DEPTH = 8;
+const MAX_GITHUB_DIRECTORY_REQUESTS = 50;
+const MAX_GITHUB_CONTENTS_ITEMS = 1000;
+
 /** Fetch directory listing from GitHub Contents API at a pinned SHA. */
 async function fetchGitHubDirectory(
   owner: string,
@@ -3796,7 +3809,63 @@ async function fetchGitHubDirectory(
   if (!Array.isArray(data)) {
     throw new Error(`Expected directory listing from ${url}, got a single file`);
   }
+  if (data.length >= MAX_GITHUB_CONTENTS_ITEMS) {
+    throw new Error(
+      `GitHub directory listing reached the ${String(MAX_GITHUB_CONTENTS_ITEMS)}-item Contents API limit`
+    );
+  }
   return data as GitHubContentItem[];
+}
+
+/** Recursively collect safe files while preserving their source-relative paths. */
+async function fetchGitHubDirectoryFiles(
+  owner: string,
+  repo: string,
+  path: string,
+  sha: string,
+  relativePath: string[],
+  depth: number,
+  traversal: GitHubDirectoryTraversal
+): Promise<GitHubDirectoryFile[]> {
+  if (depth > MAX_GITHUB_DIRECTORY_DEPTH) {
+    throw new Error(
+      `GitHub directory package exceeds the maximum depth of ${String(MAX_GITHUB_DIRECTORY_DEPTH)}`
+    );
+  }
+  if (traversal.requests >= MAX_GITHUB_DIRECTORY_REQUESTS) {
+    throw new Error(
+      `GitHub directory package exceeds the ${String(MAX_GITHUB_DIRECTORY_REQUESTS)} request limit`
+    );
+  }
+  traversal.requests++;
+  const items = await fetchGitHubDirectory(owner, repo, path, sha);
+  const files: GitHubDirectoryFile[] = [];
+
+  for (const item of items) {
+    if (!isSafePathComponent(item.name)) {
+      console.log(`  Skipped (unsafe path component): ${item.name}`);
+      continue;
+    }
+
+    const itemRelativePath = [...relativePath, item.name];
+    if (item.type === 'file') {
+      files.push({ sourcePath: item.path, relativePath: itemRelativePath });
+    } else if (item.type === 'dir') {
+      files.push(
+        ...(await fetchGitHubDirectoryFiles(
+          owner,
+          repo,
+          item.path,
+          sha,
+          itemRelativePath,
+          depth + 1,
+          traversal
+        ))
+      );
+    }
+  }
+
+  return files;
 }
 
 /** Download a file from raw.githubusercontent.com at a pinned SHA. */
@@ -3825,6 +3894,20 @@ export async function workflowInstallCommand(
   cwd: string,
   force?: boolean
 ): Promise<void> {
+  try {
+    await installWorkflow(slug, cwd, force);
+  } catch (error) {
+    const err = error as Error;
+    getLog().error(
+      { error: err.message, errorType: err.constructor.name, err, slug },
+      'cli.workflow_install_failed'
+    );
+    throw err;
+  }
+}
+
+/** Install a marketplace entry into the current repository. */
+async function installWorkflow(slug: string, cwd: string, force?: boolean): Promise<void> {
   const entries = await fetchMarketplace();
   const entry = entries.find(e => e.slug === slug);
 
@@ -3854,7 +3937,16 @@ export async function workflowInstallCommand(
   const archonDir = join(repoRoot, '.archon');
 
   if (isDirectoryUrl(entry.sourceUrl)) {
-    await installDirectory(entry, slug, archonDir, force, existsSync, mkdirSync, writeFileSync);
+    await installDirectory(
+      entry,
+      slug,
+      archonDir,
+      repoRoot,
+      force,
+      existsSync,
+      mkdirSync,
+      writeFileSync
+    );
   } else {
     await installSingleFile(entry, slug, archonDir, force, existsSync, mkdirSync, writeFileSync);
   }
@@ -3862,6 +3954,7 @@ export async function workflowInstallCommand(
   console.log(`Run with: archon workflow run ${slug} "<message>"`);
 }
 
+/** Install one pinned marketplace workflow file. */
 async function installSingleFile(
   entry: MarketplaceEntryJson,
   slug: string,
@@ -3890,10 +3983,12 @@ async function installSingleFile(
   console.log(`Installed '${entry.name}' to ${destPath}`);
 }
 
+/** Preflight and install a pinned marketplace directory package. */
 async function installDirectory(
   entry: MarketplaceEntryJson,
   slug: string,
   archonDir: string,
+  repoRoot: string,
   force: boolean | undefined,
   existsSync: (p: string) => boolean,
   mkdirSync: (p: string, opts: { recursive: boolean }) => void,
@@ -3923,15 +4018,10 @@ async function installDirectory(
     );
   }
 
-  // Install the main workflow YAML
-  const mainContent = await downloadRawFile(owner, repo, mainYaml.path, entry.sha);
-  mkdirSync(workflowsDir, { recursive: true });
-  writeFileSync(destWorkflow, mainContent);
-  console.log(`  Workflow: ${destWorkflow}`);
-
-  // Install supporting files by convention
+  // Collect every directory listing before writing so traversal limits fail atomically.
   const subdirs = items.filter(f => f.type === 'dir');
-  let installedCount = 1;
+  const traversal = { requests: 1 };
+  const supportingFiles: { files: GitHubDirectoryFile[]; targetDir: string }[] = [];
 
   for (const subdir of subdirs) {
     if (!isSafePathComponent(subdir.name)) {
@@ -3939,32 +4029,39 @@ async function installDirectory(
       continue;
     }
 
-    const subItems = await fetchGitHubDirectory(owner, repo, subdir.path, entry.sha);
-    const files = subItems.filter(f => f.type === 'file');
-
     let targetDir: string;
     if (subdir.name === 'commands') {
       targetDir = join(archonDir, 'commands');
     } else if (subdir.name === 'scripts') {
       targetDir = join(archonDir, 'scripts');
+    } else if (subdir.name === 'skills') {
+      targetDir = join(repoRoot, '.claude', 'skills');
     } else {
-      // Other subdirs (e.g. skills) go under .archon/<dirname>
+      // Other supporting directories retain their name under .archon/.
       targetDir = join(archonDir, subdir.name);
     }
 
-    mkdirSync(targetDir, { recursive: true });
+    supportingFiles.push({
+      files: await fetchGitHubDirectoryFiles(owner, repo, subdir.path, entry.sha, [], 1, traversal),
+      targetDir,
+    });
+  }
 
+  const mainContent = await downloadRawFile(owner, repo, mainYaml.path, entry.sha);
+  mkdirSync(workflowsDir, { recursive: true });
+  writeFileSync(destWorkflow, mainContent);
+  console.log(`  Workflow: ${destWorkflow}`);
+
+  let installedCount = 1;
+  for (const { files, targetDir } of supportingFiles) {
     for (const file of files) {
-      if (!isSafePathComponent(file.name)) {
-        console.log(`  Skipped (unsafe filename): ${file.name}`);
-        continue;
-      }
-      const destFile = join(targetDir, file.name);
+      const destFile = join(targetDir, ...file.relativePath);
       if (existsSync(destFile) && !force) {
         console.log(`  Skipped (exists): ${destFile}`);
         continue;
       }
-      const content = await downloadRawFile(owner, repo, file.path, entry.sha);
+      mkdirSync(dirname(destFile), { recursive: true });
+      const content = await downloadRawFile(owner, repo, file.sourcePath, entry.sha);
       writeFileSync(destFile, content);
       console.log(`  Installed: ${destFile}`);
       installedCount++;


### PR DESCRIPTION
## Problem and outcome

Directory marketplace packages document nested `skills/<name>/` folders. The installer drops every nested file and writes Skills to a path providers do not scan.

- Outcome: preserve nested package files and install Skills under `.claude/skills/`.
- Invariant: validate every destination component and keep downloads pinned to the declared SHA.
- Scope: leave single-file installs, marketplace metadata, and workflow execution unchanged.
- Root cause: `installDirectory()` keeps only immediate files and maps `skills/` to `.archon/skills/`.

## Review guidance

- Start with `packages/cli/src/commands/workflow.ts:3821` for bounded recursive collection.
- Then review `installDirectory()` at line 3987 and its tests at line 7920.
- The contribution guide changes one destination path.

## Solution

`fetchGitHubDirectoryFiles()` walks safe directory entries and preserves relative paths. It caps depth, API requests, and Contents API listing size. `installDirectory()` preflights every listing before its first write, maps `skills/` to `.claude/skills/`, creates nested parent directories, and keeps the existing `--force` behavior.

Install failures now include structured context through the existing logger.

## Behavior change

Before this change, nested package files are omitted and Skills go to `.archon/skills/`. After this change, nested files retain their paths and Skills install to `.claude/skills/<name>/`.

Unsafe path components remain skipped. Existing files remain unchanged unless the caller uses `--force`.

## Validation

- `bun test packages/cli/src/commands/workflow.test.ts`: 268 passed, 0 failed, 598 assertions.
- `bun run validate`: passed on current `dev`. This includes generated checks, type-checking, zero-warning lint, formatting, installer tests, all package tests, and script tests.

The regression suite covers nested installation, unsafe components, existing files, forced replacement, traversal depth, request limits, capped listings, and fail-before-write behavior.

## Delivery considerations

- Compatibility: single-file workflows do not change.
- Security: destination components remain validated. Downloads remain SHA-pinned.
- Rollback: reverting this commit restores the previous installer.
- Documentation: `CONTRIBUTING.md` now names the provider-discoverable Skill path.

## Links

- Closes #2664
- Supersedes #2669
