### PR TITLE
fix(server): web adapter persists message category, matching CLI

### DIFF
--- a/packages/server/src/adapters/web/persistence.test.ts
+++ b/packages/server/src/adapters/web/persistence.test.ts
@@ -348,4 +348,61 @@ describe('MessagePersistence', () => {
       expect(metadata?.toolCalls?.[0]?.duration).toBeGreaterThanOrEqual(0);
     });
   });
+
+  describe('flush — category persisted in metadata (#2576)', () => {
+    test('persists workflow_result category so reloaded history renders the result card', async () => {
+      // Console's ChatStream gates the workflow-result card on `message.category === 'workflow_result'`.
+      // Before the fix the web adapter dropped `category` at flush time, so the gate was always false
+      // after a reload — exactly the regression the issue reports.
+      persistence.setConversationDbId('conv-1', 'db-uuid-1');
+      const workflowResult = { workflowName: 'review', runId: 'run-123' };
+      persistence.appendText('conv-1', 'result payload', {
+        category: 'workflow_result',
+        workflowResult,
+      });
+
+      await persistence.flush('conv-1');
+
+      expect(mockAddMessage).toHaveBeenCalledTimes(1);
+      const metadata = mockAddMessage.mock.calls[0][3] as {
+        category?: string;
+        workflowResult?: { workflowName: string; runId: string };
+      };
+      expect(metadata?.category).toBe('workflow_result');
+      expect(metadata?.workflowResult).toEqual(workflowResult);
+    });
+
+    test('persists workflow_status category alongside content', async () => {
+      persistence.setConversationDbId('conv-1', 'db-uuid-1');
+      persistence.appendText('conv-1', '🚀 starting', { category: 'workflow_status' });
+
+      await persistence.flush('conv-1');
+
+      expect(mockAddMessage).toHaveBeenCalledTimes(1);
+      const metadata = mockAddMessage.mock.calls[0][3] as { category?: string };
+      expect(metadata?.category).toBe('workflow_status');
+    });
+
+    test('persists workflow_dispatch_status category', async () => {
+      persistence.setConversationDbId('conv-1', 'db-uuid-1');
+      persistence.appendText('conv-1', '✅ done', { category: 'workflow_dispatch_status' });
+
+      await persistence.flush('conv-1');
+
+      const metadata = mockAddMessage.mock.calls[0][3] as { category?: string };
+      expect(metadata?.category).toBe('workflow_dispatch_status');
+    });
+
+    test('omits category key entirely when segment has no category (CLI parity)', async () => {
+      // Mirrors the CLI adapter's conditional spread shape: only set the key when present.
+      persistence.setConversationDbId('conv-1', 'db-uuid-1');
+      persistence.appendText('conv-1', 'plain text');
+
+      await persistence.flush('conv-1');
+
+      expect(mockAddMessage).toHaveBeenCalledTimes(1);
+      const metadata = mockAddMessage.mock.calls[0][3] as Record<string, unknown>;
+      expect('category' in metadata).toBe(false);
+    });
+  });
 });

--- a/packages/server/src/adapters/web/persistence.ts
+++ b/packages/server/src/adapters/web/persistence.ts
@@ -258,6 +258,7 @@ export class MessagePersistence {
         }));
         const metadata = {
           ...(toolCalls.length > 0 ? { toolCalls } : {}),
+          ...(seg.category ? { category: seg.category } : {}),
           ...(seg.workflowDispatch ? { workflowDispatch: seg.workflowDispatch } : {}),
           ...(seg.workflowResult ? { workflowResult: seg.workflowResult } : {}),
         };


### PR DESCRIPTION
## Problem and outcome

The web adapter segments an assistant message in memory on `metadata.category`, then drops that field when it writes the row to the database — so every web-adapter-persisted message has `category === null` after a reload. The CLI adapter persists it correctly. This means the console's workflow-result card (gated on `message.category === 'workflow_result'` in `ChatStream.tsx:42`) and its System-chatter toggle (gated on `isSystemCategory(m.category)` in `RunStream.tsx:151`) both work during a live session and silently stop working after a page refresh.

- **Outcome:** web-adapter-persisted messages carry `category` on the row, exactly as the CLI adapter already does. Reloaded console history classifies the same way live history does.
- **Invariant:** the CLI and web adapters produce rows with the same `category` shape, so any future consumer can read it without branching on adapter.
- **Scope boundary:** no backfill of existing rows. New rows only; the console already treats `null` as "not system" and the workflow-result card is also gated on `workflowResult !== null`, so legacy rows keep rendering.
- **Root cause:** `packages/server/src/adapters/web/persistence.ts` already holds `category` on `BufferedSegment`, but the `metadata` object built at flush time spread only `toolCalls`, `workflowDispatch`, and `workflowResult` — `seg.category` was in scope and simply not included.

## Review guidance

- **Feedback requested:** correctness of the conditional-spread shape (omit-when-empty vs always-set) and that the sweep for sibling held-then-dropped fields is genuinely exhaustive.
- **Start here:** `packages/server/src/adapters/web/persistence.ts:259` — the one-line spread that closes the gap.
- **Review order:** `persistence.ts` (`flush()` metadata build) → `persistence.test.ts` (four new tests under the `#2576` describe block) → the CLI precedent at `packages/cli/src/adapters/cli-adapter.ts:52` for parity.
- **Lower-attention areas:** the three omitted-when-empty "category never set" tests in the existing `appendText` block already cover `tool_call_formatted` and `isolation_context`, so the new describe block does not re-test those — combined with the four new tests it pins all five `MessageMetadata['category']` values.
- **Known risk or uncertainty:** None.

## Solution

Add the conditional spread the CLI adapter already uses (`packages/cli/src/adapters/cli-adapter.ts:52`) inside the existing `metadata` object in `flush()`, sitting next to the three sibling spreads so the symmetry is visible:

```ts
const metadata = {
  ...(toolCalls.length > 0 ? { toolCalls } : {}),
  ...(seg.category ? { category: seg.category } : {}),
  ...(seg.workflowDispatch ? { workflowDispatch: seg.workflowDispatch } : {}),
  ...(seg.workflowResult ? { workflowResult: seg.workflowResult } : {}),
};
```

This is the smallest coherent change: one token (`category`) on one row, conditional on a field that `BufferedSegment` already carries. Mirroring the omit-when-empty shape of the three adjacent spreads keeps the row shape identical to the CLI adapter — including the absence of a `category: undefined` key on plain-text rows, which matters because the console's `isSystemCategory(...)` predicate treats `undefined`/`null` the same way and would otherwise have to defend against the new key.

The issue explicitly asked for a sweep of sibling held-then-dropped fields. `BufferedSegment` has three metadata-shaped keys (`category`, `workflowDispatch`, `workflowResult`) and all three are now spread; there is no fourth.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Reloaded web-adapter rows always have `category: null`; the console's workflow-result card and System-chatter toggle are absent on history | Reloaded web-adapter rows carry the same `category` the CLI adapter persists, so the result card and System toggle classify history the same way they classify the live view |
| **Failure behavior** | The two console features silently fail to engage on history — no error, just no UI | No behavior change for plain-text rows; the new key only appears on rows whose segment had a category |

## Architecture

```mermaid
flowchart LR
  S["sendMessage(msg, {category})"] --> P["MessagePersistence.appendText<br/>stores category on BufferedSegment"]
  P --> F["MessagePersistence.flush<br/>spreads category into metadata"]
  F --> D[("messages table<br/>row.metadata.category")]
  D --> C["Console<br/>ChatStream / RunStream"]
```

### Changed seams

| Boundary or contract | Change | Evidence |
|---|---|---|
| `BufferedSegment → messages.metadata` | additive `category` key; omitted when the segment has none | `packages/server/src/adapters/web/persistence.ts:259`; `persistence.test.ts` (`#2576` block, 4 tests) |
| `CLI vs web adapter row shape` | parity restored — both write `category` on the same key, under the same omit-when-empty rule | `packages/cli/src/adapters/cli-adapter.ts:52` (precedent, unchanged) |

## Validation

- `bun test packages/server/src/adapters/web/persistence.test.ts` — 28 pass / 0 fail (was 24/0; added 4) — proves the four persisted-category paths and CLI-parity omit shape.
- `bun --filter @archon/server test` — exit code `0` — proves no regression in the wider server suite.
- `bun --filter @archon/server type-check` — exit code `0`.
- `bun x eslint packages/server/src/adapters/web/persistence.ts --cache` — clean. The test file is intentionally ignored by the project's eslint config; that is project policy.
- `bun x prettier --check packages/server/src/adapters/web/persistence.ts packages/server/src/adapters/web/persistence.test.ts` — all matched files use Prettier code style.
- Regression-checked the three "persists X category" tests against the unpatched code: each fails without the fix and passes with it. The omit-when-empty test passes in both states (correctly — it pins a behavior-preservation guarantee, not a regression).
- **Not verified:** Nothing material. All outcome-relevant behavior (the persisted-category paths for every enum value and the omit shape) is covered by the test suite.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | Purely additive on new rows; existing `category: null` rows stay as-is, and the console already tolerates that | `packages/web/src/experiments/console/components/RunStream.tsx:151` (`isSystemCategory` treats `null` as "not system"); `ChatStream.tsx:42` (workflow-result card additionally gated on `workflowResult !== null`) |
| Security / permissions / data | No change in exposure; `category` is a classification enum, not user content | — |
| Rollout / rollback | Single one-line spread; revert restores the prior behavior with no cleanup, and legacy rows are unaffected in either direction | — |
| Observability | None needed; the bug was silent (no error, just absent UI) and the fix is observable from the row | — |
| Documentation / communication | None; behavior was an internal adapter inconsistency, not a documented public surface | — |

## Links

- Closes #2576
- Related #2571 — put `category` on the SSE wire for the live view; this PR closes the history gap that change surfaced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Message categories are now preserved when messages are saved.
  - Workflow result metadata remains available across workflow result, status, and dispatch-status messages.
  - Messages without a category continue to omit category metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->