### PR TITLE
fix(core): a fresh approval gate no longer inherits the previous gate's cache tokens

### DIFF
--- a/packages/core/src/db/workflows.resume-cas.integration.test.ts
+++ b/packages/core/src/db/workflows.resume-cas.integration.test.ts
@@ -11,6 +11,7 @@
  * ./connection with a real adapter, conflicting with workflows.test.ts's fake.
  */
 import { describe, test, expect, mock } from 'bun:test';
+import type { TokenUsage } from '@archon/providers/types';
 
 mock.module('@archon/paths', () => ({
   createLogger: () => ({
@@ -220,11 +221,11 @@ describe('claimWriteback — real SQLite CAS', () => {
 // ---------------------------------------------------------------------------
 // Gate approve/reject staging (#2075) — the run stays 'paused' after a gate
 // resolution instead of masquerading as 'failed'. This exercises the REAL
-// SQLite json_patch path end-to-end: staging write, resumable pickup (both the
+// SQLite JSON write path end-to-end: staging write, resumable pickup (both the
 // parent-conversation query the orchestrator uses and the working-path query
 // the CLI uses), the resume CAS, the double-resolution guard, and — critically
-// — that a fresh pause clears the previous gate's `resolved` marker despite
-// json_patch's deep-merge semantics.
+// — that a fresh pause carries nothing from the previous gate, which only a
+// real engine can prove (the mock suite runs the Postgres dialect).
 // ---------------------------------------------------------------------------
 
 /**
@@ -292,12 +293,12 @@ describe('gate approve staging — real SQLite end-to-end (#2075)', () => {
     await expect(resumeWorkflowRun('gate-1')).rejects.toThrow(WorkflowNotResumableError);
   });
 
-  test('a fresh pause clears the previous resolution despite json_patch deep-merge', async () => {
+  test('a fresh pause replaces the previous gate context, clearing its resolution', async () => {
     // Continue the run from the previous test: it is 'running' with
     // approval.resolved = 'approved' still in metadata (never cleared on
-    // resume by design). The next gate's pause MUST reset it — on SQLite
-    // json_patch deep-merges the new approval context into the old one, so an
-    // omitted key would leak the stale 'approved' and falsely block this gate.
+    // resume by design). The next gate's pause MUST reset it — the write
+    // replaces the whole approval object, so a key this gate does not set
+    // cannot carry the stale 'approved' over and falsely block it.
     await pauseWorkflowRun('gate-1', {
       nodeId: 'second-gate',
       message: 'Approve step 2?',
@@ -308,7 +309,6 @@ describe('gate approve staging — real SQLite end-to-end (#2075)', () => {
     expect(repaused?.status).toBe('paused');
     const approval = repaused?.metadata.approval as Record<string, unknown>;
     expect(approval.nodeId).toBe('second-gate');
-    // json_patch removes keys patched with null — 'resolved' must be gone/null.
     expect(approval.resolved ?? null).toBeNull();
 
     // And the second gate is approvable again.
@@ -316,6 +316,140 @@ describe('gate approve staging — real SQLite end-to-end (#2075)', () => {
     const staged = await getWorkflowRun('gate-1');
     expect((staged?.metadata.approval as Record<string, unknown>).resolved).toBe('approved');
     expect(staged?.status).toBe('paused');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #2673 — a later gate must not inherit an earlier gate's approval data. The
+// numeric half is the dangerous one: SQLite's json_patch is RFC 7396 and
+// recurses, so before the wholesale-replace write, interior keys of the nested
+// `signaledTokens` object survived from the previous gate and became real token
+// accounting on resume (readSignaledTokens in dag-executor). Only a real engine
+// can catch this; the mock suite runs the Postgres dialect, where `||` already
+// replaced the object.
+// ---------------------------------------------------------------------------
+describe('fresh gate usage is its own — real SQLite end-to-end (#2673)', () => {
+  /** Pause `runId` on a gate carrying `signaledTokens` and read the stored object back. */
+  async function pauseWithTokens(
+    runId: string,
+    nodeId: string,
+    signaledTokens: TokenUsage
+  ): Promise<Record<string, unknown> | undefined> {
+    await pauseWorkflowRun(runId, {
+      nodeId,
+      message: `gate ${nodeId}`,
+      type: 'interactive_loop',
+      iteration: 1,
+      signaledTokens,
+    });
+    const run = await getWorkflowRun(runId);
+    const approval = run?.metadata.approval as Record<string, unknown> | undefined;
+    return approval?.signaledTokens as Record<string, unknown> | undefined;
+  }
+
+  test('a second gate whose usage omits the cache axes does not inherit them', async () => {
+    await seedPausedRun('usage-cache', 'wf-usage-cache', { nodeId: 'seed', message: 'seed' });
+
+    // Gate 1: a provider that reports cache telemetry.
+    await resumeWorkflowRun('usage-cache');
+    const first = await pauseWithTokens('usage-cache', 'gate-1', {
+      input: 40,
+      output: 4,
+      cacheRead: 20,
+      cacheWrite: 3,
+    });
+    expect(first).toEqual({ input: 40, output: 4, cacheRead: 20, cacheWrite: 3 });
+
+    // Gate 2: a provider with no cache telemetry at all.
+    await resumeWorkflowRun('usage-cache');
+    const second = await pauseWithTokens('usage-cache', 'gate-2', { input: 90, output: 9 });
+
+    // Exactly the second gate's usage — no fabricated cache counts.
+    expect(second).toEqual({ input: 90, output: 9 });
+  });
+
+  test("a second gate's exact total is not flagged as a floor by the first gate", async () => {
+    await seedPausedRun('usage-partial', 'wf-usage-partial', { nodeId: 'seed', message: 'seed' });
+
+    // Gate 1 paused on a FLOOR (#2671): its cache totals are known-incomplete.
+    await resumeWorkflowRun('usage-partial');
+    await pauseWithTokens('usage-partial', 'gate-1', {
+      input: 10,
+      output: 1,
+      cacheRead: 50,
+      cacheWrite: 2,
+      cachePartial: true,
+    });
+
+    // Gate 2 knows its complete usage, so it declares no cachePartial.
+    await resumeWorkflowRun('usage-partial');
+    const second = await pauseWithTokens('usage-partial', 'gate-2', {
+      input: 90,
+      output: 9,
+      cacheRead: 5,
+      cacheWrite: 1,
+    });
+
+    expect(second).toEqual({ input: 90, output: 9, cacheRead: 5, cacheWrite: 1 });
+    expect(second?.cachePartial).toBeUndefined();
+  });
+
+  test('a gate that sets no optional fields stores none of them', async () => {
+    await seedPausedRun('usage-reset', 'wf-usage-reset', { nodeId: 'seed', message: 'seed' });
+
+    // A loop gate with the full optional payload.
+    await resumeWorkflowRun('usage-reset');
+    await pauseWorkflowRun('usage-reset', {
+      nodeId: 'loop-gate',
+      message: 'Review?',
+      type: 'interactive_loop',
+      iteration: 2,
+      sessionId: 'sess-1',
+      sessionProvider: 'claude',
+      completionSignaled: true,
+      signaledOutput: 'REPORT',
+      signaledTokens: { input: 40, output: 4, cacheRead: 20, cacheWrite: 3 },
+      signaledCostUsd: 0.02,
+      commandSnapshot: 'loop body',
+      onRejectPrompt: 'Fix: $REJECTION_REASON',
+      childRunId: 'child-1',
+    });
+
+    // A plain approval gate that declares none of them.
+    await resumeWorkflowRun('usage-reset');
+    await pauseWorkflowRun('usage-reset', {
+      nodeId: 'plain-gate',
+      message: 'Approve?',
+      type: 'approval',
+    });
+
+    const run = await getWorkflowRun('usage-reset');
+    expect(run?.metadata.approval).toEqual({
+      nodeId: 'plain-gate',
+      message: 'Approve?',
+      type: 'approval',
+    });
+  });
+
+  test('run-level metadata outside the approval object still merges', async () => {
+    await seedPausedRun(
+      'usage-extra',
+      'wf-usage-extra',
+      { nodeId: 'seed', message: 'seed' },
+      { rejection_count: 2 }
+    );
+
+    await resumeWorkflowRun('usage-extra');
+    await pauseWorkflowRun(
+      'usage-extra',
+      { nodeId: 'writeback', message: 'Apply changes?', type: 'writeback' },
+      { pending_writeback: true }
+    );
+
+    const run = await getWorkflowRun('usage-extra');
+    expect(run?.metadata.pending_writeback).toBe(true);
+    // Pre-existing top-level key untouched by the approval replace.
+    expect(run?.metadata.rejection_count).toBe(2);
   });
 });
 

--- a/packages/core/src/db/workflows.test.ts
+++ b/packages/core/src/db/workflows.test.ts
@@ -341,7 +341,7 @@ describe('workflows database', () => {
   });
 
   describe('pauseWorkflowRun', () => {
-    test('pauses a running run and resets the gate resolution marker', async () => {
+    test('replaces the approval object rather than merging into it', async () => {
       mockQuery.mockResolvedValueOnce(createQueryResult([], 1));
 
       await pauseWorkflowRun('workflow-run-123', {
@@ -353,27 +353,24 @@ describe('workflows database', () => {
       const [query, params] = mockQuery.mock.calls[0] as [string, unknown[]];
       expect(query).toContain("status = 'paused'");
       expect(query).toContain("AND status = 'running'");
-      // resolved must be an EXPLICIT null on every fresh pause: SQLite's
-      // json_patch deep-merges the new approval context into the stored one, so
-      // an omitted key would let a stale 'approved' from the previous gate
-      // survive and falsely block this gate (#2075).
-      const payload = JSON.parse(params[1] as string) as {
-        approval: Record<string, unknown>;
-      };
-      expect(payload.approval.resolved).toBeNull();
-      expect(payload.approval.nodeId).toBe('review');
-      // completionSignaled/signaledOutput follow the same explicit-null rule
-      // (#2074): standard approval pauses never set them, so they must be
-      // written as null (never omitted — JSON.stringify drops undefined and
-      // SQLite would keep a stale value from a previous interactive-loop gate).
-      expect(payload.approval.completionSignaled).toBeNull();
-      expect(payload.approval.signaledOutput).toBeNull();
-      expect(payload.approval.signaledTokens).toBeNull();
-      expect(payload.approval.signaledCostUsd).toBeNull();
-      // commandSnapshot (command-backed interactive loops) follows the same
-      // rule — a stale snapshot from a prior loop gate must never survive
-      // into an unrelated pause.
-      expect(payload.approval.commandSnapshot).toBeNull();
+      // The approval object is SET wholesale, never folded into the stored one —
+      // this suite runs the Postgres dialect, so it pins that branch of
+      // writeApprovalMetadata (#2673). Top-level run metadata still merges.
+      expect(query).toContain(
+        "metadata = jsonb_set(metadata || $2::jsonb, '{approval}', $3::jsonb, true)"
+      );
+
+      // $2 is run-level metadata (empty here); $3 is the complete gate context,
+      // bound separately so the replace can target it.
+      expect(JSON.parse(params[1] as string)).toEqual({});
+      // Exactly what the caller passed — no explicit-null reset list. Every field
+      // this gate leaves unset is absent, which is what makes a prior gate's value
+      // unable to survive at any depth.
+      expect(JSON.parse(params[2] as string)).toEqual({
+        nodeId: 'review',
+        message: 'Please review',
+        type: 'approval',
+      });
     });
 
     test('preserves interactive-loop signal and usage fields when the gate provides them', async () => {
@@ -392,20 +389,34 @@ describe('workflows database', () => {
       });
 
       const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
-      const payload = JSON.parse(params[1] as string) as {
-        approval: Record<string, unknown>;
-      };
-      expect(payload.approval.completionSignaled).toBe(true);
-      expect(payload.approval.signaledOutput).toBe('REPORT');
-      expect(payload.approval.signaledTokens).toEqual({
+      const approval = JSON.parse(params[2] as string) as Record<string, unknown>;
+      expect(approval.completionSignaled).toBe(true);
+      expect(approval.signaledOutput).toBe('REPORT');
+      expect(approval.signaledTokens).toEqual({
         input: 40,
         output: 4,
         cacheRead: 20,
         cacheWrite: 0,
       });
-      expect(payload.approval.signaledCostUsd).toBe(0.02);
-      expect(payload.approval.commandSnapshot).toBe('Loaded command body');
-      expect(payload.approval.resolved).toBeNull();
+      expect(approval.signaledCostUsd).toBe(0.02);
+      expect(approval.commandSnapshot).toBe('Loaded command body');
+      expect(approval.resolved).toBeUndefined();
+    });
+
+    test('folds caller-supplied run metadata into the same write', async () => {
+      mockQuery.mockResolvedValueOnce(createQueryResult([], 1));
+
+      await pauseWorkflowRun(
+        'workflow-run-123',
+        { nodeId: '__writeback__', message: 'Apply changes?', type: 'writeback' },
+        { pending_writeback: true }
+      );
+
+      const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+      // Same atomic UPDATE, so there is no window where the run is paused
+      // without the marker (M3) — it merges at the top level, beside `approval`.
+      expect(JSON.parse(params[1] as string)).toEqual({ pending_writeback: true });
+      expect((JSON.parse(params[2] as string) as { nodeId: string }).nodeId).toBe('__writeback__');
     });
 
     test('throws when the run is not running', async () => {

--- a/packages/core/src/db/workflows.ts
+++ b/packages/core/src/db/workflows.ts
@@ -128,6 +128,32 @@ function unresolvedGateClause(): string {
 }
 
 /**
+ * SQL expression writing a fresh approval gate: merge the caller's run-level
+ * metadata into the column at the TOP level, then set `metadata.approval` to the
+ * bound value WHOLESALE. Dialect-aware and kept in ONE place beside
+ * unresolvedGateClause so the two forms cannot drift.
+ *
+ * Deliberately NOT dialect.jsonMerge, because the two merge operators disagree
+ * one level down: Postgres `||` is shallow, so `approval` is replaced; SQLite's
+ * json_patch is RFC 7396 and RECURSES, so a nested object like
+ * `approval.signaledTokens` was merged key by key and interior keys the new gate
+ * omitted survived from the previous gate — fabricating cache-token counts no
+ * provider reported (#2673). Replacing the whole object makes "this gate's
+ * context, and only this gate's" structural on both dialects instead of a list
+ * of resets that every new nested field re-arms.
+ *
+ * @param mergeParamIndex - param holding top-level run metadata (may be `{}`)
+ * @param approvalParamIndex - param holding the complete ApprovalContext
+ */
+function writeApprovalMetadata(mergeParamIndex: number, approvalParamIndex: number): string {
+  const merge = `$${String(mergeParamIndex)}`;
+  const approval = `$${String(approvalParamIndex)}`;
+  return getDatabaseType() === 'postgresql'
+    ? `jsonb_set(metadata || ${merge}::jsonb, '{approval}', ${approval}::jsonb, true)`
+    : `json_set(json_patch(metadata, ${merge}), '$.approval', json(${approval}))`;
+}
+
+/**
  * An audit event written atomically with a gate resolution (#2146). The winning
  * resolver inserts these in the SAME transaction as the resolution UPDATE, so a
  * failed event write rolls the resolution back — a resolved gate can never be
@@ -160,6 +186,13 @@ export interface GateResolutionEvent {
  * Wrapping the resolution and its audit rows in one transaction closes the
  * separate gap where a post-commit event-write failure stranded a resolved gate
  * with no audit event and no way to retry (#2146).
+ *
+ * This one merges (unlike the wholesale pause write — writeApprovalMetadata) and
+ * is safe to, because it stamps the SAME gate rather than opening a new one:
+ * every caller passes `{ ...approval, resolved }`, the stored context plus fields,
+ * so SQLite's deep-merge and a replace produce identical rows. A caller that ever
+ * passed a PARTIAL approval would silently keep the stored values on SQLite and
+ * drop them on Postgres — pass the whole context, or use the pause write's form.
  */
 export async function resolveApprovalGate(
   id: string,
@@ -1027,58 +1060,35 @@ export async function cancelWorkflowRun(id: string): Promise<{ cancelled: boolea
  * Sets status to 'paused' and stores approval context in metadata.
  * Does NOT set completed_at — the run is not finished.
  *
- * `resolved`, completion state, and persisted loop usage are reset to an
- * explicit null on every fresh pause so a prior gate's resolution or signal
- * state can never leak into this one: SQLite's json_patch deep-merges the new
- * context into the stored one (an omitted key would keep the old value —
- * JSON.stringify drops undefined, so the values are computed explicitly), and
- * RFC 7396 null removes the key; Postgres `||` replaces the approval object
- * wholesale. See ApprovalContext.resolved / .completionSignaled.
+ * The stored `metadata.approval` is REPLACED with `approvalContext` wholesale
+ * (writeApprovalMetadata), never merged into. So a fresh pause stores exactly
+ * the keys the caller set — at every depth — and nothing a prior gate of the
+ * same run left behind can survive, on either dialect (#2673). Readers treat an
+ * absent key exactly like a JSON null (`!= null`, `=== true`, `?? ''`), and
+ * unresolvedGateClause's `IS NULL` matches both, so omission is the reset.
+ *
+ * `extraMetadata` still merges at the TOP level, so run-level keys the pause
+ * does not own (e.g. `pending_writeback`, `rejection_count`) are preserved.
  */
 export async function pauseWorkflowRun(
   id: string,
   approvalContext: ApprovalContext,
   extraMetadata?: Record<string, unknown>
 ): Promise<void> {
-  const dialect = getDialect();
   try {
     const result = await pool.query(
       `UPDATE remote_agent_workflow_runs
-       SET status = 'paused', metadata = ${dialect.jsonMerge('metadata', 2)}
+       SET status = 'paused', metadata = ${writeApprovalMetadata(2, 3)}
        WHERE id = $1 AND status = 'running'`,
       [
         id,
-        JSON.stringify({
-          approval: {
-            ...approvalContext,
-            resolved: null,
-            // Explicit-null reset of EVERY optional approval sub-field on each fresh
-            // pause (L1) — SQLite's json_patch deep-merges the new approval into the
-            // stored one, so a field the caller omits would otherwise inherit a stale
-            // value from a PRIOR gate in the same run (e.g. an earlier node's
-            // onRejectPrompt misrouting this gate's reject). RFC 7396 null removes the
-            // key; Postgres `||` replaces the approval object wholesale. Readers treat
-            // null as absent (`!= null`).
-            completionSignaled: approvalContext.completionSignaled ?? null,
-            signaledOutput: approvalContext.signaledOutput ?? null,
-            signaledTokens: approvalContext.signaledTokens ?? null,
-            signaledCostUsd: approvalContext.signaledCostUsd ?? null,
-            onRejectPrompt: approvalContext.onRejectPrompt ?? null,
-            onRejectMaxAttempts: approvalContext.onRejectMaxAttempts ?? null,
-            captureResponse: approvalContext.captureResponse ?? null,
-            iteration: approvalContext.iteration ?? null,
-            sessionId: approvalContext.sessionId ?? null,
-            sessionProvider: approvalContext.sessionProvider ?? null,
-            commandSnapshot: approvalContext.commandSnapshot ?? null,
-            // #2121 Phase 2: the child_workflow gate's target child. Reset explicitly
-            // like every other optional sub-field so a prior gate's childRunId can't
-            // leak into a later non-child gate via SQLite json_patch deep-merge.
-            childRunId: approvalContext.childRunId ?? null,
-          },
-          // Fold caller-supplied run-level metadata (e.g. `pending_writeback`) into the
-          // SAME atomic write so there is no window where the run is paused without it (M3).
-          ...(extraMetadata ?? {}),
-        }),
+        // Caller-supplied run-level metadata (e.g. `pending_writeback`) rides the SAME
+        // atomic write so there is no window where the run is paused without it (M3).
+        JSON.stringify(extraMetadata ?? {}),
+        // The complete gate context. JSON.stringify drops undefined, and the write
+        // replaces rather than merges, so an optional field the caller left unset is
+        // simply absent — no explicit-null reset list to keep in sync.
+        JSON.stringify(approvalContext),
       ]
     );
     if (result.rowCount === 0) {

--- a/packages/core/src/operations/workflow-operations.ts
+++ b/packages/core/src/operations/workflow-operations.ts
@@ -540,11 +540,15 @@ export async function rejectWorkflow(
   const rejectReason = reason ?? 'Rejected';
   const currentCount = (run.metadata.rejection_count as number | undefined) ?? 0;
   const maxAttempts = approval?.onRejectMaxAttempts ?? 3;
-  // `!= null` (not `!== undefined`): a gate with no on_reject leaves this ABSENT
-  // today (pauseWorkflowRun replaces the approval object wholesale, #2673), but runs
-  // paused by builds before that change hold a stored explicit null. Both must read
-  // as "not configured", so keep the loose check — tightening it would cancel a
-  // legacy paused run's rework on resume.
+  // `!= null` (not `!== undefined`): "no on_reject" reaches this read in two stored
+  // shapes. Absent — every pause since #2673 (the approval object is replaced
+  // wholesale, so an unset field is simply not there), and every SQLite pause before
+  // it too, since json_patch is RFC 7396 and DELETED the key the old explicit-null
+  // reset patched. An explicit JSON null — Postgres runs paused before #2673, where
+  // `||` stored the null as written. Keep the loose check: `null !== undefined` is
+  // true, so tightening would read such a run as HAVING an on_reject and stage a
+  // rework the workflow never declared — and the resume path takes its prompt from
+  // `node.approval.on_reject` (dag-executor), which is exactly what is missing.
   const onRejectConfigured = approval?.onRejectPrompt != null;
   const maxAttemptsReached = onRejectConfigured && currentCount + 1 >= maxAttempts;
   // The on_reject rework is staged (run stays 'paused') only when a prompt is

--- a/packages/core/src/operations/workflow-operations.ts
+++ b/packages/core/src/operations/workflow-operations.ts
@@ -540,9 +540,11 @@ export async function rejectWorkflow(
   const rejectReason = reason ?? 'Rejected';
   const currentCount = (run.metadata.rejection_count as number | undefined) ?? 0;
   const maxAttempts = approval?.onRejectMaxAttempts ?? 3;
-  // `!= null` (not `!== undefined`): pauseWorkflowRun now explicit-nulls this field
-  // on every pause when the gate has no on_reject (L1 dialect-parity reset), so a
-  // null must read as "not configured" exactly like an absent key.
+  // `!= null` (not `!== undefined`): a gate with no on_reject leaves this ABSENT
+  // today (pauseWorkflowRun replaces the approval object wholesale, #2673), but runs
+  // paused by builds before that change hold a stored explicit null. Both must read
+  // as "not configured", so keep the loose check — tightening it would cancel a
+  // legacy paused run's rework on resume.
   const onRejectConfigured = approval?.onRejectPrompt != null;
   const maxAttemptsReached = onRejectConfigured && currentCount + 1 >= maxAttempts;
   // The on_reject rework is staged (run stays 'paused') only when a prompt is

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -21347,9 +21347,11 @@ describe('executeDagWorkflow -- provider-boundary session threading (#1992)', ()
 
   it('interactive loop_group gate with no live cursor pauses with EXPLICIT null session fields', async () => {
     // Body tail is a PARALLEL layer (two sibling nodes, nothing downstream), which
-    // resets the sequential cursor before the gate. The pause payload must state
+    // resets the sequential cursor before the gate. The pause payload states
     // sessionId/sessionProvider as explicit nulls rather than omitting them, so the
-    // resume path reads "this gate had no cursor" instead of "the gate said nothing".
+    // stored gate record says outright that this gate had no cursor. Readers accept
+    // either shape (dag-executor restores only on `typeof … === 'string'`); this
+    // pins the payload the gate writes, not a distinction the resume path makes.
     mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'checked, not done yet' };
       yield { type: 'result', sessionId: 'parallel-tail-sess' };

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -21347,10 +21347,9 @@ describe('executeDagWorkflow -- provider-boundary session threading (#1992)', ()
 
   it('interactive loop_group gate with no live cursor pauses with EXPLICIT null session fields', async () => {
     // Body tail is a PARALLEL layer (two sibling nodes, nothing downstream), which
-    // resets the sequential cursor before the gate. The pause payload must write
-    // sessionId/sessionProvider as explicit nulls — key omission would let SQLite's
-    // json_patch deep-merge keep a stale pair from a previous pause of this run
-    // (same convention as ApprovalContext.resolved).
+    // resets the sequential cursor before the gate. The pause payload must state
+    // sessionId/sessionProvider as explicit nulls rather than omitting them, so the
+    // resume path reads "this gate had no cursor" instead of "the gate said nothing".
     mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'checked, not done yet' };
       yield { type: 'result', sessionId: 'parallel-tail-sess' };

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -4295,14 +4295,10 @@ async function executeLoopGroupNode(
         // Persist the body's session cursor so a resumed fresh_context: false loop
         // continues the pre-pause conversation (restored into the cursor on resume).
         // The provider tag rides along so the restore never threads the session into
-        // a different provider (#1992). EXPLICIT null (not key omission) when there
-        // is no cursor — SQLite's json_patch deep-merge would otherwise let a stale
-        // sessionId/sessionProvider from a previous pause of this run survive (same
-        // convention as `resolved`; RFC 7396 null removes the key).
+        // a different provider (#1992). null = this pause has no cursor to restore.
         sessionId: loopLastSequentialSession?.sessionId ?? null,
         sessionProvider: loopLastSequentialSession?.provider ?? null,
-        // Signal state for finalize-on-bare-approve (#2074): written unconditionally
-        // for honesty; pauseWorkflowRun nulls both on every fresh pause.
+        // Signal state for finalize-on-bare-approve (#2074).
         completionSignaled: completionDetected,
         signaledOutput: completionDetected ? lastIterationOutput : null,
         // NO `signaledTokens` — a loop_group gate has no consumer for it. The body's
@@ -5891,12 +5887,9 @@ async function executeLoopNode(
         message: honestMessage,
         type: 'interactive_loop',
         iteration: i,
-        // Explicit null (never key omission) when there is no session — SQLite's
-        // json_patch deep-merge would otherwise let a stale sessionId from a previous
-        // pause of this run survive (same convention as `resolved`).
+        // null = this pause has no session to restore.
         sessionId: currentSessionId ?? null,
-        // Signal state for finalize-on-bare-approve (#2074): written unconditionally
-        // for honesty; pauseWorkflowRun nulls both on every fresh pause.
+        // Signal state for finalize-on-bare-approve (#2074).
         completionSignaled: completionDetected,
         signaledOutput: completionDetected ? lastIterationOutput : null,
         // Cumulative usage consumed through this gate. A resumed loop seeds its

--- a/packages/workflows/src/schemas/workflow-run.ts
+++ b/packages/workflows/src/schemas/workflow-run.ts
@@ -245,16 +245,15 @@ export interface ApprovalContext {
   iteration?: number;
   /**
    * Session ID to restore on resume (interactive loops only). Gate pauses write an
-   * EXPLICIT null (never omit the key) when there is no session to restore — same
-   * json_patch rationale as `resolved` below: on SQLite an omitted key would let a
-   * stale session id from a previous pause of the same run survive the deep-merge.
+   * explicit null when the loop has no session cursor to restore; readers treat that
+   * exactly like an absent key.
    */
   sessionId?: string | null;
   /**
    * Provider that created `sessionId` (#1992). Persisted by loop_group gates and
    * restored together with the session id so a resumed loop never threads the
    * session into a node that resolves to a different provider (cross-provider
-   * resume is impossible). Same explicit-null-on-pause convention as `sessionId`.
+   * resume is impossible). Same null-means-no-cursor convention as `sessionId`.
    * Absent on single-node loop gates — those restore the session into the same
    * node, so the provider is the same by construction.
    */
@@ -271,22 +270,19 @@ export interface ApprovalContext {
    * 'rejected' = rejection recorded with an on_reject rework staged.
    * null/undefined = gate unresolved (awaiting the human).
    *
-   * Lifecycle: pauseWorkflowRun writes `resolved: null` on every fresh pause —
-   * an EXPLICIT null rather than key omission because SQLite's json_patch
-   * deep-merges the fresh context into the stored one (an omitted key would let
-   * a stale 'approved' from the previous gate survive and falsely block the
-   * next gate), while RFC 7396 null removes the key; Postgres `||` replaces the
-   * approval object wholesale. Never cleared on resume — matches the
-   * never-clear convention for approval_response/rejection_reason/
-   * loop_user_input (consumed in place; the next pause resets it).
+   * Lifecycle: never cleared on resume — matching the never-clear convention for
+   * approval_response/rejection_reason/loop_user_input (consumed in place). The
+   * next fresh pause is what resets it: pauseWorkflowRun REPLACES the whole
+   * approval object, so a gate that sets no `resolved` stores none and a prior
+   * gate's 'approved' cannot survive to block it (#2673).
    */
   resolved?: 'approved' | 'rejected' | null;
   /**
    * Interactive-loop only. True when the iteration this gate paused on emitted the
    * completion signal (detectCompletionSignal / until_bash exit 0). Read at resume by
    * executeLoopNode/executeLoopGroupNode: a signal-bearing gate approved WITHOUT feedback
-   * finalizes the node from `signaledOutput` instead of re-running. Reset to null on every
-   * fresh pause (see pauseWorkflowRun) for the same SQLite json_patch reason as `resolved`.
+   * finalizes the node from `signaledOutput` instead of re-running. Cleared by the next
+   * fresh pause the same way `resolved` is — the whole approval object is replaced.
    */
   completionSignaled?: boolean | null;
   /**

--- a/packages/workflows/src/subrun.test.ts
+++ b/packages/workflows/src/subrun.test.ts
@@ -200,9 +200,11 @@ class InMemoryStore implements IWorkflowStore {
     const r = this.runs.get(id);
     if (r) {
       r.status = 'paused';
+      // Mirrors the real store: `approval` is REPLACED wholesale (so nothing from a
+      // prior gate survives) while run-level metadata merges at the top level.
       r.metadata = {
         ...r.metadata,
-        approval: { ...approvalContext, resolved: null },
+        approval: { ...approvalContext },
         ...(extraMetadata ?? {}),
       };
     }

--- a/packages/workflows/src/subrun.test.ts
+++ b/packages/workflows/src/subrun.test.ts
@@ -200,9 +200,10 @@ class InMemoryStore implements IWorkflowStore {
     const r = this.runs.get(id);
     if (r) {
       r.status = 'paused';
-      // Mirrors the real store's write order: run-level metadata merges at the top
-      // level FIRST, then `approval` is set wholesale — so nothing from a prior gate
-      // survives, and the gate context wins over a same-named extra key.
+      // Mirrors the real store's write ORDER: run-level metadata is folded in first,
+      // then `approval` is set wholesale — so nothing from a prior gate survives and
+      // the gate context wins over a same-named extra key. Only the order; a JS
+      // spread cannot model both dialects' merge depth for `extraMetadata`.
       r.metadata = {
         ...r.metadata,
         ...(extraMetadata ?? {}),

--- a/packages/workflows/src/subrun.test.ts
+++ b/packages/workflows/src/subrun.test.ts
@@ -200,12 +200,13 @@ class InMemoryStore implements IWorkflowStore {
     const r = this.runs.get(id);
     if (r) {
       r.status = 'paused';
-      // Mirrors the real store: `approval` is REPLACED wholesale (so nothing from a
-      // prior gate survives) while run-level metadata merges at the top level.
+      // Mirrors the real store's write order: run-level metadata merges at the top
+      // level FIRST, then `approval` is set wholesale — so nothing from a prior gate
+      // survives, and the gate context wins over a same-named extra key.
       r.metadata = {
         ...r.metadata,
-        approval: { ...approvalContext },
         ...(extraMetadata ?? {}),
+        approval: { ...approvalContext },
       };
     }
     return Promise.resolve();


### PR DESCRIPTION
## Problem and outcome

On SQLite — the default backend — a later interactive gate in the same run reported cache-token counts that no provider ever sent. It failed silently and in the unsafe direction: overstated cache understates full-price input, so the run's cost figures were wrong for a gate that never used the cache.

- **Outcome:** A fresh approval gate stores exactly its own `ApprovalContext`. A second gate whose usage omits `cacheRead`/`cacheWrite` no longer inherits the first gate's numbers, and a gate-1 `cachePartial` floor no longer marks gate 2's exact total as a floor.
- **Invariant:** A fresh pause stores exactly the keys the caller set — at every nesting depth — and nothing a prior gate of the same run left behind survives, on either dialect.
- **Scope boundary:** `dialect.jsonMerge` is unchanged, as are its nine other call sites (run metadata, sessions, isolation environments). `resolveApprovalGate` also keeps its merge — every caller passes the full stored context plus fields, so a merge and a replace produce identical rows there; its docblock now records that requirement.
- **Root cause:** The pause wrote the approval object through `dialect.jsonMerge`, which on SQLite is `json_patch` — RFC 7396, which *recurses*. The explicit-null reset guarded only the top-level approval fields, so interior keys of the nested `signaledTokens` object that the new gate omitted were left untouched by the merge and survived from the earlier gate. On resume `readSignaledTokens` (`packages/workflows/src/dag-executor.ts:3596`) read them back as real token accounting.

## Review guidance

- **Feedback requested:** Correctness of the two SQL expressions, and whether the helper belongs in `workflows.ts` rather than on `SqlDialect`.
- **Start here:** `packages/core/src/db/workflows.ts:130-155` — `writeApprovalMetadata`, the dialect-aware replace that the whole fix rests on.
- **Review order:** `writeApprovalMetadata` → its use in `pauseWorkflowRun` (`packages/core/src/db/workflows.ts:1073-1094`) and the reset block it deletes → the new SQLite cases in `packages/core/src/db/workflows.resume-cas.integration.test.ts` → the comment corrections in `packages/workflows/src/schemas/workflow-run.ts` and `packages/workflows/src/dag-executor.ts`.
- **Lower-attention areas:** The `dag-executor.ts` and `workflow-run.ts` changes are comment-only; the `?? null` values they describe are unchanged. `subrun.test.ts` updates a fake store to mirror the new contract.
- **Known risk or uncertainty:** The Postgres branch has no automated test against a live engine — the repo has no PG-backed test harness. It was verified manually against PostgreSQL 18.0 and is behaviour-identical to today's `||`; see Validation.

## Solution

`pauseWorkflowRun` stops merging the approval object and sets it wholesale, while caller-supplied run-level metadata (`pending_writeback`) still merges at the top level in the same atomic UPDATE:

- Postgres: `jsonb_set(metadata || $2::jsonb, '{approval}', $3::jsonb, true)`
- SQLite: `json_set(json_patch(metadata, $2), '$.approval', json($3))`

The helper lives beside `unresolvedGateClause()` (`packages/core/src/db/workflows.ts:112-128`) and `claimWriteback`'s `extract` (`:1117-1120`), the two existing in-file dialect-branched SQL fragments, so the change stays in one file and leaves `SqlDialect` and its hand-maintained mock untouched.

Fixing it this way is what lets the 14-line explicit-null reset block and its 12-line justification be deleted rather than extended. Resetting `signaledTokens`' interior axes would have fixed this instance and re-armed the same trap for the next nested field added to `ApprovalContext`; replacing the object makes the guarantee structural. Every reader already treats an absent key exactly like a JSON null (`!= null`, `=== true`, `?? ''`), and `unresolvedGateClause`'s `IS NULL` matches both, so omission is now the reset.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | On SQLite, gate 2's stored `signaledTokens` kept gate 1's `cacheRead`/`cacheWrite`/`cachePartial` for any axis gate 2 omitted; those counts flowed into the node total, `total_cache_read_tokens`/`total_cache_write_tokens`, and telemetry | Gate 2 stores only its own usage; Postgres behaviour is unchanged |
| **Failure behavior** | Silent — the numbers looked plausible and skewed cost in the unsafe direction | No failure path involved; the write is one statement, as before |

## Architecture

```mermaid
flowchart LR
  A[pauseWorkflowRun] --> B[writeApprovalMetadata]
  B ==>|"jsonb_set(… '{approval}' …)"| P[(Postgres)]
  B ==>|"json_set(… '$.approval' …)"| S[(SQLite)]
  A -->|top-level run metadata| M[jsonMerge semantics, unchanged]
```

### Changed seams

| Boundary or contract | Change | Evidence |
|---|---|---|
| `pauseWorkflowRun → workflow_runs.metadata` | `approval` is replaced wholesale instead of deep-merged; the payload splits into two bound params (run metadata, approval context) | `packages/core/src/db/workflows.ts:130-155,1073-1094`; `workflows.resume-cas.integration.test.ts` (#2673 block); `workflows.test.ts` `pauseWorkflowRun` suite |
| `ApprovalContext` optional fields | An unset field is now absent rather than an explicit JSON null | `packages/workflows/src/schemas/workflow-run.ts`; readers already accept both |

## Validation

- `bun run validate` — passed (exit 0) — full gate: bundled/schema/vendor-map/capability-matrix checks, type-check, `lint --max-warnings 0`, `format:check`, `test:install`, full test suite.
- `bun test src/db/workflows.resume-cas.integration.test.ts` (packages/core) — 28 pass, 0 fail — proves both behaviours against a real `bun:sqlite`.
- Same file run against the pre-fix `workflows.ts` — 2 fail, exactly the reported symptom: the cache-axis case received 2 extra keys (`cacheRead`, `cacheWrite`), the floor case 1 extra (`cachePartial`). The guards were seen red before they were seen green.
- `bun test src/db/workflows.test.ts` (packages/core) — 94 pass, 0 fail — this suite pins `getDatabaseType` to `postgresql`, so it exercises and asserts the Postgres branch of the new expression and the split params.
- Manual, PostgreSQL 18.0: `jsonb_set(metadata || $M::jsonb, '{approval}', $A::jsonb, true)` produces the same row today's `||` does for a two-gate sequence, and a NULL `metadata` still yields NULL — so the Postgres half is behaviour-preserving, not a behaviour change.
- Manual, `bun:sqlite` 3.51.0: the issue's reproduction confirmed before the fix; the new expression stores only the new gate's keys and preserves top-level merged keys.
- **Not verified:** Postgres behaviour by an automated test — the repository has no PG-backed test harness (`check:schema-upgrades` is a separate CI job with its own database). Covered by the manual run above plus the dialect-expression assertion in the mock suite.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | None. No schema change. Runs already paused keep their stored explicit nulls, and every reader treats null and absent identically, so an in-flight paused run resumes unchanged | `packages/workflows/src/dag-executor.ts:3600,3807,3845,4729`; `manage-run-tool.ts:278,284` |
| Rollout / rollback | One file's write expression; reverting the commit restores previous behaviour exactly | Single commit |

## Links

- Closes #2673
- Related #2671
- Plan: https://github.com/coleam00/Archon/issues/2673#issuecomment-5369434780


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workflow approval metadata replacement when a workflow pauses, preventing outdated gate, usage, or session details from carrying over.
  * Preserved unrelated workflow metadata while updating approval information.
  * Improved consistency across SQLite, PostgreSQL, and in-memory workflow execution.
  * Ensured fresh pauses reset approval and completion details correctly.
  * Improved handling of missing or explicitly cleared approval and rejection fields during workflow resume and rejection flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->