### PR TITLE
test(workflows): a new TokenUsage axis fails type-check at every seam that carries it

### DIFF
--- a/packages/core/src/db/workflow-events.test.ts
+++ b/packages/core/src/db/workflow-events.test.ts
@@ -716,8 +716,9 @@ describe('workflow-events', () => {
 // `getDagResumeSnapshot` rebuilds a persisted `data.tokens` field by field, so
 // an axis it does not know about is dropped from every resumed run's total.
 // Its writer is in @archon/workflows, and that half is guarded there under the
-// same block name — but the two halves cannot meet in one test, so this side
-// cannot be a round trip.
+// same block name. The two cannot share a test: the writer is only reachable by
+// driving `executeDagWorkflow` through that file's own mock harness, which is
+// not importable. So this side cannot be a round trip.
 //
 // It is pinned to `mergeTokenUsage` instead, which is the decoder's actual
 // downstream contract: `getDagResumeSnapshot` folds what it decodes through

--- a/packages/core/src/db/workflow-events.test.ts
+++ b/packages/core/src/db/workflow-events.test.ts
@@ -2,6 +2,11 @@ import { mock, describe, test, expect, beforeEach } from 'bun:test';
 import { createMockLogger } from '../test/mocks/logger';
 import { createQueryResult, mockPostgresDialect } from '../test/mocks/database';
 import type { WorkflowEventRow } from './workflow-events';
+import {
+  AXIS_SPECIMEN,
+  RESUME_SNAPSHOT_AXIS_KEYS,
+  expectSeamCarriesAxes,
+} from '../test/token-usage-axes';
 
 // Mock logger to suppress noisy output during tests
 const mockLogger = createMockLogger();
@@ -705,5 +710,43 @@ describe('workflow-events', () => {
 
       await expect(getDagResumeSnapshot('run-error')).rejects.toThrow('connection refused');
     });
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// TokenUsage axis seam guard (#2674) — the reader half
+//
+// `getDagResumeSnapshot` rebuilds a persisted `data.tokens` field by field, so
+// an axis it does not know about is dropped from every resumed run's total.
+// Its writer lives in @archon/workflows, which cannot be imported from here;
+// that half is guarded in that package's dag-executor tests, under the same
+// block name.
+//
+// The type-level anchors are in `src/test/token-usage-axes.ts`, NOT in this
+// file: `packages/core/tsconfig.json` excludes `**/*.test.ts` from type-check,
+// so an anchor placed here would never fail. That module explains the rest.
+// ───────────────────────────────────────────────────────────────────────────
+describe('TokenUsage axis seam guard', () => {
+  test('getDagResumeSnapshot carries every axis it claims', async () => {
+    // A single contributing row keeps the fold an identity, so each carried axis
+    // must come back at exactly the value the event stored.
+    mockQuery.mockResolvedValueOnce(
+      createQueryResult([
+        {
+          step_name: 'node-a',
+          event_type: 'node_completed',
+          data: { tokens: AXIS_SPECIMEN },
+        },
+      ])
+    );
+
+    const { tokens } = await getDagResumeSnapshot('run-axis-seam');
+
+    expectSeamCarriesAxes(
+      expect,
+      'getDagResumeSnapshot',
+      RESUME_SNAPSHOT_AXIS_KEYS,
+      tokens as unknown as Record<string, unknown> | undefined
+    );
   });
 });

--- a/packages/core/src/db/workflow-events.test.ts
+++ b/packages/core/src/db/workflow-events.test.ts
@@ -2,11 +2,8 @@ import { mock, describe, test, expect, beforeEach } from 'bun:test';
 import { createMockLogger } from '../test/mocks/logger';
 import { createQueryResult, mockPostgresDialect } from '../test/mocks/database';
 import type { WorkflowEventRow } from './workflow-events';
-import {
-  AXIS_SPECIMEN,
-  RESUME_SNAPSHOT_AXIS_KEYS,
-  expectSeamCarriesAxes,
-} from '../test/token-usage-axes';
+import { AXIS_SPECIMEN } from '../test/token-usage-axes';
+import { mergeTokenUsage } from '@archon/providers/types';
 
 // Mock logger to suppress noisy output during tests
 const mockLogger = createMockLogger();
@@ -718,18 +715,26 @@ describe('workflow-events', () => {
 //
 // `getDagResumeSnapshot` rebuilds a persisted `data.tokens` field by field, so
 // an axis it does not know about is dropped from every resumed run's total.
-// Its writer lives in @archon/workflows, which cannot be imported from here;
-// that half is guarded in that package's dag-executor tests, under the same
-// block name.
+// Its writer is in @archon/workflows, and that half is guarded there under the
+// same block name — but the two halves cannot meet in one test, so this side
+// cannot be a round trip.
 //
-// The type-level anchors are in `src/test/token-usage-axes.ts`, NOT in this
-// file: `packages/core/tsconfig.json` excludes `**/*.test.ts` from type-check,
-// so an anchor placed here would never fail. That module explains the rest.
+// It is pinned to `mergeTokenUsage` instead, which is the decoder's actual
+// downstream contract: `getDagResumeSnapshot` folds what it decodes through
+// that same function (`workflow-events.ts:335`). Any axis the fold keeps, the
+// decoder must keep; any axis the fold drops is absent from both sides. That is
+// strictly stronger than a hand-written key map here would be, because a map
+// could be dispositioned `null` — truthfully, since the decoder really does
+// drop the axis — while the writer next door carries it, and both packages
+// would stay green. Pinning to the fold makes that disagreement a failure.
+//
+// The type anchor is `AXIS_SPECIMEN` in `src/test/token-usage-axes.ts`, NOT in
+// this file: core's tsconfig excludes `**/*.test.ts` from type-check, so an
+// anchor placed here would never fire. That module explains the rest.
 // ───────────────────────────────────────────────────────────────────────────
 describe('TokenUsage axis seam guard', () => {
-  test('getDagResumeSnapshot carries every axis it claims', async () => {
-    // A single contributing row keeps the fold an identity, so each carried axis
-    // must come back at exactly the value the event stored.
+  test('getDagResumeSnapshot carries every axis the fold keeps', async () => {
+    mockQuery.mockClear();
     mockQuery.mockResolvedValueOnce(
       createQueryResult([
         {
@@ -742,11 +747,10 @@ describe('TokenUsage axis seam guard', () => {
 
     const { tokens } = await getDagResumeSnapshot('run-axis-seam');
 
-    expectSeamCarriesAxes(
-      expect,
-      'getDagResumeSnapshot',
-      RESUME_SNAPSHOT_AXIS_KEYS,
-      tokens as unknown as Record<string, unknown> | undefined
-    );
+    // A single contributing row keeps the fold an identity, so a lossless
+    // decoder must return exactly what the fold makes of the specimen.
+    expect(tokens).toEqual(mergeTokenUsage([AXIS_SPECIMEN]));
+    // ...and that must be a real object, not two matching `undefined`s.
+    expect(tokens).toBeDefined();
   });
 });

--- a/packages/core/src/test/token-usage-axes.ts
+++ b/packages/core/src/test/token-usage-axes.ts
@@ -1,25 +1,31 @@
 /**
- * TokenUsage axis seam guard anchors for @archon/core (#2674).
+ * TokenUsage axis anchor for @archon/core's seam guard (#2674).
  *
- * These live in `src/test/` rather than beside their assertions in
+ * This lives in `src/test/` rather than beside its assertion in
  * `src/db/workflow-events.test.ts` for one reason: `packages/core/tsconfig.json`
- * excludes `**\/*.test.ts` from type-check (removing that exclusion surfaces 968
- * pre-existing errors, so it is load-bearing). An anchor placed in a test file
- * here would never fail, which would make it decoration. `src/test/` is inside
- * `include: ["src/**\/*"]` and is not a `.test.ts` file, so it IS type-checked —
- * the same directory that already holds this package's shared test mocks.
+ * excludes `**\/*.test.ts` from type-check (removing that exclusion surfaces
+ * ~966 pre-existing errors, so it is load-bearing). An anchor placed in a test
+ * file here would never fail, which would make it decoration. `src/test/` is
+ * inside `include: ["src/**\/*"]` and is not a `.test.ts` file, so it IS
+ * type-checked — the same directory that already holds this package's shared
+ * test mocks.
  *
  * Duplicated from the matching block in `@archon/workflows`'
- * `dag-executor.test.ts` on purpose. Sharing would mean exporting test
- * scaffolding across a package boundary, and each copy is what puts its OWN
- * package's `tsc --noEmit` inside the guard.
+ * `dag-executor.test.ts`. That is deliberate, and NOT because the packages
+ * cannot see each other — `@archon/core` depends on `@archon/workflows` and
+ * imports it today (the layering ban runs the other way). It is because each
+ * copy is what puts its OWN package's `tsc --noEmit` inside the guard: an
+ * anchor imported from elsewhere would fail once, in one program, instead of
+ * once per package that carries usage. Two literals of the same type cannot
+ * silently diverge on the dimension that matters, because both are pinned to
+ * `Required<TokenUsage>`.
  */
 
 import type { TokenUsage } from '@archon/providers/types';
 
 /**
- * One value per axis, all distinct so a swapped key spelling fails instead of
- * passing on a coincidence.
+ * One value per axis, all distinct so a swapped field fails instead of passing
+ * on a coincidence.
  *
  * `Required<TokenUsage>` is the anchor. Adding `foo?: number` to `TokenUsage`
  * fails here with `TS2741: Property 'foo' is missing in type ... but required in
@@ -34,59 +40,3 @@ export const AXIS_SPECIMEN: Required<TokenUsage> = {
   total: 6400,
   cost: 0.25,
 };
-
-/**
- * How one seam spells each axis on its wire. `null` = this seam deliberately
- * does not carry the axis. Exhaustive over `keyof TokenUsage`, so a new axis is
- * a compile error until someone decides which it is.
- */
-export type SeamAxisKeys = Record<keyof TokenUsage, string | null>;
-
-/**
- * `getDagResumeSnapshot` (`src/db/workflow-events.ts`) rebuilds a persisted
- * `data.tokens` field by field, so an axis it does not know about is dropped
- * from every resumed run's total. Its writer is in `@archon/workflows`, which
- * cannot be imported from here; that half is guarded in that package.
- *
- * `total` and `cost` are `null`. This decoder reads cost from the event's own
- * `data.cost_usd` scalar, never off the usage object — cost is lifted onto the
- * result message's `cost` field back at the provider boundary. And `total` is
- * dropped by the first fold: `mergeTokenUsage` documents that it does not
- * aggregate it, so it never reaches a persisted event to be decoded.
- */
-export const RESUME_SNAPSHOT_AXIS_KEYS: SeamAxisKeys = {
-  input: 'input',
-  output: 'output',
-  cacheRead: 'cacheRead',
-  cacheWrite: 'cacheWrite',
-  cachePartial: 'cachePartial',
-  total: null,
-  cost: null,
-};
-
-/**
- * Assert that every axis `keys` declares carried arrived under its declared key
- * with the specimen's value.
- *
- * Seam and axis ride the compared object's KEY, not a sibling field: bun's diff
- * prints only a narrow window around the changed line, so a sibling `axis` field
- * is elided and the failure never says which axis went missing.
- *
- * `expect` is passed in rather than imported, so this module stays free of
- * `bun:test` and can be type-checked as ordinary source.
- */
-export function expectSeamCarriesAxes(
-  expect: (actual: unknown) => { toEqual: (expected: unknown) => void },
-  seam: string,
-  keys: SeamAxisKeys,
-  carried: Record<string, unknown> | undefined
-): void {
-  expect({ [`${seam} carried usage`]: carried !== undefined }).toEqual({
-    [`${seam} carried usage`]: true,
-  });
-  for (const [axis, key] of Object.entries(keys) as [keyof TokenUsage, string | null][]) {
-    if (key === null) continue;
-    const label = `${seam} → ${axis} (as '${key}')`;
-    expect({ [label]: carried?.[key] }).toEqual({ [label]: AXIS_SPECIMEN[axis] });
-  }
-}

--- a/packages/core/src/test/token-usage-axes.ts
+++ b/packages/core/src/test/token-usage-axes.ts
@@ -1,0 +1,92 @@
+/**
+ * TokenUsage axis seam guard anchors for @archon/core (#2674).
+ *
+ * These live in `src/test/` rather than beside their assertions in
+ * `src/db/workflow-events.test.ts` for one reason: `packages/core/tsconfig.json`
+ * excludes `**\/*.test.ts` from type-check (removing that exclusion surfaces 968
+ * pre-existing errors, so it is load-bearing). An anchor placed in a test file
+ * here would never fail, which would make it decoration. `src/test/` is inside
+ * `include: ["src/**\/*"]` and is not a `.test.ts` file, so it IS type-checked —
+ * the same directory that already holds this package's shared test mocks.
+ *
+ * Duplicated from the matching block in `@archon/workflows`'
+ * `dag-executor.test.ts` on purpose. Sharing would mean exporting test
+ * scaffolding across a package boundary, and each copy is what puts its OWN
+ * package's `tsc --noEmit` inside the guard.
+ */
+
+import type { TokenUsage } from '@archon/providers/types';
+
+/**
+ * One value per axis, all distinct so a swapped key spelling fails instead of
+ * passing on a coincidence.
+ *
+ * `Required<TokenUsage>` is the anchor. Adding `foo?: number` to `TokenUsage`
+ * fails here with `TS2741: Property 'foo' is missing in type ... but required in
+ * type 'Required<TokenUsage>'`, before any test runs.
+ */
+export const AXIS_SPECIMEN: Required<TokenUsage> = {
+  input: 5000,
+  output: 1200,
+  cacheRead: 4000,
+  cacheWrite: 250,
+  cachePartial: true,
+  total: 6400,
+  cost: 0.25,
+};
+
+/**
+ * How one seam spells each axis on its wire. `null` = this seam deliberately
+ * does not carry the axis. Exhaustive over `keyof TokenUsage`, so a new axis is
+ * a compile error until someone decides which it is.
+ */
+export type SeamAxisKeys = Record<keyof TokenUsage, string | null>;
+
+/**
+ * `getDagResumeSnapshot` (`src/db/workflow-events.ts`) rebuilds a persisted
+ * `data.tokens` field by field, so an axis it does not know about is dropped
+ * from every resumed run's total. Its writer is in `@archon/workflows`, which
+ * cannot be imported from here; that half is guarded in that package.
+ *
+ * `total` and `cost` are `null`. This decoder reads cost from the event's own
+ * `data.cost_usd` scalar, never off the usage object — cost is lifted onto the
+ * result message's `cost` field back at the provider boundary. And `total` is
+ * dropped by the first fold: `mergeTokenUsage` documents that it does not
+ * aggregate it, so it never reaches a persisted event to be decoded.
+ */
+export const RESUME_SNAPSHOT_AXIS_KEYS: SeamAxisKeys = {
+  input: 'input',
+  output: 'output',
+  cacheRead: 'cacheRead',
+  cacheWrite: 'cacheWrite',
+  cachePartial: 'cachePartial',
+  total: null,
+  cost: null,
+};
+
+/**
+ * Assert that every axis `keys` declares carried arrived under its declared key
+ * with the specimen's value.
+ *
+ * Seam and axis ride the compared object's KEY, not a sibling field: bun's diff
+ * prints only a narrow window around the changed line, so a sibling `axis` field
+ * is elided and the failure never says which axis went missing.
+ *
+ * `expect` is passed in rather than imported, so this module stays free of
+ * `bun:test` and can be type-checked as ordinary source.
+ */
+export function expectSeamCarriesAxes(
+  expect: (actual: unknown) => { toEqual: (expected: unknown) => void },
+  seam: string,
+  keys: SeamAxisKeys,
+  carried: Record<string, unknown> | undefined
+): void {
+  expect({ [`${seam} carried usage`]: carried !== undefined }).toEqual({
+    [`${seam} carried usage`]: true,
+  });
+  for (const [axis, key] of Object.entries(keys) as [keyof TokenUsage, string | null][]) {
+    if (key === null) continue;
+    const label = `${seam} → ${axis} (as '${key}')`;
+    expect({ [label]: carried?.[key] }).toEqual({ [label]: AXIS_SPECIMEN[axis] });
+  }
+}

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -59,6 +59,7 @@ import {
   getProviderCapabilities,
 } from '@archon/providers';
 import type { SendQueryOptions } from '@archon/providers';
+import { mergeTokenUsage, type TokenUsage } from '@archon/providers/types';
 clearRegistry();
 registerBuiltinProviders();
 // Pi is a community provider (best-effort structured output) — register it so the
@@ -23952,5 +23953,366 @@ describe('childOutcomeFromRun cache reporting', () => {
     // toEqual alone would still pass on `cachePartial: undefined`; the key must be absent,
     // because absence is what every reader treats as "this total is exact".
     expect(outcome.tokens).not.toHaveProperty('cachePartial');
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// TokenUsage axis seam guard (#2674)
+//
+// `TokenUsage` crosses boundaries where its fields are re-listed by hand on
+// both sides, with nothing tying writer to reader. #2662 added one optional
+// field, `cachePartial`, and three carrying sites dropped it while the full
+// suite stayed green.
+//
+// The guard is two TYPE-level anchors plus runtime proof of what they claim:
+//
+//   1. `Required<TokenUsage>` — adding an axis makes AXIS_SPECIMEN a compile
+//      error, so `bun run type-check` fails before a single test runs.
+//   2. `Record<keyof TokenUsage, string | null>` — each seam's key map is
+//      exhaustive, so a new axis must be dispositioned per seam: a key it is
+//      carried under, or `null` for "this seam deliberately does not carry it".
+//   3. Every non-null entry is then driven through the REAL production path,
+//      because a declared key spelling is only a claim until a run proves it.
+//
+// One seam is missing from this block: `getDagResumeSnapshot` is in
+// @archon/core, which this package cannot import. It is guarded there, under
+// the same block name — but with its anchors in `src/test/token-usage-axes.ts`
+// rather than the test file, because core's tsconfig excludes `**/*.test.ts`
+// from type-check. Anchors here can sit inline; this package type-checks tests.
+//
+// What this guard does NOT do: make a new *site* loud. No type can require an
+// author to register the hand-mapped seam they just wrote. The maps below are
+// the discoverable inventory a reviewer checks a new site against.
+// ───────────────────────────────────────────────────────────────────────────
+describe('TokenUsage axis seam guard', () => {
+  /**
+   * One value per axis, all distinct so a swapped key spelling fails instead of
+   * passing on a coincidence.
+   *
+   * `Required<TokenUsage>` is the anchor. Adding `foo?: number` to TokenUsage
+   * fails here with `TS2741: Property 'foo' is missing in type ... but required
+   * in type 'Required<TokenUsage>'`.
+   *
+   * A provider never sets `cachePartial` — it is aggregation-only (see the field
+   * docs in @archon/providers types). The specimen sets it anyway because this
+   * guard tests CARRIAGE, not the fold rule that normally produces the flag;
+   * `mergeTokenUsage` propagates an incoming `cachePartial`, so a one-node run
+   * is enough to observe the axis at every seam.
+   */
+  const AXIS_SPECIMEN: Required<TokenUsage> = {
+    input: 5000,
+    output: 1200,
+    cacheRead: 4000,
+    cacheWrite: 250,
+    cachePartial: true,
+    total: 6400,
+    cost: 0.25,
+  };
+
+  /**
+   * How one seam spells each axis on its wire. `null` = this seam deliberately
+   * does not carry the axis. Exhaustive over `keyof TokenUsage`, so a new axis
+   * is a compile error at every seam until someone decides which it is.
+   */
+  type SeamAxisKeys = Record<keyof TokenUsage, string | null>;
+
+  /**
+   * Seams that carry the `TokenUsage` object whole, so the axis names ARE the
+   * wire keys. They share one map because they share one decision: a new axis
+   * either rides the object or does not. Each still gets its own assertion —
+   * "carries it whole" is a claim about today's code, not a guarantee.
+   *
+   * `total` and `cost` cross NO seam below, and both `null`s are load-bearing:
+   *  - `cost` is lifted off the usage object at the PROVIDER boundary, onto the
+   *    result message's own `cost` field (Pi's event bridge does exactly that).
+   *    Every seam below carries that scalar — `total_cost_usd`, `cost_usd`,
+   *    `costUsd`, `signaledCostUsd` — and none reads `TokenUsage.cost`.
+   *  - `total` is set by Pi's event bridge and dropped by the first fold:
+   *    `mergeTokenUsage` documents that it does not aggregate it. So a Pi node's
+   *    reasoning-inclusive total reaches no seam. Recorded here, not fixed here.
+   */
+  const WHOLE_OBJECT_AXIS_KEYS: SeamAxisKeys = {
+    input: 'input',
+    output: 'output',
+    cacheRead: 'cacheRead',
+    cacheWrite: 'cacheWrite',
+    cachePartial: 'cachePartial',
+    total: null,
+    cost: null,
+  };
+
+  /** Run metadata written by persistRunUsage and read back by childOutcomeFromRun. */
+  const RUN_METADATA_AXIS_KEYS: SeamAxisKeys = {
+    input: 'total_tokens_in',
+    output: 'total_tokens_out',
+    cacheRead: 'total_cache_read_tokens',
+    cacheWrite: 'total_cache_write_tokens',
+    cachePartial: 'total_cache_partial',
+    total: null,
+    cost: null,
+  };
+
+  /** Terminal telemetry props — a third spelling, remapped again inside @archon/paths. */
+  const TELEMETRY_AXIS_KEYS: SeamAxisKeys = {
+    input: 'tokensIn',
+    output: 'tokensOut',
+    cacheRead: 'cacheReadTokens',
+    cacheWrite: 'cacheWriteTokens',
+    cachePartial: 'cachePartialTokens',
+    total: null,
+    cost: null,
+  };
+
+  /**
+   * Assert that every axis `keys` declares carried arrived under its declared key
+   * with the specimen's value.
+   *
+   * Seam and axis are folded into the compared object's KEY, not into a sibling
+   * field: bun's diff prints only a narrow window around the changed line, so a
+   * sibling `axis` field is elided from the failure and the report names the seam
+   * without saying which axis went missing.
+   */
+  function expectSeamCarriesAxes(
+    seam: string,
+    keys: SeamAxisKeys,
+    carried: Record<string, unknown> | undefined
+  ): void {
+    expect({ [`${seam} carried usage`]: carried !== undefined }).toEqual({
+      [`${seam} carried usage`]: true,
+    });
+    for (const [axis, key] of Object.entries(keys) as [keyof TokenUsage, string | null][]) {
+      if (key === null) continue;
+      const label = `${seam} → ${axis} (as '${key}')`;
+      expect({ [label]: carried?.[key] }).toEqual({ [label]: AXIS_SPECIMEN[axis] });
+    }
+  }
+
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = join(tmpdir(), `dag-axis-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(testDir, { recursive: true });
+    mockSendQueryDag.mockClear();
+    mockGetAgentProviderDag.mockClear();
+    mockCaptureWorkflowCompleted.mockClear();
+    mockGetAgentProviderDag.mockImplementation(() => ({
+      sendQuery: mockSendQueryDag,
+      getType: () => 'claude',
+      getCapabilities: mockClaudeCapabilities,
+    }));
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(testDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  /**
+   * One AI node whose provider reports the specimen. Four seams read off this
+   * single run: the node event, the run metadata, the telemetry props, and the
+   * JSONL transcript row.
+   */
+  async function runSpecimenDag(): Promise<{
+    store: MockWorkflowStore;
+    runId: string;
+    logDir: string;
+  }> {
+    mockSendQueryDag.mockImplementation(async function* () {
+      yield { type: 'assistant', content: 'done' };
+      yield { type: 'result', sessionId: 'axis-sid', tokens: AXIS_SPECIMEN };
+    });
+    const store = createMockStore();
+    const logDir = join(testDir, 'logs');
+    const workflowRun = makeWorkflowRun('axis-seam-run');
+    await executeDagWorkflow(
+      createMockDeps(store),
+      createMockPlatform(),
+      'conv-dag',
+      testDir,
+      { name: 'axis-seam', nodes: [{ id: 'step', prompt: 'Do thing.' }] },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      logDir,
+      'main',
+      'docs/',
+      minimalConfig
+    );
+    return { store, runId: workflowRun.id, logDir };
+  }
+
+  function nodeCompletedTokens(store: MockWorkflowStore, stepName: string): unknown {
+    const completed = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls.filter(
+      (call: unknown[]) => {
+        const event = call[0] as { event_type: string; step_name?: string };
+        return event.event_type === 'node_completed' && event.step_name === stepName;
+      }
+    );
+    expect(completed.length).toBe(1);
+    return (
+      (completed[0][0] as { data: Record<string, unknown> }).data as {
+        tokens?: Record<string, unknown>;
+      }
+    ).tokens;
+  }
+
+  it('aggregation fold (mergeTokenUsage) carries every axis it claims', () => {
+    // The chokepoint: every other seam's value passes through this fold first.
+    // It rebuilds `{input, output}` rather than spreading, which is why a new
+    // axis needs a deliberate merge rule here before any seam can carry it.
+    expectSeamCarriesAxes(
+      'mergeTokenUsage',
+      WHOLE_OBJECT_AXIS_KEYS,
+      mergeTokenUsage([AXIS_SPECIMEN]) as unknown as Record<string, unknown>
+    );
+  });
+
+  it('node_completed event carries every axis it claims', async () => {
+    const { store } = await runSpecimenDag();
+    expectSeamCarriesAxes(
+      'node_completed.data.tokens',
+      WHOLE_OBJECT_AXIS_KEYS,
+      nodeCompletedTokens(store, 'step') as Record<string, unknown>
+    );
+  });
+
+  it('run metadata round-trips every axis it claims, writer to reader', async () => {
+    const { store } = await runSpecimenDag();
+    const written = runUsageWrites(store);
+    expect(written.length).toBe(1);
+    // Writer: persistRunUsage's `total_*` key list.
+    expectSeamCarriesAxes('run metadata (write)', RUN_METADATA_AXIS_KEYS, written[0]);
+    // Reader: childOutcomeFromRun's SEPARATE, independently maintained key list.
+    // Nothing in production fails if the two disagree — this is the pair the
+    // issue calls the sharpest illustration of the seam.
+    expectSeamCarriesAxes(
+      'run metadata (read)',
+      WHOLE_OBJECT_AXIS_KEYS,
+      childOutcomeFromRun(
+        makeWorkflowRun('axis-child', { status: 'completed', metadata: written[0] })
+      ).tokens as unknown as Record<string, unknown>
+    );
+  });
+
+  it('terminal telemetry props carry every axis they claim', async () => {
+    await runSpecimenDag();
+    expect(mockCaptureWorkflowCompleted).toHaveBeenCalledTimes(1);
+    expectSeamCarriesAxes(
+      'telemetry props',
+      TELEMETRY_AXIS_KEYS,
+      mockCaptureWorkflowCompleted.mock.calls[0][0] as unknown as Record<string, unknown>
+    );
+  });
+
+  it('JSONL transcript node_complete row carries every axis it claims', async () => {
+    const { runId, logDir } = await runSpecimenDag();
+    const rows = (await readFile(join(logDir, `${runId}.jsonl`), 'utf-8'))
+      .trim()
+      .split('\n')
+      .map(line => JSON.parse(line) as Record<string, unknown>);
+    const nodeComplete = rows.find(row => row.type === 'node_complete' && row.step === 'step');
+    expectSeamCarriesAxes(
+      'JSONL node_complete.tokens',
+      WHOLE_OBJECT_AXIS_KEYS,
+      nodeComplete?.tokens as Record<string, unknown>
+    );
+  });
+
+  it('loop gate round-trips every axis it claims, pause to resume', async () => {
+    // Writer: the gate persists the loop's cumulative usage whole.
+    mockSendQueryDag.mockImplementation(async function* () {
+      yield { type: 'assistant', content: 'Pass one. <promise>APPROVED</promise>' };
+      yield { type: 'result', sessionId: 'axis-loop-sid', tokens: AXIS_SPECIMEN };
+    });
+    const loopNodes: DagNode[] = [
+      {
+        id: 'refine',
+        loop: {
+          fresh_context: false,
+          prompt: 'Refine.',
+          until: 'APPROVED',
+          max_iterations: 10,
+          interactive: true,
+          gate_message: 'Review.',
+        },
+      },
+    ];
+    const pausingDeps = createMockDeps();
+    await executeDagWorkflow(
+      pausingDeps,
+      createMockPlatform(),
+      'conv-dag',
+      testDir,
+      { name: 'axis-loop-pause', nodes: loopNodes },
+      makeWorkflowRun('axis-loop-pause-run'),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+    const pauseCalls = (
+      pausingDeps.store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>
+    ).mock.calls;
+    expect(pauseCalls.length).toBe(1);
+    const signaledTokens = (pauseCalls[0][1] as { signaledTokens?: Record<string, unknown> })
+      .signaledTokens;
+    expectSeamCarriesAxes('loop gate (write)', WHOLE_OBJECT_AXIS_KEYS, signaledTokens);
+
+    // Reader: readSignaledTokens decodes it through a fixed key destructure.
+    // Resumed on a BARE approve so the finalize path (#2074) completes from the
+    // persisted usage without running another iteration — a new iteration would
+    // add its own usage and destroy the value identity this assertion needs.
+    mockSendQueryDag.mockClear();
+    mockSendQueryDag.mockImplementation(async function* () {
+      yield { type: 'assistant', content: 'should never run' };
+      yield { type: 'result', sessionId: 'never' };
+    });
+    const resumingDeps = createMockDeps();
+    await executeDagWorkflow(
+      resumingDeps,
+      createMockPlatform(),
+      'conv-dag',
+      testDir,
+      { name: 'axis-loop-resume', nodes: loopNodes },
+      makeWorkflowRun('axis-loop-resume-run', {
+        metadata: {
+          approval: {
+            type: 'interactive_loop',
+            nodeId: 'refine',
+            iteration: 1,
+            sessionId: 'axis-loop-sid',
+            message: 'gate',
+            completionSignaled: true,
+            signaledOutput: 'REPORT',
+            signaledTokens,
+          },
+          loop_user_input: 'Approved',
+          loop_feedback_given: false,
+        },
+      }),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+    expect(mockSendQueryDag.mock.calls.length).toBe(0);
+    expectSeamCarriesAxes(
+      'loop gate (read)',
+      WHOLE_OBJECT_AXIS_KEYS,
+      nodeCompletedTokens(resumingDeps.store, 'refine') as Record<string, unknown>
+    );
   });
 });

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -23974,11 +23974,21 @@ describe('childOutcomeFromRun cache reporting', () => {
 //   3. Every non-null entry is then driven through the REAL production path,
 //      because a declared key spelling is only a claim until a run proves it.
 //
-// One seam is missing from this block: `getDagResumeSnapshot` is in
-// @archon/core, which this package cannot import. It is guarded there, under
-// the same block name — but with its anchors in `src/test/token-usage-axes.ts`
-// rather than the test file, because core's tsconfig excludes `**/*.test.ts`
-// from type-check. Anchors here can sit inline; this package type-checks tests.
+// SCOPE: the workflow engine's seams. `getDagResumeSnapshot` is one of them but
+// lives in @archon/core, which this package cannot import; it is guarded there,
+// under the same block name, with its anchor in `src/test/token-usage-axes.ts`
+// rather than a test file because core's tsconfig excludes `**/*.test.ts` from
+// type-check. Anchors here can sit inline; this package type-checks its tests.
+//
+// Two hand-mapped hops are deliberately OUTSIDE the guard, both in telemetry:
+//   - `captureChatTurn` (@archon/core orchestrator-agent) maps usage for the
+//     direct-chat path, carrying gross totals only;
+//   - `@archon/paths` remaps `buildRunUsageProps`'s output a fourth time on the
+//     way to PostHog, and sits at the root of the dependency order, so it cannot
+//     import `TokenUsage` and no anchor can fire there.
+// A new axis therefore reaches PostHog only if someone follows it past this
+// block. Tracked separately; this block covers the first hop, where the
+// `TokenUsage` axes are still named.
 //
 // What this guard does NOT do: make a new *site* loud. No type can require an
 // author to register the hand-mapped seam they just wrote. The maps below are
@@ -24022,14 +24032,19 @@ describe('TokenUsage axis seam guard', () => {
    * either rides the object or does not. Each still gets its own assertion —
    * "carries it whole" is a claim about today's code, not a guarantee.
    *
-   * `total` and `cost` cross NO seam below, and both `null`s are load-bearing:
-   *  - `cost` is lifted off the usage object at the PROVIDER boundary, onto the
-   *    result message's own `cost` field (Pi's event bridge does exactly that).
-   *    Every seam below carries that scalar — `total_cost_usd`, `cost_usd`,
-   *    `costUsd`, `signaledCostUsd` — and none reads `TokenUsage.cost`.
-   *  - `total` is set by Pi's event bridge and dropped by the first fold:
-   *    `mergeTokenUsage` documents that it does not aggregate it. So a Pi node's
-   *    reasoning-inclusive total reaches no seam. Recorded here, not fixed here.
+   * `total` and `cost` cross none of the seams below, and both `null`s are
+   * load-bearing — each is asserted absent, not merely declared:
+   *  - No seam below reads `TokenUsage.cost`. Each carries its own scalar
+   *    (`total_cost_usd`, `cost_usd`, `costUsd`, `signaledCostUsd`) sourced from
+   *    the result message's `cost` field, which providers are expected to set —
+   *    Pi's event bridge copies it there. `opencode/multi-agent.ts` does not, so
+   *    on that path cost is stranded on the usage object. The fold seam carries
+   *    no cost scalar at all.
+   *  - `total` is set by the Claude provider and by Pi's event bridge, and
+   *    dropped by the first fold: `mergeTokenUsage` documents that it does not
+   *    aggregate it. So no seam below carries it. It is NOT a dead axis — its
+   *    live reader is `formatCostFooter` in @archon/adapters, on the unfolded
+   *    direct-chat path that never passes through the fold. Recorded, not fixed.
    */
   const WHOLE_OBJECT_AXIS_KEYS: SeamAxisKeys = {
     input: 'input',
@@ -24065,7 +24080,15 @@ describe('TokenUsage axis seam guard', () => {
 
   /**
    * Assert that every axis `keys` declares carried arrived under its declared key
-   * with the specimen's value.
+   * with the specimen's value, AND that every axis it declares `null` really is
+   * absent.
+   *
+   * The negative half matters as much as the positive one. Without it a `null`
+   * asserts nothing and stays green forever after it stops being true — teach
+   * `mergeTokenUsage` to aggregate `total` and it would start flowing to the
+   * five seams that spread the object whole while the two renaming seams drop
+   * it, with every map still reading `total: null`. That is #2662 again, for the
+   * axis most likely to move next.
    *
    * Seam and axis are folded into the compared object's KEY, not into a sibling
    * field: bun's diff prints only a narrow window around the changed line, so a
@@ -24081,7 +24104,13 @@ describe('TokenUsage axis seam guard', () => {
       [`${seam} carried usage`]: true,
     });
     for (const [axis, key] of Object.entries(keys) as [keyof TokenUsage, string | null][]) {
-      if (key === null) continue;
+      if (key === null) {
+        // No declared key to look under, so the axis's own name is what a
+        // careless passthrough would surface it as.
+        const label = `${seam} → ${axis} (declared not carried)`;
+        expect({ [label]: carried?.[axis] }).toEqual({ [label]: undefined });
+        continue;
+      }
       const label = `${seam} → ${axis} (as '${key}')`;
       expect({ [label]: carried?.[key] }).toEqual({ [label]: AXIS_SPECIMEN[axis] });
     }
@@ -24108,6 +24137,19 @@ describe('TokenUsage axis seam guard', () => {
     } catch {
       // ignore cleanup errors
     }
+    // Restore the file-level provider stubs. `mockClear()` drops call records
+    // but leaves implementations in place, and this block's last test installs a
+    // generator that yields "should never run" — a describe appended after this
+    // one (the header invites exactly that) would inherit it.
+    mockSendQueryDag.mockImplementation(async function* () {
+      yield { type: 'assistant', content: 'DAG AI response' };
+      yield { type: 'result', sessionId: 'dag-session-id' };
+    });
+    mockGetAgentProviderDag.mockImplementation(_provider => ({
+      sendQuery: mockSendQueryDag,
+      getType: () => 'claude',
+      getCapabilities: mockClaudeCapabilities,
+    }));
   });
 
   /**

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -24040,11 +24040,12 @@ describe('TokenUsage axis seam guard', () => {
    *    Pi's event bridge copies it there. `opencode/multi-agent.ts` does not, so
    *    on that path cost is stranded on the usage object. The fold seam carries
    *    no cost scalar at all.
-   *  - `total` is set by the Claude provider and by Pi's event bridge, and
-   *    dropped by the first fold: `mergeTokenUsage` documents that it does not
-   *    aggregate it. So no seam below carries it. It is NOT a dead axis — its
-   *    live reader is `formatCostFooter` in @archon/adapters, on the unfolded
-   *    direct-chat path that never passes through the fold. Recorded, not fixed.
+   *  - `total` is set by the Claude provider, Pi's event bridge and OpenCode's
+   *    token normalizer, then dropped by the first fold — `mergeTokenUsage`
+   *    documents that it does not aggregate it — so no seam below carries it.
+   *    It is NOT a dead axis: its live reader is `formatCostFooter` in
+   *    @archon/adapters, on the direct-chat path, which never folds. Recorded,
+   *    not fixed.
    */
   const WHOLE_OBJECT_AXIS_KEYS: SeamAxisKeys = {
     input: 'input',
@@ -24086,9 +24087,9 @@ describe('TokenUsage axis seam guard', () => {
    * The negative half matters as much as the positive one. Without it a `null`
    * asserts nothing and stays green forever after it stops being true — teach
    * `mergeTokenUsage` to aggregate `total` and it would start flowing to the
-   * five seams that spread the object whole while the two renaming seams drop
-   * it, with every map still reading `total: null`. That is #2662 again, for the
-   * axis most likely to move next.
+   * seams that spread the object whole while the ones that rebuild or rename it
+   * drop it — with every map still reading `total: null` and every row green.
+   * That is #2662 again, for the axis most likely to move next.
    *
    * Seam and axis are folded into the compared object's KEY, not into a sibling
    * field: bun's diff prints only a narrow window around the changed line, so a

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -24040,12 +24040,13 @@ describe('TokenUsage axis seam guard', () => {
    *    Pi's event bridge copies it there. `opencode/multi-agent.ts` does not, so
    *    on that path cost is stranded on the usage object. The fold seam carries
    *    no cost scalar at all.
-   *  - `total` is set by the Claude provider, Pi's event bridge and OpenCode's
-   *    token normalizer, then dropped by the first fold — `mergeTokenUsage`
-   *    documents that it does not aggregate it — so no seam below carries it.
-   *    It is NOT a dead axis: its live reader is `formatCostFooter` in
-   *    @archon/adapters, on the direct-chat path, which never folds. Recorded,
-   *    not fixed.
+   *  - `total` is set by several providers (Claude, Pi, and both OpenCode
+   *    paths — the multi-agent one re-synthesizes it after its own internal
+   *    fold) and then dropped by the engine's fold: `mergeTokenUsage` documents
+   *    that it does not aggregate it. So no seam below carries it. It is NOT a
+   *    dead axis: it is read by `formatCostFooter` in @archon/adapters on the
+   *    direct-chat path, which never folds, and by OpenCode's own multi-agent
+   *    sum. Recorded, not fixed.
    */
   const WHOLE_OBJECT_AXIS_KEYS: SeamAxisKeys = {
     input: 'input',


### PR DESCRIPTION
## Problem and outcome

`TokenUsage` crosses nine boundaries where its fields are re-listed by hand on both sides, with nothing tying writer to reader. Adding an axis compiles cleanly everywhere and is silently dropped at whichever site you forget. This is not hypothetical: #2662 added one optional field, `cachePartial`, and **three of the carrying sites dropped it** while `bun run validate` stayed green across 7,655 tests.

I reproduced the complaint before building anything. Adding `reasoning?: number` to `TokenUsage` on `dev` leaves `@archon/providers`, `@archon/workflows`, `@archon/core` **and** `@archon/paths` all type-checking clean.

- **Outcome:** the same edit now fails `bun run type-check`, which runs before lint, format and every test suite in `bun run validate`, with five errors — the two `Required<TokenUsage>` specimens and the three seam key maps — covering every seam's decision. Where a seam declares it carries an axis, a test drives that axis through the real production path and proves it.
- **Invariant:** every axis of `TokenUsage` is accounted for at every **workflow-engine** seam that carries one across a boundary — either carried under a named key a test verifies, or declared not carried and asserted absent. Two telemetry hops are deliberately outside that scope; see below.
- **Scope boundary:** **no production code changed.** The existing sites keep their current behavior; #2674's acceptance says this is about preventing the next regression, not re-fixing the last one. The failure path is untouched: the DB `node_failed` event already carries usage at four of its six write sites (`...nodeUsageEventData()`); the surface carrying none is the **JSONL failure row** (`logNodeError` takes no usage — #2614), and #2609 is a different gap again, mid-stream failure spend being unavailable to `getDagResumeSnapshot` on resume.

## Review guidance

- **Feedback requested:** whether the two anchors are the right pair, and whether any seam in the table is mis-declared. A wrong `null` is the one way this guard can lie.
- **Start here:** `packages/workflows/src/dag-executor.test.ts:24012` (`AXIS_SPECIMEN`) and `:24027` (`SeamAxisKeys`). Everything else follows from those two types.
- **Review order:** the workflows block header (what the guard does and does not do) → the three key maps → `expectSeamCarriesAxes` → the six rows → `packages/core/src/test/token-usage-axes.ts` (why core's anchor sits outside its test file) → the core row.
- **Lower-attention areas:** the six runtime rows are mechanical once the maps are agreed. Each was observed failing under a targeted production mutation (table below).
- **Known risk or uncertainty:** the guard makes a new **axis** loud. It cannot make a new **site** loud — no type can require an author to register the hand-mapped seam they just wrote. That limit is stated in the block header rather than implied, and the maps are the inventory a reviewer checks a new site against.

## Solution

The loud failure had to be a **compile** error, not a failing assertion. A test that enumerates the axes in a runtime array is itself a hand-maintained list — the exact hazard being guarded. So there are two type-level anchors:

1. `AXIS_SPECIMEN: Required<TokenUsage>` — one distinct value per axis. Adding an optional field fails here with `TS2741: Property 'x' is missing ... but required in type 'Required<TokenUsage>'`.
2. `SeamAxisKeys = Record<keyof TokenUsage, string | null>` — one per seam: the key the axis rides under on that seam's wire, or `null` for "this seam deliberately does not carry it". Exhaustive, so a new axis is a compile error at every seam until it is dispositioned individually.

Anchor 2 is what makes anchor 1 useful, and the runtime rows are what make anchor 2 honest: a key spelling is only a claim until a real run proves production writes it. Each row drives the specimen through the actual path — a real DAG against a mocked provider, the real `.jsonl` off disk, the real `childOutcomeFromRun`.

Core's row is the one exception to the map shape, arrived at during review. `getDagResumeSnapshot` is the only seam whose writer and reader sit in different packages, so it cannot be a round trip — which would leave two independently dispositionable maps that nothing compares. It is pinned to `mergeTokenUsage` instead, the fold its decoder actually feeds (`workflow-events.ts:335`): any axis the fold keeps, the decoder must keep. That is strictly stronger than a map there, and it deletes one.

Seams that carry the object whole share one map, because they share one decision. The two that rename — run metadata's writer and telemetry — each get their own, because each is an independent hand-written list. The run-metadata *reader* renames back to the axis names, so it shares the whole-object map.

The guard lives in two existing test files rather than new ones: `dag-executor.test.ts` already owns every harness the eight workflows-side seams need and already `mock.module()`s what it must, so this adds no new `bun test` invocation and no cross-file mock pollution.

`sumTokenUsage` gets no row. It spreads rather than rebuilds and delegates to `mergeTokenUsage`, so it is already on the path of four rows — and the `mergeTokenUsage` mutation below failing **all six** rows is the evidence that the fold, not the wrapper, owns the decision.

## Architecture

```mermaid
flowchart TD
  T["TokenUsage"]
  T --> A["mergeTokenUsage — the fold"]
  A --> B["run metadata (total_*)"]
  A --> C["node_completed data.tokens"]
  A --> D["telemetry props (tokensIn / cacheReadTokens)"]
  A --> E["JSONL transcript (WorkflowUsage)"]
  A --> F["loop gate (approval.signaledTokens)"]
  B -. read .-> B2["childOutcomeFromRun"]
  C -. read .-> C2["getDagResumeSnapshot — @archon/core"]
  F -. read .-> F2["readSignaledTokens"]
```

Solid edges are writes, dotted edges are reads. The three dotted pairs are the drift hazard: each writer and reader maintains its key list independently, and nothing in production fails if the two disagree.

### Changed seams

None. This PR adds no production behavior. The nine boundaries above are the seams it *observes*:

| Boundary | Key spelling | Guarded at |
|---|---|---|
| `mergeTokenUsage` fold | axis names | `dag-executor.test.ts` |
| run metadata write → read | `total_*` → axis names | `dag-executor.test.ts` (both halves, one round trip) |
| `node_completed` `data.tokens` write | axis names | `dag-executor.test.ts` |
| `node_completed` `data.tokens` read | axis names | `packages/core/src/db/workflow-events.test.ts` |
| telemetry props | `tokensIn` / `cacheReadTokens` / `cachePartialTokens` | `dag-executor.test.ts` |
| JSONL `node_complete` row | axis names | `dag-executor.test.ts` |
| loop gate write → read | axis names | `dag-executor.test.ts` (both halves, pause then resume) |

The telemetry seam is **not in the issue's table**. It is the only one with two hand-written remappings in series — `TokenUsage` → `buildRunUsageProps` → `@archon/paths` renames again to `tokens_in` / `cache_read_tokens` / `cache_partial`. The guard covers the first hop, where the `TokenUsage` axes are still named.

## Validation

- `bun run validate` — exit 0. Type-check across 11 packages, lint at `--max-warnings 0`, format clean, every package suite green.
- `bun test src/dag-executor.test.ts` (workflows) — 566 pass, 0 fail (560 before). `bun test src/db/workflow-events.test.ts` (core) — 31 pass, 0 fail (30 before).
- **Baseline — the defect reproduces.** With `reasoning?: number` added to `TokenUsage` and the guard absent, all four carrying packages type-checked clean.
- **The anchors were observed red.** Same axis added *with* the guard: workflows raised `TS2741` four times (specimen + three seam maps) and core once (specimen). Reverted; both clean again.
- **The runtime rows are not vacuous.** Seven production mutations, each caught by exactly the matching row and nothing else, then reverted:

| Mutation to production code | Row(s) that went red |
|---|---|
| `childOutcomeFromRun` drops `cachePartial` | run metadata round-trip (read half) |
| `persistRunUsage` drops `total_cache_partial` | run metadata round-trip (write half) |
| `buildRunUsageProps` drops `cachePartialTokens` | telemetry props |
| `readSignaledTokens` drops `cachePartial` | loop gate round-trip (read half) |
| `nodeUsageEventData` rebuilds instead of spreading | node_completed **and** JSONL transcript |
| `mergeTokenUsage` drops the flag | **all six** workflows rows |
| `getDagResumeSnapshot` drops `cachePartial` | core row |

  The first and fourth are literally two of the three holes #2662 shipped. A failure names the seam, the axis and the wire key: `"run metadata (read) → cachePartial (as 'cachePartial')": true` vs `undefined`.

- **Review corrections were themselves proven.** Two mutations that were **invisible before review** now fail:
  - teach `mergeTokenUsage` to aggregate `total` — four whole-object rows go red on `"… → total (declared not carried)": 6400`, where before every map read `total: null` and asserted nothing. This is the guard's own stated failure mode, closed.
  - teach the fold to aggregate `total` while `getDagResumeSnapshot` still drops it — core's row goes red. A hand-written key map could **not** have caught this: `total: null` there would have been truthful about the decoder while the writer next door carried it. Core's row is now pinned to `mergeTokenUsage`, the decoder's real downstream contract, and its key map is deleted.
- **Not verified:** no live run against a real provider. Every row asserts on real writer output — the real `.jsonl` on disk, the real store calls, the real telemetry payload — with only the provider stream mocked, so the untested remainder is a vendor's own usage reporting, which producers map and this PR does not touch.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | None. Test-only; no production file, schema, or stored data is touched. | `git show --stat` — 3 files, all under test surfaces |
| Rollout / rollback | Single-commit revert with no runtime consequence. | — |
| Observability | This *is* the observability change: the next axis surfaces at `bun run type-check` instead of at a consumer reading a silently narrowed total. | The mutation table above |

### Two things the guard records but does not fix

Both are pre-existing, unchanged here, and written into the comments where the `null` sits rather than left implicit:

- `TokenUsage.total` is set by four producers — Claude (`claude/provider.ts:120`), Pi (`community/pi/event-bridge.ts:111`) and both OpenCode paths (`opencode/tokens.ts:25`, and `multi-agent.ts:357`, which re-synthesizes it *after* its own internal fold) — then dropped by the engine's fold, since `mergeTokenUsage` documents that it does not aggregate it. So no seam in the table carries it. It is **not** a dead axis: its two readers are `formatCostFooter` in `@archon/adapters` (`slack/blocks.ts:81`, tested), on the direct-chat path that never folds, and OpenCode's own multi-agent sum (`multi-agent.ts:358`). Every seam declares `total: null` for that reason, and each `null` is now asserted absent.
- No seam in the table reads `TokenUsage.cost`. Each carries its own scalar (`total_cost_usd`, `cost_usd`, `costUsd`, `signaledCostUsd`) sourced from the result message's `cost` field, which providers are expected to set. `opencode/multi-agent.ts:361-386` does not — it populates `TokenUsage.cost` and yields a chunk with no `cost` field, so on that path cost is stranded on the usage object. Worth knowing before anyone concludes the axis is redundant.

### Two telemetry hops are outside this guard — #2687

Filed rather than folded in, because they are a distinct outcome in two other packages:

- `@archon/paths` remaps `buildRunUsageProps`'s output a **fourth** time on the way to PostHog. Proven by experiment during review: a new axis can be added, aggregated, plumbed into `buildRunUsageProps`, dispositioned `carried` here, pass this guard's telemetry row green — and never reach PostHog, because spreading `...runUsageProps` into the capture literal is not excess-property-checked. `@archon/paths` has no `@archon/*` dependencies, so it cannot import `TokenUsage` and no anchor of this shape can fire there.
- `captureChatTurn` (`orchestrator-agent.ts:2431`, `:2692`) is the same seam for direct chat, in two copies, carrying gross totals only. Live consequence today, unrelated to any future axis: `chat_turn_handled` reports no cache axes at all.

This PR's block header names both rather than implying coverage.

### On #2609

#2609 will add usage to the failure path (`node_failed`, and `logNodeError` which takes none today). The guard is table-driven precisely so that lands as **one new row per new half**, not a rewrite: a failure-path write is the same shape as the `node_completed` write row already here, and it would reuse the existing `WHOLE_OBJECT_AXIS_KEYS` map unchanged.

### One deviation worth flagging

Core's anchor lives in `packages/core/src/test/token-usage-axes.ts`, not beside its assertion. `packages/core/tsconfig.json` excludes `**/*.test.ts` from type-check, so an anchor in the test file **never fires** — I hit exactly that and caught it only because the workflows anchor went red and core's did not. Removing that exclusion surfaces **966** pre-existing type errors, so it stays. `src/test/` is inside `include: ["src/**/*"]`, is not a `.test.ts` file, and is already this package's home for shared test support (`src/test/mocks/`). Verified red under an added axis after the move.

## Links

- Closes #2674
- Related #2662 — the regression that demonstrated this
- Related #1331 — the first time this type grew
- Related #2609 — the failure-path gap, deliberately out of scope
- Implementation plan: https://github.com/coleam00/Archon/issues/2674#issuecomment-5370169735