### PR TITLE
fix(workflows): a failed node's spend now reaches the run transcript

### DIFF
--- a/packages/core/src/db/workflow-events.ts
+++ b/packages/core/src/db/workflow-events.ts
@@ -221,10 +221,28 @@ export async function listWorkflowEventsSince(
  *
  * Both usage axes are summed from `node_completed` and `node_failed` rows, and only
  * from rows that are not marked `data.aggregate`. Failed rows contribute spend but
- * never completed outputs, so their nodes remain eligible for resume. Cache axes sum
- * over the rows that reported them and carry `cachePartial` when any row did not, so a
- * pre-#2654 row narrows the cache total instead of erasing it. Two distinct
- * duplication hazards:
+ * never completed outputs, so their nodes remain eligible for resume.
+ *
+ * This makes a run's total MONEY BURNED, not the cost of the surviving path — the
+ * figure an operator watching a budget wants, and a deliberate change from what the
+ * number meant before failed rows were summed (#2654). Three consequences follow, all
+ * intended:
+ *
+ * - The same node's first and second attempt both count. A node that failed at $0.02
+ *   and succeeded at $0.03 on resume contributes $0.05, because both rows are real
+ *   spend.
+ * - `retry:` counts every attempt, for the same reason — `runNodeRetryLoop` writes one
+ *   event per attempt.
+ * - An `always_run` node re-executes on every resume pass and its spend accrues each
+ *   time.
+ *
+ * A resumed run's total therefore exceeds what the surviving path cost, and grows with
+ * each resume. That is the point; it is not double counting, which is what the two
+ * exclusions below prevent.
+ *
+ * Cache axes sum over the rows that reported them and carry `cachePartial` when any row
+ * did not, so a pre-#2654 row narrows the cache total instead of erasing it. Two
+ * distinct duplication hazards:
  *
  * - `node_skipped_prior_success` rows replay a node an earlier pass already counted, so
  *   counting them would multiply that node's usage by the number of resume passes.

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -405,6 +405,19 @@ function loaderBypassingWorkflow(
 
 // --- Tests ---
 
+/**
+ * A run's JSONL transcript, parsed. Module-scoped so every describe reads a run's
+ * transcript the same way.
+ */
+const readTranscript = async (
+  logDir: string,
+  runId: string
+): Promise<Array<Record<string, unknown>>> =>
+  (await readFile(join(logDir, `${runId}.jsonl`), 'utf-8'))
+    .trim()
+    .split('\n')
+    .map(line => JSON.parse(line) as Record<string, unknown>);
+
 describe('buildTopologicalLayers', () => {
   it('single node with no dependencies -> one layer', () => {
     const layers = buildTopologicalLayers([node('a')]);
@@ -5967,15 +5980,6 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     // gets believed. Absence is the honest answer.
     expect(completedEvent?.[0].data).not.toHaveProperty('tokens');
   });
-
-  const readTranscript = async (
-    logDir: string,
-    runId: string
-  ): Promise<Array<Record<string, unknown>>> =>
-    (await readFile(join(logDir, `${runId}.jsonl`), 'utf-8'))
-      .trim()
-      .split('\n')
-      .map(line => JSON.parse(line) as Record<string, unknown>);
 
   it('writes node and run cost to the transcript, matching the persisted events', async () => {
     mockSendQueryDag.mockImplementation(async function* () {
@@ -14021,10 +14025,7 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
       minimalConfig
     );
 
-    const rows = (await readFile(join(logDir, `${workflowRun.id}.jsonl`), 'utf-8'))
-      .trim()
-      .split('\n')
-      .map(line => JSON.parse(line) as Record<string, unknown>);
+    const rows = await readTranscript(logDir, workflowRun.id);
 
     const failureRow = rows.find(row => row.type === 'node_error' && row.step === 'b');
     expect(failureRow?.cost_usd).toBe(0.02);
@@ -14107,10 +14108,7 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
 
     // Prove the abort branch is the one that ran: it is the only path that reports
     // exactly 'Cancelled by user'.
-    const rows = (await readFile(join(logDir, `${workflowRun.id}.jsonl`), 'utf-8'))
-      .trim()
-      .split('\n')
-      .map(line => JSON.parse(line) as Record<string, unknown>);
+    const rows = await readTranscript(logDir, workflowRun.id);
     const cancelRow = rows.find(row => row.type === 'node_error' && row.step === 'only');
     expect(cancelRow?.error).toBe('Cancelled by user');
     expect(cancelRow?.cost_usd).toBe(0.02);
@@ -14173,10 +14171,7 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
       setSystemTime();
     }
 
-    const rows = (await readFile(join(logDir, `${workflowRun.id}.jsonl`), 'utf-8'))
-      .trim()
-      .split('\n')
-      .map(line => JSON.parse(line) as Record<string, unknown>);
+    const rows = await readTranscript(logDir, workflowRun.id);
     const cancelRow = rows.find(row => row.type === 'node_error' && row.step === 'only');
     expect(cancelRow?.error).toBe('Cancelled by user');
     expect(cancelRow?.cost_usd).toBe(0.02);
@@ -24480,10 +24475,7 @@ describe('TokenUsage axis seam guard', () => {
 
   it('JSONL transcript node_complete row carries every axis it claims', async () => {
     const { runId, logDir } = await runSpecimenDag();
-    const rows = (await readFile(join(logDir, `${runId}.jsonl`), 'utf-8'))
-      .trim()
-      .split('\n')
-      .map(line => JSON.parse(line) as Record<string, unknown>);
+    const rows = await readTranscript(logDir, runId);
     const nodeComplete = rows.find(row => row.type === 'node_complete' && row.step === 'step');
     expectSeamCarriesAxes(
       'JSONL node_complete.tokens',
@@ -24497,10 +24489,7 @@ describe('TokenUsage axis seam guard', () => {
     // because logNodeError spreads the same WorkflowUsage carrier logNodeComplete
     // does — one decision, so a new axis either rides both rows or neither.
     const { runId, logDir } = await runSpecimenDag('failed');
-    const rows = (await readFile(join(logDir, `${runId}.jsonl`), 'utf-8'))
-      .trim()
-      .split('\n')
-      .map(line => JSON.parse(line) as Record<string, unknown>);
+    const rows = await readTranscript(logDir, runId);
     const nodeError = rows.find(row => row.type === 'node_error' && row.step === 'step');
     expectSeamCarriesAxes(
       'JSONL node_error.tokens',

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -13966,6 +13966,222 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
     ]);
   });
 
+  it('a node that fails mid-stream reports its spend in the transcript, not just the DB', async () => {
+    // #2609's worked example. Node A completes at $0.01; node B burns $0.02 and then
+    // the provider throws. The DB row has carried that $0.02 since #2654 — the JSONL
+    // failure row did not, because logNodeError had no usage parameter. The two sinks
+    // disagreeing about what a node cost is the bug.
+    let call = 0;
+    mockSendQueryDag.mockImplementation(async function* () {
+      call++;
+      if (call === 1) {
+        yield { type: 'assistant', content: 'node A output' };
+        yield { type: 'result', sessionId: 'sid-a', cost: 0.01, tokens: { input: 10, output: 1 } };
+        return;
+      }
+      // Node B streams, reports what it burned, and the same result chunk carries the
+      // provider's error — so the node throws with its usage already accumulated. This
+      // is the ordering that makes the bug reachable: the spend is real and the node
+      // still ends at a failure writer.
+      yield { type: 'assistant', content: 'node B got this far' };
+      yield {
+        type: 'result',
+        sessionId: 'sid-b',
+        cost: 0.02,
+        tokens: { input: 20, output: 2 },
+        isError: true,
+        errorSubtype: 'stream_error',
+      };
+    });
+
+    const store = createMockStore();
+    const logDir = join(testDir, 'logs');
+    const workflowRun = makeWorkflowRun('spend-transcript-run');
+
+    await executeDagWorkflow(
+      createMockDeps(store),
+      createMockPlatform(),
+      'conv-spend',
+      testDir,
+      {
+        name: 'spend-transcript',
+        nodes: [
+          { id: 'a', prompt: 'Cheap work.' },
+          { id: 'b', prompt: 'Expensive work that dies.', depends_on: ['a'] },
+        ],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      logDir,
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    const rows = (await readFile(join(logDir, `${workflowRun.id}.jsonl`), 'utf-8'))
+      .trim()
+      .split('\n')
+      .map(line => JSON.parse(line) as Record<string, unknown>);
+
+    const failureRow = rows.find(row => row.type === 'node_error' && row.step === 'b');
+    expect(failureRow?.cost_usd).toBe(0.02);
+    expect(failureRow?.tokens).toEqual({ input: 20, output: 2 });
+
+    // The completed node was already right; asserting it here proves the transcript
+    // now accounts for the whole run rather than trading one gap for another.
+    const completeRow = rows.find(row => row.type === 'node_complete' && row.step === 'a');
+    expect(completeRow?.cost_usd).toBe(0.01);
+
+    // Same figure in the persisted event: the fix closes the gap between the sinks
+    // rather than moving it.
+    const failedEvents = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls.filter(
+      (c: unknown[]) => {
+        const e = c[0] as { event_type: string; step_name?: string };
+        return e.event_type === 'node_failed' && e.step_name === 'b';
+      }
+    );
+    expect(failedEvents.length).toBe(1);
+    expect((failedEvents[0][0] as { data: Record<string, unknown> }).data.cost_usd).toBe(0.02);
+
+    // And the run total is the money burned across both nodes.
+    expect(runUsageWrites(store)).toEqual([
+      { total_cost_usd: 0.03, total_tokens_in: 30, total_tokens_out: 3 },
+    ]);
+  });
+
+  it('a node cancelled by the user leaves its spend in the transcript', async () => {
+    // The abort branch called no logNodeError at all, so a cancelled node produced no
+    // transcript row whatsoever — not even one without usage (#2693). It is the only
+    // terminal outcome in executeNodeInternal that was missing from the transcript.
+    //
+    // The cancel is driven the way production drives it: the throttled mid-stream
+    // status check sees a non-running run and aborts. setSystemTime jumps past
+    // CANCEL_CHECK_INTERVAL_MS between chunks so that check fires deterministically,
+    // and the usage-bearing result chunk is delivered BEFORE the jump so the node has
+    // something to report by the time it is torn down.
+    let usageDelivered = false;
+    mockSendQueryDag.mockImplementation(async function* () {
+      // A live background task keeps the stream open past the result chunk, which is
+      // what lets the node still be streaming once it has usage to report.
+      yield {
+        type: 'background_tasks',
+        tasks: [{ taskId: 't-live', taskType: 'local_agent', description: 'still running' }],
+      };
+      yield { type: 'assistant', content: 'partial work' };
+      yield { type: 'result', sessionId: 'sid-x', cost: 0.02, tokens: { input: 30, output: 3 } };
+      usageDelivered = true;
+      setSystemTime(new Date(Date.now() + 11_000));
+      yield { type: 'assistant', content: 'MUST NOT BE REACHED' };
+    });
+
+    const store = createMockStore();
+    (store.getWorkflowRunStatus as Mock<() => Promise<string | null>>).mockImplementation(() =>
+      Promise.resolve(usageDelivered ? 'cancelled' : 'running')
+    );
+    const logDir = join(testDir, 'logs');
+    const workflowRun = makeWorkflowRun('cancel-transcript-run');
+
+    try {
+      await executeDagWorkflow(
+        createMockDeps(store),
+        createMockPlatform(),
+        'conv-cancel',
+        testDir,
+        { name: 'cancel-transcript', nodes: [{ id: 'only', prompt: 'Work.' }] },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'state'),
+        logDir,
+        'main',
+        'docs/',
+        minimalConfig
+      );
+    } finally {
+      setSystemTime(); // restore the real clock
+    }
+
+    // Prove the abort branch is the one that ran: it is the only path that reports
+    // exactly 'Cancelled by user'.
+    const rows = (await readFile(join(logDir, `${workflowRun.id}.jsonl`), 'utf-8'))
+      .trim()
+      .split('\n')
+      .map(line => JSON.parse(line) as Record<string, unknown>);
+    const cancelRow = rows.find(row => row.type === 'node_error' && row.step === 'only');
+    expect(cancelRow?.error).toBe('Cancelled by user');
+    expect(cancelRow?.cost_usd).toBe(0.02);
+    expect(cancelRow?.tokens).toEqual({ input: 30, output: 3 });
+  });
+
+  it('a cancel that surfaces as a thrown error still leaves a transcript row', async () => {
+    // The abort has TWO exits. One returns from the streaming-cancel branch; the other
+    // reaches the outer catch, because an aborted node with `output_format` is refused a
+    // reask and throws instead. Only the first was fixed at first, which would have made
+    // a cancelled node's transcript row depend on whether the node declared
+    // `output_format` — the provider-shaped inconsistency #2693 exists to remove.
+    let usageDelivered = false;
+    mockSendQueryDag.mockImplementation(async function* () {
+      yield {
+        type: 'background_tasks',
+        tasks: [{ taskId: 't-live', taskType: 'local_agent', description: 'still running' }],
+      };
+      yield { type: 'assistant', content: 'prose, not the declared JSON' };
+      yield { type: 'result', sessionId: 'sid-of', cost: 0.02, tokens: { input: 30, output: 3 } };
+      usageDelivered = true;
+      setSystemTime(new Date(Date.now() + 11_000));
+      yield { type: 'assistant', content: 'MUST NOT BE REACHED' };
+    });
+
+    const store = createMockStore();
+    (store.getWorkflowRunStatus as Mock<() => Promise<string | null>>).mockImplementation(() =>
+      Promise.resolve(usageDelivered ? 'cancelled' : 'running')
+    );
+    const logDir = join(testDir, 'logs');
+    const workflowRun = makeWorkflowRun('cancel-throw-run');
+
+    try {
+      await executeDagWorkflow(
+        createMockDeps(store),
+        createMockPlatform(),
+        'conv-cancel-throw',
+        testDir,
+        {
+          name: 'cancel-throw',
+          nodes: [
+            {
+              id: 'only',
+              prompt: 'Work.',
+              output_format: { type: 'object', properties: { status: { type: 'string' } } },
+            },
+          ],
+        },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'state'),
+        logDir,
+        'main',
+        'docs/',
+        minimalConfig
+      );
+    } finally {
+      setSystemTime();
+    }
+
+    const rows = (await readFile(join(logDir, `${workflowRun.id}.jsonl`), 'utf-8'))
+      .trim()
+      .split('\n')
+      .map(line => JSON.parse(line) as Record<string, unknown>);
+    const cancelRow = rows.find(row => row.type === 'node_error' && row.step === 'only');
+    expect(cancelRow?.error).toBe('Cancelled by user');
+    expect(cancelRow?.cost_usd).toBe(0.02);
+  });
+
   it('records usage when the run is CANCELLED out of band mid-flight', async () => {
     // A cancel is driven by another process (CLI abandon, the API abandon route, a
     // fan-out cancelling a child), so the cancelling side has no usage in scope. The
@@ -24159,18 +24375,27 @@ describe('TokenUsage axis seam guard', () => {
    * single run: the node event, the run metadata, the telemetry props, and the
    * JSONL transcript row.
    */
-  async function runSpecimenDag(): Promise<{
+  async function runSpecimenDag(outcome: 'completed' | 'failed' = 'completed'): Promise<{
     store: MockWorkflowStore;
     runId: string;
     logDir: string;
   }> {
     mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'done' };
-      yield { type: 'result', sessionId: 'axis-sid', tokens: AXIS_SPECIMEN };
+      yield {
+        type: 'result',
+        sessionId: 'axis-sid',
+        tokens: AXIS_SPECIMEN,
+        // The provider reports its usage and its failure on the SAME chunk, so the
+        // node reaches a failure writer with the specimen already accumulated. Any
+        // earlier throw would leave nothing for the failure sink to carry, and the
+        // row would pass the guard by being empty on both sides.
+        ...(outcome === 'failed' ? { isError: true, errorSubtype: 'stream_error' } : {}),
+      };
     });
     const store = createMockStore();
     const logDir = join(testDir, 'logs');
-    const workflowRun = makeWorkflowRun('axis-seam-run');
+    const workflowRun = makeWorkflowRun(`axis-seam-run-${outcome}`);
     await executeDagWorkflow(
       createMockDeps(store),
       createMockPlatform(),
@@ -24264,6 +24489,23 @@ describe('TokenUsage axis seam guard', () => {
       'JSONL node_complete.tokens',
       WHOLE_OBJECT_AXIS_KEYS,
       nodeComplete?.tokens as Record<string, unknown>
+    );
+  });
+
+  it('JSONL transcript node_error row carries every axis it claims', async () => {
+    // The failure sink joins the guard here (#2693). It reuses the whole-object map
+    // because logNodeError spreads the same WorkflowUsage carrier logNodeComplete
+    // does — one decision, so a new axis either rides both rows or neither.
+    const { runId, logDir } = await runSpecimenDag('failed');
+    const rows = (await readFile(join(logDir, `${runId}.jsonl`), 'utf-8'))
+      .trim()
+      .split('\n')
+      .map(line => JSON.parse(line) as Record<string, unknown>);
+    const nodeError = rows.find(row => row.type === 'node_error' && row.step === 'step');
+    expectSeamCarriesAxes(
+      'JSONL node_error.tokens',
+      WHOLE_OBJECT_AXIS_KEYS,
+      nodeError?.tokens as Record<string, unknown>
     );
   });
 

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -2814,9 +2814,12 @@ async function executeNodeInternal(
       getLog().error({ err, nodeId: node.id }, 'dag_node_failed');
     }
     // Transcript row on BOTH branches. The persisted event below is written either way,
-    // and a cancel reaches this catch only when the provider SDK threw on abort rather
-    // than ending its stream — an implementation detail of the provider that must not
-    // decide whether the run's transcript records the node at all (#2693).
+    // so the transcript must not disagree with it depending on how the cancel arrived.
+    // A cancel reaches this catch mainly through the engine's own structured-output
+    // gate: it runs before the streaming-cancel branch and cannot reask once the signal
+    // is aborted, so an aborted node declaring `output_format` throws here instead of
+    // returning there. A provider SDK that throws on abort also lands here. Neither is
+    // a reason for a node to be missing from the run's transcript (#2693).
     await logNodeError(logDir, workflowRun.id, node.id, failureMessage, nodeUsageEventData());
 
     deps.store
@@ -4665,12 +4668,15 @@ async function executeLoopNode(
     } = {}
   ): Promise<NodeExecutionResult> => {
     getLog().error({ nodeId: node.id, error, ...(extras.data ?? {}) }, 'loop_node.failed');
-    // A loop that failed part-way still paid for the iterations it ran, so the
-    // transcript row carries the same totals as the persisted event below (#2693).
-    await logNodeError(logDir, workflowRun.id, node.id, error, {
+    // A loop that failed part-way still paid for the iterations it ran. Built once and
+    // spread into both sinks, so the transcript row and the persisted event cannot
+    // disagree — the same reason executeNodeInternal routes both through
+    // nodeUsageEventData (#2693).
+    const loopUsage: WorkflowUsage = {
       ...(extras.tokens !== undefined ? { tokens: extras.tokens } : {}),
       ...(extras.costUsd !== undefined ? { cost_usd: extras.costUsd } : {}),
-    });
+    };
+    await logNodeError(logDir, workflowRun.id, node.id, error, loopUsage);
     deps.store
       .createWorkflowEvent({
         workflow_run_id: workflowRun.id,
@@ -4678,8 +4684,7 @@ async function executeLoopNode(
         step_name: stepName,
         data: {
           error,
-          ...(extras.costUsd !== undefined ? { cost_usd: extras.costUsd } : {}),
-          ...(extras.tokens !== undefined ? { tokens: extras.tokens } : {}),
+          ...loopUsage,
           ...(extras.data ?? {}),
         },
       })

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -809,6 +809,12 @@ function shouldRetryNodeFailure(
  * the backoff math and user-facing wording are defined once and can't drift.
  * `initialOutput` seeds `output` for the unreachable zero-iteration case. Usage is
  * accumulated across failed attempts so a later success still reports all paid work.
+ *
+ * Each attempt also writes its OWN terminal event carrying only that attempt's usage,
+ * so the event log and this accumulated total agree rather than double-counting: two
+ * attempts costing $0.02 then $0.03 leave two rows summing to $0.05, which is what this
+ * returns. That is the "money burned" reading of a run's total — every attempt counts
+ * (#2654 made failed rows contribute; see getDagResumeSnapshot for what that means).
  */
 async function runNodeRetryLoop(
   node: DagNode,
@@ -1754,10 +1760,8 @@ async function executeNodeInternal(
   const batchMessages: string[] = [];
 
   // What this node reported, built once and passed whole rather than re-listed per sink:
-  // the DB event on every outcome, and the JSONL transcript row on completion. The JSONL
-  // FAILURE row is still outside it — logNodeError takes no usage, so a node that spent
-  // money and then failed records that spend in the DB and not in the transcript (#2614).
-  // See WorkflowUsage.
+  // the DB event and the JSONL transcript row, on every outcome that can hold spend —
+  // completion, failure, and user cancellation alike (#2693). See WorkflowUsage.
   const nodeUsageEventData = (): WorkflowUsage => ({
     ...(nodeTokens !== undefined ? { tokens: nodeTokens } : {}),
     ...(nodeCostUsd !== undefined ? { cost_usd: nodeCostUsd } : {}),
@@ -2552,6 +2556,16 @@ async function executeNodeInternal(
         { nodeId: node.id, durationMs: duration },
         'dag_node_cancelled_during_streaming'
       );
+      // Cancellation is a terminal outcome like any other failure, and the work it
+      // interrupted was already paid for. This branch wrote no transcript row at all
+      // until #2693, so a cancelled node's spend reached the DB and nothing else.
+      await logNodeError(
+        logDir,
+        workflowRun.id,
+        node.id,
+        'Cancelled by user',
+        nodeUsageEventData()
+      );
 
       deps.store
         .createWorkflowEvent({
@@ -2607,7 +2621,7 @@ async function executeNodeInternal(
     if (creditError) {
       const duration = Date.now() - nodeStartTime;
       getLog().warn({ nodeId: node.id, durationMs: duration }, 'dag.node_credit_exhausted');
-      await logNodeError(logDir, workflowRun.id, node.id, creditError);
+      await logNodeError(logDir, workflowRun.id, node.id, creditError, nodeUsageEventData());
 
       deps.store
         .createWorkflowEvent({
@@ -2650,7 +2664,7 @@ async function executeNodeInternal(
         ? `Node '${node.id}' timed out with no output (idle for ${String(effectiveIdleTimeout / 60000)} min). The provider did not emit any content before the watchdog fired — likely time-to-first-token exceeded the timeout. Consider increasing idle_timeout or reducing prompt size.`
         : `Node '${node.id}' produced no assistant output. The provider stream closed without yielding content — likely a silent provider rejection or stream interruption.`;
       getLog().error({ nodeId: node.id, durationMs: duration }, 'dag.node_empty_output');
-      await logNodeError(logDir, workflowRun.id, node.id, emptyError);
+      await logNodeError(logDir, workflowRun.id, node.id, emptyError, nodeUsageEventData());
 
       deps.store
         .createWorkflowEvent({
@@ -2798,8 +2812,12 @@ async function executeNodeInternal(
       getLog().info({ nodeId: node.id }, 'dag_node_cancelled_via_abort');
     } else {
       getLog().error({ err, nodeId: node.id }, 'dag_node_failed');
-      await logNodeError(logDir, workflowRun.id, node.id, failureMessage);
     }
+    // Transcript row on BOTH branches. The persisted event below is written either way,
+    // and a cancel reaches this catch only when the provider SDK threw on abort rather
+    // than ending its stream — an implementation detail of the provider that must not
+    // decide whether the run's transcript records the node at all (#2693).
+    await logNodeError(logDir, workflowRun.id, node.id, failureMessage, nodeUsageEventData());
 
     deps.store
       .createWorkflowEvent({
@@ -4647,7 +4665,12 @@ async function executeLoopNode(
     } = {}
   ): Promise<NodeExecutionResult> => {
     getLog().error({ nodeId: node.id, error, ...(extras.data ?? {}) }, 'loop_node.failed');
-    await logNodeError(logDir, workflowRun.id, node.id, error);
+    // A loop that failed part-way still paid for the iterations it ran, so the
+    // transcript row carries the same totals as the persisted event below (#2693).
+    await logNodeError(logDir, workflowRun.id, node.id, error, {
+      ...(extras.tokens !== undefined ? { tokens: extras.tokens } : {}),
+      ...(extras.costUsd !== undefined ? { cost_usd: extras.costUsd } : {}),
+    });
     deps.store
       .createWorkflowEvent({
         workflow_run_id: workflowRun.id,
@@ -9091,7 +9114,7 @@ export async function executeDagWorkflow(
    * tests) may omit it, in which case a `workflow:` node fails fast.
    */
   runChildWorkflow?: RunChildWorkflowFn,
-  /** Cumulative usage restored from prior node_completed events on resume. */
+  /** Cumulative usage restored on resume, from prior completion AND failure events. */
   priorUsage?: PriorRunUsage,
   /** Private run-scoped handles restored before a cold resume transitions to running. */
   priorNodeSessions?: readonly WorkflowRunNodeSession[],

--- a/packages/workflows/src/logger.test.ts
+++ b/packages/workflows/src/logger.test.ts
@@ -30,6 +30,7 @@ import {
   logWorkflowError,
   logWorkflowComplete,
   logNodeComplete,
+  logNodeError,
   type WorkflowEvent,
 } from './logger';
 
@@ -168,6 +169,46 @@ describe('Workflow Logger', () => {
       const [absent] = await readLogFile('no-cost');
       expect(zero.cost_usd).toBe(0);
       expect('cost_usd' in absent).toBe(false);
+    });
+  });
+
+  describe('logNodeError', () => {
+    it('records what the node spent before it failed', async () => {
+      await logNodeError(testDir, 'fail-cost', 'step1', 'provider stream died', {
+        tokens: { input: 120, output: 10, cacheRead: 80, cacheWrite: 0 },
+        cost_usd: 0.02,
+      });
+
+      const [event] = await readLogFile('fail-cost');
+      expect(event.type).toBe('node_error');
+      expect(event.error).toBe('provider stream died');
+      expect(event.cost_usd).toBe(0.02);
+      expect(event.tokens).toEqual({ input: 120, output: 10, cacheRead: 80, cacheWrite: 0 });
+    });
+
+    it('keeps a reported zero cost distinct from an unreported one', async () => {
+      // Same distinction the completion row protects: Codex reports no cost at all
+      // (#2334), so an absent key must not be readable as "spent nothing".
+      await logNodeError(testDir, 'fail-zero', 'step1', 'boom', { cost_usd: 0 });
+      await logNodeError(testDir, 'fail-unreported', 'step1', 'boom', {
+        tokens: { input: 5, output: 1 },
+      });
+
+      const [zero] = await readLogFile('fail-zero');
+      const [absent] = await readLogFile('fail-unreported');
+      expect(zero.cost_usd).toBe(0);
+      expect('cost_usd' in absent).toBe(false);
+    });
+
+    it('writes no usage keys for a failure that could not have spent anything', async () => {
+      // A missing command file, a substitution error, a bash exit code: these fail
+      // before any provider call, and their callers pass nothing.
+      await logNodeError(testDir, 'fail-bare', 'step1', 'command file not found');
+
+      const [event] = await readLogFile('fail-bare');
+      expect(event.error).toBe('command file not found');
+      expect('cost_usd' in event).toBe(false);
+      expect('tokens' in event).toBe(false);
     });
   });
 

--- a/packages/workflows/src/logger.ts
+++ b/packages/workflows/src/logger.ts
@@ -54,9 +54,17 @@ export interface WorkflowEvent {
  *
  * One carrier, passed whole. The same payload used to be spelled out by hand at every
  * sink, and cost was simply forgotten at the transcript one — an axis added here now
- * reaches the JSONL row and the DB event together or not at all (#2674). Both terminal
- * outcomes carry it: a node that failed after spending reports that spend the same way
- * a node that completed does (#2693).
+ * reaches the JSONL row and the DB event together or not at all (#2674). A node that
+ * failed after spending reports that spend the same way a node that completed does
+ * (#2693).
+ *
+ * That symmetry holds per SINK, not yet across every node type. A `loop:` node's
+ * cumulative totals reach its transcript row on failure and its persisted event on
+ * either outcome, but no success exit writes a terminal transcript row for the loop's
+ * own id — only per-iteration rows, which carry duration and no usage. `workflow:` and
+ * fan-out nodes write no transcript rows at all. So do not read an absent `cost_usd` on
+ * a run's transcript as "the whole run was free"; read it per row, where it means the
+ * provider reported no cost. Completing that coverage is #2614's audit.
  *
  * Each axis is omitted when nothing was reported for it, so an absent `cost_usd` means
  * the provider reported no cost (Codex reports none at all — #2334) and `0` means it

--- a/packages/workflows/src/logger.ts
+++ b/packages/workflows/src/logger.ts
@@ -54,7 +54,9 @@ export interface WorkflowEvent {
  *
  * One carrier, passed whole. The same payload used to be spelled out by hand at every
  * sink, and cost was simply forgotten at the transcript one — an axis added here now
- * reaches the JSONL row and the DB event together or not at all (#2674).
+ * reaches the JSONL row and the DB event together or not at all (#2674). Both terminal
+ * outcomes carry it: a node that failed after spending reports that spend the same way
+ * a node that completed does (#2693).
  *
  * Each axis is omitted when nothing was reported for it, so an absent `cost_usd` means
  * the provider reported no cost (Codex reports none at all — #2334) and `0` means it
@@ -228,16 +230,27 @@ export async function logNodeSkip(
   });
 }
 
-/** Log DAG node error */
+/**
+ * Log DAG node error, with what the node spent before it failed.
+ *
+ * A node that fails mid-stream keeps the usage it already burned, so the failure row
+ * carries spend for the same reason the completion row does (#2693). Callers whose
+ * failure happens before any provider call — a missing command file, a substitution
+ * error, a bash exit code — pass nothing, and the absent keys mean exactly that.
+ */
 export async function logNodeError(
   logDir: string,
   workflowRunId: string,
   nodeId: string,
-  error: string
+  error: string,
+  usage?: WorkflowUsage
 ): Promise<void> {
   await logWorkflowEvent(logDir, workflowRunId, {
     type: 'node_error',
     step: nodeId,
     error,
+    // Spread whole: the caller already omitted every unreported axis, and a guard here
+    // would have to re-decide that per field — which is how `0` becomes absent.
+    ...usage,
   });
 }


### PR DESCRIPTION
## Problem and outcome

A node that burned money and then failed recorded that spend in the database and not in the JSONL run transcript. `logNodeError` took only `(logDir, workflowRunId, nodeId, error)`, while its sibling `logNodeComplete` has carried the full `WorkflowUsage` payload since #2676 — so the two sinks disagreed about what a failed node cost. The transcript is the artifact an operator reaches for when asking what a run actually did, and failed attempts are exactly the part worth seeing.

- **Outcome:** a node that fails after reporting usage writes that usage to the transcript, carrying the same `cost_usd` and `tokens` as its `node_failed` database row. A user-cancelled node now produces a transcript row at all, which it never did before.
- **Invariant:** wherever a node-failure row is written, the JSONL row and the persisted event report the same axes. An axis added to `TokenUsage` reaches both or neither — now enforced for the failure sink by the #2685 seam guard.
- **Scope boundary:** the database and resume halves are untouched; #2654 already shipped them. Three node-completion gaps are deliberately left: `workflow:` and fan-out nodes write no transcript rows at all, a `loop:` node's success exits write no terminal transcript row for its own id, and `logWorkflowError` still takes no usage. All three are completion-side or run-level and belong to #2614's coverage audit — see Solution.
- **Root cause:** `logNodeError` had no parameter to pass usage to. Every affected call site already holds that usage and hands it to `createWorkflowEvent` two lines away.

## Review guidance

- **Feedback requested:** whether the third fix (the outer catch's `cancelled` branch) belongs in this PR — #2693 names only the streaming-cancel branch, and I fixed both. Reasoning under Solution.
- **Start here:** `logNodeError` in `packages/workflows/src/logger.ts` — the whole change follows from its new fifth parameter.
- **Review order:** `logger.ts` (the carrier) → the `logNodeError` call sites in `dag-executor.ts` → the two cancel exits → the seam-guard row and behavioral tests → the three prose corrections.
- **Lower-attention areas:** the prose corrections in `getDagResumeSnapshot` and `runNodeRetryLoop` change no behavior. They describe the money-burned semantic #2654 introduced, which nothing stated where a reader would meet it.
- **Known risk or uncertainty:** None. The transcript has no consumers yet (#2614 is the issue to surface it), so the added keys cannot break a reader.

## Solution

`logNodeError` gained an optional `WorkflowUsage` parameter, spread whole, mirroring `logNodeComplete`. This reuses the carrier #2676 built for exactly this purpose rather than adding a parallel usage path. The call sites that hold usage now pass it: credit exhaustion, the empty-output guard, the outer catch in `executeNodeInternal`, and `failLoopNode`. The writers that fail before any provider call — command-file load, prompt substitution, `executeBashNode`, script discovery, named-script not-found, `executeScriptNode`'s catch — keep passing nothing, so an absent key still means "nothing was reported" rather than "reported zero". That distinction matters because Codex reports no cost at all (#2334); it has a test.

**Both user-cancel exits, not just the one the issue names.** The abort has two. The streaming-cancel branch returned without ever calling `logNodeError` — that is the hole #2693 describes. The second is the outer catch, whose `cancelled` branch also skipped `logNodeError`; an aborted node that declared `output_format` reaches it, because `canReask` is false once the signal is aborted and the node throws instead of returning. Fixing only the first would have made a cancelled node's transcript row depend on whether the node declared `output_format` — a provider-shaped inconsistency of the kind this issue exists to remove. Both exits now write a row, and the second has its own test proven red against the fixed first.

**`workflow:` and fan-out nodes are excluded on purpose.** Their `failResult` helpers already accept cost and tokens, and `logDir` is on `RunLayersContext`, so a transcript row would have been cheap. But those node types write no transcript rows in any state — no `node_start`, no `node_complete`, no `node_error`. Adding only the failure row would make a `workflow:` node visible in the transcript exclusively when it fails, which is a worse transcript than one that omits it consistently. Giving them a full lifecycle belongs to #2614's coverage audit.

**A `loop:` node now reports its cumulative spend on failure and not on success**, which review raised and which I have documented rather than closed. `failLoopNode` carries the loop's totals; the only `logNodeComplete` on that path is per-iteration and carries duration alone, so no success exit writes a terminal transcript row for the loop's own id. Closing it means adding a new terminal row shape at three separate success exits — a completion-path addition this failure-scoped PR did not set out to make, and one whose shape belongs with whoever builds the transcript reader. What I did instead is remove the false claim it would have contradicted: `WorkflowUsage`'s docblock no longer says both terminal outcomes carry usage, and now names loop completion, `workflow:`/fan-out, and the per-row reading of an absent `cost_usd` explicitly. #2614 owns the behavioral half.

**Prose the #2654 semantic left false.** `executeDagWorkflow`'s `priorUsage` doc said cumulative usage is restored from `node_completed` events on resume; the snapshot has summed failed rows since #2654. `getDagResumeSnapshot` stated its summing rule without ever saying what the total now *means* — it is money burned, not the cost of the surviving path, so the same node's two attempts both count, `retry:` counts every attempt, and an `always_run` node accrues on each resume pass. All three are intended consequences and are now written down where a reader meets the function. `runNodeRetryLoop` did not record that each attempt writes its own event, which is why the event log and the accumulated total agree at 0.02 + 0.03 = 0.05 instead of double-counting.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | A failed node's JSONL row carried `error` and nothing else; the matching database row carried `cost_usd` and `tokens`. | The JSONL row carries the same usage as the database row. |
| **Failure behavior** | A user-cancelled node produced no JSONL row at all — the node appeared in the transcript as a `node_start` that never terminated. | It produces a `node_error` row reading `Cancelled by user`, carrying what it spent, from either abort exit. |

### Changed seams

| Boundary or contract | Change | Evidence |
|---|---|---|
| `WorkflowUsage → JSONL node_error row` | New sink; spreads the carrier whole | `JSONL transcript node_error row carries every axis it claims` in the seam guard |
| `executeNodeInternal cancel → transcript` | Row now written from both abort exits | `a node cancelled by the user leaves its spend in the transcript`, `a cancel that surfaces as a thrown error still leaves a transcript row` |

## Validation

- `bun run validate` — exit 0 — all ten stages green: generated-file checks, type-check across every package, eslint at `--max-warnings 0`, prettier, installer tests, and the full per-package suite.
- **Every new test was observed failing first.** With the source reverted and the tests kept: the mid-stream case reports `cost_usd` `Expected: 0.02, Received: undefined`; the cancel case reports `error` `Expected: "Cancelled by user", Received: undefined`, because no row existed; the two `logNodeError` logger tests fail. The catch-path cancel was proven separately by mutating only that hunk back to its original shape with everything else fixed, so it is load-bearing on its own rather than incidentally covered.
- **The seam guard was proven red twice**, because a guard that has only been seen green is a claim. Dropping `tokens` from the failure row flips `"JSONL node_error.tokens carried usage"` from `true` to `false`. The sharper mutation — carrying `tokens` but rebuilding it as `{input, output}`, which is the #2662 failure mode the guard exists for — reports `"JSONL node_error.tokens → cacheRead (as 'cacheRead')": 4000 → undefined`, naming the exact axis rather than just the seam.
- The acceptance scenario is a two-node DAG matching #2609's worked example: node A completes at $0.01, node B reports $0.02 and fails on the same result chunk. It asserts the transcript failure row, the completion row, the persisted event, and the $0.03 run total together, so the fix is shown to close the gap between the sinks rather than move it.
- **Not verified:** no live paid-provider run. Usage arrives through the typed provider result chunk, which the tests drive directly at that boundary.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | Additive keys on a JSONL row type that already exists. Historical rows keep no usage, and an absent key already means "not reported". Nothing parses the transcript today. | #2614 is the issue to surface it |
| Rollout / rollback | Revert is the diff. No schema, stored state, or run-lifecycle change. | — |
| Observability | This is the observability fix: wasted spend on a failed-then-resumed run becomes visible in the log people read, not only in the database. | The two cancel tests and the acceptance test |

## Links

- Closes #2693
- Related #2609, #2654, #2676, #2685, #2614


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Usage data is now preserved when workflow nodes fail, are cancelled, run out of credits, or produce empty output.
  * Cost and token totals now accurately include failed and retried attempts.
  * Resumed workflows retain usage from previous completions and failures.
  * Usage details remain available in workflow logs and run totals, including zero-cost results.

* **Documentation**
  * Clarified how failed attempts, retries, and resumed executions contribute to cumulative usage and spending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
