### PR TITLE
fix(orchestrator): capture fresh source for the nothing-to-resume fallback

### DIFF
--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -2297,6 +2297,57 @@ describe('workflow dispatch routing — interactive flag', () => {
     expect(opts.preparedSource?.manifest?.captured_at).toBe('2026-08-21T00:00:00.000Z');
   });
 
+  test('foreground_resume_detected: fresh-run-in-same-worktree refuses with the capture-failure message when prepareWorkflowSource rejects (#2686)', async () => {
+    // The new capture call inside the resume-null fallback introduces a SECOND call site
+    // of `captureFreshSource(...)` whose failure path is unexercised by the success-only
+    // test above. A regression that drops `if (!captured) return;` or reorders the
+    // user-visible notice would land uncaught without this test — `executeWorkflow`
+    // would be called against an undefined capture and the user would see the generic
+    // "starting fresh in the same worktree" notice instead of the capture-failure one.
+    //
+    // Note on the lifecycle: `captureFreshSource` calls `owner.hold` AFTER
+    // `prepareWorkflowSource` returns, so a `prepareWorkflowSource` rejection skips
+    // the hold entirely (no reclaim because nothing was held). The
+    // `['hold:/capture', 'reclaim:/capture']` shape is exercised separately by the
+    // "keeps holding the capture when the dispatch refuses after taking it" test
+    // above — that one runs `prepareWorkflowSource` cleanly and trips a gate AFTER
+    // the hold.
+    const { prepareWorkflowSource } = await import('@archon/workflows/executor');
+    (prepareWorkflowSource as ReturnType<typeof mock>).mockImplementationOnce(() =>
+      Promise.reject(new Error('disk full'))
+    );
+
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    mockHandleCommand.mockReturnValueOnce(Promise.resolve(makeWorkflowResult(true)));
+    mockFindResumableRunByParentConversation.mockReturnValueOnce(
+      Promise.resolve(
+        makeResumableRun({
+          id: 'empty-prior-run',
+          status: 'paused',
+        })
+      )
+    );
+    mockHydrateResumableRun.mockReturnValueOnce(Promise.resolve(null));
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/workflow run test-workflow');
+
+    // No run started against an undefined capture.
+    expect(mockExecuteWorkflow).not.toHaveBeenCalled();
+    // The user-visible failure notice names the workflow and the underlying error.
+    const sent = platform.sendMessage.mock.calls.map(c => String(c[1])).join('\n');
+    expect(sent).toContain(
+      'Could not capture the workflow source for **test-workflow**: disk full'
+    );
+    // The generic "starting fresh in the same worktree" notice must NOT fire — that
+    // would mislead the user into thinking a fresh run started when none did.
+    expect(sent).not.toContain('starting fresh in the same worktree');
+    // The capture was never held (rejection landed BEFORE `owner.hold`), so the
+    // owner has nothing to reclaim.
+    expect(capturedSourceOwnerCalls).toEqual([]);
+  });
+
   test('foreground_resume_detected: fresh-run-in-same-worktree captures and executes the FRESHLY captured graph (#2686)', async () => {
     // (#2686) Regression for the mixed-vintage shape: when a paused run had nothing to
     // resume, the orchestrator must capture source here and execute the freshly resolved

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -2249,6 +2249,8 @@ describe('workflow dispatch routing — interactive flag', () => {
     // hydrateResumableRun finds nothing worth resuming (zero completed nodes,
     // no interactive-loop state), the orchestrator must NOT throw — it sends
     // a user-visible notice and starts a fresh run on the same worktree.
+    // (#2686) The fresh run row must freeze its OWN workflow source — not
+    // inherit the prior run's frozen graph against live commands/scripts.
     mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
     mockGetCodebase.mockReturnValueOnce(
       Promise.resolve(makeDispatchCodebase({ default_branch: 'develop' }))
@@ -2278,12 +2280,98 @@ describe('workflow dispatch routing — interactive flag', () => {
       baseBranch?: string;
       preCreatedRun?: unknown;
       priorCompletedNodes?: unknown;
+      preparedSource?: { captureRoot?: string; manifest?: { captured_at?: string } };
     };
     expect(opts.parentConversationId).toBe('conv-1-db');
     // The fresh-run-in-same-worktree branch still threads the codebase default.
     expect(opts.baseBranch).toBe('develop');
     expect(opts.preCreatedRun).toBeUndefined();
     expect(opts.priorCompletedNodes).toBeUndefined();
+    // (#2686) This is the key regression assertion: the fresh run row carries
+    // the captured source so its run row records `workflow_source` from this
+    // moment, not the prior run's frozen bytes. Before the fix, `preparedSource`
+    // was undefined here because the outer `if (!willContinueExistingRun)` block
+    // was skipped.
+    expect(opts.preparedSource).toBeDefined();
+    expect(opts.preparedSource?.captureRoot).toBe('/capture');
+    expect(opts.preparedSource?.manifest?.captured_at).toBe('2026-08-21T00:00:00.000Z');
+  });
+
+  test('foreground_resume_detected: fresh-run-in-same-worktree captures and executes the FRESHLY captured graph (#2686)', async () => {
+    // (#2686) Regression for the mixed-vintage shape: when a paused run had nothing to
+    // resume, the orchestrator must capture source here and execute the freshly resolved
+    // graph — not the prior run's frozen definition against live command/script bytes.
+    // Before the fix, the outer `if (!willContinueExistingRun)` block was skipped because
+    // `willContinueExistingRun` was true, leaving `preparedSource` undefined and the
+    // executor in `source_unprepared_live` mode against the prior run's frozen graph.
+    const { prepareWorkflowSource } = await import('@archon/workflows/executor');
+    const freshWorkflow = makeTestWorkflow({
+      name: 'test-workflow',
+      description: 'freshly captured from disk',
+    });
+    // Capture returns a non-empty scope so the helper actually re-resolves the workflow.
+    (prepareWorkflowSource as ReturnType<typeof mock>).mockImplementationOnce(() =>
+      Promise.resolve({
+        runId: 'prepared-run-id',
+        captureRoot: '/capture',
+        origin: '/origin',
+        manifest: {
+          version: 1,
+          engine_version: 'test',
+          origin: '/origin',
+          captured_at: '2026-08-21T00:00:00.000Z',
+          digest: 'test-digest',
+          file_count: 1,
+          byte_count: 1,
+          scopes: ['project'],
+        },
+        roots: {
+          project: '/capture/project',
+          globalWorkflows: '/capture/global/workflows',
+          globalCommands: '/capture/global/commands',
+          globalScripts: '/capture/global/scripts',
+          bundledWorkflows: '/capture/bundled',
+        },
+      })
+    );
+    // Discovery off the FRESH capture returns a workflow distinct from the one the
+    // resume-input would otherwise feed executeWorkflow. If the orchestrator handed
+    // `executeWorkflow` the wrong graph, the description below would mismatch.
+    mockDiscoverWorkflowsWithConfig.mockReturnValueOnce(
+      Promise.resolve({
+        workflows: [{ workflow: freshWorkflow }],
+        errors: [],
+      })
+    );
+
+    mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(makeDispatchConversation()));
+    mockGetCodebase.mockReturnValueOnce(Promise.resolve(makeDispatchCodebase()));
+    mockHandleCommand.mockReturnValueOnce(Promise.resolve(makeWorkflowResult(true)));
+    mockFindResumableRunByParentConversation.mockReturnValueOnce(
+      Promise.resolve(
+        makeResumableRun({
+          id: 'empty-prior-run',
+          status: 'paused',
+        })
+      )
+    );
+    mockHydrateResumableRun.mockReturnValueOnce(Promise.resolve(null));
+
+    const platform = makePlatform();
+    await handleMessage(platform, 'conv-1', '/workflow run test-workflow');
+
+    expect(prepareWorkflowSource).toHaveBeenCalled();
+    expect(mockExecuteWorkflow).toHaveBeenCalled();
+    const callArgs = mockExecuteWorkflow.mock.calls[0] as unknown[];
+    // The workflow argument (position 4) is the freshly resolved graph, NOT the
+    // resume-input graph. Before the fix this was the prior run's frozen graph.
+    expect(callArgs[4]).toBe(freshWorkflow);
+    // Capture lifecycle: hold then adopt — the prior branch's `if (preparedSource)
+    // owner.adopt()` is now a live guard, not inert.
+    expect(capturedSourceOwnerCalls).toEqual(['hold:/capture', 'adopt']);
+    // The user-visible notice still fires.
+    const sent = platform.sendMessage.mock.calls.map(c => String(c[1])).join('\n');
+    expect(sent).toContain('starting fresh in the same worktree');
   });
 
   test('calls dispatchBackgroundWorkflow for non-interactive workflow on web', async () => {

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -827,7 +827,16 @@ async function dispatchOrchestratorWorkflowOwned(
   // For a fresh run: freeze, then re-resolve the workflow FROM the frozen copy, so the
   // definition executed and the resources beside it are one consistent set of bytes.
   const runCwd = conversation.cwd ?? codebase.default_cwd;
+  // `preparedSource` is the outer binding the resume branch's defensive guard reads
+  // (always undefined there — step 2 didn't run for a continuation). The two fresh
+  // dispatches read `freshCaptured` directly, so the helper's narrowed return type
+  // survives: a downstream `let` of type `PreparedWorkflowSource | undefined` would
+  // defeat the narrowing and leave the `if (preparedSource) owner.adopt();` guards
+  // structurally always-true at runtime.
   let preparedSource: PreparedWorkflowSource | undefined;
+  let freshCaptured:
+    | { preparedSource: PreparedWorkflowSource; workflow: WorkflowDefinition }
+    | undefined;
 
   if (willContinueExistingRun && resumableRun) {
     // Continuing: execute the GRAPH this run froze, not the one on disk now. Skipping
@@ -858,10 +867,9 @@ async function dispatchOrchestratorWorkflowOwned(
   }
 
   if (!willContinueExistingRun) {
-    const captured = await captureFreshSource(owner, runCwd, workflow, conversationId, platform);
-    if (!captured) return; // capture failed, message already sent
-    preparedSource = captured.preparedSource;
-    workflow = captured.workflow;
+    freshCaptured = await captureFreshSource(owner, runCwd, workflow, conversationId, platform);
+    if (!freshCaptured) return; // capture failed, message already sent
+    workflow = freshCaptured.workflow;
   }
 
   // Signature gate (#2470, #2554): resolve this invocation's declared inputs from the
@@ -1123,14 +1131,16 @@ async function dispatchOrchestratorWorkflowOwned(
       // the mixed-vintage shape #2660 exists to remove.
       const captured = await captureFreshSource(owner, runCwd, workflow, conversationId, platform);
       if (!captured) return; // capture failed, message already sent
-      preparedSource = captured.preparedSource;
       workflow = captured.workflow;
       await platform.sendMessage(
         conversationId,
         `⚠️ Prior run for **${workflow.name}** had no completed nodes; starting fresh in the same worktree.`
       );
-      // Handing the capture to a run: it owns the bytes and their lifetime now.
-      if (preparedSource) owner.adopt();
+      // Handing the capture to a run: it owns the bytes and their lifetime now. `captured`
+      // proves `preparedSource` is non-undefined via the helper's narrowed return type, so
+      // the previous outer-`let`-defeating `if (preparedSource) owner.adopt();` guard
+      // collapses to an unconditional adopt here.
+      owner.adopt();
       await executeWorkflow(
         deps,
         platform,
@@ -1144,7 +1154,7 @@ async function dispatchOrchestratorWorkflowOwned(
           parentConversationId: conversation.id,
           userId,
           source,
-          preparedSource,
+          preparedSource: captured.preparedSource,
           parseWarnings: options?.parseWarnings,
           baseBranch: codebaseBaseBranch,
           resolveChildIsolation,
@@ -1191,9 +1201,24 @@ async function dispatchOrchestratorWorkflowOwned(
       throw err;
     }
   } else {
-    // Fresh foreground execution: web interactive workflows + all chat platforms
+    // Fresh foreground execution: web interactive workflows + all chat platforms.
+    // Reaching this branch means `resumableRun?.working_path` is falsy, which implies
+    // `willContinueExistingRun` was false and step 2 above ran. `freshCaptured` is
+    // invariantly defined here — the previous outer-`let`-defeating
+    // `if (preparedSource) owner.adopt();` guard collapsed to an unconditional adopt
+    // by reading from the hoisted capture instead.
+    if (!freshCaptured) {
+      // Should never trigger; the reasoning above is the invariant. If it does, the
+      // dispatch returned a `preparedSource: undefined` to the executor and we are
+      // about to fall into the executor's `source_unprepared_live` branch — the
+      // mixed-vintage shape #2660 exists to remove — so refuse loudly rather than
+      // ship that regression silently.
+      throw new Error(
+        'orchestrator invariant violated: fresh-foreground dispatch reached without a captured source'
+      );
+    }
     // Handing the capture to a run: it owns the bytes and their lifetime now.
-    if (preparedSource) owner.adopt();
+    owner.adopt();
     await executeWorkflow(
       createWorkflowDeps(),
       platform,
@@ -1207,7 +1232,7 @@ async function dispatchOrchestratorWorkflowOwned(
         parentConversationId: conversation.id,
         userId,
         source,
-        preparedSource,
+        preparedSource: freshCaptured.preparedSource,
         parseWarnings: options?.parseWarnings,
         baseBranch: codebaseBaseBranch,
         resolveChildIsolation,

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -858,48 +858,10 @@ async function dispatchOrchestratorWorkflowOwned(
   }
 
   if (!willContinueExistingRun) {
-    try {
-      const workflowSourceRoot = await resolveWorkflowSourceRoot(runCwd);
-      preparedSource = await prepareWorkflowSource(createWorkflowDeps(), {
-        sourceRoot: workflowSourceRoot ?? runCwd,
-      });
-      // From here the owner reclaims it unless a run adopts it, whichever way we leave.
-      owner.hold(preparedSource);
-      // Re-resolve only when files were actually frozen. An empty capture means the
-      // definition came from the bundled set a binary embeds as constants — immutable for
-      // that binary, with nothing on disk to re-read.
-      if (preparedSource.manifest.scopes.length > 0) {
-        const { workflows: capturedWorkflows } = await discoverWorkflowsWithConfig(
-          runCwd,
-          loadConfig,
-          preparedSource.roots
-        );
-        const reResolved = resolveWorkflowName(
-          workflow.name,
-          capturedWorkflows.map(w => w.workflow)
-        );
-        if (!reResolved) {
-          // No manual cleanup: the owner reclaims anything unadopted on the way out.
-          await platform.sendMessage(
-            conversationId,
-            `Could not read workflow **${workflow.name}** from this run's captured source. ` +
-              'Nothing has been started.'
-          );
-          return;
-        }
-        workflow = reResolved;
-      }
-      await recordSelectedWorkflow(preparedSource.captureRoot, workflow.name);
-    } catch (error) {
-      const err = error as Error;
-      getLog().error({ err, workflowName: workflow.name }, 'workflow.source_capture_failed');
-      await platform.sendMessage(
-        conversationId,
-        `Could not capture the workflow source for **${workflow.name}**: ${err.message}. ` +
-          'Nothing has been started.'
-      );
-      return;
-    }
+    const captured = await captureFreshSource(owner, runCwd, workflow, conversationId, platform);
+    if (!captured) return; // capture failed, message already sent
+    preparedSource = captured.preparedSource;
+    workflow = captured.workflow;
   }
 
   // Signature gate (#2470, #2554): resolve this invocation's declared inputs from the
@@ -1154,6 +1116,15 @@ async function dispatchOrchestratorWorkflowOwned(
         await platform.sendMessage(conversationId, deferredInputError.message);
         return;
       }
+      // This branch IS a fresh run, even though the outer block entered via the resume
+      // menu (#2686). Capture the source here so the run freezes the bytes it actually
+      // executes against; without this it would inherit the prior run's frozen graph
+      // and let the executor fall back to live command/script lookup, which is exactly
+      // the mixed-vintage shape #2660 exists to remove.
+      const captured = await captureFreshSource(owner, runCwd, workflow, conversationId, platform);
+      if (!captured) return; // capture failed, message already sent
+      preparedSource = captured.preparedSource;
+      workflow = captured.workflow;
       await platform.sendMessage(
         conversationId,
         `⚠️ Prior run for **${workflow.name}** had no completed nodes; starting fresh in the same worktree.`
@@ -1243,6 +1214,76 @@ async function dispatchOrchestratorWorkflowOwned(
         inputs: resolvedInputs,
       }
     );
+  }
+}
+
+/**
+ * Freeze the workflow source and re-resolve the workflow FROM the freeze.
+ *
+ * A fresh run row is created from the captured bytes — commands and scripts beside
+ * the DAG come from the same moment as the DAG itself. Without this, an edited
+ * workflow would silently run its new graph against pre-edit command bytes; this is
+ * the exact shape #2660 exists to remove, and the exact shape that must be avoided in
+ * the fresh-run-in-same-worktree fallback (#2686).
+ *
+ * On success: hands the staged capture to the owner (`hold`), records the selected
+ * workflow name, and returns both the prepared source and the freshly resolved graph.
+ * The caller adopts when a run takes over.
+ *
+ * On failure: sends the user-facing message and returns `undefined`. The caller MUST
+ * `return` immediately — the owner reclaims any unadopted capture on the way out, so
+ * no manual cleanup is needed.
+ */
+async function captureFreshSource(
+  owner: CapturedSourceOwner,
+  runCwd: string,
+  workflow: WorkflowDefinition,
+  conversationId: string,
+  platform: IPlatformAdapter
+): Promise<{ preparedSource: PreparedWorkflowSource; workflow: WorkflowDefinition } | undefined> {
+  try {
+    const workflowSourceRoot = await resolveWorkflowSourceRoot(runCwd);
+    const preparedSource = await prepareWorkflowSource(createWorkflowDeps(), {
+      sourceRoot: workflowSourceRoot ?? runCwd,
+    });
+    // From here the owner reclaims it unless a run adopts it, whichever way we leave.
+    owner.hold(preparedSource);
+    // Re-resolve only when files were actually frozen. An empty capture means the
+    // definition came from the bundled set a binary embeds as constants — immutable for
+    // that binary, with nothing on disk to re-read.
+    let resolvedWorkflow = workflow;
+    if (preparedSource.manifest.scopes.length > 0) {
+      const { workflows: capturedWorkflows } = await discoverWorkflowsWithConfig(
+        runCwd,
+        loadConfig,
+        preparedSource.roots
+      );
+      const reResolved = resolveWorkflowName(
+        workflow.name,
+        capturedWorkflows.map(w => w.workflow)
+      );
+      if (!reResolved) {
+        // No manual cleanup: the owner reclaims anything unadopted on the way out.
+        await platform.sendMessage(
+          conversationId,
+          `Could not read workflow **${workflow.name}** from this run's captured source. ` +
+            'Nothing has been started.'
+        );
+        return undefined;
+      }
+      resolvedWorkflow = reResolved;
+    }
+    await recordSelectedWorkflow(preparedSource.captureRoot, resolvedWorkflow.name);
+    return { preparedSource, workflow: resolvedWorkflow };
+  } catch (error) {
+    const err = error as Error;
+    getLog().error({ err, workflowName: workflow.name }, 'workflow.source_capture_failed');
+    await platform.sendMessage(
+      conversationId,
+      `Could not capture the workflow source for **${workflow.name}**: ${err.message}. ` +
+        'Nothing has been started.'
+    );
+    return undefined;
   }
 }
 


### PR DESCRIPTION
## Problem and outcome

The "prior run had no completed nodes" fallback in `dispatchOrchestratorWorkflowOwned` was the one continuation path that did not freeze its own workflow source. `preparedSource` was assigned only inside `if (!willContinueExistingRun)`; reaching the fallback forced that condition to be false, so the four `preparedSource` references around the branch — both `if (preparedSource) owner.adopt()` guards and both `preparedSource,` opts fields into `executeWorkflow` — were mechanically inert. The new run row recorded no `workflow_source` metadata, and the executor fell through to `source_unprepared_live`, running the prior run's frozen DAG against whatever command/script bytes were on disk now. That is the mixed-vintage shape #2660 exists to remove, on a path #2660 does not cover.

- **Outcome:** A fresh run created from the nothing-to-resume fallback now freezes its own workflow source and executes the freshly captured graph. The four inert references become live.
- **Invariant:** Every run row — fresh or continuation — is created from a capture of its own workflow source, so the DAG and the commands/scripts it executes come from the same moment.
- **Scope boundary:** Only the nothing-to-resume branch is touched. The continuation branch (`resolveContinuationWorkflow`), the resume detection at line 815, and `hydrateResumableRun` are unchanged. Option B (reuse the prior run's capture) is explicitly rejected by the issue's Decision.
- **Root cause:** `preparedSource` was guarded by `if (!willContinueExistingRun)`. At the fallback's call site that condition was false by construction, so capture was skipped. The four references around the branch were inert by the same construction.

## Review guidance

- **Feedback requested:** Correctness of the helper extraction and the call-site ordering inside the fallback. Whether `resolvedInputs` re-gating after capture belongs in this PR or a separate one.
- **Start here:** `packages/core/src/orchestrator/orchestrator-agent.ts:1130` — the new capture call inside the fallback, between the deferred-input-error check and the user-visible "starting fresh" notice.
- **Review order:**
  1. `packages/core/src/orchestrator/orchestrator-agent.ts` — the new `captureFreshSource` helper (defined just below the caller), then the existing call site (inside `if (!willContinueExistingRun)`), then the new call site.
  2. `packages/core/src/orchestrator/orchestrator-agent.test.ts` — the new regression test, then the assertions added to the existing fallback test.
- **Lower-attention areas:** The review-round correction collapsed the two fresh-path `if (preparedSource) owner.adopt()` guards to unconditional `owner.adopt()` (the helper's narrowed return type proves the capture exists), and both fresh `executeWorkflow` calls pass the helper's `preparedSource` directly. The continuation branch keeps the outer `preparedSource` binding, deliberately always `undefined` there — a continuation's source comes from the run row.
- **Known risk or uncertainty:** `resolvedInputs` is computed by the signature gate against the workflow that was in scope when `willContinueExistingRun` was true (the prior run's frozen graph). If the freshly captured graph's `inputs:` schema differs from the prior run's, `resolvedInputs` may carry a key that is not in the new schema or miss a key that is now required. This is a pre-existing edge case for any resume-with-no-completed-nodes path and is out of scope for #2686; it would need a separate design to re-gate after capture.

## Solution

Extract the capture-and-re-resolve sequence from `if (!willContinueExistingRun)` into a top-level helper `captureFreshSource(...)`. The helper calls `prepareWorkflowSource(...)` from `runCwd`, `owner.hold(preparedSource)` so the owner reclaims on any return path, re-resolves the workflow from `preparedSource.roots` (only when the capture actually froze files — a non-empty `scopes` array), records the selected workflow, and returns `{preparedSource, workflow}` — or returns `undefined` after sending the capture-failure user message.

Call the helper from both sites: the existing `if (!willContinueExistingRun)` branch (pure refactor — same observable behavior) and the fallback's `else` branch (the fix). Inside the fallback, the deferred-input-error check still runs first so a contract violation surfaces before any capture cost; then the helper runs; then the existing "starting fresh in the same worktree" notice; then the now-live `owner.adopt()` guard; then `executeWorkflow` with `preparedSource` in the opts (now live) and the freshly resolved `workflow` (replacing the prior run's inherited frozen graph).

This is the smallest coherent solution because:

- One helper does the work for two callers without inventing a future abstraction.
- The four inert references are resolved: the two fresh-path guards collapse to unconditional `owner.adopt()` (which still follows `owner.hold(...)` inside the helper), both fresh opts fields pass the helper's definite `preparedSource`, and the continuation branch's `undefined` becomes documented intent rather than an accident.
- `willContinueExistingRun` keeps its semantics; the explicit decision to capture is made inside the branch, where the dispatch actually knows it is about to create a new run row.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | The fallback creates a run row with no `workflow_source` metadata and executes the prior run's frozen graph against live commands/scripts on disk. | The fallback creates a run row with `workflow_source` from the new capture and executes the freshly captured graph against the captured commands/scripts. |
| **Failure behavior** | Capture was not attempted, so capture failure was unreachable here. | Capture failure sends the same user-facing message used by the ordinary fresh-run path and returns; the owner reclaims the staged capture automatically. |

## Architecture

```mermaid
flowchart LR
  A[dispatchOrchestratorWorkflowOwned] --> B{willContinueExistingRun?}
  B -- no --> E1[captureFreshSource] --> F1[executeWorkflow with preparedSource + fresh graph]
  B -- yes --> C{resumable hydration returned a payload?}
  C -- yes --> H[Continuation path unchanged]
  C -- no --> D[Nothing-to-resume fallback]
  D -- deferred-input check ok --> E2[captureFreshSource] --> F2[executeWorkflow with preparedSource + fresh graph]
  E1 -. failure .-> G1[User-facing message, owner reclaims, return]
  E2 -. failure .-> G2[User-facing message, owner reclaims, return]
```

## Changed seams

| Boundary or contract | Change | Evidence |
|---|---|---|
| `dispatchOrchestratorWorkflowOwned` → `executeWorkflow` (fallback path) | Now passes a defined `preparedSource` and the freshly re-resolved `workflow` instead of `undefined` and the inherited prior-run graph. | `orchestrator-agent.ts:1130`; new regression test `foreground_resume_detected: fresh-run-in-same-worktree captures and executes the FRESHLY captured graph (#2686)` asserts `opts.preparedSource` is defined and `callArgs[4]` is the freshly resolved workflow. |
| `runRow.workflow_source` metadata | Now recorded for run rows created by the fallback, so a later resume of that run reads from its own capture instead of falling through to live lookup. | The captured `preparedSource` (with `captureRoot` and `manifest.captured_at`) reaches `executeWorkflow`. |
| `owner.adopt()` guards | Now live in the fallback path; capture happens here, so `hold` and `adopt` are both reached. | `captureFreshSource` calls `owner.hold(preparedSource)`; the subsequent `if (preparedSource) owner.adopt()` runs against a defined value. The new test asserts the lifecycle (`hold:/capture` then `adopt`). |

## Validation

Run on `archon/task-fix-1787342902327` at commit `d6063906`:

- `cd packages/core && bun test src/orchestrator/orchestrator-agent.test.ts` — 258 pass, 0 fail (up from 257 because of the new regression test).
- `cd packages/core && bun run test` — 0 fail across all test files in `packages/core`.
- `bun --filter '*' --parallel test` (root) — 0 fail across all workspace packages.
- `cd packages/core && bun run type-check` — exit 0.
- `bun run type-check` (root) — every workspace package exit 0.
- `bun run lint --max-warnings 0` (root) — clean.
- `bun run format:check` (root) — clean.

The new regression test (`foreground_resume_detected: fresh-run-in-same-worktree captures and executes the FRESHLY captured graph (#2686)`) asserts:

- `prepareWorkflowSource` is called from the fallback.
- `executeWorkflow` receives the freshly resolved workflow (matched by a distinctive description), not the resume-input workflow.
- `opts.preparedSource` is defined with the captured `captureRoot` and `manifest.captured_at`.
- The capture lifecycle is balanced (`hold:/capture` followed by `adopt`).
- The user-visible "starting fresh in the same worktree" notice still fires.

The existing fallback test (`foreground_resume_detected: falls through to fresh run when hydration returns null`) was extended to assert `opts.preparedSource` is defined with the captured `captureRoot` and `manifest.captured_at` — without the fix, this assertion would fail because `preparedSource` was `undefined`.

- **Not verified:** Nothing material — all outcome-relevant behavior is covered by the new and extended tests above.

## Links

- Closes #2686



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workflow resume behavior when the existing workflow state cannot be restored.
  - Fresh workflow definitions are now captured before starting a new run, ensuring execution uses the latest available workflow.
  - Prevented execution when source capture fails and provided a clear error message.
  - Successfully captured workflows are now re-evaluated and adopted before execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->