### PR TITLE
feat(workflows): the run transcript now records what each node and the run cost

### DIFF
--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -1538,6 +1538,15 @@ cacheWrite` is exact when `cachePartial` is absent and an upper bound on full-pr
 when it is set. An axis no node reported stays absent, and cache usage in records created
 before this contract cannot be recovered.
 
+Read cost from `cost_usd`, not from the token counts. Because `input` is gross, pricing a
+node by hand means getting four axes and the cache rates right; `cost_usd` is the number the
+provider itself reported. JSONL `node_complete.cost_usd` and persisted
+`node_completed.data.cost_usd` carry it for a node, and JSONL `workflow_complete` carries the
+run totals as `cost_usd` and `tokens`, matching run metadata `total_cost_usd` and
+`total_tokens_*`. An absent `cost_usd` means the provider reported no cost — Codex reports
+none — while `0` means it reported zero. A run that spent nothing on AI, such as a bash-only
+workflow, carries no `cost_usd` rather than `0`.
+
 ### Choosing the child's checkout with `isolation:`
 
 `isolation:` decides which working directory the child run executes in. It is valid **only**

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -5967,6 +5967,106 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     expect(completedEvent?.[0].data).not.toHaveProperty('tokens');
   });
 
+  const readTranscript = async (
+    logDir: string,
+    runId: string
+  ): Promise<Array<Record<string, unknown>>> =>
+    (await readFile(join(logDir, `${runId}.jsonl`), 'utf-8'))
+      .trim()
+      .split('\n')
+      .map(line => JSON.parse(line) as Record<string, unknown>);
+
+  it('writes node and run cost to the transcript, matching the persisted events', async () => {
+    mockSendQueryDag.mockImplementation(async function* () {
+      yield { type: 'assistant', content: 'out' };
+      yield {
+        type: 'result',
+        sessionId: 'cost-sid',
+        cost: 0.3,
+        tokens: { input: 100, output: 10 },
+      };
+    });
+
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const logDir = join(testDir, 'logs');
+
+    await executeDagWorkflow(
+      mockDeps,
+      createMockPlatform(),
+      'conv-transcript-cost',
+      testDir,
+      { name: 'transcript-cost', nodes: [{ id: 'step1', command: 'step1' }] },
+      makeWorkflowRun('transcript-cost-run'),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      logDir,
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    const transcript = await readTranscript(logDir, 'transcript-cost-run');
+    const nodeRow = transcript.find(e => e.type === 'node_complete' && e.step === 'step1');
+    const runRow = transcript.find(e => e.type === 'workflow_complete');
+
+    const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls as Array<
+      [{ event_type: string; step_name: string; data?: Record<string, unknown> }]
+    >;
+    const completedEvent = eventCalls.find(
+      ([event]) => event.event_type === 'node_completed' && event.step_name === 'step1'
+    );
+
+    expect(nodeRow?.cost_usd).toBe(0.3);
+    expect(nodeRow?.tokens).toEqual({ input: 100, output: 10 });
+    // Both sinks read the one carrier, so the transcript can never disagree with the
+    // event the console and `workflow get` render.
+    expect(nodeRow?.cost_usd).toBe(completedEvent?.[0].data?.cost_usd);
+    expect(runRow?.cost_usd).toBe(0.3);
+    expect(runRow?.tokens).toEqual({ input: 100, output: 10 });
+  });
+
+  it('leaves cost off the transcript when the provider reports none', async () => {
+    mockSendQueryDag.mockImplementation(async function* () {
+      yield { type: 'assistant', content: 'out' };
+      // Codex reports no cost at all (#2334). Writing 0 here would claim the node was
+      // free, and a reader summing the transcript would believe it.
+      yield { type: 'result', sessionId: 'no-cost-sid', tokens: { input: 100, output: 10 } };
+    });
+
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const logDir = join(testDir, 'logs');
+
+    await executeDagWorkflow(
+      mockDeps,
+      createMockPlatform(),
+      'conv-transcript-no-cost',
+      testDir,
+      { name: 'transcript-no-cost', nodes: [{ id: 'step1', command: 'step1' }] },
+      makeWorkflowRun('transcript-no-cost-run'),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      logDir,
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    const transcript = await readTranscript(logDir, 'transcript-no-cost-run');
+    const nodeRow = transcript.find(e => e.type === 'node_complete' && e.step === 'step1');
+    const runRow = transcript.find(e => e.type === 'workflow_complete');
+
+    expect(nodeRow).toBeDefined();
+    expect(nodeRow).not.toHaveProperty('cost_usd');
+    expect(nodeRow?.tokens).toEqual({ input: 100, output: 10 });
+    expect(runRow).not.toHaveProperty('cost_usd');
+  });
+
   // ─── Background Agent Task Gating (#2083) ───────────────────────────────
 
   describe('background task completion gating (#2083)', () => {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -6065,6 +6065,9 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     expect(nodeRow).not.toHaveProperty('cost_usd');
     expect(nodeRow?.tokens).toEqual({ input: 100, output: 10 });
     expect(runRow).not.toHaveProperty('cost_usd');
+    // The two run-level axes are decided independently, so a missing cost must not
+    // suppress the tokens that were reported.
+    expect(runRow?.tokens).toEqual({ input: 100, output: 10 });
   });
 
   // ─── Background Agent Task Gating (#2083) ───────────────────────────────

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -1740,8 +1740,11 @@ async function executeNodeInternal(
   let nodeResolvedModel: ResolvedModel | undefined;
   const batchMessages: string[] = [];
 
-  // What this node reported, built once and passed whole to every sink — the DB event
-  // on each outcome and the JSONL transcript row. See WorkflowUsage for why.
+  // What this node reported, built once and passed whole rather than re-listed per sink:
+  // the DB event on every outcome, and the JSONL transcript row on completion. The JSONL
+  // FAILURE row is still outside it — logNodeError takes no usage, so a node that spent
+  // money and then failed records that spend in the DB and not in the transcript (#2614).
+  // See WorkflowUsage.
   const nodeUsageEventData = (): WorkflowUsage => ({
     ...(nodeTokens !== undefined ? { tokens: nodeTokens } : {}),
     ...(nodeCostUsd !== undefined ? { cost_usd: nodeCostUsd } : {}),

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -108,6 +108,7 @@ import {
   logTool,
   logWorkflowComplete,
   logWorkflowError,
+  type WorkflowUsage,
 } from './logger';
 import { withIdleTimeout, STEP_IDLE_TIMEOUT_MS } from './utils/idle-timeout';
 import { mapWithLimit } from './utils/map-with-limit';
@@ -1739,7 +1740,9 @@ async function executeNodeInternal(
   let nodeResolvedModel: ResolvedModel | undefined;
   const batchMessages: string[] = [];
 
-  const nodeUsageEventData = (): Record<string, unknown> => ({
+  // What this node reported, built once and passed whole to every sink — the DB event
+  // on each outcome and the JSONL transcript row. See WorkflowUsage for why.
+  const nodeUsageEventData = (): WorkflowUsage => ({
     ...(nodeTokens !== undefined ? { tokens: nodeTokens } : {}),
     ...(nodeCostUsd !== undefined ? { cost_usd: nodeCostUsd } : {}),
   });
@@ -2698,7 +2701,7 @@ async function executeNodeInternal(
     getLog().info({ nodeId: node.id, durationMs: duration }, 'dag_node_completed');
     await logNodeComplete(logDir, workflowRun.id, node.id, node.command ?? '<inline>', {
       durationMs: duration,
-      tokens: nodeTokens,
+      ...nodeUsageEventData(),
     });
 
     deps.store
@@ -2709,8 +2712,7 @@ async function executeNodeInternal(
         data: {
           duration_ms: duration,
           node_output: nodeOutputText,
-          ...(nodeTokens !== undefined ? { tokens: nodeTokens } : {}),
-          ...(nodeCostUsd !== undefined ? { cost_usd: nodeCostUsd } : {}),
+          ...nodeUsageEventData(),
           ...(nodeStopReason ? { stop_reason: nodeStopReason } : {}),
           ...(nodeNumTurns !== undefined ? { num_turns: nodeNumTurns } : {}),
           ...(nodeResolvedModel
@@ -9680,7 +9682,13 @@ export async function executeDagWorkflow(
       { workflowId: workflowRun.id }
     );
   }
-  await logWorkflowComplete(logDir, workflowRun.id);
+  await logWorkflowComplete(logDir, workflowRun.id, {
+    // `> 0` rather than `!== undefined`, mirroring persistRunUsage above: the accumulator
+    // is a plain number seeded at 0, so zero is the only way it can say "no AI usage" —
+    // and a bash-only run must not read as a free AI run on the transcript either.
+    ...(totalCostUsd > 0 ? { cost_usd: totalCostUsd } : {}),
+    ...(totalTokens !== undefined ? { tokens: totalTokens } : {}),
+  });
   const duration = Date.now() - dagStartTime;
   const emitter = getWorkflowEventEmitter();
   emitter.emit({

--- a/packages/workflows/src/logger.test.ts
+++ b/packages/workflows/src/logger.test.ts
@@ -142,6 +142,33 @@ describe('Workflow Logger', () => {
         cacheWrite: 0,
       });
     });
+
+    it('records the reported cost alongside the tokens', async () => {
+      await logNodeComplete(testDir, 'cost-test', 'step1', 'implement', {
+        durationMs: 1200,
+        tokens: { input: 120, output: 10 },
+        cost_usd: 0.0042,
+      });
+
+      const events = await readLogFile('cost-test');
+      expect(events[0].cost_usd).toBe(0.0042);
+      expect(events[0].duration_ms).toBe(1200);
+      expect(events[0].tokens).toEqual({ input: 120, output: 10 });
+    });
+
+    it('keeps a reported zero cost distinct from an unreported one', async () => {
+      // Codex reports no cost at all (#2334), so the absent key has to mean exactly
+      // that. A provider that reports 0 spent nothing, and must still say so.
+      await logNodeComplete(testDir, 'zero-cost', 'step1', 'implement', { cost_usd: 0 });
+      await logNodeComplete(testDir, 'no-cost', 'step1', 'implement', {
+        tokens: { input: 5, output: 1 },
+      });
+
+      const [zero] = await readLogFile('zero-cost');
+      const [absent] = await readLogFile('no-cost');
+      expect(zero.cost_usd).toBe(0);
+      expect('cost_usd' in absent).toBe(false);
+    });
   });
 
   describe('logAssistant', () => {
@@ -207,6 +234,20 @@ Line 3`;
       const events = await readLogFile('complete-test');
       expect(events).toHaveLength(1);
       expect(events[0].type).toBe('workflow_complete');
+      // A run with no AI usage carries no usage keys at all.
+      expect('cost_usd' in events[0]).toBe(false);
+      expect('tokens' in events[0]).toBe(false);
+    });
+
+    it('records what the whole run spent', async () => {
+      await logWorkflowComplete(testDir, 'complete-usage-test', {
+        cost_usd: 0.19,
+        tokens: { input: 900, output: 120, cacheRead: 400 },
+      });
+
+      const events = await readLogFile('complete-usage-test');
+      expect(events[0].cost_usd).toBe(0.19);
+      expect(events[0].tokens).toEqual({ input: 900, output: 120, cacheRead: 400 });
     });
   });
 

--- a/packages/workflows/src/logger.ts
+++ b/packages/workflows/src/logger.ts
@@ -42,11 +42,25 @@ export interface WorkflowEvent {
   tool_input?: Record<string, unknown>;
   duration_ms?: number;
   tokens?: WorkflowTokenUsage;
+  cost_usd?: number;
   check?: string;
   result?: 'pass' | 'fail' | 'warn' | 'unknown';
   error?: string;
   ts: string;
 }
+
+/**
+ * What a node or a whole run spent, in the transcript's own field names.
+ *
+ * One carrier, passed whole. The same payload used to be spelled out by hand at every
+ * sink, and cost was simply forgotten at the transcript one — an axis added here now
+ * reaches the JSONL row and the DB event together or not at all (#2674).
+ *
+ * Each axis is omitted when nothing was reported for it, so an absent `cost_usd` means
+ * the provider reported no cost (Codex reports none at all — #2334) and `0` means it
+ * reported zero. Build it with `!== undefined` tests, never truthiness.
+ */
+export type WorkflowUsage = Pick<WorkflowEvent, 'tokens' | 'cost_usd'>;
 
 /**
  * Get log file path for a workflow run.
@@ -153,11 +167,16 @@ export async function logWorkflowError(
 }
 
 /**
- * Log workflow completion
+ * Log workflow completion, with what the whole run spent.
  */
-export async function logWorkflowComplete(logDir: string, workflowRunId: string): Promise<void> {
+export async function logWorkflowComplete(
+  logDir: string,
+  workflowRunId: string,
+  usage?: WorkflowUsage
+): Promise<void> {
   await logWorkflowEvent(logDir, workflowRunId, {
     type: 'workflow_complete',
+    ...usage,
   });
 }
 
@@ -181,14 +200,17 @@ export async function logNodeComplete(
   workflowRunId: string,
   nodeId: string,
   commandName: string,
-  meta?: { durationMs?: number; tokens?: WorkflowTokenUsage }
+  meta?: { durationMs?: number } & WorkflowUsage
 ): Promise<void> {
+  const { durationMs, ...usage } = meta ?? {};
   await logWorkflowEvent(logDir, workflowRunId, {
     type: 'node_complete',
     step: nodeId,
     content: commandName,
-    ...(meta?.durationMs !== undefined ? { duration_ms: meta.durationMs } : {}),
-    ...(meta?.tokens ? { tokens: meta.tokens } : {}),
+    ...(durationMs !== undefined ? { duration_ms: durationMs } : {}),
+    // Spread whole: the caller already omitted every unreported axis, and a guard here
+    // would have to re-decide that per field — which is how `0` becomes absent.
+    ...usage,
   });
 }
 


### PR DESCRIPTION
## Problem and outcome

The per-run JSONL transcript at `~/.archon/workspaces/<project>/logs/<runId>.jsonl` recorded how many tokens a node used but never what it cost. Anyone reconstructing spend from it had to price four token axes by hand and get the cache rates right, and `tokens.input` is **gross** prompt input (cache reads and writes are components of it, not additions to it), which is exactly the part that is easy to get wrong. The executor already held the provider-reported cost at that point and wrote it to the DB `node_completed` event three lines later.

- **Outcome:** `node_complete` rows carry `cost_usd`, and the `workflow_complete` row carries the run totals as `cost_usd` and `tokens`. Reading spend out of a transcript no longer involves arithmetic.
- **Invariant:** A transcript row reports the same usage as the DB event for that same unit of work, and an unreported cost stays **absent** rather than becoming `0`. Codex reports no cost at all (#2334), so `0` has to keep meaning "the provider reported zero".
- **Scope boundary:** Only the cost gap named in [this comment](https://github.com/coleam00/Archon/issues/2614#issuecomment-5368036624). No transcript path printing, no `workflow logs <id> --follow`, and no other audit-coverage work. #2614 stays open for those.

## Review guidance

- **Feedback requested:** Correctness of the absent-vs-zero handling at both levels, and whether the shared carrier is the right shape for the seam.
- **Start here:** `packages/workflows/src/logger.ts:52-63` — the `WorkflowUsage` carrier. Everything else follows from it.
- **Review order:** `logger.ts` (field + carrier + two writers) → `dag-executor.ts:1745` (`nodeUsageEventData` now typed as the carrier) → `dag-executor.ts:2702` and `:2715` (both sinks spread the same value) → `dag-executor.ts:9685` (run totals) → the two test files.
- **Lower-attention areas:** The docs paragraph is an addition to the existing token-contract paragraph; the surrounding wording is untouched.
- **Known risk or uncertainty:** The run level uses `totalCostUsd > 0` while the node level uses `!== undefined`. That asymmetry is deliberate and commented: the run accumulator is a plain number seeded at `0` and cannot express "unreported", and `persistRunUsage` already made this exact call for the run row. Disagreeing would make the transcript and the run row report different things.

## Solution

The bug was not a missing field, it was a missing carrier. Inside `executeNodeInternal` the same two-axis usage payload was spelled out by hand three separate times: once in `nodeUsageEventData()` for the failure paths, once inline on the success DB event, and once more, minus cost, in the transcript call. The transcript spelling is the one that forgot cost.

So this adds one shape instead of one field. `WorkflowUsage` is `Pick<WorkflowEvent, 'tokens' | 'cost_usd'>` in `logger.ts`: the transcript's own field names, which are also the DB event's, so nothing translates at the boundary. `nodeUsageEventData()` is now typed as that carrier and spread whole into both sinks, which deleted the inline copy on the DB event. `logNodeComplete`'s meta becomes `{ durationMs?: number } & WorkflowUsage` and `logWorkflowComplete` gains an optional `usage` parameter, both spreading the carrier rather than re-deciding per field. A future usage axis now reaches the transcript and the DB event together or reaches neither.

The carrier omits an axis at construction when nothing was reported for it, so the writers need no guard. This matters: the existing writer used a *truthy* test for tokens, and copying that idiom for cost would have turned a genuine `$0` into an absent field.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | `node_complete` had `duration_ms` and `tokens`; `workflow_complete` had nothing but its type and timestamp | `node_complete` also has `cost_usd`; `workflow_complete` has `cost_usd` and `tokens` for the whole run |
| **Failure behavior** | A provider that reported no cost was indistinguishable from one that reported `$0`, since neither reached the file | An unreported cost writes no key at all; a reported `0` writes `0`. A run with no AI spend (bash-only) writes no run-level `cost_usd`, matching the run row |

## Architecture

```mermaid
flowchart LR
  N[node result: nodeTokens + nodeCostUsd] --> C["nodeUsageEventData(): WorkflowUsage"]
  C ==> T["JSONL node_complete"]
  C ==> D["DB node_completed.data"]
  R[runCtx totals] --> W["JSONL workflow_complete"]
  R --> P["run row metadata (persistRunUsage)"]
```

### Changed seams

| Boundary or contract | Change | Evidence |
|---|---|---|
| `executeNodeInternal → JSONL transcript` | `logNodeComplete` meta widened from `{ durationMs, tokens }` to `{ durationMs } & WorkflowUsage`; the caller passes the same carrier the DB event gets | `packages/workflows/src/dag-executor.ts:2702`, `packages/workflows/src/logger.ts:198-213` |
| `executeNodeInternal → DB node_completed` | Inline `tokens` / `cost_usd` re-listing replaced by the carrier; values unchanged | `packages/workflows/src/dag-executor.ts:2715` |
| `executeDagWorkflow → JSONL transcript` | `logWorkflowComplete` gains an optional `usage` argument carrying the run totals | `packages/workflows/src/dag-executor.ts:9685`, `packages/workflows/src/logger.ts:172-181` |
| `WorkflowEvent` row shape | New optional `cost_usd`; purely additive to an append-only file | `packages/workflows/src/logger.ts:45` |

## Validation

- `bun run validate` — passed (exit 0) — all 11 packages type-check clean, lint at `--max-warnings 0`, format clean, and every package suite green.
- `bun test src/logger.test.ts` (in `packages/workflows`) — 19 pass, 0 fail — proves the writer records a reported cost, keeps a reported `0` as `0`, omits the key entirely when nothing was reported, and writes run-level usage only when supplied.
- `bun test src/dag-executor.test.ts` (in `packages/workflows`) — 560 pass, 0 fail — the two new cases run a real DAG against a mocked provider, read the actual `.jsonl` off disk, and assert the node row's `cost_usd` equals the DB event's, plus the run row's total.
- Each new assertion was **observed failing** against a deliberately broken implementation before being trusted: reverting the transcript call to `tokens: nodeTokens` failed with `Expected: 0.3, Received: undefined`; writing `nodeCostUsd ?? 0` failed the absent-key test with `Received value: 0`; writing the run cost unconditionally failed the same test on the `workflow_complete` row; guarding the writer with truthiness instead of spreading the carrier failed the reported-zero test with `Expected: 0, Received: undefined`. All four mutations were reverted and the suites re-run green.
- **Not verified:** No live end-to-end run against a real provider. The transcript rows are asserted from the real file written by the real writer through the real executor path, with only the provider stream mocked, so the untested remainder is the provider's own cost reporting, which this PR does not change.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | Purely additive to an append-only log. Rows written before this change simply lack the key, and the only reader in the repo parses per line by field name. No schema change, so no migration or `check:schema-upgrades` involvement. | `packages/workflows/src/logger.test.ts:52-58` is the sole transcript reader |
| Rollout / rollback | Single-commit revert; no stored state depends on the new field. | — |
| Documentation / communication | The JSONL usage contract paragraph now states the cost contract alongside the token one, including absent-vs-zero. | `packages/docs-web/src/content/docs/guides/authoring-workflows.md:1541-1548` |

### Known remaining gaps in the same leg

Both are deliberate and stay with the open issue rather than widening this PR:

- Failure rows carry no usage at either level. `logNodeError` and `logWorkflowError` take none, so a node (or a run) that spent money and then failed records that spend on the DB event and the run row but not in the transcript. The comment above `nodeUsageEventData()` now says exactly that rather than claiming every sink is covered.
- `loop:` per-iteration rows still carry no usage. They carry no tokens today either, so nothing new is asymmetric, and a correct per-iteration figure is not a straightforward carry: `iterationCost` holds only the last attempt's value and reasked attempts fold separately into `loopTotalCostUsd`. The loop node's spend still reaches the run total.

## Links

- Related #2614 — this delivers only the cost gap from that issue's "Complete" leg. Part of #2614, not a fix for it; the issue stays open for transcript discoverability and `workflow logs --follow`.
- Implementation plan: https://github.com/coleam00/Archon/issues/2614#issuecomment-5369474743


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Workflow and node transcripts now consistently record provider-reported token usage and costs.
  - Explicit zero-cost results are preserved, while unavailable cost data remains omitted.
  - Workflow completion records include aggregate usage details when available.
  - Cost totals are surfaced consistently across JSONL logs, persisted events, and run metadata.

- **Documentation**
  - Added guidance on using provider-reported costs for workflow and node accounting.
  - Documented cost-data locations, absent-versus-zero behavior, and bash-only workflow considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
