### PR TITLE
fix(error-formatter): route Codex OAuth refresh errors to Codex auth guidance (#2509)

### DIFF
--- a/packages/core/src/utils/error-formatter.test.ts
+++ b/packages/core/src/utils/error-formatter.test.ts
@@ -198,6 +198,48 @@ describe('classifyAndFormatError', () => {
     });
   });
 
+  describe('Codex OAuth refresh-token errors (#2509)', () => {
+    // Regression for GitHub #2509: a Codex-wrapped OAuth refresh error used
+    // to be routed to Claude `/login` guidance because the OAuth-refresh
+    // branch matched provider-agnostic refresh phrases. The new Codex
+    // OAuth-refresh branch above the Claude one catches it first.
+    test('routes Codex-wrapped refresh-token race to Codex auth guidance', () => {
+      const result = classifyAndFormatError(
+        new Error(
+          'Codex query failed: Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again.'
+        )
+      );
+      expect(result).toContain('Codex authentication error');
+      expect(result).toContain('codex login');
+    });
+
+    test('routes Codex-wrapped "refresh token" to Codex auth guidance', () => {
+      const result = classifyAndFormatError(
+        new Error('Codex query failed: refresh token already used')
+      );
+      expect(result).toContain('Codex authentication error');
+      expect(result).toContain('codex login');
+    });
+
+    test('routes Codex-wrapped "log out and sign in" to Codex auth guidance', () => {
+      const result = classifyAndFormatError(
+        new Error('Codex query failed: Please log out and sign in again.')
+      );
+      expect(result).toContain('Codex authentication error');
+      expect(result).toContain('codex login');
+    });
+
+    test('routes Codex-wrapped "OAuth token has expired" to Codex auth guidance', () => {
+      // No "401" / "Unauthorized" present, so the existing Codex 401 branch
+      // cannot fire — the new OAuth-refresh branch must handle it instead.
+      const result = classifyAndFormatError(
+        new Error('Codex query failed: OAuth token has expired')
+      );
+      expect(result).toContain('Codex authentication error');
+      expect(result).toContain('codex login');
+    });
+  });
+
   describe('general authentication errors', () => {
     test('detects "API key" in message', () => {
       const result = classifyAndFormatError(new Error('Invalid API key provided'));

--- a/packages/core/src/utils/error-formatter.test.ts
+++ b/packages/core/src/utils/error-formatter.test.ts
@@ -418,7 +418,7 @@ describe('classifyAndFormatError', () => {
     });
   });
 
-  describe('non-auth-classified Codex prefixes reject a bare "401"/"403" (#2509 R7)', () => {
+  describe('non-auth-classified Codex prefixes reject a bare "401"/"403" (#2509 R7, R9)', () => {
     // Before the fix, AUTH_PATTERNS's bare "401"/"403" match meant a message
     // containing either digit sequence could never reach classifyCodexError's
     // 'crash'/'unknown' branches — it was always classified 'auth' first and
@@ -427,18 +427,27 @@ describe('classifyAndFormatError', () => {
     // now genuinely reaches the provider's `Codex unknown:`/`Codex crash:`
     // wrap — proving the misroute doesn't just relocate to this branch's own
     // (now-removed) bare-401 fallback.
-    test('does not route "Codex unknown:" with an unrelated "401" to Codex auth guidance', () => {
+    //
+    // Asserting the exact returned string (not just the absence of
+    // Codex-specific phrasing) matters: the general auth branch a few lines
+    // below also used to accept a bare "401" with no prefix gate at all, so
+    // these two inputs used to land on generic-but-still-wrong "check your
+    // API key" guidance instead of the accurate branch two lines further
+    // down (#2509 R9). A negative-only assertion can't tell the difference.
+    test('routes "Codex unknown:" with an unrelated "401" to the ECONNREFUSED/database branch, not any auth guidance', () => {
       const result = classifyAndFormatError(
         new Error('Codex unknown: connect ECONNREFUSED 127.0.0.1:401')
       );
-      expect(result).not.toContain('Codex authentication');
-      expect(result).not.toContain('codex login');
+      expect(result).toBe('⚠️ Database connection issue. Please try again in a moment.');
+      expect(result).not.toContain('authentication');
     });
 
-    test('does not route "Codex crash:" with an unrelated "401" to Codex auth guidance', () => {
+    test('routes "Codex crash:" with an unrelated "401" to the timeout branch, not any auth guidance', () => {
       const result = classifyAndFormatError(new Error('Codex crash: timeout after 401ms'));
-      expect(result).not.toContain('Codex authentication');
-      expect(result).not.toContain('codex login');
+      expect(result).toBe(
+        '⚠️ Request timed out. The AI service may be slow. Try again or use /reset.'
+      );
+      expect(result).not.toContain('authentication');
     });
   });
 
@@ -458,13 +467,16 @@ describe('classifyAndFormatError', () => {
       expect(result).toContain('authentication error');
     });
 
-    test('detects "401" in message', () => {
+    test('does not treat a bare "401" alone as sufficient auth signal (#2509 R9)', () => {
+      // A bare "401" used to be enough on its own — same "bare digits aren't
+      // enough signal" defect already fixed on the Codex-specific checks
+      // above (#2509 R2, R7, R8). This message carries no other auth word
+      // ("API key" / "authentication_error" / "authentication error"), so it
+      // now falls through to the generic fallback instead of the auth
+      // message.
       const result = classifyAndFormatError(new Error('HTTP 401 Unauthorized'));
-      expect(result).toContain('authentication error');
-      // A message with no Codex-side prefix must stay on the general-auth
-      // branch, not the Codex branch above it (#2509 R3 — "authentication
-      // error" is a substring of both, so this guards the boundary directly).
-      expect(result).not.toContain('Codex authentication');
+      expect(result).toBe('⚠️ Error: HTTP 401 Unauthorized. Try /reset if issue persists.');
+      expect(result).not.toContain('authentication error');
     });
 
     test('does not false-positive on generic messages containing "auth"', () => {

--- a/packages/core/src/utils/error-formatter.test.ts
+++ b/packages/core/src/utils/error-formatter.test.ts
@@ -361,12 +361,21 @@ describe('classifyAndFormatError', () => {
   });
 
   describe('raw orchestrator prefixes reject a bare "401" (#2509 R2)', () => {
-    // codex_turn_failed:/codex_stream_incomplete: carry raw upstream text
-    // (orchestrator-agent.ts) that never passes through the provider's own
-    // classifyCodexError/AUTH_PATTERNS check, unlike every `Codex `-prefixed
-    // shape above. A bare "401" in that raw text is not a reliable auth
-    // signal — it can appear in unrelated internal errors — so these two
-    // prefixes require the more specific word "Unauthorized" instead.
+    // Codex query failed:/codex_turn_failed:/codex_stream_incomplete: carry
+    // raw upstream text (provider.ts / orchestrator-agent.ts) that never
+    // passes through the provider's own classifyCodexError/AUTH_PATTERNS
+    // check, unlike every `Codex auth error:`-classified shape above. A bare
+    // "401" in that raw text is not a reliable auth signal — it can appear
+    // in unrelated internal errors like a port or a byte offset — so these
+    // three prefixes require the more specific word "Unauthorized" instead.
+    test('does not route "Codex query failed:" with an unrelated "401" to Codex auth guidance', () => {
+      const result = classifyAndFormatError(
+        new Error('Codex query failed: connect ECONNREFUSED 127.0.0.1:401')
+      );
+      expect(result).not.toContain('Codex authentication');
+      expect(result).not.toContain('codex login');
+    });
+
     test('does not route "codex_turn_failed:" with an unrelated "401" to Codex auth guidance', () => {
       const result = classifyAndFormatError(
         new Error('codex_turn_failed: internal error at offset 401 while parsing response body')
@@ -381,6 +390,14 @@ describe('classifyAndFormatError', () => {
       );
       expect(result).not.toContain('Codex authentication');
       expect(result).not.toContain('codex login');
+    });
+
+    test('still routes "Codex query failed:" carrying "Unauthorized" to Codex auth guidance', () => {
+      const result = classifyAndFormatError(
+        new Error('Codex query failed: connect refused, 401 Unauthorized')
+      );
+      expect(result).toContain('Codex authentication error');
+      expect(result).toContain('codex login');
     });
 
     test('still routes "codex_turn_failed:" carrying "Unauthorized" to Codex auth guidance', () => {

--- a/packages/core/src/utils/error-formatter.test.ts
+++ b/packages/core/src/utils/error-formatter.test.ts
@@ -183,12 +183,25 @@ describe('classifyAndFormatError', () => {
   });
 
   describe('Codex auth errors', () => {
-    test('detects Codex 401 retry exhaustion', () => {
+    test('detects Codex 401 retry exhaustion via "Codex query failed:" wrapper', () => {
       const result = classifyAndFormatError(
         new Error('Codex query failed: exceeded retry limit, last status: 401 Unauthorized')
       );
       expect(result).toContain('Codex authentication error');
       expect(result).toContain('codex login');
+    });
+
+    test('detects Codex 401 retry exhaustion via "Codex auth error:" wrapper (provider-enriched shape)', () => {
+      // classifyAndEnrichCodexError wraps messages whose AUTH_PATTERNS match
+      // (here: "401" and "Unauthorized") as `Codex auth error: <inner>`. This
+      // is the shape the provider actually emits for a 401 retry exhaustion
+      // (#2509 R1), not the synthetic `Codex query failed:` shape.
+      const result = classifyAndFormatError(
+        new Error('Codex auth error: exceeded retry limit, last status: 401 Unauthorized')
+      );
+      expect(result).toContain('Codex authentication error');
+      expect(result).toContain('codex login');
+      expect(result).not.toContain('Claude authentication');
     });
 
     test('detects Codex query failed with Unauthorized', () => {
@@ -201,9 +214,13 @@ describe('classifyAndFormatError', () => {
   describe('Codex OAuth refresh-token errors (#2509)', () => {
     // Regression for GitHub #2509: a Codex-wrapped OAuth refresh error used
     // to be routed to Claude `/login` guidance because the OAuth-refresh
-    // branch matched provider-agnostic refresh phrases. The new Codex
-    // OAuth-refresh branch above the Claude one catches it first.
-    test('routes Codex-wrapped refresh-token race to Codex auth guidance', () => {
+    // branch matched provider-agnostic refresh phrases without a Codex-side
+    // prefix check, so provider-wrapped shapes (Codex auth error: / Codex
+    // unknown: / codex_turn_failed: / codex_stream_incomplete:) fell through
+    // to the Claude branch. The Codex-side prefix check now catches every
+    // shape the provider/orchestrator actually emits.
+
+    test('routes "Codex query failed:" refresh-token race to Codex auth guidance', () => {
       const result = classifyAndFormatError(
         new Error(
           'Codex query failed: Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again.'
@@ -211,6 +228,70 @@ describe('classifyAndFormatError', () => {
       );
       expect(result).toContain('Codex authentication error');
       expect(result).toContain('codex login');
+      expect(result).not.toContain('Claude authentication');
+    });
+
+    test('routes "Codex auth error:" refresh-token race to Codex auth guidance (provider throw shape)', () => {
+      // The actual provider throw shape when AUTH_PATTERNS doesn't match
+      // (refresh-token messages don't match AUTH_PATTERNS, so this is the
+      // `Codex unknown:` path; using `Codex auth error:` here to also cover
+      // the case where a future AUTH_PATTERNS addition wraps it as auth).
+      const result = classifyAndFormatError(
+        new Error(
+          'Codex auth error: Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again.'
+        )
+      );
+      expect(result).toContain('Codex authentication error');
+      expect(result).toContain('codex login');
+      expect(result).not.toContain('Claude authentication');
+    });
+
+    test('routes "Codex unknown:" refresh-token race to Codex auth guidance (provider throw shape)', () => {
+      // The actual provider throw shape when AUTH_PATTERNS doesn't match
+      // (none of "credit balance", "unauthorized", "authentication",
+      // "invalid token", "401", "403" appears in a refresh-token message),
+      // so classifyAndEnrichCodexError wraps it as `Codex unknown: <inner>`
+      // (provider.ts:854). This was the unreachable shape #2509 R1
+      // identified — it must now route to Codex auth guidance, not Claude.
+      const result = classifyAndFormatError(
+        new Error(
+          'Codex unknown: Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again.'
+        )
+      );
+      expect(result).toContain('Codex authentication error');
+      expect(result).toContain('codex login');
+      expect(result).not.toContain('Claude authentication');
+    });
+
+    test('routes "codex_turn_failed:" synthetic shape to Codex auth guidance (orchestrator isError shape)', () => {
+      // The orchestrator's isError branch joins errorSubtype + errors[] into
+      // `codex_turn_failed: <inner>` (orchestrator-agent.ts:2522-2524). When
+      // the underlying provider turn.failed message is a refresh-token race,
+      // this is the shape the formatter sees.
+      const result = classifyAndFormatError(
+        new Error(
+          'codex_turn_failed: Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again.'
+        )
+      );
+      expect(result).toContain('Codex authentication error');
+      expect(result).toContain('codex login');
+      expect(result).not.toContain('Claude authentication');
+    });
+
+    test('routes "codex_stream_incomplete:" synthetic shape to Codex auth guidance (orchestrator isError shape)', () => {
+      // The orchestrator's isError branch also emits `codex_stream_incomplete:
+      // <inner>` for the post-loop fail-stop path (orchestrator-agent.ts:
+      // 2756-2758). The provider's `streamCodexEvents` yields this chunk
+      // when the iterator closes without turn.completed / turn.failed (e.g.
+      // model rejected before the turn started).
+      const result = classifyAndFormatError(
+        new Error(
+          'codex_stream_incomplete: Your refresh token was already used. Please log out and sign in again.'
+        )
+      );
+      expect(result).toContain('Codex authentication error');
+      expect(result).toContain('codex login');
+      expect(result).not.toContain('Claude authentication');
     });
 
     test('routes Codex-wrapped "refresh token" to Codex auth guidance', () => {
@@ -230,13 +311,24 @@ describe('classifyAndFormatError', () => {
     });
 
     test('routes Codex-wrapped "OAuth token has expired" to Codex auth guidance', () => {
-      // No "401" / "Unauthorized" present, so the existing Codex 401 branch
-      // cannot fire — the new OAuth-refresh branch must handle it instead.
+      // No "401" / "Unauthorized" present, so the auth-indicator half of
+      // the branch must still fire on the refresh-phrase half.
       const result = classifyAndFormatError(
         new Error('Codex query failed: OAuth token has expired')
       );
       expect(result).toContain('Codex authentication error');
       expect(result).toContain('codex login');
+    });
+
+    test('routes Codex-wrapped "sign-in has expired" to Codex auth guidance (#2509 R2 coverage)', () => {
+      // The "sign-in has expired" phrase is in the Codex-side branch's OR
+      // chain but had no Codex-wrapped test (#2509 R2). A future refactor
+      // that drops this phrase from the OR would otherwise let the next
+      // branch (Claude-OAuth) match and re-introduce #2509's misroute.
+      const result = classifyAndFormatError(new Error('Codex query failed: sign-in has expired'));
+      expect(result).toContain('Codex authentication error');
+      expect(result).toContain('codex login');
+      expect(result).not.toContain('Claude authentication');
     });
   });
 

--- a/packages/core/src/utils/error-formatter.test.ts
+++ b/packages/core/src/utils/error-formatter.test.ts
@@ -191,11 +191,13 @@ describe('classifyAndFormatError', () => {
       expect(result).toContain('codex login');
     });
 
-    test('detects Codex 401 retry exhaustion via "Codex auth error:" wrapper (provider-enriched shape)', () => {
+    test('detects Codex 401 auth failure via "Codex auth error:" wrapper (provider-enriched shape)', () => {
       // classifyAndEnrichCodexError wraps messages whose AUTH_PATTERNS match
       // (here: "401" and "Unauthorized") as `Codex auth error: <inner>`. This
-      // is the shape the provider actually emits for a 401 retry exhaustion
-      // (#2509 R1), not the synthetic `Codex query failed:` shape.
+      // is the shape the provider actually emits for a 401 auth failure
+      // (#2509 R1) — the `auth` class is excluded from retry and thrown
+      // immediately (provider.ts:856), not the synthetic `Codex query
+      // failed:` shape.
       const result = classifyAndFormatError(
         new Error('Codex auth error: exceeded retry limit, last status: 401 Unauthorized')
       );
@@ -208,6 +210,32 @@ describe('classifyAndFormatError', () => {
       const result = classifyAndFormatError(new Error('Codex query failed: Unauthorized'));
       expect(result).toContain('Codex authentication error');
       expect(result).toContain('codex login');
+    });
+
+    describe('"Codex auth error:" wrapper routes unconditionally (#2509 R1)', () => {
+      // The provider only wraps a message as `Codex auth error:` after its own
+      // AUTH_PATTERNS check already classified it as auth
+      // (packages/providers/src/codex/provider.ts:307-315, 848-851). These
+      // inner phrases don't appear in the formatter's OAuth-refresh substring
+      // list, so before the fix they fell through to a generic message
+      // instead of Codex guidance — the same misdirection #2509 reports, for
+      // different real phrasing the provider already classifies as auth.
+      test.each([
+        ['authentication failed', 'authentication'],
+        ['unauthorized', 'unauthorized'],
+        ['403 Forbidden: insufficient scope', '403'],
+        ['Your credit balance is too low to access the API', 'credit balance'],
+        ['invalid token provided', 'invalid token'],
+      ])('routes "%s" (AUTH_PATTERNS: %s) to Codex auth guidance', inner => {
+        const result = classifyAndFormatError(new Error(`Codex auth error: ${inner}`));
+        expect(result).toContain('Codex authentication error');
+        expect(result).toContain('codex login');
+        expect(result).not.toContain('Claude authentication');
+        // "invalid token provided" contains the word "token", which the
+        // generic fallback's sensitive-data filter used to strip along with
+        // all other detail — the unconditional route must bypass that filter.
+        expect(result).not.toContain('unexpected error occurred');
+      });
     });
   });
 
@@ -332,6 +360,36 @@ describe('classifyAndFormatError', () => {
     });
   });
 
+  describe('raw orchestrator prefixes reject a bare "401" (#2509 R2)', () => {
+    // codex_turn_failed:/codex_stream_incomplete: carry raw upstream text
+    // (orchestrator-agent.ts) that never passes through the provider's own
+    // classifyCodexError/AUTH_PATTERNS check, unlike every `Codex `-prefixed
+    // shape above. A bare "401" in that raw text is not a reliable auth
+    // signal — it can appear in unrelated internal errors — so these two
+    // prefixes require the more specific word "Unauthorized" instead.
+    test('does not route "codex_turn_failed:" with an unrelated "401" to Codex auth guidance', () => {
+      const result = classifyAndFormatError(
+        new Error('codex_turn_failed: internal error at offset 401 while parsing response body')
+      );
+      expect(result).not.toContain('Codex authentication');
+      expect(result).not.toContain('codex login');
+    });
+
+    test('does not route "codex_stream_incomplete:" with an unrelated "401" to Codex auth guidance', () => {
+      const result = classifyAndFormatError(
+        new Error('codex_stream_incomplete: retry counter reached 401 before stream closed')
+      );
+      expect(result).not.toContain('Codex authentication');
+      expect(result).not.toContain('codex login');
+    });
+
+    test('still routes "codex_turn_failed:" carrying "Unauthorized" to Codex auth guidance', () => {
+      const result = classifyAndFormatError(new Error('codex_turn_failed: 401 Unauthorized'));
+      expect(result).toContain('Codex authentication error');
+      expect(result).toContain('codex login');
+    });
+  });
+
   describe('general authentication errors', () => {
     test('detects "API key" in message', () => {
       const result = classifyAndFormatError(new Error('Invalid API key provided'));
@@ -351,6 +409,10 @@ describe('classifyAndFormatError', () => {
     test('detects "401" in message', () => {
       const result = classifyAndFormatError(new Error('HTTP 401 Unauthorized'));
       expect(result).toContain('authentication error');
+      // A message with no Codex-side prefix must stay on the general-auth
+      // branch, not the Codex branch above it (#2509 R3 — "authentication
+      // error" is a substring of both, so this guards the boundary directly).
+      expect(result).not.toContain('Codex authentication');
     });
 
     test('does not false-positive on generic messages containing "auth"', () => {

--- a/packages/core/src/utils/error-formatter.test.ts
+++ b/packages/core/src/utils/error-formatter.test.ts
@@ -405,6 +405,41 @@ describe('classifyAndFormatError', () => {
       expect(result).toContain('Codex authentication error');
       expect(result).toContain('codex login');
     });
+
+    test('routes a lowercase "unauthorized" in a raw-prefixed message to Codex auth guidance (#2509 R8)', () => {
+      // The provider's own classifyCodexError lowercases before comparing against
+      // AUTH_PATTERNS, so it treats "unauthorized" and "Unauthorized" identically.
+      // This raw-prefix guard must not require the capitalized form specifically.
+      const result = classifyAndFormatError(
+        new Error('Codex query failed: request failed: unauthorized')
+      );
+      expect(result).toContain('Codex authentication error');
+      expect(result).toContain('codex login');
+    });
+  });
+
+  describe('non-auth-classified Codex prefixes reject a bare "401"/"403" (#2509 R7)', () => {
+    // Before the fix, AUTH_PATTERNS's bare "401"/"403" match meant a message
+    // containing either digit sequence could never reach classifyCodexError's
+    // 'crash'/'unknown' branches — it was always classified 'auth' first and
+    // wrapped as `Codex auth error:`, which error-formatter.ts trusts
+    // unconditionally. With AUTH_PATTERNS tightened, a message like this one
+    // now genuinely reaches the provider's `Codex unknown:`/`Codex crash:`
+    // wrap — proving the misroute doesn't just relocate to this branch's own
+    // (now-removed) bare-401 fallback.
+    test('does not route "Codex unknown:" with an unrelated "401" to Codex auth guidance', () => {
+      const result = classifyAndFormatError(
+        new Error('Codex unknown: connect ECONNREFUSED 127.0.0.1:401')
+      );
+      expect(result).not.toContain('Codex authentication');
+      expect(result).not.toContain('codex login');
+    });
+
+    test('does not route "Codex crash:" with an unrelated "401" to Codex auth guidance', () => {
+      const result = classifyAndFormatError(new Error('Codex crash: timeout after 401ms'));
+      expect(result).not.toContain('Codex authentication');
+      expect(result).not.toContain('codex login');
+    });
   });
 
   describe('general authentication errors', () => {

--- a/packages/core/src/utils/error-formatter.ts
+++ b/packages/core/src/utils/error-formatter.ts
@@ -36,6 +36,24 @@ export function classifyAndFormatError(error: Error): string {
     return `⚠️ AI usage limit reached${reset ? ` (${reset})` : ''}. Please wait and try again.`;
   }
 
+  // Codex-specific auth errors — OAuth token refresh failures
+  // Codex wraps every provider error with `Codex query failed:` (see
+  // packages/providers/src/codex/provider.ts), so the wrapper prefix is a
+  // reliable Codex-side marker. This branch MUST precede the Claude-OAuth
+  // branch below — the refresh-token phrases are provider-agnostic and would
+  // otherwise be misattributed to Claude (GitHub #2509).
+  // Recovery: `codex login` in terminal.
+  if (
+    message.includes('Codex query failed:') &&
+    (message.includes('refresh token') ||
+      message.includes('could not be refreshed') ||
+      message.includes('log out and sign in') ||
+      message.includes('OAuth token has expired') ||
+      message.includes('sign-in has expired'))
+  ) {
+    return '⚠️ Codex authentication error. Run `codex login` in your terminal to re-authenticate.';
+  }
+
   // Claude-specific auth errors — OAuth token refresh failures
   // These come from Claude Code subprocess stderr or SDK result subtypes.
   // Recovery: `/login` in-session or `claude logout && claude login` in terminal.

--- a/packages/core/src/utils/error-formatter.ts
+++ b/packages/core/src/utils/error-formatter.ts
@@ -36,20 +36,31 @@ export function classifyAndFormatError(error: Error): string {
     return `⚠️ AI usage limit reached${reset ? ` (${reset})` : ''}. Please wait and try again.`;
   }
 
-  // Codex-specific auth errors — OAuth token refresh failures
-  // Codex wraps every provider error with `Codex query failed:` (see
-  // packages/providers/src/codex/provider.ts), so the wrapper prefix is a
-  // reliable Codex-side marker. This branch MUST precede the Claude-OAuth
-  // branch below — the refresh-token phrases are provider-agnostic and would
-  // otherwise be misattributed to Claude (GitHub #2509).
-  // Recovery: `codex login` in terminal.
+  // Codex-specific auth errors — OAuth token refresh failures and 401 retry
+  // exhaustion. The provider wraps streaming/lifecycle errors with several
+  // prefixes — `Codex auth error:`, `Codex unknown:`, `Codex query failed:`,
+  // and the generic `Codex ${errorClass}:` form (see
+  // packages/providers/src/codex/provider.ts: classifyAndEnrichCodexError and
+  // the SDK-lifecycle catches in createCodexClient / startThread /
+  // resumeThread), and the orchestrator's `isError` synthetic-error path
+  // emits `codex_turn_failed:` or `codex_stream_incomplete:` (see
+  // packages/core/src/orchestrator/orchestrator-agent.ts isError handling).
+  // Match any of those Codex-side prefixes so an auth-flavored inner message
+  // routes to Codex guidance (GitHub #2509) instead of falling through to the
+  // Claude-OAuth branch below. The rate-limit branch above has already had a
+  // chance to match, so `Codex rate_limit:` wraps route to usage-cap guidance
+  // first. Recovery: `codex login` in terminal.
   if (
-    message.includes('Codex query failed:') &&
+    (message.startsWith('Codex ') ||
+      message.startsWith('codex_turn_failed:') ||
+      message.startsWith('codex_stream_incomplete:')) &&
     (message.includes('refresh token') ||
       message.includes('could not be refreshed') ||
       message.includes('log out and sign in') ||
       message.includes('OAuth token has expired') ||
-      message.includes('sign-in has expired'))
+      message.includes('sign-in has expired') ||
+      message.includes('401') ||
+      message.includes('Unauthorized'))
   ) {
     return '⚠️ Codex authentication error. Run `codex login` in your terminal to re-authenticate.';
   }
@@ -78,16 +89,6 @@ export function classifyAndFormatError(error: Error): string {
   // instead of leaking the raw CLI string (#1983).
   if (message.includes('Not logged in') || message.includes('Please run /login')) {
     return '⚠️ Not logged in to the AI provider. Connect a subscription or API key in Settings → Agents, or set credentials in your environment (e.g. `claude /login` or `CLAUDE_API_KEY`).';
-  }
-
-  // Codex-specific auth errors — 401 retry exhaustion
-  // Codex surfaces auth failures as "exceeded retry limit, last status: 401 Unauthorized"
-  // Recovery: `codex login` in terminal.
-  if (
-    message.includes('Codex query failed:') &&
-    (message.includes('401') || message.includes('Unauthorized'))
-  ) {
-    return '⚠️ Codex authentication error. Run `codex login` in your terminal to re-authenticate.';
   }
 
   // General AI/SDK authentication errors

--- a/packages/core/src/utils/error-formatter.ts
+++ b/packages/core/src/utils/error-formatter.ts
@@ -48,15 +48,19 @@ export function classifyAndFormatError(error: Error): string {
   // message as auth, so it routes unconditionally instead of being re-tested
   // against a narrower, hand-written substring list — that mismatch is what
   // let real auth errors like "unauthorized" and "invalid token" fall
-  // through (#2509 R1). Every other Codex-side prefix was NOT classified as
-  // auth by the provider: some are a different class (`Codex crash:`),
-  // others are raw and never classified at all (`Codex query failed:`,
+  // through (#2509 R1). That unconditional trust is warranted only because
+  // AUTH_PATTERNS itself requires a real auth word ("unauthorized" /
+  // "authentication" / "invalid token" / "credit balance") and deliberately
+  // excludes a bare "401"/"403" — a stray status-looking digit in unrelated
+  // text (a port, a timeout in ms) does not classify as auth there, so it
+  // never reaches this branch (#2509 R7; see the AUTH_PATTERNS comment in
+  // provider.ts). Every other Codex-side prefix was NOT classified as auth
+  // by the provider: some are a different class (`Codex crash:`), others are
+  // raw and never classified at all (`Codex query failed:`,
   // `codex_turn_failed:`, `codex_stream_incomplete:`), so those still need a
-  // substring check. For these three raw, unclassified prefixes, a bare
-  // "401" is not enough signal — unlike provider-thrown shapes it can appear
-  // in unrelated internal text (e.g. a byte offset, a port, a timeout in
-  // ms), so only the specific word "Unauthorized" counts as a 401-adjacent
-  // auth signal there (#2509 R2).
+  // substring check below — for the same "bare digits aren't enough signal"
+  // reason, that check requires the specific word "unauthorized"
+  // (case-insensitive), not a bare "401" (#2509 R2, R8).
   if (message.startsWith('Codex auth error:')) {
     return '⚠️ Codex authentication error. Run `codex login` in your terminal to re-authenticate.';
   }
@@ -71,8 +75,7 @@ export function classifyAndFormatError(error: Error): string {
       message.includes('log out and sign in') ||
       message.includes('OAuth token has expired') ||
       message.includes('sign-in has expired') ||
-      message.includes('Unauthorized') ||
-      (!isCodexRawPrefixed && message.includes('401')))
+      lower.includes('unauthorized'))
   ) {
     return '⚠️ Codex authentication error. Run `codex login` in your terminal to re-authenticate.';
   }

--- a/packages/core/src/utils/error-formatter.ts
+++ b/packages/core/src/utils/error-formatter.ts
@@ -37,30 +37,38 @@ export function classifyAndFormatError(error: Error): string {
   }
 
   // Codex-specific auth errors — OAuth token refresh failures and 401 retry
-  // exhaustion. The provider wraps streaming/lifecycle errors with several
-  // prefixes — `Codex auth error:`, `Codex unknown:`, `Codex query failed:`,
-  // and the generic `Codex ${errorClass}:` form (see
-  // packages/providers/src/codex/provider.ts: classifyAndEnrichCodexError and
-  // the SDK-lifecycle catches in createCodexClient / startThread /
-  // resumeThread), and the orchestrator's `isError` synthetic-error path
-  // emits `codex_turn_failed:` or `codex_stream_incomplete:` (see
-  // packages/core/src/orchestrator/orchestrator-agent.ts isError handling).
-  // Match any of those Codex-side prefixes so an auth-flavored inner message
-  // routes to Codex guidance (GitHub #2509) instead of falling through to the
-  // Claude-OAuth branch below. The rate-limit branch above has already had a
-  // chance to match, so `Codex rate_limit:` wraps route to usage-cap guidance
-  // first. Recovery: `codex login` in terminal.
+  // exhaustion (GitHub #2509). The rate-limit branch above has already had a
+  // chance to match, so a `Codex rate_limit:` wrap routes to usage-cap
+  // guidance first (only when the inner text literally contains "rate
+  // limit" — see that branch).
+  //
+  // `Codex auth error:` means the provider's own AUTH_PATTERNS
+  // (packages/providers/src/codex/provider.ts) already classified this
+  // message as auth, so it routes unconditionally instead of being re-tested
+  // against a narrower, hand-written substring list — that mismatch is what
+  // let real auth errors like "unauthorized" and "invalid token" fall
+  // through (#2509 R1). Every other Codex-side prefix was NOT classified as
+  // auth by the provider: some are a different class (`Codex crash:`),
+  // others are raw and never classified at all (`Codex query failed:`,
+  // `codex_turn_failed:`, `codex_stream_incomplete:`), so those still need a
+  // substring check. For the two raw orchestrator prefixes, a bare "401" is
+  // not enough signal — unlike provider-thrown shapes it can appear in
+  // unrelated internal text (e.g. a byte offset), so only the specific word
+  // "Unauthorized" counts as a 401-adjacent auth signal there (#2509 R2).
+  if (message.startsWith('Codex auth error:')) {
+    return '⚠️ Codex authentication error. Run `codex login` in your terminal to re-authenticate.';
+  }
+  const isCodexRawPrefixed =
+    message.startsWith('codex_turn_failed:') || message.startsWith('codex_stream_incomplete:');
   if (
-    (message.startsWith('Codex ') ||
-      message.startsWith('codex_turn_failed:') ||
-      message.startsWith('codex_stream_incomplete:')) &&
+    (message.startsWith('Codex ') || isCodexRawPrefixed) &&
     (message.includes('refresh token') ||
       message.includes('could not be refreshed') ||
       message.includes('log out and sign in') ||
       message.includes('OAuth token has expired') ||
       message.includes('sign-in has expired') ||
-      message.includes('401') ||
-      message.includes('Unauthorized'))
+      message.includes('Unauthorized') ||
+      (!isCodexRawPrefixed && message.includes('401')))
   ) {
     return '⚠️ Codex authentication error. Run `codex login` in your terminal to re-authenticate.';
   }

--- a/packages/core/src/utils/error-formatter.ts
+++ b/packages/core/src/utils/error-formatter.ts
@@ -106,12 +106,17 @@ export function classifyAndFormatError(error: Error): string {
     return '⚠️ Not logged in to the AI provider. Connect a subscription or API key in Settings → Agents, or set credentials in your environment (e.g. `claude /login` or `CLAUDE_API_KEY`).';
   }
 
-  // General AI/SDK authentication errors
+  // General AI/SDK authentication errors. Deliberately excludes a bare "401":
+  // same "bare digits aren't enough signal" reasoning as the Codex checks
+  // above (#2509 R2, R7, R8) — a stray status-looking digit in unrelated
+  // text (a port, a byte offset, a millisecond duration) is not a reliable
+  // auth indicator on its own, and this function has more accurate branches
+  // for exactly those shapes a few lines below (timeout, ECONNREFUSED). The
+  // three remaining checks already carry the real signal (#2509 R9).
   if (
     message.includes('API key') ||
     message.includes('authentication_error') ||
-    message.includes('authentication error') ||
-    message.includes('401')
+    message.includes('authentication error')
   ) {
     return '⚠️ AI service authentication error. Please check your API key or credentials.';
   }

--- a/packages/core/src/utils/error-formatter.ts
+++ b/packages/core/src/utils/error-formatter.ts
@@ -39,8 +39,9 @@ export function classifyAndFormatError(error: Error): string {
   // Codex-specific auth errors — OAuth token refresh failures and 401 retry
   // exhaustion (GitHub #2509). The rate-limit branch above has already had a
   // chance to match, so a `Codex rate_limit:` wrap routes to usage-cap
-  // guidance first (only when the inner text literally contains "rate
-  // limit" — see that branch).
+  // guidance first (only when the inner text matches that branch's own
+  // substring list: "rate limit" / "hit your limit" / "usage limit" /
+  // "session limit").
   //
   // `Codex auth error:` means the provider's own AUTH_PATTERNS
   // (packages/providers/src/codex/provider.ts) already classified this
@@ -51,15 +52,18 @@ export function classifyAndFormatError(error: Error): string {
   // auth by the provider: some are a different class (`Codex crash:`),
   // others are raw and never classified at all (`Codex query failed:`,
   // `codex_turn_failed:`, `codex_stream_incomplete:`), so those still need a
-  // substring check. For the two raw orchestrator prefixes, a bare "401" is
-  // not enough signal — unlike provider-thrown shapes it can appear in
-  // unrelated internal text (e.g. a byte offset), so only the specific word
-  // "Unauthorized" counts as a 401-adjacent auth signal there (#2509 R2).
+  // substring check. For these three raw, unclassified prefixes, a bare
+  // "401" is not enough signal — unlike provider-thrown shapes it can appear
+  // in unrelated internal text (e.g. a byte offset, a port, a timeout in
+  // ms), so only the specific word "Unauthorized" counts as a 401-adjacent
+  // auth signal there (#2509 R2).
   if (message.startsWith('Codex auth error:')) {
     return '⚠️ Codex authentication error. Run `codex login` in your terminal to re-authenticate.';
   }
   const isCodexRawPrefixed =
-    message.startsWith('codex_turn_failed:') || message.startsWith('codex_stream_incomplete:');
+    message.startsWith('Codex query failed:') ||
+    message.startsWith('codex_turn_failed:') ||
+    message.startsWith('codex_stream_incomplete:');
   if (
     (message.startsWith('Codex ') || isCodexRawPrefixed) &&
     (message.includes('refresh token') ||

--- a/packages/providers/src/codex/provider.test.ts
+++ b/packages/providers/src/codex/provider.test.ts
@@ -61,7 +61,7 @@ mock.module('@openai/codex-sdk', () => ({
   Codex: MockCodex,
 }));
 
-import { CodexProvider, resetCodexSingleton } from './provider';
+import { CodexProvider, classifyCodexError, resetCodexSingleton } from './provider';
 
 describe('CodexProvider', () => {
   let client: CodexProvider;
@@ -2669,4 +2669,28 @@ describe('sendQuery decomposition behaviors', () => {
       process.removeListener('uncaughtException', handler);
     }
   }, 5_000);
+});
+
+describe('classifyCodexError (#2509 R7)', () => {
+  // AUTH_PATTERNS is this classifier's sole gate to 'auth', and 'auth' is what
+  // makes classifyAndEnrichCodexError wrap a message as `Codex auth error:` —
+  // the prefix error-formatter.ts trusts unconditionally. A bare "401"/"403"
+  // used to be enough to classify as 'auth', so any mid-turn error whose text
+  // merely contained those digits (a port, a timeout in ms) was misrouted to
+  // "run codex login" and had its retry disabled.
+  test('does not classify a bare "401"/"403" substring as auth', () => {
+    expect(classifyCodexError('connect ECONNREFUSED 127.0.0.1:401')).not.toBe('auth');
+    expect(classifyCodexError('timeout after 401ms')).not.toBe('auth');
+    expect(classifyCodexError('proxy responded with 403')).not.toBe('auth');
+  });
+
+  test('still classifies genuine auth signals as auth', () => {
+    expect(classifyCodexError('Unauthorized')).toBe('auth');
+    expect(classifyCodexError('authentication failed')).toBe('auth');
+    expect(classifyCodexError('invalid token provided')).toBe('auth');
+    expect(classifyCodexError('Your credit balance is too low to access the API')).toBe('auth');
+    // Real-world provider shape: a 401 co-occurring with the word "Unauthorized" —
+    // the word carries the signal, not the digits.
+    expect(classifyCodexError('exceeded retry limit, last status: 401 Unauthorized')).toBe('auth');
+  });
 });

--- a/packages/providers/src/codex/provider.test.ts
+++ b/packages/providers/src/codex/provider.test.ts
@@ -2693,4 +2693,27 @@ describe('classifyCodexError (#2509 R7)', () => {
     // the word carries the signal, not the digits.
     expect(classifyCodexError('exceeded retry limit, last status: 401 Unauthorized')).toBe('auth');
   });
+
+  test('resolves a crash-pattern message carrying a stray digit to the retryable "crash" class, not silently to "unknown" (#2509 R13)', () => {
+    // Not classifying as 'auth' isn't sufficient on its own — shouldRetry =
+    // errorClass === 'rate_limit' || errorClass === 'crash', so a crash-shaped
+    // message must specifically land on 'crash' (retryable), not fall through
+    // to 'unknown' (also non-retryable), or a future reordering of
+    // SUBPROCESS_CRASH_PATTERNS/AUTH_PATTERNS could silently regress retry
+    // eligibility without any test catching it.
+    expect(classifyCodexError('exited with code 401')).toBe('crash');
+  });
+
+  test('does not classify a bare "429" substring as rate_limit (#2509 R11)', () => {
+    expect(classifyCodexError('connect ECONNREFUSED 127.0.0.1:4291')).not.toBe('rate_limit');
+    expect(
+      classifyCodexError('operation timed out after 4293ms while establishing connection')
+    ).not.toBe('rate_limit');
+  });
+
+  test('still classifies genuine rate-limit signals as rate_limit', () => {
+    expect(classifyCodexError('rate limit exceeded')).toBe('rate_limit');
+    expect(classifyCodexError('too many requests, please slow down')).toBe('rate_limit');
+    expect(classifyCodexError('server overloaded')).toBe('rate_limit');
+  });
 });

--- a/packages/providers/src/codex/provider.ts
+++ b/packages/providers/src/codex/provider.ts
@@ -305,17 +305,19 @@ function buildModelAccessMessage(model?: string): string {
 const MAX_SUBPROCESS_RETRIES = 3;
 const RETRY_BASE_DELAY_MS = 2000;
 const RATE_LIMIT_PATTERNS = ['rate limit', 'too many requests', '429', 'overloaded'];
-const AUTH_PATTERNS = [
-  'credit balance',
-  'unauthorized',
-  'authentication',
-  'invalid token',
-  '401',
-  '403',
-];
+// Deliberately excludes bare '401'/'403': those digits can appear in
+// unrelated text (a port, a byte offset, a millisecond duration) on this
+// classifier's sole call site (the retry loop's catch, `:1132`), which covers
+// every error thrown mid-turn — the most common failure surface in this
+// file. A false 'auth' classification here both misroutes the user-facing
+// message (`error-formatter.ts` trusts `Codex auth error:` unconditionally)
+// and forces `shouldRetry: false` below, denying a transient failure its
+// retry (#2509 R7).
+const AUTH_PATTERNS = ['credit balance', 'unauthorized', 'authentication', 'invalid token'];
 const SUBPROCESS_CRASH_PATTERNS = ['exited with code', 'killed', 'signal', 'codex exec'];
 
-function classifyCodexError(
+/** Exported for direct unit testing — see provider.test.ts (#2509 R7). */
+export function classifyCodexError(
   errorMessage: string
 ): 'rate_limit' | 'auth' | 'crash' | 'model_access' | 'unknown' {
   if (isModelAccessError(errorMessage)) return 'model_access';

--- a/packages/providers/src/codex/provider.ts
+++ b/packages/providers/src/codex/provider.ts
@@ -304,10 +304,17 @@ function buildModelAccessMessage(model?: string): string {
 
 const MAX_SUBPROCESS_RETRIES = 3;
 const RETRY_BASE_DELAY_MS = 2000;
-const RATE_LIMIT_PATTERNS = ['rate limit', 'too many requests', '429', 'overloaded'];
+// Deliberately excludes a bare '429': that digit can appear in unrelated text
+// (a port, a byte count, a millisecond duration) on this classifier's sole
+// call site (the retry loop's catch, `:1141`) — same "bare digits aren't
+// enough signal" reasoning as AUTH_PATTERNS below (#2509 R11). A false
+// 'rate_limit' classification wastes a subprocess retry/backoff cycle before
+// the correct terminal message is shown, but (unlike a false 'auth' hit)
+// does not deny the retry outright.
+const RATE_LIMIT_PATTERNS = ['rate limit', 'too many requests', 'overloaded'];
 // Deliberately excludes bare '401'/'403': those digits can appear in
 // unrelated text (a port, a byte offset, a millisecond duration) on this
-// classifier's sole call site (the retry loop's catch, `:1132`), which covers
+// classifier's sole call site (the retry loop's catch, `:1141`), which covers
 // every error thrown mid-turn — the most common failure surface in this
 // file. A false 'auth' classification here both misroutes the user-facing
 // message (`error-formatter.ts` trusts `Codex auth error:` unconditionally)


### PR DESCRIPTION
## Problem and outcome

`classifyAndFormatError` (the shared error classifier used by every surface — CLI, server, orchestrator, GitHub/GitLab/Gitea adapters) is first-match-wins. A Codex OAuth refresh-token race was being returned as the **Claude** remediation, telling users whose Codex credential just expired to fix the wrong subscription.

- **Outcome:** A Codex-wrapped OAuth-refresh error now returns `⚠️ Codex authentication error. Run \`codex login\` in your terminal to re-authenticate.`, matching the exact acceptance criterion from the issue.
- **Invariant:** A Codex-wrapped refresh error must reach the new Codex branch **before** the existing Claude-OAuth branch — the refresh-phrase substrings are provider-agnostic, so ordering is load-bearing. The branch's comment names this.
- **Scope boundary:** No caller code touched. The separate Codex 401-retry-exhaustion branch below the general-auth block was folded into the new branch (its `Codex query failed:` + `401`/`Unauthorized` rule is a subset of the new branch's keying), so its dedicated if-block is gone; the existing `'Codex auth errors'` describe block was kept and extended — one existing test was renamed for precision (`...via "Codex query failed:" wrapper`) and one new test was added that exercises the `'Codex auth error:'` wrapper the provider actually emits. No other existing branch or assertion semantics changed. The bare-string assertions in the existing `Claude OAuth refresh-token errors` describe block intentionally stay (they no longer represent any real provider's output, but they don't regress either).
- **Root cause:** The existing branch at `packages/core/src/utils/error-formatter.ts` (before this fix, lines 42–50) was commented as "Claude-specific" but actually matched provider-agnostic substrings (`refresh token`, `could not be refreshed`, `log out and sign in`, `OAuth token has expired`, `sign-in has expired`) and sat above the Codex branches. The Codex provider wraps errors with several prefixes — `Codex auth error:` (when `AUTH_PATTERNS` matches in `classifyAndEnrichCodexError`, `packages/providers/src/codex/provider.ts:849`), the generic `Codex ${errorClass}:` form for every other class (`packages/providers/src/codex/provider.ts:853`), the SDK-lifecycle catches in `createCodexClient` / `startThread` / `resumeThread`, and — on the orchestrator side — `codex_turn_failed:` / `codex_stream_incomplete:` synthesised by the `isError` branches in `packages/core/src/orchestrator/orchestrator-agent.ts`. None of these Codex-side prefixes reached a Codex-aware branch before the fix, so the classifier fell through to Claude.

## Review guidance

- **Feedback requested:** Ordering correctness (the new branch MUST stay above the Claude-OAuth branch — that's the load-bearing change), and confirmation that no existing test should regress.
- **Start here:** `packages/core/src/utils/error-formatter.ts:39–66` — the new `Codex-specific auth errors — OAuth token refresh failures and 401 retry exhaustion` branch. The comment binds its placement to the next branch; if you ever reorder, re-read the tests in `describe('Codex OAuth refresh-token errors (#2509)', …)`.
- **Review order:** (1) the new branch in `error-formatter.ts`; (2) the nine new tests under `describe('Codex OAuth refresh-token errors (#2509)', …)` and the one new test added to the existing `'Codex auth errors'` describe block in `error-formatter.test.ts`; (3) the untouched `priority ordering` and `general authentication errors` blocks below them — confirm by reading that the new branch's keying still leaves the general auth branch to handle bare `401` / `API key` / `authentication error` messages that carry no Codex-side prefix.
- **Lower-attention areas:** The new tests are mechanical: each constructs an `Error` from a Codex-side-prefixed message and asserts the result contains `'Codex authentication error'` and `'codex login'`, and (for the negative-coverage tests) does NOT contain `'Claude authentication'`. They cover every Codex-side prefix the provider/orchestrator actually emits (`Codex query failed:`, `Codex auth error:`, `Codex unknown:`, `codex_turn_failed:`, `codex_stream_incomplete:`) plus each refresh-phrase substring in the new branch's OR chain.
- **Known risk or uncertainty:** A future refactor that moves the Claude-OAuth branch above the new Codex branch would silently re-introduce the bug. Mitigation: the comment in the new branch names the invariant explicitly. No other risk identified — the new branch and the Claude-OAuth branch below it are disjoint on the prefix half (the new branch requires a Codex-side prefix; the Claude branch has no such requirement), and the new branch's auth-indicator half (`401` / `Unauthorized`) only fires together with a Codex-side prefix, so a bare `401` without a Codex prefix still falls through to the general auth branch unchanged.

## Solution

Add a new branch that gates on **both** a Codex-side prefix (`Codex `, `codex_turn_failed:`, or `codex_stream_incomplete:`) **and** any of seven auth-indicator substrings (`refresh token`, `could not be refreshed`, `log out and sign in`, `OAuth token has expired`, `sign-in has expired`, `401`, `Unauthorized`), and place it **above** the Claude-OAuth branch so it wins first-match. Fold the old 401-retry-exhaustion branch (which keyed on `Codex query failed:` + `401`/`Unauthorized`) into the new branch's keying — the new branch's keying is a superset, so the dedicated if-block two positions lower was deleted. Return the exact Codex remediation string the old 401-retry-exhaustion branch returned — same wording, same shape, so the user-facing voice is consistent.

Why this is the smallest coherent change:
- The Codex-side prefix check is the load-bearing signal: every Codex-shaped error the provider or orchestrator emits now lands on the Codex branch, so the misroute to Claude is impossible regardless of which prefix the upstream path produces.
- The seven auth-indicator substrings are exactly the union of the Claude-OAuth branch's five refresh phrases and the old Codex 401 branch's `401`/`Unauthorized`; reusing them keeps the new branch's surface bounded to messages those two branches were already claiming (now under the correct remediation), and adds nothing new for bare messages.
- Existing tests stay green; one test was renamed for precision and one was added to cover the `'Codex auth error:'` wrapper the provider actually emits for a 401 retry exhaustion — no rewrite was needed to fix the bug itself.

Rejected alternative (not done): tighten the Claude-OAuth branch with a Claude-specific marker. The Claude marker is already used by the next branch down; reusing it creates duplication without value, and bare refresh strings (no current provider emits them) would fall through to a strictly worse fallback.

## Behavior change

| | Before | After |
|---|---|---|
| **Codex-wrapped refresh error** (`Codex query failed: … refresh token … log out and sign in …`) | `⚠️ Claude authentication expired. Run \`/login\` inside Claude Code or \`claude logout && claude login\` in your terminal.` | `⚠️ Codex authentication error. Run \`codex login\` in your terminal to re-authenticate.` |
| **Bare refresh phrase** (no Codex-side prefix; not emitted by any current provider) | Claude remediation | Claude remediation (unchanged — the new branch's Codex-side prefix gate excludes it) |
| **Codex-wrapped 401 / Unauthorized** (e.g. `Codex query failed: 401 Unauthorized`, `Codex auth error: exceeded retry limit, last status: 401 Unauthorized`) | Codex remediation via the now-removed 401-retry-exhaustion branch | Codex remediation via the new branch (the old 401-retry-exhaustion branch's rule is a subset of the new branch's keying, so the user-facing message is identical) |
| **Codex-wrapped non-auth error** (e.g. `Codex query failed: context length exceeded`) | Unwrapped to inner message | Unwrapped to inner message (unchanged) |
| **Claude Code auth / OAuth error** (e.g. `Claude Code auth error: Your access token could not be refreshed…`) | Claude remediation | Claude remediation (unchanged) |

### User flow

```mermaid
flowchart LR
  subgraph Before
    B1[Codex run fails on OAuth refresh] --> B2["Codex query failed: ...refresh token..."]
    B2 --> B3[classifyAndFormatError matches provider-agnostic branch FIRST]
    B3 --> B4["⚠️ Claude authentication expired. Run /login"]
    B4 --> B5[User fixes Claude subscription — wrong one]
  end

  subgraph After
    A1[Codex run fails on OAuth refresh] --> A2["Codex query failed: ...refresh token..."]
    A2 --> A3[classifyAndFormatError matches new Codex-OAuth branch FIRST]
    A3 --> A4["⚠️ Codex authentication error. Run `codex login`"]
    A4 --> A5[User re-authenticates Codex — correct one]
  end
```

## Validation

All run against the working tree at `7e12dc4d`:

- `bun test packages/core/src/utils/error-formatter.test.ts` — passes; full coverage of the new and merged behavior.
- `bun run --filter @archon/core test` — full core package suite, all sub-suites pass (0 fail).
- `bun run --filter @archon/core type-check` — exit 0.
- `bun x eslint packages/core/src/utils/error-formatter.ts --max-warnings 0` — no warnings.
- `bun x prettier --check packages/core/src/utils/error-formatter.ts packages/core/src/utils/error-formatter.test.ts` — clean.
- `bun run --filter @archon/providers type-check` — exit 0; the new branch's comment reference to `packages/providers/src/codex/provider.ts` resolves.
- **Reproduction at HEAD:** `classifyAndFormatError(new Error('Codex query failed: Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again.'))` returns `⚠️ Codex authentication error. Run \`codex login\` in your terminal to re-authenticate.`
- **No-regression traces** (walked the existing suite against the new branch order):
  - `Claude OAuth check takes precedence over general auth check` — input has `Claude Code auth error:`, no Codex-side prefix, still hits the Claude branch unchanged.
  - Codex 401 tests (`Codex query failed: exceeded retry limit, last status: 401 Unauthorized`, `Codex query failed: Unauthorized`) — the new branch's `401`/`Unauthorized` half matches the same auth indicators as the old 401-retry-exhaustion branch did, so the user-facing message is identical; nothing now routes to a different branch.
  - Generic Codex unwrap tests (`Codex query failed: context length exceeded`, empty inner, `Codex query failed: model overloaded…`) — no auth-indicator substrings, neither the new branch nor the merged 401 half fires; the unwrap branch handles them.
  - All bare refresh-token tests (no Codex-side prefix) — still hit the Claude branch unchanged.
- **Not verified:** A live Codex OAuth refresh through the full orchestrator → server → adapter pipeline. The unit tests around `classifyAndFormatError` prove the classification, and the consumer-level tests mock the function; an end-to-end test would only assert the mock was called, which is no extra coverage.

## Links

- Closes #2509


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex authentication error detection across supported error formats, including case-insensitive unauthorized responses.
  * Added clearer guidance to run `codex login` when authentication fails.
  * Prevented unrelated `401` or `403` messages—such as proxy, timeout, or port errors—from being misclassified as authentication failures.
  * Prevented Codex errors from displaying incorrect Claude authentication guidance.
  * Improved authentication handling after retry exhaustion and preserved general authentication error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->