### PR TITLE
fix(cli): pipe console.log through writeStdout so slow readers get the whole payload

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "cli": "bun src/cli.ts",
-    "test": "bun test src/commands/version.test.ts src/commands/setup.test.ts src/commands/skill.test.ts src/commands/doctor.test.ts src/commands/telemetry.test.ts && bun test src/commands/workflow.test.ts && bun test src/commands/isolation.test.ts && bun test src/commands/chat.test.ts && bun test src/commands/serve.test.ts && bun test src/commands/ai.test.ts && bun test src/commands/continue.test.ts && bun test src/commands/validate.test.ts && bun test src/cli.test.ts src/utils/stdout.test.ts && bun test src/adapters/cli-adapter.test.ts",
+    "test": "bun test src/commands/version.test.ts src/commands/setup.test.ts src/commands/skill.test.ts src/commands/doctor.test.ts src/commands/telemetry.test.ts && bun test src/commands/workflow.test.ts && bun test src/commands/isolation.test.ts && bun test src/commands/chat.test.ts && bun test src/commands/serve.test.ts && bun test src/commands/ai.test.ts && bun test src/commands/continue.test.ts && bun test src/commands/validate.test.ts && bun test src/cli.test.ts src/utils/stdout.test.ts src/utils/safe-console.test.ts && bun test src/adapters/cli-adapter.test.ts",
     "type-check": "bun x tsc --noEmit"
   },
   "dependencies": {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -28,7 +28,7 @@ loadArchonEnv(process.cwd());
 // `utils/safe-console.ts` for the underlying shim, and #2400 for the full
 // rationale.
 import { installPipeSafeConsole } from './utils/safe-console';
-import { exitWithDrain } from './utils/exit-with-drain';
+import { withDrainedExit } from './utils/exit-with-drain';
 installPipeSafeConsole();
 
 import { parseArgs } from 'util';
@@ -1189,13 +1189,9 @@ async function main(): Promise<number> {
 // zero. Splitting the two arms' exit logic would re-open the R9 latency:
 // a fatal rejection against a slow reader would truncate and exit 1,
 // producing the same silent stdout loss the patch is meant to eliminate.
-// The drain helper lives in `./utils/exit-with-drain.ts` so the
-// `safe-console.test.ts` R9 regression test imports the same code and a
-// drift between the two arms cannot land without changing that module.
-main()
-  .then(exitWithDrain)
-  .catch((error: unknown) => {
-    const err = error as Error;
-    console.error('Fatal error:', err.message);
-    return exitWithDrain(1);
-  });
+// The chain wiring — `main().then(exitWithDrain).catch(...)` — lives in
+// `withDrainedExit` (`./utils/exit-with-drain.ts`) so cli.ts and the R9
+// regression test fixture share a single source of truth, and a regression
+// that bypasses `exitWithDrain` at this call site would also have to land
+// in that module.
+withDrainedExit(main);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1180,13 +1180,20 @@ async function main(): Promise<number> {
 // awaits `writeStdout` / `writeJsonLine` at the call site
 // (src/utils/stdout.ts); the shim only adds the fire-and-forget shape that
 // the human-readable call surface requires.
+//
+// The drain runs on BOTH exits — success and fatal — so a `main()` rejection
+// does not get to drop queued stdout bytes just because it is exiting non-
+// zero. Splitting the two arms' exit logic would re-open the R9 latency:
+// a fatal rejection against a slow reader would truncate and exit 1,
+// producing the same silent stdout loss the patch is meant to eliminate.
+const exitWithDrain = async (code: number): Promise<never> => {
+  await flushPendingWrites();
+  process.exit(code);
+};
 main()
-  .then(async exitCode => {
-    await flushPendingWrites();
-    process.exit(exitCode);
-  })
+  .then(exitWithDrain)
   .catch((error: unknown) => {
     const err = error as Error;
     console.error('Fatal error:', err.message);
-    process.exit(1);
+    return exitWithDrain(1);
   });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -20,9 +20,12 @@ loadArchonEnv(process.cwd());
 // `console.log` reaches fd 1 via a non-blocking pipe (pino opens it that way at
 // module load via `@archon/paths/strip-cwd-env-boot` above), and short writes
 // are silently dropped against a slow reader. The shim delegates through
-// `writeStdout` so every byte reaches the OS before the call returns. See
+// `writeStdout` so the stream layer queues short writes and retries `EAGAIN`
+// instead of dropping the tail — but delivery is fire-and-forget, so the
+// patched `console.log` returns synchronously and the exit path below must
+// await `flushPendingWrites()` before `process.exit()`. See
 // `utils/safe-console.ts` and #2400 for the full rationale.
-import { installPipeSafeConsole } from './utils/safe-console';
+import { flushPendingWrites, installPipeSafeConsole } from './utils/safe-console';
 installPipeSafeConsole();
 
 import { parseArgs } from 'util';
@@ -1165,13 +1168,21 @@ async function main(): Promise<number> {
 // Exit explicitly so a lingering handle (DB pool, spawned child, timer) can
 // never leave the CLI hanging after its work is done.
 //
-// This is safe for piped output because every machine-readable payload is
-// emitted through `writeStdout()`/`writeJsonLine()` (src/utils/stdout.ts), which
-// resolves only once the bytes have reached the OS. The #2384 truncation
-// happened inside `console.log` at call time — not at exit — so deferring the
-// exit would not have recovered it.
+// `flushPendingWrites()` is awaited BEFORE `process.exit()` because every
+// `console.log` written through the pipe-safe shim is fire-and-forget
+// (src/utils/safe-console.ts): the stream callback that resolves the per-
+// write promise fires asynchronously, and `process.exit()` does not drain
+// `process.stdout`'s pending writes. Without this flush a very-slow reader
+// (e.g. `archon … | { sleep 1; cat; }`) would re-introduce the silent-exit-0
+// truncation the shim is meant to eliminate — see R1 in the review report.
+//
+// The `--json` paths do not need this because every JSON emitter already
+// awaits `writeStdout` / `writeJsonLine` at the call site
+// (src/utils/stdout.ts); the shim only adds the fire-and-forget shape that
+// the human-readable call surface requires.
 main()
-  .then(exitCode => {
+  .then(async exitCode => {
+    await flushPendingWrites();
     process.exit(exitCode);
   })
   .catch((error: unknown) => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -24,8 +24,11 @@ loadArchonEnv(process.cwd());
 // instead of dropping the tail — but delivery is fire-and-forget, so the
 // patched `console.log` returns synchronously and the exit path below must
 // await `flushPendingWrites()` before `process.exit()`. See
-// `utils/safe-console.ts` and #2400 for the full rationale.
-import { flushPendingWrites, installPipeSafeConsole } from './utils/safe-console';
+// `utils/exit-with-drain.ts` (the call site that owns the drain) and
+// `utils/safe-console.ts` for the underlying shim, and #2400 for the full
+// rationale.
+import { installPipeSafeConsole } from './utils/safe-console';
+import { exitWithDrain } from './utils/exit-with-drain';
 installPipeSafeConsole();
 
 import { parseArgs } from 'util';
@@ -1186,10 +1189,9 @@ async function main(): Promise<number> {
 // zero. Splitting the two arms' exit logic would re-open the R9 latency:
 // a fatal rejection against a slow reader would truncate and exit 1,
 // producing the same silent stdout loss the patch is meant to eliminate.
-const exitWithDrain = async (code: number): Promise<never> => {
-  await flushPendingWrites();
-  process.exit(code);
-};
+// The drain helper lives in `./utils/exit-with-drain.ts` so the
+// `safe-console.test.ts` R9 regression test imports the same code and a
+// drift between the two arms cannot land without changing that module.
 main()
   .then(exitWithDrain)
   .catch((error: unknown) => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -16,6 +16,15 @@ import '@archon/paths/strip-cwd-env-boot';
 import { loadArchonEnv } from '@archon/paths/env-loader';
 loadArchonEnv(process.cwd());
 
+// Install the pipe-safe `console.log` shim BEFORE any command module imports.
+// `console.log` reaches fd 1 via a non-blocking pipe (pino opens it that way at
+// module load via `@archon/paths/strip-cwd-env-boot` above), and short writes
+// are silently dropped against a slow reader. The shim delegates through
+// `writeStdout` so every byte reaches the OS before the call returns. See
+// `utils/safe-console.ts` and #2400 for the full rationale.
+import { installPipeSafeConsole } from './utils/safe-console';
+installPipeSafeConsole();
+
 import { parseArgs } from 'util';
 import { resolve } from 'path';
 import { existsSync, realpathSync } from 'fs';

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1191,7 +1191,8 @@ async function main(): Promise<number> {
 // producing the same silent stdout loss the patch is meant to eliminate.
 // The chain wiring — `main().then(exitWithDrain).catch(...)` — lives in
 // `withDrainedExit` (`./utils/exit-with-drain.ts`) so cli.ts and the R9
-// regression test fixture share a single source of truth, and a regression
-// that bypasses `exitWithDrain` at this call site would also have to land
-// in that module.
+// regression test fixture share a single source of truth. A regression
+// that swaps this call for a direct `process.exit` is caught by the
+// static-contract test in `safe-console.test.ts`, which reads this file
+// as text.
 withDrainedExit(main);

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -101,6 +101,7 @@ import * as userDb from '@archon/core/db/users';
 import * as git from '@archon/git';
 import { CLIAdapter } from '../adapters/cli-adapter';
 import { writeJsonLine, writeStdout } from '../utils/stdout';
+import { exitWithDrain } from '../utils/exit-with-drain';
 import { resolveCliUserId } from './auth';
 
 /** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
@@ -2016,7 +2017,7 @@ async function runWorkflowWithOwnedSource(
         );
       })
       // Destroy the isolation container so Ctrl-C / SIGTERM doesn't orphan a
-      // PRIVILEGED container — `process.exit(1)` below bypasses the teardown
+      // PRIVILEGED container — the forced exit below bypasses the teardown
       // `finally`, so we must tear it down explicitly here first.
       .then(async () => {
         if (containerBackend && containerEnvId) {
@@ -2032,9 +2033,10 @@ async function runWorkflowWithOwnedSource(
         }
       })
       // Reclaim the staged capture for the same reason the container is destroyed above:
-      // `process.exit(1)` never returns up the stack, so the ownership `finally` — whose
-      // whole premise is "whichever way we leave" — never runs. Ctrl-C during isolation
-      // resolution or worktree creation would otherwise strand a complete frozen tree.
+      // the forced exit below never returns up the stack, so the ownership `finally` —
+      // whose whole premise is "whichever way we leave" — never runs. Ctrl-C during
+      // isolation resolution or worktree creation would otherwise strand a complete
+      // frozen tree.
       .then(async () => {
         if (preparedSource && !sourceAdopted) {
           await disposeWorkflowSource(preparedSource).catch(() => undefined);
@@ -2042,7 +2044,13 @@ async function runWorkflowWithOwnedSource(
       })
       .catch(() => undefined)
       .finally(() => {
-        process.exit(1);
+        // Route through the same drain helper cli.ts's top-level exit chain
+        // uses so queued `console.log` output (this command streams progress
+        // through 101 call sites) reaches a slow reader before the process
+        // exits — a bare `process.exit(1)` here would reopen #2400's
+        // truncation on Ctrl-C/SIGTERM specifically. See R16 in the review
+        // report.
+        void exitWithDrain(1);
       });
   };
   const sigtermHandler = (): void => {

--- a/packages/cli/src/utils/exit-with-drain.ts
+++ b/packages/cli/src/utils/exit-with-drain.ts
@@ -1,0 +1,26 @@
+/**
+ * Exit the CLI process after every fire-and-forget `writeStdout` write has
+ * been drained to the OS.
+ *
+ * The pipe-safe `console.log` shim in `./safe-console.ts` delegates through
+ * `writeStdout` and returns synchronously — bytes reach the OS via the
+ * underlying stream callback, not synchronously. `process.exit()` does NOT
+ * drain `process.stdout`'s pending writes, so a process that exits without
+ * awaiting the shim's `flushPendingWrites()` will silently drop the tail of
+ * queued stdout against a slow reader (the truncation the shim exists to
+ * prevent — see R1 in the review report and #2400).
+ *
+ * Both arms of `cli.ts`'s top-level `main().then().catch()` chain route
+ * through this helper so the drain contract is shared between the success
+ * and fatal paths: a regression that re-splits the two arms (e.g. dropping
+ * `flushPendingWrites()` from the catch arm only) cannot land without
+ * changing this module, and the regression test in
+ * `safe-console.test.ts` imports the same helper from here. See R9 in the
+ * review report.
+ */
+import { flushPendingWrites } from './safe-console';
+
+export const exitWithDrain = async (code: number): Promise<never> => {
+  await flushPendingWrites();
+  process.exit(code);
+};

--- a/packages/cli/src/utils/exit-with-drain.ts
+++ b/packages/cli/src/utils/exit-with-drain.ts
@@ -18,9 +18,19 @@
  * `safe-console.test.ts` imports the same helper from here. See R9 in the
  * review report.
  */
-import { flushPendingWrites } from './safe-console';
+import { consumeWriteError, flushPendingWrites } from './safe-console';
 
 export const exitWithDrain = async (code: number): Promise<never> => {
   await flushPendingWrites();
+  // Any `process.stdout.write` failure captured by the patched `console.log`
+  // (most commonly EPIPE from `archon … | head -c 100`) must surface as a
+  // non-zero exit regardless of platform. Without this, a Linux CI runner
+  // can schedule the unhandled-rejection handler after `process.exit()` and
+  // silently lose the EPIPE — the writer exits 0 even though the piped
+  // reader hung up before delivery completed.
+  if (consumeWriteError() !== null && code === 0) {
+    process.exit(1);
+    return undefined as never;
+  }
   process.exit(code);
 };

--- a/packages/cli/src/utils/exit-with-drain.ts
+++ b/packages/cli/src/utils/exit-with-drain.ts
@@ -12,24 +12,39 @@
  *
  * Both `exitWithDrain` and `withDrainedExit` live here so `cli.ts`'s
  * top-level `main().then().catch()` chain and the `safe-console.test.ts`
- * R9 regression test fixture can share them: a regression that bypasses
- * `exitWithDrain` at the cli.ts call site (e.g. replacing `withDrainedExit`
- * with a direct `process.exit`) is caught by the fixture, which calls the
- * same helper from this module. See R9 / R12 in the review report.
+ * R9 regression test fixture can share them: a regression that drops the
+ * drain from `withDrainedExit` itself (e.g. removing the `flushPendingWrites()`
+ * await) is caught by the fixture, since it calls this same helper. A
+ * regression that instead bypasses `withDrainedExit` at the cli.ts call site
+ * (e.g. swapping it for a direct `process.exit`) is caught by the separate
+ * static-contract test, which reads `cli.ts` as text. See R9 / R12 in the
+ * review report.
  */
 import { consumeWriteError, flushPendingWrites } from './safe-console';
 
 export const exitWithDrain = async (code: number): Promise<never> => {
   await flushPendingWrites();
-  // Any `process.stdout.write` failure captured by the patched `console.log`
-  // (most commonly EPIPE from `archon … | head -c 100`) must surface as a
-  // non-zero exit regardless of platform. Without this, a Linux CI runner
-  // can schedule the unhandled-rejection handler after `process.exit()` and
-  // silently lose the EPIPE — the writer exits 0 even though the piped
-  // reader hung up before delivery completed.
-  if (consumeWriteError() !== null && code === 0) {
-    process.exit(1);
-    return undefined as never;
+  const writeError = consumeWriteError();
+  if (writeError !== null) {
+    // EPIPE (a reader that hung up, e.g. `archon … | head -c 100`) is
+    // expected and needs no extra trail — the non-zero exit code below is
+    // the correct signal. Any other write failure (e.g. ENOSPC) is
+    // genuinely unexpected and would otherwise leave zero diagnostic trail,
+    // since the patched `console.log` is fire-and-forget and never
+    // re-throws — log it here, BEFORE the forced exit below, since
+    // `process.exit()` terminates the process synchronously and nothing
+    // after it runs. See R17 in the review report.
+    if (writeError.code !== 'EPIPE') {
+      console.error('Fatal error: failed to write output:', writeError.message);
+    }
+    // Any `process.stdout.write` failure captured by the patched `console.log`
+    // must surface as a non-zero exit regardless of platform. Without this, a
+    // Linux CI runner can schedule the unhandled-rejection handler after
+    // `process.exit()` and silently lose the EPIPE — the writer exits 0 even
+    // though the piped reader hung up before delivery completed.
+    if (code === 0) {
+      process.exit(1);
+    }
   }
   process.exit(code);
 };
@@ -49,16 +64,14 @@ export const exitWithDrain = async (code: number): Promise<never> => {
  * `process.exit(1)` — impossible without changing this module, which is
  * what the R9 test now catches. See R12 in the review report.
  */
-export function withDrainedExit(
-  main: () => Promise<number>,
-  logFatal: (error: Error) => void = (error): void => {
-    console.error('Fatal error:', error.message);
-  }
-): Promise<never> {
+export function withDrainedExit(main: () => Promise<number>): Promise<never> {
   return main()
     .then(exitWithDrain)
     .catch(async (error: unknown) => {
-      logFatal(error as Error);
+      // `main()` can reject with anything JS allows (not only `Error`
+      // instances), so normalize before reading `.message`.
+      const message = error instanceof Error ? error.message : String(error);
+      console.error('Fatal error:', message);
       return exitWithDrain(1);
     });
 }

--- a/packages/cli/src/utils/exit-with-drain.ts
+++ b/packages/cli/src/utils/exit-with-drain.ts
@@ -10,13 +10,12 @@
  * queued stdout against a slow reader (the truncation the shim exists to
  * prevent — see R1 in the review report and #2400).
  *
- * Both arms of `cli.ts`'s top-level `main().then().catch()` chain route
- * through this helper so the drain contract is shared between the success
- * and fatal paths: a regression that re-splits the two arms (e.g. dropping
- * `flushPendingWrites()` from the catch arm only) cannot land without
- * changing this module, and the regression test in
- * `safe-console.test.ts` imports the same helper from here. See R9 in the
- * review report.
+ * Both `exitWithDrain` and `withDrainedExit` live here so `cli.ts`'s
+ * top-level `main().then().catch()` chain and the `safe-console.test.ts`
+ * R9 regression test fixture can share them: a regression that bypasses
+ * `exitWithDrain` at the cli.ts call site (e.g. replacing `withDrainedExit`
+ * with a direct `process.exit`) is caught by the fixture, which calls the
+ * same helper from this module. See R9 / R12 in the review report.
  */
 import { consumeWriteError, flushPendingWrites } from './safe-console';
 
@@ -34,3 +33,32 @@ export const exitWithDrain = async (code: number): Promise<never> => {
   }
   process.exit(code);
 };
+
+/**
+ * Run `main()` to completion, routing BOTH the resolved code (via
+ * `exitWithDrain(code)`) and the fatal rejection (via `console.error` +
+ * `exitWithDrain(1)`) through the same drain helper. This is the
+ * single source of truth for the top-level `main().then().catch()`
+ * chain shape that `cli.ts` uses and that the `safe-console.test.ts` R9
+ * regression test fixture exercises.
+ *
+ * The chain wiring used to be duplicated as a string literal in two
+ * places (cli.ts and the R9 fixture). Extracting it here makes a
+ * regression that drops the drain from the catch arm only — e.g.
+ * replacing `.catch(..., () => exitWithDrain(1))` with a direct
+ * `process.exit(1)` — impossible without changing this module, which is
+ * what the R9 test now catches. See R12 in the review report.
+ */
+export function withDrainedExit(
+  main: () => Promise<number>,
+  logFatal: (error: Error) => void = (error): void => {
+    console.error('Fatal error:', error.message);
+  }
+): Promise<never> {
+  return main()
+    .then(exitWithDrain)
+    .catch(async (error: unknown) => {
+      logFatal(error as Error);
+      return exitWithDrain(1);
+    });
+}

--- a/packages/cli/src/utils/safe-console.test.ts
+++ b/packages/cli/src/utils/safe-console.test.ts
@@ -195,4 +195,75 @@ describePosix('CLI human-readable console.log over a real pipe (#2400)', () => {
     expect({ bytes: piped.byteLength }).toEqual({ bytes: reference.byteLength });
     expect(piped.equals(reference)).toBe(true);
   }, 120_000);
+
+  /**
+   * Regression guard for R9 (review report): the `.catch()` arm of cli.ts's
+   * top-level promise chain must also drain `pendingWrites` before calling
+   * `process.exit(1)` — otherwise a fatal `main()` rejection against a slow
+   * reader drops queued stdout bytes the same way the success arm used to
+   * pre-R1. The success-arm R1 test above would not catch a regression here
+   * (it drives `workflow list`, which returns 0); this test drives a small
+   * fixture that mirrors the cli.ts exit chain (`main().then().catch()`)
+   * and throws after emitting a known marker through the patched
+   * `console.log`. With the drain shared across both arms the marker is
+   * delivered to a slow pipe; without it the bytes are truncated.
+   *
+   * The fixture is a self-contained TS script under `scratch/`. It imports
+   * the shim from the source tree (not from a published package) so a
+   * regression in `flushPendingWrites()` itself is also caught here.
+   */
+  it('drains queued console.log writes before process.exit(1) on the catch arm (R9)', () => {
+    const marker = `R9-MARKER-${Date.now()}`;
+    // Mirror the cli.ts exit chain verbatim (with the fix): success and
+    // fatal both route through `exitWithDrain`, which awaits
+    // `flushPendingWrites()` before `process.exit()`. If a future change
+    // drops the drain from the `.catch()` arm only, this fixture will not
+    // catch it directly — but the test still pins the safe-console drain
+    // contract for the catch path, and the structural fix in cli.ts is
+    // what makes both arms share the drain.
+    const fixturePath = join(scratch, 'r9-fixture.ts');
+    const shimEntry = join(import.meta.dir, 'safe-console.ts');
+    writeFileSync(
+      fixturePath,
+      [
+        `import { flushPendingWrites, installPipeSafeConsole } from ${JSON.stringify(shimEntry)};`,
+        `installPipeSafeConsole();`,
+        `// Emit a large payload FIRST so the pipe buffer (64 KiB on macOS)`,
+        `// fills and the marker cannot reach the OS before the catch arm`,
+        `// exits the process. The marker is written LAST so it sits behind`,
+        `// the pipe-full payload; without the drain the marker is dropped`,
+        `// when process.exit fires.`,
+        `for (let i = 0; i < 4000; i++) console.log('x'.repeat(200));`,
+        `console.log(${JSON.stringify(marker)});`,
+        `// Simulate a fatal main() rejection.`,
+        `async function main(): Promise<number> { throw new Error('simulated fatal'); }`,
+        `const exitWithDrain = async (code: number): Promise<never> => {`,
+        `  await flushPendingWrites();`,
+        `  process.exit(code);`,
+        `};`,
+        `main().then(exitWithDrain).catch((error: unknown) => {`,
+        `  const err = error as Error;`,
+        `  console.error('Fatal error:', err.message);`,
+        `  return exitWithDrain(1);`,
+        `});`,
+        ``,
+      ].join('\n')
+    );
+
+    const target = join(scratch, 'r9-output.txt');
+    // Sleep 1 s on the consumer side — same calibration as the R1 test,
+    // longer than the fixture's own runtime so without the drain the
+    // queued bytes are lost when process.exit fires.
+    const result = runShell(
+      `"${BUN}" "${fixturePath}" 2>/dev/null | { sleep 1; cat; } > "${target}"; exit \${PIPESTATUS[0]}`
+    );
+    const output = readFileSync(target, 'utf8');
+
+    // The marker must be present and the writer must have exited non-zero
+    // (the simulated throw). Both are part of the contract: a future
+    // regression that swallows the throw and exits 0 would also be
+    // caught by the status assertion.
+    expect(result.status).toBe(1);
+    expect(output).toContain(marker);
+  }, 60_000);
 });

--- a/packages/cli/src/utils/safe-console.test.ts
+++ b/packages/cli/src/utils/safe-console.test.ts
@@ -45,6 +45,8 @@ import { spawnSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { consumeWriteError, installPipeSafeConsole, restoreConsole } from './safe-console';
+import { exitWithDrain } from './exit-with-drain';
 
 const CLI_ENTRY = join(import.meta.dir, '..', 'cli.ts');
 const BUN = process.execPath;
@@ -155,17 +157,23 @@ describePosix('CLI human-readable console.log over a real pipe (#2400)', () => {
 
   /**
    * Regression guard for the EPIPE propagation contract
-   * (`safe-console.ts` file comment: "Bun surfaces EPIPE as a process
-   * error, matching the behavior of the original `console.log` when the
-   * reader hangs up"). A defensive `writeStdout(text).catch(() => {})`
-   * regression in the shim would turn `archon … | head -c 100` into a
-   * silent exit 0; the only test above uses `cat` and would not catch it.
+   * (`safe-console.ts` file comment + `exit-with-drain.ts`'s
+   * `consumeWriteError()` branch). A defensive
+   * `writeStdout(text).catch(() => {})` regression in the shim that
+   * failed to record the error in `writeError` would turn
+   * `archon … | head -c 100` into a silent exit 0 on the Linux CI runner
+   * — the only test above uses `cat` and would not catch it.
    *
    * `head -c 100` closes the read end of the pipe after the first 100
    * bytes, so the writer's next `process.stdout.write` fails with EPIPE.
-   * Bun's default unhandled-rejection-fatal policy then exits non-zero.
-   * We capture `${PIPESTATUS[0]}` (the writer's status) so the surrounding
-   * pipeline cannot mask a non-zero exit with a clean `head`.
+   * The shim records that error in `writeError`, `exitWithDrain()` reads
+   * it back via `consumeWriteError()` after the drain, and the writer
+   * exits non-zero regardless of whether Bun's unhandled-rejection trap
+   * fires before or after `process.exit()` (macOS fires it before, Linux
+   * CI schedules it after — see `safe-console.ts` file comment for the
+   * full ordering analysis). We capture `${PIPESTATUS[0]}` (the writer's
+   * status) so the surrounding pipeline cannot mask a non-zero exit with
+   * a clean `head`.
    */
   it('propagates EPIPE as a non-zero exit when the consumer hangs up early', () => {
     const result = runShell(
@@ -265,4 +273,200 @@ describePosix('CLI human-readable console.log over a real pipe (#2400)', () => {
     expect(result.status).toBe(1);
     expect(output).toContain(marker);
   }, 60_000);
+});
+
+/**
+ * Unit-level companion to the R5 pipe test above. The pipe test is the
+ * integration check (it spawns a real `bun … | head -c 100` pipeline); on
+ * macOS the patched `console.log`'s unhandled-rejection trap fires before
+ * `process.exit()` and the writer happens to exit 1 even without the
+ * `consumeWriteError()` branch in `exit-with-drain.ts`. On the Linux CI
+ * runner the trap is scheduled after `process.exit()` has taken effect, so
+ * the rejection is silently swallowed and the writer exits 0 — that is what
+ * the CI failure looked like.
+ *
+ * This test mocks `process.stdout.write` to fail with EPIPE so the
+ * contract is exercised deterministically on every platform: the shim must
+ * record the error in `writeError`, `consumeWriteError()` must surface it,
+ * and `exitWithDrain(0)` must exit non-zero. A regression that drops any of
+ * those three steps lands here, independent of timing.
+ */
+describe('safe-console + exit-with-drain — EPIPE unit contract (R5)', () => {
+  const originalWrite = process.stdout.write.bind(process.stdout);
+
+  afterAll(() => {
+    restoreConsole();
+    // Restore process.stdout.write even if a test threw mid-flight so the
+    // other test files in this run are not contaminated.
+    process.stdout.write = originalWrite as typeof process.stdout.write;
+  });
+
+  it('records a process.stdout.write failure in writeError and consumeWriteError() surfaces it', async () => {
+    // Install fresh so the unit-test branch runs in isolation even if a
+    // sibling test already called installPipeSafeConsole().
+    installPipeSafeConsole();
+
+    // Mock process.stdout.write to fail with EPIPE on the next call.
+    const epipe = Object.assign(new Error('EPIPE: broken pipe, write'), {
+      code: 'EPIPE' as const,
+    });
+    let calls = 0;
+    (process.stdout as unknown as { write: typeof process.stdout.write }).write = ((
+      _chunk: unknown,
+      ...args: unknown[]
+    ) => {
+      calls++;
+      const callback =
+        typeof args[0] === 'function' ? (args[0] as (err?: Error | null) => void) : args[1];
+      if (typeof callback === 'function') callback(epipe);
+      return true;
+    }) as typeof process.stdout.write;
+
+    try {
+      console.log('this will fail with EPIPE');
+
+      // Wait for the in-flight write to reject and pendingWrites to drain.
+      // flushPendingWrites resolves via Promise.allSettled so it never
+      // throws on a rejected write — the rejection is observed.
+      // Importing flushPendingWrites here keeps the call chain explicit
+      // and avoids relying on the export order from safe-console.ts.
+      const { flushPendingWrites } = await import('./safe-console');
+      await flushPendingWrites();
+
+      expect(calls).toBe(1);
+      const err = consumeWriteError();
+      expect(err).not.toBeNull();
+      expect((err as NodeJS.ErrnoException).code).toBe('EPIPE');
+      // consumeWriteError is a one-shot — a second call must return null so
+      // a later exitWithDrain(0) does not double-flip the exit code.
+      expect(consumeWriteError()).toBeNull();
+    } finally {
+      (process.stdout as unknown as { write: typeof process.stdout.write }).write =
+        originalWrite as typeof process.stdout.write;
+    }
+  }, 30_000);
+
+  /**
+   * `exitWithDrain(0)` must exit 1 when `consumeWriteError()` returns an
+   * error — this is the deterministic path that closes the Linux-CI
+   * regression. We assert the resolved exit code by intercepting
+   * `process.exit` (rather than letting it terminate the test runner).
+   */
+  it('exitWithDrain(0) calls process.exit(1) when writeError is set', () => {
+    // Restore stdout.write (the previous test's finally block already did,
+    // but assert it explicitly so the contract is self-describing).
+    (process.stdout as unknown as { write: typeof process.stdout.write }).write =
+      originalWrite as typeof process.stdout.write;
+
+    // Seed writeError the same way the shim does, then run the exit helper
+    // with a captured process.exit to observe the resulting code.
+    const epipe = Object.assign(new Error('EPIPE: broken pipe, write'), {
+      code: 'EPIPE' as const,
+    });
+    (process.stdout as unknown as { write: typeof process.stdout.write }).write = ((
+      _chunk: unknown,
+      ...args: unknown[]
+    ) => {
+      const callback =
+        typeof args[0] === 'function' ? (args[0] as (err?: Error | null) => void) : args[1];
+      if (typeof callback === 'function') callback(epipe);
+      return true;
+    }) as typeof process.stdout.write;
+
+    const originalExit = process.exit.bind(process);
+    let observed: number | undefined;
+    (process as unknown as { exit: (code?: number) => never }).exit = ((code?: number) => {
+      observed = code;
+      // Throw to short-circuit exitWithDrain's second process.exit call —
+      // we only care which code the first one passes.
+      throw new Error('observed exit');
+    }) as (code?: number) => never;
+
+    try {
+      installPipeSafeConsole();
+      console.log('this will fail with EPIPE');
+      // The exit helper awaits flushPendingWrites before reading writeError,
+      // so we let the microtask queue drain.
+      void exitWithDrain(0).catch(() => {
+        // The first process.exit throws 'observed exit' on purpose; the
+        // helper never reaches the second one because it throws first.
+      });
+    } catch {
+      // installPipeSafeConsole does not throw — nothing to catch here.
+    } finally {
+      // Drain the in-flight write so writeError is recorded before we
+      // assert. flushPendingWrites resolves on the next microtask.
+      // We await it here in a finally because the catch above does not
+      // re-await the original chain.
+    }
+
+    // Allow the rejection to propagate so consumeWriteError sees it.
+    return new Promise<void>(resolve => {
+      setImmediate(() => {
+        try {
+          expect(observed).toBe(1);
+        } finally {
+          (process as unknown as { exit: (code?: number) => never }).exit = originalExit as (
+            code?: number
+          ) => never;
+          (process.stdout as unknown as { write: typeof process.stdout.write }).write =
+            originalWrite as typeof process.stdout.write;
+          restoreConsole();
+          resolve();
+        }
+      });
+    });
+  }, 30_000);
+
+  it('exitWithDrain(nonZero) preserves the caller-supplied code even when writeError is set', () => {
+    (process.stdout as unknown as { write: typeof process.stdout.write }).write =
+      originalWrite as typeof process.stdout.write;
+
+    // Same mock as the previous test — we only need writeError populated.
+    const epipe = Object.assign(new Error('EPIPE: broken pipe, write'), {
+      code: 'EPIPE' as const,
+    });
+    (process.stdout as unknown as { write: typeof process.stdout.write }).write = ((
+      _chunk: unknown,
+      ...args: unknown[]
+    ) => {
+      const callback =
+        typeof args[0] === 'function' ? (args[0] as (err?: Error | null) => void) : args[1];
+      if (typeof callback === 'function') callback(epipe);
+      return true;
+    }) as typeof process.stdout.write;
+
+    const originalExit = process.exit.bind(process);
+    let observed: number | undefined;
+    (process as unknown as { exit: (code?: number) => never }).exit = ((code?: number) => {
+      observed = code;
+      throw new Error('observed exit');
+    }) as (code?: number) => never;
+
+    try {
+      installPipeSafeConsole();
+      console.log('this will fail with EPIPE');
+      void exitWithDrain(7).catch(() => {});
+    } catch {
+      // installPipeSafeConsole does not throw.
+    }
+
+    return new Promise<void>(resolve => {
+      setImmediate(() => {
+        try {
+          // exitWithDrain(7) should exit 7 — the EPIPE error must NOT
+          // overwrite an already non-zero caller-supplied code.
+          expect(observed).toBe(7);
+        } finally {
+          (process as unknown as { exit: (code?: number) => never }).exit = originalExit as (
+            code?: number
+          ) => never;
+          (process.stdout as unknown as { write: typeof process.stdout.write }).write =
+            originalWrite as typeof process.stdout.write;
+          restoreConsole();
+          resolve();
+        }
+      });
+    });
+  }, 30_000);
 });

--- a/packages/cli/src/utils/safe-console.test.ts
+++ b/packages/cli/src/utils/safe-console.test.ts
@@ -219,10 +219,13 @@ describePosix('CLI human-readable console.log over a real pipe (#2400)', () => {
    * the shim from the source tree (not from a published package) so a
    * regression in `flushPendingWrites()` itself is also caught here. It
    * also imports `withDrainedExit` from the same module cli.ts imports it
-   * from (`./utils/exit-with-drain.ts`), so the chain wiring is a single
-   * source of truth: a regression that bypasses `exitWithDrain` at the
-   * cli.ts call site has to land in `withDrainedExit` and would also
-   * drop the drain from this fixture's chain.
+   * from (`./utils/exit-with-drain.ts`), so a regression inside
+   * `withDrainedExit`/`exitWithDrain` itself (e.g. dropping the
+   * `flushPendingWrites()` await) is caught here too. A regression that
+   * instead bypasses `withDrainedExit` at the cli.ts call site — swapping
+   * it for a direct `process.exit` — is NOT caught by this fixture, since
+   * the fixture never imports cli.ts; that case is caught by the separate
+   * static-contract test below.
    */
   it('drains queued console.log writes before process.exit(1) on the catch arm (R9)', () => {
     const marker = `R9-MARKER-${Date.now()}`;
@@ -230,9 +233,10 @@ describePosix('CLI human-readable console.log over a real pipe (#2400)', () => {
     // fatal both route through `exitWithDrain`, which awaits
     // `flushPendingWrites()` before `process.exit()`. The chain wiring
     // lives in `withDrainedExit` (`./utils/exit-with-drain.ts`), imported
-    // from the same module cli.ts imports it from, so a regression that
-    // bypasses `exitWithDrain` at the cli.ts call site has to land in
-    // that helper — the same module this fixture imports from.
+    // from the same module cli.ts imports it from, so a regression inside
+    // that shared module is caught here too. A bypass of `withDrainedExit`
+    // specifically at the cli.ts call site is NOT caught by this fixture
+    // (see the static-contract test below).
     const fixturePath = join(scratch, 'r9-fixture.ts');
     const shimEntry = join(import.meta.dir, 'safe-console.ts');
     const exitWithDrainEntry = join(import.meta.dir, 'exit-with-drain.ts');
@@ -272,6 +276,35 @@ describePosix('CLI human-readable console.log over a real pipe (#2400)', () => {
     expect(result.status).toBe(1);
     expect(output).toContain(marker);
   }, 60_000);
+
+  /**
+   * R20 (review report): `withDrainedExit`'s default fatal-error handler
+   * prints `Fatal error: <message>` to stderr — the only diagnostic a user
+   * sees on an uncaught `main()` rejection. The R9 fixture above redirects
+   * stderr to `/dev/null`, so this content has never been captured or
+   * asserted by any test. This variant redirects stderr to a file instead
+   * and asserts the message survives.
+   */
+  it('withDrainedExit logs the fatal rejection message to stderr (R20)', () => {
+    const fixturePath = join(scratch, 'r20-fixture.ts');
+    const exitWithDrainEntry = join(import.meta.dir, 'exit-with-drain.ts');
+    writeFileSync(
+      fixturePath,
+      [
+        `import { withDrainedExit } from ${JSON.stringify(exitWithDrainEntry)};`,
+        `async function main(): Promise<number> { throw new Error('r20 simulated fatal'); }`,
+        `withDrainedExit(main);`,
+        ``,
+      ].join('\n')
+    );
+
+    const stderrTarget = join(scratch, 'r20-stderr.txt');
+    const result = runShell(`"${BUN}" "${fixturePath}" > /dev/null 2> "${stderrTarget}"`);
+    const stderr = readFileSync(stderrTarget, 'utf8');
+
+    expect(result.status).toBe(1);
+    expect(stderr).toContain('Fatal error: r20 simulated fatal');
+  }, 30_000);
 
   /**
    * Static-contract test for R12 (review report): even with the chain
@@ -496,6 +529,71 @@ describe('safe-console + exit-with-drain — EPIPE unit contract (R5)', () => {
           ) => never;
           (process.stdout as unknown as { write: typeof process.stdout.write }).write =
             originalWrite as typeof process.stdout.write;
+          restoreConsole();
+          resolve();
+        }
+      });
+    });
+  }, 30_000);
+
+  /**
+   * R19 (review report): every EPIPE fixture above uses `code: 'EPIPE'` —
+   * the exit-code-flip logic has no EPIPE-specific branch, but nothing
+   * proved that until now. A non-EPIPE write failure (e.g. `ENOSPC`) must
+   * still force `exitWithDrain(0)` to exit 1, and — per R17 — must also be
+   * logged, since it carries no other diagnostic trail (the patched
+   * `console.log` is fire-and-forget and never re-throws).
+   */
+  it('exitWithDrain(0) still exits 1 and logs a non-EPIPE write failure', () => {
+    (process.stdout as unknown as { write: typeof process.stdout.write }).write =
+      originalWrite as typeof process.stdout.write;
+
+    const enospc = Object.assign(new Error('ENOSPC: no space left on device, write'), {
+      code: 'ENOSPC' as const,
+    });
+    (process.stdout as unknown as { write: typeof process.stdout.write }).write = ((
+      _chunk: unknown,
+      ...args: unknown[]
+    ) => {
+      const callback =
+        typeof args[0] === 'function' ? (args[0] as (err?: Error | null) => void) : args[1];
+      if (typeof callback === 'function') callback(enospc);
+      return true;
+    }) as typeof process.stdout.write;
+
+    const originalExit = process.exit.bind(process);
+    let observed: number | undefined;
+    (process as unknown as { exit: (code?: number) => never }).exit = ((code?: number) => {
+      observed = code;
+      throw new Error('observed exit');
+    }) as (code?: number) => never;
+
+    const originalError = console.error;
+    let loggedArgs: unknown[] | undefined;
+    console.error = ((...args: unknown[]) => {
+      loggedArgs = args;
+    }) as typeof console.error;
+
+    try {
+      installPipeSafeConsole();
+      console.log('this will fail with ENOSPC');
+      void exitWithDrain(0).catch(() => {});
+    } catch {
+      // installPipeSafeConsole does not throw.
+    }
+
+    return new Promise<void>(resolve => {
+      setImmediate(() => {
+        try {
+          expect(observed).toBe(1);
+          expect(loggedArgs?.join(' ')).toContain('ENOSPC: no space left on device, write');
+        } finally {
+          (process as unknown as { exit: (code?: number) => never }).exit = originalExit as (
+            code?: number
+          ) => never;
+          (process.stdout as unknown as { write: typeof process.stdout.write }).write =
+            originalWrite as typeof process.stdout.write;
+          console.error = originalError;
           restoreConsole();
           resolve();
         }

--- a/packages/cli/src/utils/safe-console.test.ts
+++ b/packages/cli/src/utils/safe-console.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Real-pipe regression tests for #2400 (piped human-readable `console.log`
+ * silently truncates against a slow reader).
+ *
+ * ## Why these tests spawn a shell pipeline
+ *
+ * The bug only exists when fd 1 is a **non-blocking pipe**, which is what a
+ * shell creates for `archon … | less`. The causal chain is identical to
+ * `--json` truncation in #2384:
+ *
+ *  1. Importing `@archon/paths` builds the pino root logger, whose default
+ *     destination opens fd 1 in non-blocking mode.
+ *  2. On a non-blocking pipe a `console.log` call that exceeds the pipe's
+ *     buffer can return a short count, and the stream drops the unwritten tail
+ *     without error.
+ *
+ * That is why `> out.txt` always looked fine: a regular-file fd stays
+ * blocking. PR #2389 routed every `--json` payload through `writeStdout`
+ * (`utils/stdout.ts`) and closed that gap. #2400 is the symmetrical gap for
+ * human-readable `console.log` calls, fixed by monkey-patching `console.log`
+ * to delegate through the same `writeStdout` primitive (see
+ * `utils/safe-console.ts`).
+ *
+ * `Bun.spawn` with `stdout: 'pipe'` does NOT reproduce the truncation, and
+ * neither does mocking `process.stdout.write` — both replace the exact thing
+ * that was broken. These tests therefore drive a genuine
+ * `bun … workflow list | { sleep 0.5; cat; } > file` shell pipeline.
+ *
+ * ## Calibration (measured on macOS/arm64, bun 1.3.11)
+ *
+ * The payload size and consumer pattern below are not arbitrary. Against the
+ * pre-fix code, a ~1.07 MB `workflow list` payload piped to
+ * `{ sleep 0.5; cat; }` truncated in 5/5 runs (delivery 89–96%). The same
+ * harness against the patched code delivered 10/10 byte-identical to the
+ * file redirect. The slow consumer (`sleep 0.5` before reading) is what makes
+ * the truncation deterministic — a plain `cat` only truncates ~1% of runs at
+ * this payload size because cat drains the pipe faster than the writer fills
+ * it. Do not "simplify" the consumer back to plain `cat` without re-measuring
+ * against a pre-fix build; the test would silently stop catching regressions.
+ *
+ * POSIX-only: Windows has no equivalent non-blocking-pipe path and no bash.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const CLI_ENTRY = join(import.meta.dir, '..', 'cli.ts');
+const BUN = process.execPath;
+
+/** Tuned so the human-readable payload lands in the proven truncation window. */
+const WORKFLOW_COUNT = 150;
+const DESCRIPTION_CHARS = 7000;
+/** Piped runs per assertion. Pre-fix truncates 5/5; post-fix passes 10/10. */
+const PIPED_RUNS = 5;
+
+let repoDir: string;
+let archonHome: string;
+let scratch: string;
+
+function runShell(script: string): { status: number | null; stdout: string } {
+  // LOG_LEVEL=silent silences pino's diagnostic lines so two CLI invocations
+  // produce byte-identical stdout (each invocation carries a unique timestamp
+  // + pid in the first JSON line; the human-readable payload underneath is
+  // stable, but pino's preamble is not). Without this the test would diff on
+  // the pino preamble and pass trivially even when the real payload truncates.
+  const result = spawnSync('bash', ['-c', script], {
+    env: { ...process.env, ARCHON_HOME: archonHome, LOG_LEVEL: 'silent' },
+    encoding: 'utf8',
+    timeout: 120_000,
+  });
+  return { status: result.status, stdout: result.stdout ?? '' };
+}
+
+/** `archon workflow list` with stdout redirected to a regular file (blocking fd). */
+function listToFile(target: string): number | null {
+  return runShell(
+    `"${BUN}" "${CLI_ENTRY}" workflow list --cwd "${repoDir}" 2>/dev/null > "${target}"`
+  ).status;
+}
+
+/**
+ * The same command with stdout attached to a real pipe. The consumer sleeps
+ * for 500 ms before draining so the writer fills the pipe buffer before the
+ * reader pulls anything — that is what makes the pre-fix truncation
+ * deterministic. `cat` alone truncates too rarely to be a useful test.
+ */
+function listThroughPipe(target: string): number | null {
+  return runShell(
+    `"${BUN}" "${CLI_ENTRY}" workflow list --cwd "${repoDir}" 2>/dev/null | { sleep 0.5; cat; } > "${target}"; exit \${PIPESTATUS[0]}`
+  ).status;
+}
+
+beforeAll(() => {
+  scratch = mkdtempSync(join(tmpdir(), 'archon-pipe-test-'));
+  archonHome = join(scratch, 'home');
+  repoDir = join(scratch, 'repo');
+  mkdirSync(archonHome, { recursive: true });
+  const workflowsDir = join(repoDir, '.archon', 'workflows');
+  mkdirSync(workflowsDir, { recursive: true });
+  spawnSync('git', ['init', '-q', '.'], { cwd: repoDir });
+
+  const padding = 'x'.repeat(DESCRIPTION_CHARS);
+  for (let i = 0; i < WORKFLOW_COUNT; i++) {
+    const name = `probe-${String(i).padStart(3, '0')}`;
+    writeFileSync(
+      join(workflowsDir, `${name}.yaml`),
+      `name: ${name}\ndescription: ${padding}${i}\nnodes:\n  - id: only\n    prompt: hello\n`
+    );
+  }
+});
+
+afterAll(() => {
+  if (scratch) rmSync(scratch, { recursive: true, force: true });
+});
+
+const describePosix = process.platform === 'win32' ? describe.skip : describe;
+
+describePosix('CLI human-readable console.log over a real pipe (#2400)', () => {
+  it('delivers the whole document, byte-identical to a file redirect, against a slow consumer', () => {
+    const referencePath = join(scratch, 'reference.txt');
+    expect(listToFile(referencePath)).toBe(0);
+    const reference = readFileSync(referencePath);
+
+    // Guard the calibration: below the pipe capacity the bug cannot occur, so a
+    // shrinking payload would silently turn this into a no-op test.
+    expect(reference.byteLength).toBeGreaterThan(65_536);
+
+    for (let run = 0; run < PIPED_RUNS; run++) {
+      const pipedPath = join(scratch, `piped-${run}.txt`);
+      const status = listThroughPipe(pipedPath);
+      const piped = readFileSync(pipedPath);
+
+      expect({ run, status }).toEqual({ run, status: 0 });
+      // Report the byte count on failure — a bare buffer diff is unreadable.
+      expect({ run, bytes: piped.byteLength }).toEqual({ run, bytes: reference.byteLength });
+      expect(piped.equals(reference)).toBe(true);
+    }
+  }, 180_000);
+});

--- a/packages/cli/src/utils/safe-console.test.ts
+++ b/packages/cli/src/utils/safe-console.test.ts
@@ -92,6 +92,20 @@ function listThroughPipe(target: string): number | null {
   ).status;
 }
 
+/**
+ * Very-slow consumer (1 s before reading). The CLI finishes in ~620 ms; with
+ * the fire-and-forget shim and no exit-path flush, `process.exit()` would
+ * fire while bytes are still queued in the stream buffer and the truncation
+ * described in R1 (review report) returns. `flushPendingWrites()` in
+ * `cli.ts` is what closes that window — do not delete it without re-running
+ * this test.
+ */
+function listThroughVerySlowPipe(target: string): number | null {
+  return runShell(
+    `"${BUN}" "${CLI_ENTRY}" workflow list --cwd "${repoDir}" 2>/dev/null | { sleep 1; cat; } > "${target}"; exit \${PIPESTATUS[0]}`
+  ).status;
+}
+
 beforeAll(() => {
   scratch = mkdtempSync(join(tmpdir(), 'archon-pipe-test-'));
   archonHome = join(scratch, 'home');
@@ -138,4 +152,47 @@ describePosix('CLI human-readable console.log over a real pipe (#2400)', () => {
       expect(piped.equals(reference)).toBe(true);
     }
   }, 180_000);
+
+  /**
+   * Regression guard for the EPIPE propagation contract
+   * (`safe-console.ts` file comment: "Bun surfaces EPIPE as a process
+   * error, matching the behavior of the original `console.log` when the
+   * reader hangs up"). A defensive `writeStdout(text).catch(() => {})`
+   * regression in the shim would turn `archon … | head -c 100` into a
+   * silent exit 0; the only test above uses `cat` and would not catch it.
+   *
+   * `head -c 100` closes the read end of the pipe after the first 100
+   * bytes, so the writer's next `process.stdout.write` fails with EPIPE.
+   * Bun's default unhandled-rejection-fatal policy then exits non-zero.
+   * We capture `${PIPESTATUS[0]}` (the writer's status) so the surrounding
+   * pipeline cannot mask a non-zero exit with a clean `head`.
+   */
+  it('propagates EPIPE as a non-zero exit when the consumer hangs up early', () => {
+    const result = runShell(
+      `"${BUN}" "${CLI_ENTRY}" workflow list --cwd "${repoDir}" 2>/dev/null | head -c 100 > /dev/null; exit \${PIPESTATUS[0]}`
+    );
+    expect(result.status).not.toBe(0);
+  }, 60_000);
+
+  /**
+   * Regression guard for R1 (review report): the fire-and-forget shim
+   * discards the per-write completion promise, so `process.exit()` would
+   * race the stream drain and re-introduce the silent-exit-0 truncation
+   * the patch is meant to eliminate. The fix is `flushPendingWrites()` in
+   * `cli.ts` (awaited between `main()` and `process.exit()`); this test
+   * sleeps 1 s on the consumer side — longer than the CLI's own runtime —
+   * so without the flush the queued bytes are lost. With the flush in
+   * place the output is byte-identical to the file redirect.
+   */
+  it('delivers the whole document to a very-slow consumer (sleep >= 1 s) without truncating', () => {
+    const referencePath = join(scratch, 'reference.txt');
+    const pipedPath = join(scratch, 'very-slow.txt');
+    const status = listThroughVerySlowPipe(pipedPath);
+    const reference = readFileSync(referencePath);
+    const piped = readFileSync(pipedPath);
+
+    expect(status).toBe(0);
+    expect({ bytes: piped.byteLength }).toEqual({ bytes: reference.byteLength });
+    expect(piped.equals(reference)).toBe(true);
+  }, 120_000);
 });

--- a/packages/cli/src/utils/safe-console.test.ts
+++ b/packages/cli/src/utils/safe-console.test.ts
@@ -211,33 +211,36 @@ describePosix('CLI human-readable console.log over a real pipe (#2400)', () => {
    * reader drops queued stdout bytes the same way the success arm used to
    * pre-R1. The success-arm R1 test above would not catch a regression here
    * (it drives `workflow list`, which returns 0); this test drives a small
-   * fixture that mirrors the cli.ts exit chain (`main().then().catch()`)
-   * and throws after emitting a known marker through the patched
+   * fixture that throws after emitting a known marker through the patched
    * `console.log`. With the drain shared across both arms the marker is
    * delivered to a slow pipe; without it the bytes are truncated.
    *
    * The fixture is a self-contained TS script under `scratch/`. It imports
    * the shim from the source tree (not from a published package) so a
-   * regression in `flushPendingWrites()` itself is also caught here.
+   * regression in `flushPendingWrites()` itself is also caught here. It
+   * also imports `withDrainedExit` from the same module cli.ts imports it
+   * from (`./utils/exit-with-drain.ts`), so the chain wiring is a single
+   * source of truth: a regression that bypasses `exitWithDrain` at the
+   * cli.ts call site has to land in `withDrainedExit` and would also
+   * drop the drain from this fixture's chain.
    */
   it('drains queued console.log writes before process.exit(1) on the catch arm (R9)', () => {
     const marker = `R9-MARKER-${Date.now()}`;
-    // Mirror the cli.ts exit chain verbatim (with the fix): success and
+    // Mirror the cli.ts exit chain via the shared helper: success and
     // fatal both route through `exitWithDrain`, which awaits
-    // `flushPendingWrites()` before `process.exit()`. The helper is
-    // imported from the same module `cli.ts` imports it from
-    // (`./utils/exit-with-drain.ts`), so the fixture's drain and cli.ts's
-    // drain cannot drift — a regression that drops the drain from one arm
-    // only would have to land in `exit-with-drain.ts` and would also drop
-    // it from the other arm, which is what we want to catch.
+    // `flushPendingWrites()` before `process.exit()`. The chain wiring
+    // lives in `withDrainedExit` (`./utils/exit-with-drain.ts`), imported
+    // from the same module cli.ts imports it from, so a regression that
+    // bypasses `exitWithDrain` at the cli.ts call site has to land in
+    // that helper — the same module this fixture imports from.
     const fixturePath = join(scratch, 'r9-fixture.ts');
     const shimEntry = join(import.meta.dir, 'safe-console.ts');
     const exitWithDrainEntry = join(import.meta.dir, 'exit-with-drain.ts');
     writeFileSync(
       fixturePath,
       [
-        `import { flushPendingWrites, installPipeSafeConsole } from ${JSON.stringify(shimEntry)};`,
-        `import { exitWithDrain } from ${JSON.stringify(exitWithDrainEntry)};`,
+        `import { installPipeSafeConsole } from ${JSON.stringify(shimEntry)};`,
+        `import { withDrainedExit } from ${JSON.stringify(exitWithDrainEntry)};`,
         `installPipeSafeConsole();`,
         `// Emit a large payload FIRST so the pipe buffer (64 KiB on macOS)`,
         `// fills and the marker cannot reach the OS before the catch arm`,
@@ -248,11 +251,7 @@ describePosix('CLI human-readable console.log over a real pipe (#2400)', () => {
         `console.log(${JSON.stringify(marker)});`,
         `// Simulate a fatal main() rejection.`,
         `async function main(): Promise<number> { throw new Error('simulated fatal'); }`,
-        `main().then(exitWithDrain).catch((error: unknown) => {`,
-        `  const err = error as Error;`,
-        `  console.error('Fatal error:', err.message);`,
-        `  return exitWithDrain(1);`,
-        `});`,
+        `withDrainedExit(main);`,
         ``,
       ].join('\n')
     );
@@ -273,6 +272,40 @@ describePosix('CLI human-readable console.log over a real pipe (#2400)', () => {
     expect(result.status).toBe(1);
     expect(output).toContain(marker);
   }, 60_000);
+
+  /**
+   * Static-contract test for R12 (review report): even with the chain
+   * wiring extracted to `withDrainedExit`, a regression that bypasses
+   * the helper at the cli.ts call site (e.g. replacing
+   * `withDrainedExit(main)` with `main().then((c) => process.exit(c))`)
+   * is not caught by the R9 pipe test above — the fixture is a self-
+   * contained TS script that does not import cli.ts, so its own chain
+   * stays correct even when cli.ts drifts. Read cli.ts as a string and
+   * assert the call site is the shared helper, so a cli.ts bypass lands
+   * here.
+   */
+  it('routes cli.ts through withDrainedExit — no direct process.exit chain', () => {
+    const cliSrc = readFileSync(join(import.meta.dir, '..', 'cli.ts'), 'utf8');
+    // Strip line comments so a regression that comments out the import
+    // is still caught — `cliSrc.toMatch(/.../)` would still see the
+    // text inside the comment and pass falsely otherwise.
+    const codeLines = cliSrc.split('\n').filter(line => !line.trimStart().startsWith('//'));
+    const codeOnly = codeLines.join('\n');
+    // Must import the helper from the module that owns the chain shape.
+    expect(codeOnly).toMatch(
+      /import\s*\{\s*withDrainedExit\s*\}\s*from\s*['"]\.\/utils\/exit-with-drain['"]/
+    );
+    // Must invoke it at the top level, with main as the argument. Anchor
+    // on `withDrainedExit(` so a future alias import or wrap-in-helper
+    // regression is still caught.
+    expect(codeOnly).toMatch(/withDrainedExit\s*\(\s*main\s*\)/);
+    // Must NOT carry a parallel exit chain. The only legitimate
+    // `process.exit` mentions in cli.ts are comments — the filter above
+    // already stripped them, so any remaining line with `process.exit`
+    // is a regression.
+    const offendingExit = codeLines.filter(line => /process\.exit\b/.test(line));
+    expect(offendingExit).toEqual([]);
+  });
 });
 
 /**

--- a/packages/cli/src/utils/safe-console.test.ts
+++ b/packages/cli/src/utils/safe-console.test.ts
@@ -216,17 +216,20 @@ describePosix('CLI human-readable console.log over a real pipe (#2400)', () => {
     const marker = `R9-MARKER-${Date.now()}`;
     // Mirror the cli.ts exit chain verbatim (with the fix): success and
     // fatal both route through `exitWithDrain`, which awaits
-    // `flushPendingWrites()` before `process.exit()`. If a future change
-    // drops the drain from the `.catch()` arm only, this fixture will not
-    // catch it directly — but the test still pins the safe-console drain
-    // contract for the catch path, and the structural fix in cli.ts is
-    // what makes both arms share the drain.
+    // `flushPendingWrites()` before `process.exit()`. The helper is
+    // imported from the same module `cli.ts` imports it from
+    // (`./utils/exit-with-drain.ts`), so the fixture's drain and cli.ts's
+    // drain cannot drift — a regression that drops the drain from one arm
+    // only would have to land in `exit-with-drain.ts` and would also drop
+    // it from the other arm, which is what we want to catch.
     const fixturePath = join(scratch, 'r9-fixture.ts');
     const shimEntry = join(import.meta.dir, 'safe-console.ts');
+    const exitWithDrainEntry = join(import.meta.dir, 'exit-with-drain.ts');
     writeFileSync(
       fixturePath,
       [
         `import { flushPendingWrites, installPipeSafeConsole } from ${JSON.stringify(shimEntry)};`,
+        `import { exitWithDrain } from ${JSON.stringify(exitWithDrainEntry)};`,
         `installPipeSafeConsole();`,
         `// Emit a large payload FIRST so the pipe buffer (64 KiB on macOS)`,
         `// fills and the marker cannot reach the OS before the catch arm`,
@@ -237,10 +240,6 @@ describePosix('CLI human-readable console.log over a real pipe (#2400)', () => {
         `console.log(${JSON.stringify(marker)});`,
         `// Simulate a fatal main() rejection.`,
         `async function main(): Promise<number> { throw new Error('simulated fatal'); }`,
-        `const exitWithDrain = async (code: number): Promise<never> => {`,
-        `  await flushPendingWrites();`,
-        `  process.exit(code);`,
-        `};`,
         `main().then(exitWithDrain).catch((error: unknown) => {`,
         `  const err = error as Error;`,
         `  console.error('Fatal error:', err.message);`,

--- a/packages/cli/src/utils/safe-console.ts
+++ b/packages/cli/src/utils/safe-console.ts
@@ -120,8 +120,10 @@ export function installPipeSafeConsole(): void {
     pendingWrites.add(p);
   }
 
-  // Preserve the original symbol names so logs / stack traces still read
-  // "console.log" / "console.info" rather than "pipeSafeLog".
+  // Preserve the original symbol name so logs / stack traces still read
+  // "log" rather than "pipeSafeLog". (Both console.log and console.info
+  // delegate to the same function and therefore share this name — there is
+  // no separate "info" frame name to preserve.)
   Object.defineProperty(pipeSafeLog, 'name', { value: 'log', configurable: true });
 
   const consoleAny = console as {

--- a/packages/cli/src/utils/safe-console.ts
+++ b/packages/cli/src/utils/safe-console.ts
@@ -136,9 +136,9 @@ export function consumeWriteError(): NodeJS.ErrnoException | null {
  * have reached the OS, retrying short writes and `EAGAIN` through the event
  * loop (no busy-wait). See `utils/stdout.ts` for the underlying primitive.
  * Callers that DO need delivery confirmation before the process exits must
- * await `flushPendingWrites()` — see `utils/exit-with-drain.ts` (the helper
- * `cli.ts`'s top-level `main().then().catch()` chain routes both arms
- * through) and `cli.ts:1171-1202` (the comment and chain that use it).
+ * await `flushPendingWrites()` — see `utils/exit-with-drain.ts` (the
+ * `withDrainedExit` helper that owns this) and the `withDrainedExit(main)`
+ * call at the end of `cli.ts`.
  */
 export function installPipeSafeConsole(): void {
   if (installed) return;
@@ -191,6 +191,10 @@ export function installPipeSafeConsole(): void {
 export function restoreConsole(): void {
   if (!installed) return;
   installed = false;
+  // Reset alongside `installed` so a caller that restores without consuming
+  // a pending write error (via `consumeWriteError()`) doesn't leave it to be
+  // read by a later, unrelated `exitWithDrain()` call after reinstalling.
+  writeError = null;
   const consoleAny = console as {
     log: (...args: unknown[]) => void;
     info: (...args: unknown[]) => void;

--- a/packages/cli/src/utils/safe-console.ts
+++ b/packages/cli/src/utils/safe-console.ts
@@ -20,13 +20,26 @@
  * `console.log` signature so existing callers (and `spyOn(console, 'log')`
  * mocks in `workflow.test.ts` / `cli-adapter.test.ts`) keep working unchanged.
  *
+ * Delivery itself is fire-and-forget: the patched `console.log` returns
+ * synchronously and bytes reach the OS in the background via the underlying
+ * `process.stdout.write` stream callback. `cli.ts` therefore awaits
+ * `flushPendingWrites()` between `main()` resolving and `process.exit()` —
+ * `process.exit()` does not drain the stream's pending writes, so without
+ * that flush a very-slow reader (e.g. `archon … | { sleep 1; cat; }`) would
+ * re-introduce the same silent-exit-0 truncation the patch is meant to
+ * eliminate.
+ *
  * ## Scope (deliberate)
  *
- * - `console.log` is patched; `console.warn` / `console.error` / `console.info`
- *   are NOT. Those default to stderr in Bun, which is not the fd pino flipped.
- *   `console.warn` is also used by CLI commands as the deliberate
- *   "non-pino diagnostic" channel (e.g. `workflow.ts`); routing it through
- *   `writeStdout` would change where it lands, which is a separate decision.
+ * - `console.log` and `console.info` are patched; `console.warn` /
+ *   `console.error` are NOT. `console.warn`/`console.error` default to
+ *   stderr in Bun, which is not the fd pino flipped, and `console.warn` is
+ *   also used by CLI commands as the deliberate "non-pino diagnostic"
+ *   channel (e.g. `workflow.ts`); routing it through `writeStdout` would
+ *   change where it lands, which is a separate decision.
+ * - `console.info` shares fd 1 with `console.log` in Bun (it is an alias, not
+ *   a stderr method), so it would be vulnerable to the same truncation and
+ *   is patched to the same delegate.
  * - Color is hard-disabled: Bun's built-in would colorize on TTY, but human
  *   CLI text (`console.log(\`some text\`)`) does not depend on ANSI. Pino
  *   pretty-printing (used when stdout is a TTY per `paths/src/logger.ts:62`)
@@ -46,19 +59,40 @@ import { formatWithOptions } from 'node:util';
 import { writeStdout } from './stdout';
 
 const ORIGINAL_LOG = console.log.bind(console);
+const ORIGINAL_INFO = console.info.bind(console);
 
 let installed = false;
 
 /**
- * Replace `console.log` with a pipe-safe delegate that awaits full delivery
- * through `writeStdout`. Safe to call multiple times — only the first call
- * has any effect.
+ * In-flight `writeStdout` promises. `process.exit()` does NOT drain
+ * `process.stdout`'s pending writes, so the CLI entry must await this set
+ * to guarantee every byte has reached the OS before it terminates — see
+ * R1 in `artifacts/runs/ae71ab1e-…/review/report.md`.
+ */
+const pendingWrites = new Set<Promise<void>>();
+
+/**
+ * Resolve once every write queued so far has been handed to the OS in full.
+ * `cli.ts` calls this between `main()` resolving and `process.exit()` so the
+ * fire-and-forget patched `console.log` cannot race the exit and drop the
+ * tail of the output.
+ */
+export function flushPendingWrites(): Promise<void> {
+  return Promise.allSettled([...pendingWrites]).then(() => undefined);
+}
+
+/**
+ * Replace `console.log` and `console.info` with a pipe-safe delegate that
+ * routes every call through `writeStdout`. Safe to call multiple times —
+ * only the first call has any effect.
  *
- * The patched function keeps `console.log`'s void-return signature. Callers
- * that don't await it (the entire existing call surface) keep working; the
- * underlying `process.stdout.write` stream callback fires once the bytes have
- * reached the OS, retrying short writes and `EAGAIN` through the event loop
- * (no busy-wait). See `utils/stdout.ts` for the underlying primitive.
+ * The patched functions keep `console.log`'s void-return signature. Callers
+ * that don't await them (the entire existing call surface) keep working;
+ * the underlying `process.stdout.write` stream callback fires once the bytes
+ * have reached the OS, retrying short writes and `EAGAIN` through the event
+ * loop (no busy-wait). See `utils/stdout.ts` for the underlying primitive.
+ * Callers that DO need delivery confirmation before the process exits must
+ * await `flushPendingWrites()` — see `cli.ts:1169-1180`.
  */
 export function installPipeSafeConsole(): void {
   if (installed) return;
@@ -78,19 +112,40 @@ export function installPipeSafeConsole(): void {
     // Errors from `writeStdout` propagate to `process.stdout`'s uncaught
     // error handler (Bun surfaces EPIPE as a process error, matching the
     // behavior of the original `console.log` when the reader hangs up).
-    void writeStdout(text);
+    // The promise is tracked in `pendingWrites` so `flushPendingWrites()`
+    // can drain it before `process.exit()`.
+    const p = writeStdout(text).finally(() => {
+      pendingWrites.delete(p);
+    });
+    pendingWrites.add(p);
   }
 
-  // Preserve the original symbol name so logs / stack traces still read
-  // "console.log" rather than "pipeSafeLog".
+  // Preserve the original symbol names so logs / stack traces still read
+  // "console.log" / "console.info" rather than "pipeSafeLog".
   Object.defineProperty(pipeSafeLog, 'name', { value: 'log', configurable: true });
 
-  (console as { log: (...args: unknown[]) => void }).log = pipeSafeLog;
+  const consoleAny = console as {
+    log: (...args: unknown[]) => void;
+    info: (...args: unknown[]) => void;
+  };
+  consoleAny.log = pipeSafeLog;
+  consoleAny.info = pipeSafeLog;
 }
 
-/** For tests / rollback: restore the original `console.log`. */
+/** For tests / rollback: restore the original `console.log` / `console.info`. */
 export function restoreConsole(): void {
   if (!installed) return;
   installed = false;
-  (console as { log: (...args: unknown[]) => void }).log = ORIGINAL_LOG;
+  const consoleAny = console as {
+    log: (...args: unknown[]) => void;
+    info: (...args: unknown[]) => void;
+  };
+  consoleAny.log = ORIGINAL_LOG;
+  // Best-effort: if console.info was never read it may not be writable in
+  // every runtime. The patched write is the only reason we touch it.
+  try {
+    consoleAny.info = ORIGINAL_INFO;
+  } catch {
+    // ignore — test-only fallback path
+  }
 }

--- a/packages/cli/src/utils/safe-console.ts
+++ b/packages/cli/src/utils/safe-console.ts
@@ -29,6 +29,16 @@
  * re-introduce the same silent-exit-0 truncation the patch is meant to
  * eliminate.
  *
+ * If a write fails (e.g. EPIPE because a piped reader hung up after `head -c
+ * 100`), the underlying rejection is recorded in `writeError` (see below).
+ * The deterministic exit-code path lives in `consumeWriteError()`, which
+ * `exitWithDrain()` calls after draining the in-flight writes: any captured
+ * error forces a non-zero exit regardless of which platform's runtime
+ * observed the rejection first. We deliberately do NOT re-throw the error
+ * asynchronously — a re-thrown async error still races `process.exit()` on
+ * Linux and would re-introduce the very flakiness the `consumeWriteError()`
+ * path was added to remove.
+ *
  * ## Scope (deliberate)
  *
  * - `console.log` and `console.info` are patched; `console.warn` /
@@ -72,6 +82,27 @@ let installed = false;
 const pendingWrites = new Set<Promise<void>>();
 
 /**
+ * First `process.stdout.write` error observed by the patched `console.log`,
+ * if any. Cleared by `consumeWriteError()` so the exit code only flips once.
+ * EPIPE is the common case (a piped reader like `head -c 100` hangs up after
+ * its slice, then the next write to fd 1 fails with `EPIPE: broken pipe`).
+ *
+ * The shim attaches a `.catch()` to the per-write promise that records the
+ * error here. `exitWithDrain()` reads it back via `consumeWriteError()` and
+ * forces a non-zero exit when it is set — that is what makes the exit code
+ * deterministic across platforms, including the Linux CI runner where Bun
+ * schedules its unhandled-rejection handler after `process.exit()` has
+ * already taken effect and the rejection would otherwise be swallowed.
+ *
+ * The `.catch()` here marks the per-write rejection as handled (so the test
+ * runner does not see it as an unhandled error), but we do NOT re-throw it
+ * elsewhere: a re-thrown async error would still race `process.exit()` on
+ * Linux and re-introduce the very flakiness the `consumeWriteError()` path
+ * was added to remove.
+ */
+let writeError: NodeJS.ErrnoException | null = null;
+
+/**
  * Resolve once every write queued so far has been handed to the OS in full.
  * `cli.ts` calls this between `main()` resolving and `process.exit()` so the
  * fire-and-forget patched `console.log` cannot race the exit and drop the
@@ -79,6 +110,19 @@ const pendingWrites = new Set<Promise<void>>();
  */
 export function flushPendingWrites(): Promise<void> {
   return Promise.allSettled([...pendingWrites]).then(() => undefined);
+}
+
+/**
+ * Pop the first write error observed by the patched `console.log`, if any.
+ * `exitWithDrain()` calls this between draining and `process.exit()` so a
+ * failed write (typically `EPIPE`) deterministically forces a non-zero exit
+ * code, independent of the runtime's unhandled-rejection ordering. Returns
+ * `null` when every write succeeded.
+ */
+export function consumeWriteError(): NodeJS.ErrnoException | null {
+  const err = writeError;
+  writeError = null;
+  return err;
 }
 
 /**
@@ -111,15 +155,22 @@ export function installPipeSafeConsole(): void {
     const text = formatWithOptions({ colors: false, depth: 4 }, ...args) + '\n';
     // Fire-and-forget: keep `void` return so callers don't have to await,
     // and so tests that mock `console.log` with `() => {}` still pass.
-    // Errors from `writeStdout` propagate to `process.stdout`'s uncaught
-    // error handler (Bun surfaces EPIPE as a process error, matching the
-    // behavior of the original `console.log` when the reader hangs up).
+    // Errors from `writeStdout` are recorded in `writeError` and consumed by
+    // `exitWithDrain()` to force a non-zero exit (see the `writeError`
+    // comment). The Linux CI runner schedules Bun's unhandled-rejection
+    // handler after `process.exit()` has taken effect; without the explicit
+    // `writeError` flag the exit code would silently drop to 0 — see the
+    // R5 regression test in `safe-console.test.ts`.
     // The promise is tracked in `pendingWrites` so `flushPendingWrites()`
     // can drain it before `process.exit()`.
     const p = writeStdout(text).finally(() => {
       pendingWrites.delete(p);
     });
     pendingWrites.add(p);
+    p.catch((err: unknown) => {
+      const e = err as NodeJS.ErrnoException;
+      if (writeError === null) writeError = e;
+    });
   }
 
   // Preserve the original symbol name so logs / stack traces still read

--- a/packages/cli/src/utils/safe-console.ts
+++ b/packages/cli/src/utils/safe-console.ts
@@ -92,7 +92,9 @@ export function flushPendingWrites(): Promise<void> {
  * have reached the OS, retrying short writes and `EAGAIN` through the event
  * loop (no busy-wait). See `utils/stdout.ts` for the underlying primitive.
  * Callers that DO need delivery confirmation before the process exits must
- * await `flushPendingWrites()` — see `cli.ts:1169-1180`.
+ * await `flushPendingWrites()` — see `utils/exit-with-drain.ts` (the helper
+ * `cli.ts`'s top-level `main().then().catch()` chain routes both arms
+ * through) and `cli.ts:1171-1202` (the comment and chain that use it).
  */
 export function installPipeSafeConsole(): void {
   if (installed) return;

--- a/packages/cli/src/utils/safe-console.ts
+++ b/packages/cli/src/utils/safe-console.ts
@@ -1,0 +1,96 @@
+/**
+ * Pipe-safe `console.log` for CLI human-readable output.
+ *
+ * ## Why this exists (#2400)
+ *
+ * Pino's default destination opens fd 1 in non-blocking mode as a side effect
+ * of `@archon/paths` being imported — every CLI command inherits that fd
+ * state. On a non-blocking pipe (`archon … | less`, `archon … | head`,
+ * `archon … | grep`), `console.log` calls that exceed the pipe's buffer can
+ * silently drop the unwritten tail and exit 0 (see the file-redirect vs pipe
+ * asymmetry in `utils/stdout.ts`). PR #2389 fixed the machine-readable
+ * `--json` paths by routing every JSON emitter through `writeStdout` /
+ * `writeJsonLine`. This patch is the symmetrical fix for human-readable
+ * `console.log` calls — 226 of them across `packages/cli/src/commands/*.ts`,
+ * every one a piped-failure site against a slow reader.
+ *
+ * The patch delegates through the same `writeStdout` primitive that
+ * `--json` already uses, so short writes and `EAGAIN` are retried by the
+ * stream rather than lost. The `void` return shape preserves the original
+ * `console.log` signature so existing callers (and `spyOn(console, 'log')`
+ * mocks in `workflow.test.ts` / `cli-adapter.test.ts`) keep working unchanged.
+ *
+ * ## Scope (deliberate)
+ *
+ * - `console.log` is patched; `console.warn` / `console.error` / `console.info`
+ *   are NOT. Those default to stderr in Bun, which is not the fd pino flipped.
+ *   `console.warn` is also used by CLI commands as the deliberate
+ *   "non-pino diagnostic" channel (e.g. `workflow.ts`); routing it through
+ *   `writeStdout` would change where it lands, which is a separate decision.
+ * - Color is hard-disabled: Bun's built-in would colorize on TTY, but human
+ *   CLI text (`console.log(\`some text\`)`) does not depend on ANSI. Pino
+ *   pretty-printing (used when stdout is a TTY per `paths/src/logger.ts:62`)
+ *   still colorizes its own output.
+ * - Idempotent: a second call is a no-op so re-imports don't double-wrap.
+ *
+ * ## Maintainer warning
+ *
+ * Do not delete this patch because "the underlying cause lives in
+ * `@archon/paths`" — moving pino to stderr is a wider blast-radius change
+ * (server, adapters, every package that imports `@archon/paths`) and a
+ * separate design call (see #2400 plan: this file vs `logger.ts` route).
+ * Until that lands, this patch is the fix.
+ */
+
+import { formatWithOptions } from 'node:util';
+import { writeStdout } from './stdout';
+
+const ORIGINAL_LOG = console.log.bind(console);
+
+let installed = false;
+
+/**
+ * Replace `console.log` with a pipe-safe delegate that awaits full delivery
+ * through `writeStdout`. Safe to call multiple times — only the first call
+ * has any effect.
+ *
+ * The patched function keeps `console.log`'s void-return signature. Callers
+ * that don't await it (the entire existing call surface) keep working; the
+ * underlying `process.stdout.write` stream callback fires once the bytes have
+ * reached the OS, retrying short writes and `EAGAIN` through the event loop
+ * (no busy-wait). See `utils/stdout.ts` for the underlying primitive.
+ */
+export function installPipeSafeConsole(): void {
+  if (installed) return;
+  installed = true;
+
+  // `function` (not arrow) so `console.log.toString()` reports the name
+  // and stack traces point at the wrapped symbol, which helps when a test
+  // asserts on `console.log` identity.
+  function pipeSafeLog(...args: unknown[]): void {
+    // `colors: false` — Bun's built-in would colorize on TTY; CLI human
+    // output (template strings, status lines) does not depend on ANSI.
+    // `depth: 4` matches Bun's default for objects so a single-line diff in
+    // CI is meaningful.
+    const text = formatWithOptions({ colors: false, depth: 4 }, ...args) + '\n';
+    // Fire-and-forget: keep `void` return so callers don't have to await,
+    // and so tests that mock `console.log` with `() => {}` still pass.
+    // Errors from `writeStdout` propagate to `process.stdout`'s uncaught
+    // error handler (Bun surfaces EPIPE as a process error, matching the
+    // behavior of the original `console.log` when the reader hangs up).
+    void writeStdout(text);
+  }
+
+  // Preserve the original symbol name so logs / stack traces still read
+  // "console.log" rather than "pipeSafeLog".
+  Object.defineProperty(pipeSafeLog, 'name', { value: 'log', configurable: true });
+
+  (console as { log: (...args: unknown[]) => void }).log = pipeSafeLog;
+}
+
+/** For tests / rollback: restore the original `console.log`. */
+export function restoreConsole(): void {
+  if (!installed) return;
+  installed = false;
+  (console as { log: (...args: unknown[]) => void }).log = ORIGINAL_LOG;
+}


### PR DESCRIPTION
## Problem and outcome

Human-readable `console.log` output piped to a slow reader (`archon … | less`, `| head`, `| grep`, any pager) silently loses bytes while exiting 0. The reporter measured ~20% delivery on a 553 KB payload — the same root cause as the JSON-delivery bug #2384 closed, but on the remaining 226 human-readable `console.log` call sites that PR #2389 deliberately deferred.

- **Outcome:** every CLI command's human-readable stdout reaches a slow consumer in full and is byte-identical to a file redirect, against the same harness that truncates pre-fix in 5/5 runs — for every command's top-level exit path (`cli.ts`'s `main()` chain, shared via the `withDrainedExit` helper) and for `workflow run`'s Ctrl-C/SIGTERM path (one of the CLI's heaviest emitters at 101 `console.log`/`console.info` call sites). `setup.ts`'s ~46 direct `process.exit()` calls are NOT routed through the drain helper — its own console output is 8 short one-line messages, well under the pipe-buffer threshold in practice; left as a documented, low-risk gap rather than folded into this fix.
- **Invariant:** the existing `writeStdout` / `writeJsonLine` primitive (`packages/cli/src/utils/stdout.ts`) is the only path that crosses fd 1 from the CLI; both `console.log` and `console.info` (which shares fd 1 in Bun) now delegate through it. `--json` paths are untouched. `console.warn` / `console.error` still land on stderr. `spyOn(console, 'log').mockImplementation(() => {})` keeps working. A `main()` rejection with a non-`Error` value (`throw null`, a string, a plain object) is also normalized safely before the fatal-path drain runs, rather than crashing the drain handler itself.
- **Scope boundary:** pino's destination in `@archon/paths` is unchanged; the `console.warn` channel is unchanged; no call-site migration; no change to the server / adapters / web packages; `setup.ts`'s direct exits are not routed through the drain helper (see Outcome).
- **Root cause:** `@archon/paths` builds the pino root logger at module load with no explicit destination, so pino's default SonicBoom opens fd 1 in non-blocking mode. On a non-blocking pipe, a write larger than the 64 KiB buffer returns a short count and `console.log` discards the remainder without raising. A regular-file fd stays blocking — that is the file-vs-pipe asymmetry that made this invisible in most testing.

## Review guidance

- **Feedback requested:** whether the surgical CLI-only patch is acceptable given that the principled fix (pino to stderr in `paths/src/logger.ts`) has a wider blast radius — reasoning under Solution. Whether `console.log`'s `colors: false` trade-off is acceptable (covered in the file's docblock).
- **Start here:** `packages/cli/src/utils/safe-console.ts:99` (`installPipeSafeConsole`) — the shim is one function that delegates through `writeStdout`.
- **Review order:** `safe-console.ts` (the shim) → `cli.ts:19-32` (install point, deliberately placed after `@archon/paths/strip-cwd-env-boot` and before any command module import) → `cli.ts:1171-1201` (the exit path that drains pending writes on both arms via `exitWithDrain`) → `safe-console.test.ts` (real-pipe reproducer) → `package.json:11` (test script wired in).
- **Lower-attention areas:** the two-line wiring in `cli.ts` and the one-line `package.json` test-script edit are mechanical and match the existing `--json` test wiring in `stdout.test.ts`.
- **Known risk or uncertainty:** the patched `console.log` is `void`-returning and fire-and-forget. Callers that previously relied on the write completing synchronously are unchanged because they never awaited — the bytes reach the OS via the stream callback. None of the 226 call sites needed updating.

## Solution

The existing `writeStdout` primitive already solves the truncation for any caller that opts in; PR #2389 used it for every `--json` path. This patch is the symmetrical fix for the 226 human-readable `console.log` sites: monkey-patch `console.log` (and `console.info`, which shares fd 1 in Bun) once in the CLI entry to delegate through the same primitive, preserving the `void` return shape so every existing caller (and every `spyOn(console, 'log')` mock) keeps working unchanged.

The patch is installed exactly once, immediately after `loadArchonEnv(...)` (`cli.ts:32`) — after `@archon/paths` has already built the pino logger and flipped fd 1 to non-blocking, and before any command module imports. That ordering is the proof the patch is needed: removing the patch makes the regression test fail 5/5.

`console.warn` / `console.error` are deliberately not patched — they default to stderr in Bun, which is not the fd pino flipped. `console.warn` is also the deliberate "non-pino diagnostic" channel used by `workflow.ts` and other commands; routing it through `writeStdout` would change where it lands, which is a separate decision. `console.info` is patched too, because it is a stdout alias in Bun (not a stderr method) and would otherwise be vulnerable to the same truncation.

**Why this scope and not the principled fix.** Routing pino to stderr in `packages/paths/src/logger.ts:86` is the correct design regardless — a logging dependency should not share fd 1 with machine-readable payloads — but its blast radius is the entire `@archon/paths` consumer set: server, adapters, web, every package. Server-side log aggregators that scrape stdout would silently break, and tests asserting against the default destination would need rewriting. #2400 is the CLI symptom of a CLI-side coupling; the principled fix is a separate PR with its own scope analysis. This patch is reversible in one commit.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | `archon workflow list \| less` delivered ~20% of a 553 KB payload while exiting 0; any pager / `head` / `grep` lost bytes silently | Every byte reaches the consumer; piped output is byte-identical to a file redirect against a slow reader |
| **Failure behavior** | Exit code 0 regardless of truncation; no error path the user could detect | Exit code 0 still (no new failure mode); truncation no longer occurs. EPIPE from a reader that hung up surfaces through `writeStdout`, matching the existing `--json` path |

## Validation

- `bun --filter '@archon/cli' test` — 605 pass / 0 fail / 1 skip across 16 files. Includes `safe-console.test.ts`, `stdout.test.ts`, and `workflow.test.ts`'s existing SIGTERM/SIGINT regression coverage (which independently proves the Ctrl-C exit path still calls `process.exit(1)` after being routed through the drain helper).
- `bun --filter '@archon/cli' type-check` — pass.
- `bun --filter '*' type-check` — every package passes.
- `bun x eslint packages/cli/src/cli.ts packages/cli/src/utils/safe-console.ts packages/cli/src/utils/exit-with-drain.ts packages/cli/src/commands/workflow.ts --max-warnings 0` — clean.
- `bun x prettier --check` on the five touched files — clean.
- **The regression test was observed failing first.** Against the pre-fix code, `workflow list` over a 1.07 MB payload piped through `{ sleep 0.5; cat; }` truncated in 5/5 runs (delivery 89–96%, `bytes: 65536` = the pipe-buffer cap). Against the patched code the same harness passes 10/10 byte-identical to a file redirect. The slow consumer (`sleep 0.5` before draining) is what makes the truncation deterministic — plain `cat` only truncates ~1% of runs at this payload size because cat drains the pipe faster than the writer fills it, so a regression test built on plain `cat` would silently pass on pre-fix code.
- Manual repro of the reporter's use cases: `archon workflow list > file` = 220,745 bytes; `| grep -c` = 41 (correct count); `| head -c 200000` = 200,000 bytes (exactly the head cap, no short-write loss).
- **Not verified:** the 18 pre-existing `bun test` failures from `bun test` at the package level (run via `bun --filter '*' --parallel test` cross-package), which reproduce on `c5b3211a` HEAD before this change and are unrelated to #2400. The `bun run test` script (the project's own test gate) is clean.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | None. No schema, no stored state, no run-lifecycle change. `spyOn(console, 'log')` mocks keep working. The `void` return shape is preserved. | `workflow.test.ts:395`, `cli-adapter.test.ts:44` |
| Rollout / rollback | Revert the single commit. The new test is part of the same commit and must be reverted together — without the patch, the test is a calibrated reproducer that fails on every CI run. | `git revert 24e0952a` |
| Observability | This is the observability fix: piped human output is now complete, which is what users and agents reaching for `archon … \| less` were already expecting. | `safe-console.test.ts` real-pipe harness |

## Links

- Closes #2400
- Related #2384, #2389


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI output reliability when writing to pipes or redirected streams.
  * Ensured pending output is flushed before successful or failed command termination.
  * Improved handling of broken pipes and other output errors with clearer failure reporting.
  * Prevented incomplete workflow output during fatal command exits.

* **Tests**
  * Added coverage for pipe-safe output, exit handling, broken pipes, and output failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->