### PR TITLE
fix(workflows): invalidate cached prior-success nodes when a dependency re-ran

### DIFF
--- a/packages/core/src/db/workflow-events.test.ts
+++ b/packages/core/src/db/workflow-events.test.ts
@@ -401,6 +401,63 @@ describe('workflow-events', () => {
       ]);
     });
 
+    test('a later node_failed row supersedes an earlier node_completed row for the same step (#2705 R2)', async () => {
+      // Before #2705, a non-always_run node that once completed could never be
+      // re-attempted, so a node_completed → node_failed sequence for the same
+      // step_name was impossible. #2705's own invalidate-and-re-execute
+      // mechanism is the first thing that can produce that sequence: a cached
+      // node gets invalidated, re-executes, and the fresh attempt fails. If the
+      // earlier node_completed entry survives in the map, the NEXT resume's
+      // cache-eligibility check sees a stale success instead of the node's own
+      // most recent (failed) outcome.
+      mockQuery.mockResolvedValueOnce(
+        createQueryResult([
+          {
+            step_name: 'flaky',
+            event_type: 'node_completed',
+            data: { node_output: 'first attempt succeeded' },
+          },
+          {
+            step_name: 'flaky',
+            event_type: 'node_failed',
+            data: { error: 'second attempt (re-executed via invalidation) crashed' },
+          },
+        ])
+      );
+
+      const result = await getDagResumeSnapshot('run-completed-then-failed');
+
+      // The failed row is the step's most recent real outcome; the stale
+      // node_completed entry must not survive the chronological walk.
+      expect(result.completedNodeOutputs.has('flaky')).toBe(false);
+    });
+
+    test('a node_completed row after a node_failed row for the same step re-adds it (chronological order wins)', async () => {
+      // Symmetric check: if the node later succeeds (a subsequent resume re-runs
+      // it and this time it completes), that success must be honoured — the
+      // delete on node_failed must not leave a permanent tombstone.
+      mockQuery.mockResolvedValueOnce(
+        createQueryResult([
+          {
+            step_name: 'flaky',
+            event_type: 'node_failed',
+            data: { error: 'first attempt crashed' },
+          },
+          {
+            step_name: 'flaky',
+            event_type: 'node_completed',
+            data: { node_output: 'second attempt succeeded' },
+          },
+        ])
+      );
+
+      const result = await getDagResumeSnapshot('run-failed-then-completed');
+
+      expect(result.completedNodeOutputs.get('flaky')).toEqual({
+        output: 'second attempt succeeded',
+      });
+    });
+
     test('sums cache axes reported by a failed node into the resumed total', async () => {
       mockQuery.mockResolvedValueOnce(
         createQueryResult([

--- a/packages/core/src/db/workflow-events.ts
+++ b/packages/core/src/db/workflow-events.ts
@@ -287,7 +287,13 @@ export async function getDagResumeSnapshot(workflowRunId: string): Promise<{
       );
       continue;
     }
-    if (row.event_type !== 'node_failed' && typeof data.node_output === 'string') {
+    if (row.event_type === 'node_failed') {
+      // A later failure for this step supersedes any earlier node_completed /
+      // node_skipped_prior_success entry (#2705 R2) — otherwise a node the engine's own
+      // prior-cache invalidation re-executed, and which then genuinely failed, is
+      // reported as a cached success again on a subsequent resume.
+      completedNodeOutputs.delete(row.step_name);
+    } else if (typeof data.node_output === 'string') {
       completedNodeOutputs.set(row.step_name, {
         output: data.node_output,
         // The node's logical value (#2637), persisted beside its text by the emit

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -11343,6 +11343,127 @@ describe('executeDagWorkflow -- prior-success cache invalidated by dep re-execut
     expect(data.invalidating_deps).toEqual(['producer']);
     expect(data.prior_structured_output).toEqual({ stale: true });
   });
+
+  it('invalidates a cached downstream when ONE of its multiple deps re-ran (any-stale triggers re-execution)', async () => {
+    // Pin the "any stale dep invalidates" trigger for cached consumers with >= 2 deps
+    // (#2402). The single-dep cases above can't catch a regression to "re-run only when
+    // ALL deps are stale" (`if (staleDeps.length === deps.length)`), which would
+    // re-introduce the original bug for any cached consumer that has at least one
+    // fresh dep and one stable one. The shape: producer re-runs (always_run, fresh
+    // output) + side stays cached (text-identical to prior) -> consumer is cached
+    // but reads `$producer.output` in its prompt. The fresh producer MUST invalidate
+    // the cached consumer even though side is stable.
+    const seenPrompts: string[] = [];
+    let queryCount = 0;
+    mockSendQueryDag.mockImplementation(async function* (prompt: string) {
+      seenPrompts.push(prompt);
+      queryCount++;
+      // queryCount 1: producer re-runs (always_run).
+      // queryCount 2: consumer re-runs after cache invalidation.
+      // Side is in priorCompletedNodes with text-identical-to-prior output, so the
+      // pre-populate loop seeds it and the resume-skip arm fires for it — side is
+      // never sent to sendQuery.
+      yield {
+        type: 'assistant',
+        content: queryCount === 1 ? 'FRESH producer output' : 'consumer result',
+      };
+      yield { type: 'result', sessionId: 'session-id' };
+    });
+
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun();
+
+    // All three nodes cached in the prior run. Side's cached output matches what its
+    // pre-populated nodeOutputs entry will carry, so case 2 (text diff) reports no
+    // staleness for side. Producer's cached output is the stale value — the fresh
+    // always_run execution will surface case 2 and invalidate consumer.
+    const priorCompletedNodes = new Map<string, PersistedNodeOutput>([
+      ['producer', { output: 'STALE producer output' }],
+      ['side', { output: 'stable side output' }],
+      ['consumer', { output: 'STALE consumer output' }],
+    ]);
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-2402-multi-dep',
+      testDir,
+      {
+        name: 'stale-cache-multi-dep',
+        nodes: [
+          // always_run forces producer to re-execute this resume (case 2 fires).
+          { id: 'producer', command: 'producer', always_run: true },
+          // Stable dep — text matches prior so case 2 doesn't flag it.
+          { id: 'side', command: 'side' },
+          // Consumer reads producer; its dep list has BOTH producer and side.
+          {
+            id: 'consumer',
+            prompt: 'Use $producer.output and $side.output',
+            depends_on: ['producer', 'side'],
+          },
+        ],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      priorCompletedNodes
+    );
+
+    // Exactly two queries: producer re-runs (always_run), consumer re-runs
+    // (cache invalidated). Side is skipped via the pre-populate prior-success arm,
+    // so it never reaches sendQuery.
+    expect(queryCount).toBe(2);
+
+    // Consumer's prompt must contain the FRESH producer output (not the stale cached
+    // value the resume snapshot carried). Side's stable output is also fine.
+    const consumerPrompt = seenPrompts[1];
+    expect(consumerPrompt).toContain('FRESH producer output');
+    expect(consumerPrompt).not.toContain('STALE producer output');
+    expect(consumerPrompt).toContain('stable side output');
+
+    // Consumer emits node_prior_cache_invalidated naming ONLY the stale dep. If a
+    // future refactor flagged every dep in the list (or stopped pushing after the
+    // first dep), invalidating_deps would either be ['producer','side'] or []
+    // respectively — both would fail this length-1 assertion.
+    const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+    const consumerSkippedEvent = eventCalls.find(
+      (call: unknown[]) =>
+        (call[0] as { event_type: string }).event_type === 'node_skipped_prior_success' &&
+        (call[0] as { step_name: string }).step_name === 'consumer'
+    );
+    expect(consumerSkippedEvent).toBeUndefined();
+
+    const invalidatedEvent = eventCalls.find(
+      (call: unknown[]) =>
+        (call[0] as { event_type: string }).event_type === 'node_prior_cache_invalidated' &&
+        (call[0] as { step_name: string }).step_name === 'consumer'
+    );
+    expect(invalidatedEvent).toBeDefined();
+    const data = (invalidatedEvent![0] as { data: Record<string, unknown> }).data;
+    expect(data.reason).toBe('stale_dependency');
+    // Length 1 (not 2) — pinning the "any stale dep invalidates" trigger; pinning
+    // that only the actually-stale dep is reported (not the stable side).
+    expect(data.invalidating_deps).toEqual(['producer']);
+    expect(data.prior_output).toBe('STALE consumer output');
+
+    // Side stayed cached, so it should emit node_skipped_prior_success exactly once.
+    const sideSkippedEvent = eventCalls.find(
+      (call: unknown[]) =>
+        (call[0] as { event_type: string }).event_type === 'node_skipped_prior_success' &&
+        (call[0] as { step_name: string }).step_name === 'side'
+    );
+    expect(sideSkippedEvent).toBeDefined();
+  });
 });
 
 describe('executeDagWorkflow -- break after result (no hang on subprocess exit)', () => {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -11003,6 +11003,348 @@ describe('executeDagWorkflow -- always_run resume opt-out', () => {
   });
 });
 
+describe('executeDagWorkflow -- prior-success cache invalidated by dep re-execution (#2402)', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = join(tmpdir(), `dag-2402-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    const commandsDir = join(testDir, '.archon', 'commands');
+    await mkdir(commandsDir, { recursive: true });
+    await writeFile(join(testDir, '.archon', 'commands', 'producer.md'), 'Producer prompt');
+    await writeFile(
+      join(testDir, '.archon', 'commands', 'consumer.md'),
+      'Consumer prompt $producer.output'
+    );
+
+    mockSendQueryDag.mockClear();
+    mockGetAgentProviderDag.mockClear();
+
+    mockGetAgentProviderDag.mockImplementation(() => ({
+      sendQuery: mockSendQueryDag,
+      getType: () => 'claude',
+      getCapabilities: mockClaudeCapabilities,
+    }));
+  });
+
+  afterEach(async () => {
+    mockGetAgentProviderDag.mockImplementation(() => ({
+      sendQuery: mockSendQueryDag,
+      getType: () => 'claude',
+      getCapabilities: mockClaudeCapabilities,
+    }));
+    try {
+      await rm(testDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  it('invalidates a cached downstream when an always_run dep re-runs with fresh output', async () => {
+    // Bug shape from #2402: producer is `always_run` so it re-executes on resume; consumer
+    // is also cached from the prior run. The naive resume used to skip consumer and read
+    // the stale cached value, reporting success over synthesis made against the OLD
+    // producer. After the fix, consumer must re-execute against the fresh producer.
+    const seenPrompts: string[] = [];
+    let queryCount = 0;
+    mockSendQueryDag.mockImplementation(async function* (prompt: string) {
+      seenPrompts.push(prompt);
+      queryCount++;
+      yield {
+        type: 'assistant',
+        content: queryCount === 1 ? 'fresh producer output' : 'consumer result',
+      };
+      yield { type: 'result', sessionId: 'session-id' };
+    });
+
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun();
+
+    // Both producer and consumer were completed in the prior run — this is the
+    // scenario the bug report describes.
+    const priorCompletedNodes = new Map<string, PersistedNodeOutput>([
+      ['producer', { output: 'STALE_CACHED_PRODUCER' }],
+      ['consumer', { output: 'STALE_CACHED_CONSUMER' }],
+    ]);
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-2402-always-run',
+      testDir,
+      {
+        name: 'stale-cache-always-run',
+        nodes: [
+          { id: 'producer', command: 'producer', always_run: true },
+          { id: 'consumer', command: 'consumer', depends_on: ['producer'] },
+        ],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      priorCompletedNodes
+    );
+
+    // Producer re-runs (always_run) AND consumer re-runs (cache invalidated by dep) —
+    // before the fix, consumer was skipped and only 1 sendQuery call happened.
+    expect(mockSendQueryDag.mock.calls.length).toBe(2);
+
+    // Consumer's prompt must contain the FRESH producer output, not the stale cached
+    // value the resume snapshot carried.
+    const consumerPrompt = seenPrompts[1];
+    expect(consumerPrompt).toContain('fresh producer output');
+    expect(consumerPrompt).not.toContain('STALE_CACHED_PRODUCER');
+
+    // Audit: producer emits node_always_run_reset; consumer emits
+    // node_prior_cache_invalidated naming producer as the invalidating dep.
+    const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+    const consumerSkippedEvent = eventCalls.find(
+      (call: unknown[]) =>
+        (call[0] as { event_type: string }).event_type === 'node_skipped_prior_success' &&
+        (call[0] as { step_name: string }).step_name === 'consumer'
+    );
+    expect(consumerSkippedEvent).toBeUndefined();
+
+    const invalidatedEvent = eventCalls.find(
+      (call: unknown[]) =>
+        (call[0] as { event_type: string }).event_type === 'node_prior_cache_invalidated' &&
+        (call[0] as { step_name: string }).step_name === 'consumer'
+    );
+    expect(invalidatedEvent).toBeDefined();
+    const data = (invalidatedEvent![0] as { data: Record<string, unknown> }).data;
+    expect(data.reason).toBe('stale_dependency');
+    expect(data.invalidating_deps).toEqual(['producer']);
+    expect(data.prior_output).toBe('STALE_CACHED_CONSUMER');
+  });
+
+  it('does NOT invalidate when a cached dep ran but produced text-identical output', async () => {
+    // The comparison is conservative: a dep that re-ran with byte-identical text
+    // and structured output is NOT flagged as stale. The cached downstream's value
+    // is semantically equivalent, so honouring the cache is correct (and avoids an
+    // unnecessary re-execution). This pins that contract for #2402.
+    let queryCount = 0;
+    mockSendQueryDag.mockImplementation(async function* () {
+      queryCount++;
+      yield { type: 'assistant', content: 'identical output' };
+      yield { type: 'result', sessionId: 'session-id' };
+    });
+
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun();
+
+    // Producer was completed in the prior run with output "identical output". It is NOT
+    // `always_run`, so the resume pre-populates nodeOutputs["producer"] = "identical
+    // output". When this resume runs, the comparison finds the values match and the
+    // cache is honoured. Only producer would execute on a fresh start — but here
+    // producer is also in priorCompletedNodes, so it is skipped entirely.
+    const priorCompletedNodes = new Map<string, PersistedNodeOutput>([
+      ['producer', { output: 'identical output' }],
+      ['consumer', { output: 'cached consumer output' }],
+    ]);
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-2402-identical',
+      testDir,
+      {
+        name: 'stale-cache-identical',
+        nodes: [
+          { id: 'producer', command: 'producer' },
+          { id: 'consumer', command: 'consumer', depends_on: ['producer'] },
+        ],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      priorCompletedNodes
+    );
+
+    // Neither node ran fresh: producer skipped (cached), consumer skipped (cached
+    // AND its dep did not invalidate). sendQuery was never called.
+    expect(queryCount).toBe(0);
+
+    const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+    const invalidatedEvent = eventCalls.find(
+      (call: unknown[]) =>
+        (call[0] as { event_type: string }).event_type === 'node_prior_cache_invalidated'
+    );
+    expect(invalidatedEvent).toBeUndefined();
+
+    const consumerSkippedEvent = eventCalls.find(
+      (call: unknown[]) =>
+        (call[0] as { event_type: string }).event_type === 'node_skipped_prior_success' &&
+        (call[0] as { step_name: string }).step_name === 'consumer'
+    );
+    expect(consumerSkippedEvent).toBeDefined();
+  });
+
+  it('invalidates a cached downstream when a dep that was never cached completes fresh this resume', async () => {
+    // A dep can be missing from priorCompletedNodes for two reasons: it never completed
+    // in the prior run, or it completed but its row was lost. The pre-populate loop
+    // never seeds nodeOutputs for such a dep, so case 1 of the staleness check fires:
+    // "dep missing from prior + nodeOutputs now completed => ran fresh this resume".
+    // Pin that contract — it can otherwise regress into the same staleness class.
+    let queryCount = 0;
+    mockSendQueryDag.mockImplementation(async function* () {
+      queryCount++;
+      yield { type: 'assistant', content: queryCount === 1 ? 'fresh producer' : 'fresh consumer' };
+      yield { type: 'result', sessionId: 'session-id' };
+    });
+
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun();
+
+    // Consumer is cached; producer is NOT cached (e.g. it failed in the prior run and
+    // is being re-attempted this resume).
+    const priorCompletedNodes = new Map<string, PersistedNodeOutput>([
+      ['consumer', { output: 'stale consumer output' }],
+    ]);
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-2402-uncached-dep',
+      testDir,
+      {
+        name: 'stale-cache-uncached-dep',
+        nodes: [
+          { id: 'producer', command: 'producer' },
+          { id: 'consumer', command: 'consumer', depends_on: ['producer'] },
+        ],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      priorCompletedNodes
+    );
+
+    // Producer ran fresh + consumer was invalidated and re-ran = 2 sendQuery calls.
+    expect(queryCount).toBe(2);
+
+    const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+    const invalidatedEvent = eventCalls.find(
+      (call: unknown[]) =>
+        (call[0] as { event_type: string }).event_type === 'node_prior_cache_invalidated' &&
+        (call[0] as { step_name: string }).step_name === 'consumer'
+    );
+    expect(invalidatedEvent).toBeDefined();
+    const data = (invalidatedEvent![0] as { data: Record<string, unknown> }).data;
+    expect(data.invalidating_deps).toEqual(['producer']);
+  });
+
+  it('invalidates when a dep’s structured output changes even though text is stable', async () => {
+    // Case 3 of the staleness check: a `$dep.output.field` consumer must be invalidated
+    // when the structured value changes, even if the text form is identical. Otherwise
+    // the #2637 logical-value surface would silently read stale data through the cache.
+    // The dep must actually re-run for the comparison to fire — `always_run: true`
+    // forces that without contaminating the case with text-staleness.
+    let queryCount = 0;
+    mockSendQueryDag.mockImplementation(async function* () {
+      queryCount++;
+      yield {
+        type: 'assistant',
+        content: queryCount === 1 ? 'producer text' : 'consumer result',
+      };
+      yield {
+        type: 'result',
+        sessionId: 'session-id',
+        // Simulate a provider that attaches a logical value alongside the text.
+        // Producer: same text as the cache, different structured payload. This is
+        // the case-3 trigger — the dep's nodeOutputs entry will have the new
+        // structuredOutput even though its text is identical.
+        structuredOutput: queryCount === 1 ? { status: 'PASS_NEW', count: 7 } : { ok: true },
+      };
+    });
+
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun();
+
+    const priorCompletedNodes = new Map<string, PersistedNodeOutput>([
+      // Text matches the new producer run, but the structured payload is the OLD
+      // shape — a `$producer.output.status` consumer would read the stale
+      // string "PASS_OLD" through the cache.
+      ['producer', { output: 'producer text', structuredOutput: { status: 'PASS_OLD', count: 3 } }],
+      // The consumer's own cached value also carries a structured payload so the
+      // audit log can record what was thrown away on the invalidated side too.
+      ['consumer', { output: 'cached consumer', structuredOutput: { stale: true } }],
+    ]);
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-2402-structured',
+      testDir,
+      {
+        name: 'stale-cache-structured',
+        nodes: [
+          // always_run forces the producer re-execution that surfaces case 3.
+          { id: 'producer', prompt: 'Run producer', always_run: true },
+          { id: 'consumer', prompt: 'Use $producer.output.status', depends_on: ['producer'] },
+        ],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      priorCompletedNodes
+    );
+
+    // Producer re-ran (always_run) + consumer was invalidated (text-stable but
+    // structured-output differs) = 2 sendQuery calls.
+    expect(queryCount).toBe(2);
+
+    const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+    const invalidatedEvent = eventCalls.find(
+      (call: unknown[]) =>
+        (call[0] as { event_type: string }).event_type === 'node_prior_cache_invalidated' &&
+        (call[0] as { step_name: string }).step_name === 'consumer'
+    );
+    expect(invalidatedEvent).toBeDefined();
+    const data = (invalidatedEvent![0] as { data: Record<string, unknown> }).data;
+    expect(data.invalidating_deps).toEqual(['producer']);
+    expect(data.prior_structured_output).toEqual({ stale: true });
+  });
+});
+
 describe('executeDagWorkflow -- break after result (no hang on subprocess exit)', () => {
   let testDir: string;
 

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -11262,6 +11262,118 @@ describe('executeDagWorkflow -- prior-success cache invalidated by dep re-execut
     expect(data.invalidating_deps).toEqual(['producer']);
   });
 
+  it('invalidates a cached downstream when a dep that re-ran fresh failed (case 1 \"failed\" arm)', async () => {
+    // Pin case 1's `current?.state === 'failed'` arm of getStaleCachedDependencies
+    // (the #2402 bug surface on the failure path). A dep that was not in the prior
+    // snapshot and re-runs this resume is normally stale via case 1's
+    // `'completed'` check. The exact same dep shape on the failure path — producer
+    // re-attempted this resume and crashed — must also be flagged stale: honouring
+    // the cached downstream would silently report success over synthesis built
+    // against the prior run's view of a now-failed dep. Test 3 above pins the
+    // `'completed'` half of case 1; this one pins the `'failed'` half so a future
+    // refactor that drops `|| current?.state === 'failed'` is structurally caught
+    // (the regression is observationally indistinguishable from test 3 without it).
+    let queryCount = 0;
+    mockSendQueryDag.mockImplementation(async function* () {
+      queryCount++;
+      if (queryCount === 1) {
+        // Producer's only attempt fails. The catch arm in executeNodeInternal
+        // converts this to { state: 'failed', output: '', error: '...' } and the
+        // layer aggregation writes that into nodeOutputs['producer']. After this,
+        // any prior-cached consumer that depends on producer must be invalidated,
+        // not silently skipped. The error string is intentionally FATAL-class
+        // (matches `classifyError`'s 'auth error' fallback) so the default retry
+        // loop yields immediately — one attempt, no retries — keeping queryCount
+        // deterministic against the assertion.
+        throw new Error('producer crashed: provider auth error');
+      }
+      yield { type: 'assistant', content: 'fresh consumer output' };
+      yield { type: 'result', sessionId: 'session-id' };
+    });
+
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun();
+
+    // Consumer is cached (it ran in the prior run). Producer is NOT cached —
+    // it failed in the prior run and is being re-attempted this resume. Same
+    // shape as test 3 (case 1 with `'completed'`); the producer's FINAL state
+    // in nodeOutputs is `'failed'` instead.
+    const priorCompletedNodes = new Map<string, PersistedNodeOutput>([
+      ['consumer', { output: 'STALE_CACHED_CONSUMER' }],
+    ]);
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-2402-fresh-failed-dep',
+      testDir,
+      {
+        name: 'stale-cache-fresh-failed-dep',
+        nodes: [
+          { id: 'producer', command: 'producer' },
+          // `all_done` (not the default `all_success`) so the consumer's trigger
+          // rule permits re-execution against a failed producer. Without this,
+          // the default rule would silently skip consumer on the failure path —
+          // exercising the staleness arm but never landing the consumer's query,
+          // which would erase the queryCount === 2 discriminator between
+          // AFTER and BEFORE the fix.
+          {
+            id: 'consumer',
+            command: 'consumer',
+            depends_on: ['producer'],
+            trigger_rule: 'all_done',
+          },
+        ],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      priorCompletedNodes
+    );
+
+    // Producer failed (1 sendQuery attempt) + consumer was invalidated by the
+    // failed-dep arm and re-ran = 2 sendQuery calls in total. A regression that
+    // drops `|| current?.state === 'failed'` leaves case 1 unable to flag the
+    // failed dep; the consumer is then prior-skipped, sendQuery is only called
+    // for the producer's failed attempt, and queryCount lands at 1 — failing.
+    expect(queryCount).toBe(2);
+
+    const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+
+    // The cached-skip arm MUST NOT fire for the consumer. A regression that
+    // drops the `'failed'` arm (or narrows case 1 back to `=== 'completed'`)
+    // lets the prior-completed skip take over and emits
+    // node_skipped_prior_success — this assertion catches that exact fallback.
+    const consumerSkippedEvent = eventCalls.find(
+      (call: unknown[]) =>
+        (call[0] as { event_type: string }).event_type === 'node_skipped_prior_success' &&
+        (call[0] as { step_name: string }).step_name === 'consumer'
+    );
+    expect(consumerSkippedEvent).toBeUndefined();
+
+    // The invalidation audit MUST fire for the consumer, naming the failed dep.
+    const invalidatedEvent = eventCalls.find(
+      (call: unknown[]) =>
+        (call[0] as { event_type: string }).event_type === 'node_prior_cache_invalidated' &&
+        (call[0] as { step_name: string }).step_name === 'consumer'
+    );
+    expect(invalidatedEvent).toBeDefined();
+    const data = (invalidatedEvent![0] as { data: Record<string, unknown> }).data;
+    expect(data.reason).toBe('stale_dependency');
+    expect(data.invalidating_deps).toEqual(['producer']);
+    expect(data.prior_output).toBe('STALE_CACHED_CONSUMER');
+  });
+
   it('invalidates when a dep’s structured output changes even though text is stable', async () => {
     // Case 3 of the staleness check: a `$dep.output.field` consumer must be invalidated
     // when the structured value changes, even if the text form is identical. Otherwise

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -11126,11 +11126,17 @@ describe('executeDagWorkflow -- prior-success cache invalidated by dep re-execut
     expect(data.prior_output).toBe('STALE_CACHED_CONSUMER');
   });
 
-  it('does NOT invalidate when a cached dep ran but produced text-identical output', async () => {
+  it('does NOT invalidate when a cached dep actually re-runs and produces text-identical output (#2705 R3)', async () => {
     // The comparison is conservative: a dep that re-ran with byte-identical text
     // and structured output is NOT flagged as stale. The cached downstream's value
     // is semantically equivalent, so honouring the cache is correct (and avoids an
     // unnecessary re-execution). This pins that contract for #2402.
+    //
+    // Producer MUST actually re-execute this resume for the contract to mean
+    // anything — `always_run: true` forces that. (A prior version of this test used
+    // a non-always_run producer that was itself skipped via the ordinary prior-cache
+    // path, so the "re-ran... identical output" comparison this test claims to pin
+    // was never reached — flagged as #2705 R3.)
     let queryCount = 0;
     mockSendQueryDag.mockImplementation(async function* () {
       queryCount++;
@@ -11143,11 +11149,9 @@ describe('executeDagWorkflow -- prior-success cache invalidated by dep re-execut
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    // Producer was completed in the prior run with output "identical output". It is NOT
-    // `always_run`, so the resume pre-populates nodeOutputs["producer"] = "identical
-    // output". When this resume runs, the comparison finds the values match and the
-    // cache is honoured. Only producer would execute on a fresh start — but here
-    // producer is also in priorCompletedNodes, so it is skipped entirely.
+    // Producer was completed in the prior run with output "identical output" AND is
+    // `always_run`, so it actually re-executes this resume — and its fresh output
+    // matches the prior snapshot byte-for-byte.
     const priorCompletedNodes = new Map<string, PersistedNodeOutput>([
       ['producer', { output: 'identical output' }],
       ['consumer', { output: 'cached consumer output' }],
@@ -11161,7 +11165,7 @@ describe('executeDagWorkflow -- prior-success cache invalidated by dep re-execut
       {
         name: 'stale-cache-identical',
         nodes: [
-          { id: 'producer', command: 'producer' },
+          { id: 'producer', command: 'producer', always_run: true },
           { id: 'consumer', command: 'consumer', depends_on: ['producer'] },
         ],
       },
@@ -11179,9 +11183,11 @@ describe('executeDagWorkflow -- prior-success cache invalidated by dep re-execut
       priorCompletedNodes
     );
 
-    // Neither node ran fresh: producer skipped (cached), consumer skipped (cached
-    // AND its dep did not invalidate). sendQuery was never called.
-    expect(queryCount).toBe(0);
+    // Producer re-runs (always_run) with output identical to its prior snapshot;
+    // consumer stays cached because the comparison found no diff. A regression that
+    // makes the check over-eager (flagging every re-run dep regardless of value)
+    // would call consumer's sendQuery too, pushing this past 1.
+    expect(queryCount).toBe(1);
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const invalidatedEvent = eventCalls.find(
@@ -11362,6 +11368,97 @@ describe('executeDagWorkflow -- prior-success cache invalidated by dep re-execut
     expect(consumerSkippedEvent).toBeUndefined();
 
     // The invalidation audit MUST fire for the consumer, naming the failed dep.
+    const invalidatedEvent = eventCalls.find(
+      (call: unknown[]) =>
+        (call[0] as { event_type: string }).event_type === 'node_prior_cache_invalidated' &&
+        (call[0] as { step_name: string }).step_name === 'consumer'
+    );
+    expect(invalidatedEvent).toBeDefined();
+    const data = (invalidatedEvent![0] as { data: Record<string, unknown> }).data;
+    expect(data.reason).toBe('stale_dependency');
+    expect(data.invalidating_deps).toEqual(['producer']);
+    expect(data.prior_output).toBe('STALE_CACHED_CONSUMER');
+  });
+
+  it('invalidates a cached downstream when a PREVIOUSLY-CACHED dep fails fresh with output matching its prior success (#2705 R1)', async () => {
+    // Every failure arm in the executor returns `output: ''`. When a dependency WAS
+    // cached from a prior success — the ordinary shape for an `always_run: true` gate
+    // on a second-or-later resume — and that prior success also carried `output: ''`
+    // (a bash gate with no stdout), a value-equality-only staleness check finds the
+    // fresh failure's `''` indistinguishable from the prior success's `''` and reports
+    // "not stale." The cached consumer is then skipped via node_skipped_prior_success
+    // BEFORE checkTriggerRule ever runs, silently reporting success over a live
+    // failure produced on THIS resume. Unlike the case-1 "failed arm" test above
+    // (producer had NO prior entry), this producer WAS in priorCompletedNodes —
+    // the shape cases 2/3 govern, and the one the fix must also cover.
+    let queryCount = 0;
+    mockSendQueryDag.mockImplementation(async function* () {
+      queryCount++;
+      if (queryCount === 1) {
+        // Producer's only attempt fails this resume. FATAL-class error message so
+        // the retry loop yields immediately — one attempt, deterministic queryCount.
+        throw new Error('producer crashed: provider auth error');
+      }
+      yield { type: 'assistant', content: 'fresh consumer output' };
+      yield { type: 'result', sessionId: 'session-id' };
+    });
+
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun();
+
+    // Producer WAS cached from a prior success with EMPTY output — the exact value
+    // its fresh failure also produces. Consumer was cached too.
+    const priorCompletedNodes = new Map<string, PersistedNodeOutput>([
+      ['producer', { output: '' }],
+      ['consumer', { output: 'STALE_CACHED_CONSUMER' }],
+    ]);
+
+    await executeDagWorkflow(
+      mockDeps,
+      platform,
+      'conv-2705-r1-cached-dep-fresh-fail',
+      testDir,
+      {
+        name: 'stale-cache-cached-dep-fresh-fail',
+        nodes: [
+          { id: 'producer', command: 'producer', always_run: true },
+          {
+            id: 'consumer',
+            command: 'consumer',
+            depends_on: ['producer'],
+            trigger_rule: 'all_done',
+          },
+        ],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      priorCompletedNodes
+    );
+
+    // Producer's failed attempt (1) + consumer invalidated and re-ran (1) = 2. A
+    // regression that judges a previously-cached dep by value alone leaves consumer
+    // prior-skipped and queryCount stuck at 1 — failing.
+    expect(queryCount).toBe(2);
+
+    const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+    const consumerSkippedEvent = eventCalls.find(
+      (call: unknown[]) =>
+        (call[0] as { event_type: string }).event_type === 'node_skipped_prior_success' &&
+        (call[0] as { step_name: string }).step_name === 'consumer'
+    );
+    expect(consumerSkippedEvent).toBeUndefined();
+
     const invalidatedEvent = eventCalls.find(
       (call: unknown[]) =>
         (call[0] as { event_type: string }).event_type === 'node_prior_cache_invalidated' &&

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -7954,17 +7954,20 @@ interface RunLayersContext {
  * `$node.output.field` (the #2637 logical-value surface) are also invalidated
  * when only the structured form changed.
  *
- * Three cases surface a dep as "ran fresh this resume":
+ * A dep currently in `state: 'failed'` is always stale, checked first and
+ * unconditionally — regardless of whether it had a prior cached success. Every
+ * failure arm in the executor returns `output: ''`, so comparing a fresh
+ * failure's value against a prior success's value (cases 2/3 below) can find
+ * them equal and silently miss the failure; a dependency that failed on THIS
+ * resume must never be judged by value equality.
+ *
+ * Past that, three cases surface a dep as "ran fresh this resume":
  *
  * 1. The dep was never in `priorCompletedNodes` at all (never completed in the
  *    prior run, or never reached) and is now `completed` in `nodeOutputs` — it
- *    re-ran this resume with no prior cache to honour. A dep that re-ran and
- *    landed in `state: 'failed'` is treated identically: the cached downstream
- *    carries synthesis built against the prior run's view, and silently
- *    consuming it would report success over a fresh failure (the #2402 bug
- *    surface on the failure path). `'skipped'` is intentionally left out: its
- *    `output: ''` is semantically equivalent to the absent prior, so honouring
- *    the cache is safe.
+ *    re-ran this resume with no prior cache to honour. `'skipped'` is
+ *    intentionally left out: its `output: ''` is semantically equivalent to
+ *    the absent prior, so honouring the cache is safe.
  * 2. The dep's `prior.output` differs from `nodeOutputs.get(dep).output` —
  *    either an `always_run` upstream that re-executed, or any dep the engine
  *    re-ran with new content. The per-layer aggregation is the only writer of
@@ -7977,11 +7980,13 @@ interface RunLayersContext {
  *    JSONB and therefore JSON-serializable; for `undefined` vs absent values,
  *    `JSON.stringify` normalises both to a missing key.
  *
- * Note: the comparison is conservative in one direction — a dep that re-ran
- * with text- and structured-identical output will NOT be flagged. The cached
- * downstream is therefore semantically equivalent to a fresh execution in
- * that case, which is the safe direction to err in (over-run vs. stale
- * success is the bug we're closing).
+ * Note: the value-equality comparison (cases 2/3) is conservative in one
+ * direction — a dep that re-ran with text- and structured-identical output
+ * will NOT be flagged. The cached downstream is therefore semantically
+ * equivalent to a fresh execution in that case, which is the safe direction
+ * to err in (over-run vs. stale success is the bug we're closing). The
+ * failed-state check above is not subject to this leniency: a failure is
+ * never treated as equivalent to the prior success it's compared against.
  */
 function getStaleCachedDependencies(
   node: DagNode,
@@ -7994,15 +7999,20 @@ function getStaleCachedDependencies(
   for (const depId of deps) {
     const prior = priorCompletedNodes.get(depId);
     const current = nodeOutputs.get(depId);
-    // Case 1: dep was never cached; if it is now complete or failed it ran fresh this
-    // resume. `'skipped'` and missing-current (the dep is still pending or running) are
-    // intentionally left out: skipped has `output: ''` semantically equal to the absent
-    // prior, and pending/running cannot reach this helper via the resume-skip arm in
+    // A dep that failed fresh this resume is always stale, checked before — and
+    // independently of — the prior-cache lookup below. See the docstring above.
+    if (current?.state === 'failed') {
+      stale.push(depId);
+      continue;
+    }
+    // Case 1: dep was never cached; if it is now complete it ran fresh this resume.
+    // Missing-current (the dep is still pending or running) is intentionally left out:
+    // pending/running cannot reach this helper via the resume-skip arm in
     // executeDagWorkflow (`priorCompletedNodes?.has(node.id)` only fires when the
     // CONSUMER itself was cached, but its dep would be addressed by case 2/3 once it
     // finishes).
     if (prior === undefined) {
-      if (current?.state === 'completed' || current?.state === 'failed') {
+      if (current?.state === 'completed') {
         stale.push(depId);
       }
       continue;

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -7945,6 +7945,93 @@ interface RunLayersContext {
 }
 
 /**
+ * Return the IDs of `node`'s dependencies whose current `nodeOutputs` value no
+ * longer matches their cached `priorCompletedNodes` snapshot (#2402). A
+ * downstream consumer that is being considered for a prior-success skip is
+ * stale — it was last computed against the prior snapshot, not against the
+ * current `nodeOutputs` — when any of its deps is in this set. The set is
+ * built by comparing text output AND structured output so consumers using
+ * `$node.output.field` (the #2637 logical-value surface) are also invalidated
+ * when only the structured form changed.
+ *
+ * Three cases surface a dep as "ran fresh this resume":
+ *
+ * 1. The dep was never in `priorCompletedNodes` at all (never completed in the
+ *    prior run, or never reached) and is now `completed` in `nodeOutputs` — it
+ *    re-ran this resume with no prior cache to honour.
+ * 2. The dep's `prior.output` differs from `nodeOutputs.get(dep).output` —
+ *    either an `always_run` upstream that re-executed, or any dep the engine
+ *    re-ran with new content. The per-layer aggregation is the only writer of
+ *    `nodeOutputs[dep].output` other than the pre-population loop, so a diff is
+ *    proof of fresh execution.
+ * 3. The dep's `prior.structuredOutput` differs from the current one — a
+ *    subtler staleness that only matters for `$dep.output.field` consumers,
+ *    covered here so a fresh structured value can't slip past a text-stable
+ *    cache. JSON.stringify is sufficient: structured outputs are persisted to
+ *    JSONB and therefore JSON-serializable; for `undefined` vs absent values,
+ *    `JSON.stringify` normalises both to a missing key.
+ *
+ * Note: the comparison is conservative in one direction — a dep that re-ran
+ * with text- and structured-identical output will NOT be flagged. The cached
+ * downstream is therefore semantically equivalent to a fresh execution in
+ * that case, which is the safe direction to err in (over-run vs. stale
+ * success is the bug we're closing).
+ */
+function getStaleCachedDependencies(
+  node: DagNode,
+  nodeOutputs: ReadonlyMap<string, NodeOutput>,
+  priorCompletedNodes: ReadonlyMap<string, PersistedNodeOutput>
+): string[] {
+  const deps = node.depends_on ?? [];
+  if (deps.length === 0) return [];
+  const stale: string[] = [];
+  for (const depId of deps) {
+    const prior = priorCompletedNodes.get(depId);
+    const current = nodeOutputs.get(depId);
+    // Case 1: dep was never cached; if it is now complete it ran fresh this resume.
+    if (prior === undefined) {
+      if (current?.state === 'completed') {
+        stale.push(depId);
+      }
+      continue;
+    }
+    // Case 2: dep's text output differs from the prior snapshot.
+    if (current?.output !== prior.output) {
+      stale.push(depId);
+      continue;
+    }
+    // Case 3: dep's structured value differs even though text did not — only matters
+    // for `$dep.output.field` consumers, but those are exactly the surfaces that would
+    // silently read stale structured data through the cached downstream.
+    const priorStructured = prior.structuredOutput;
+    const currentStructured =
+      current !== undefined && 'structuredOutput' in current ? current.structuredOutput : undefined;
+    if (!structuredOutputsEqual(priorStructured, currentStructured)) {
+      stale.push(depId);
+    }
+  }
+  return stale;
+}
+
+/**
+ * `true` when two structured-output payloads are semantically equal for the
+ * purposes of cache invalidation. JSON.stringify is the comparison because
+ * structured outputs are persisted as JSONB — they are guaranteed JSON-shaped
+ * (objects/arrays/primitives, no cycles, no functions). `undefined` is treated
+ * as the absent payload; an explicit `null` is a real value and is distinct
+ * from absent.
+ */
+function structuredOutputsEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === undefined || b === undefined) return false;
+  try {
+    return JSON.stringify(a) === JSON.stringify(b);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Walk the topological `layers` of a DAG (or subgraph), executing each layer's nodes
  * concurrently, aggregating results into `ctx.nodeOutputs`, and accumulating usage into
  * `ctx`. Stops early (returns) when a between-layer status check sees a non-running run
@@ -8088,50 +8175,101 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
                 });
               // falls through to re-execute the node
             } else if (composedBoundaryDecision === 'run') {
-              getLog().info({ nodeId: node.id }, 'dag.node_skipped_prior_success');
-              await logNodeSkip(logDir, workflowRun.id, node.id, 'prior_success').catch(
-                (err: Error) => {
-                  getLog().warn({ err, nodeId: node.id }, 'dag.node_skip_log_write_failed');
-                }
+              // #2402 — a cached prior-success skip is only safe when every
+              // dependency's current value still matches the prior snapshot.
+              // If any dep re-ran during this resume (e.g. an `always_run: true`
+              // upstream forced a re-execution, or any dep produced fresh
+              // output), the cached value reflects the OLD dep output and would
+              // otherwise report success over stale synthesis. Invalidate and
+              // fall through to a fresh execution instead.
+              const staleDeps = getStaleCachedDependencies(
+                node,
+                ctx.nodeOutputs,
+                priorCompletedNodes
               );
-              deps.store
-                .createWorkflowEvent({
-                  workflow_run_id: workflowRun.id,
-                  event_type: 'node_skipped_prior_success',
-                  step_name: stepNamePrefix + node.id,
-                  data: {
-                    reason: 'prior_success',
-                    node_output: priorCompletedNodes.get(node.id)?.output ?? '',
-                    // Copy the logical value forward (#2637) so a SECOND resume's
-                    // snapshot still sees it — this re-emit is that resume's source.
-                    ...(priorCompletedNodes.get(node.id)?.structuredOutput !== undefined
-                      ? { structured_output: priorCompletedNodes.get(node.id)?.structuredOutput }
-                      : {}),
-                  },
-                })
-                .catch((err: Error) => {
-                  getLog().error(
-                    {
-                      err,
-                      workflowRunId: workflowRun.id,
-                      eventType: 'node_skipped_prior_success',
+              if (staleDeps.length > 0) {
+                const priorOutput = priorCompletedNodes.get(node.id)?.output ?? '';
+                getLog().info(
+                  { nodeId: node.id, invalidatingDeps: staleDeps },
+                  'dag.node_prior_cache_invalidated'
+                );
+                deps.store
+                  .createWorkflowEvent({
+                    workflow_run_id: workflowRun.id,
+                    event_type: 'node_prior_cache_invalidated',
+                    step_name: stepNamePrefix + node.id,
+                    data: {
+                      reason: 'stale_dependency',
+                      invalidating_deps: staleDeps,
+                      prior_output: priorOutput,
+                      // Carry the cached logical value too so the audit log shows
+                      // exactly what was thrown away, matching the text channel
+                      // (#2637).
+                      ...(priorCompletedNodes.get(node.id)?.structuredOutput !== undefined
+                        ? {
+                            prior_structured_output: priorCompletedNodes.get(node.id)
+                              ?.structuredOutput,
+                          }
+                        : {}),
                     },
-                    'workflow_event_persist_failed'
-                  );
+                  })
+                  .catch((err: Error) => {
+                    getLog().error(
+                      {
+                        err,
+                        workflowRunId: workflowRun.id,
+                        eventType: 'node_prior_cache_invalidated',
+                      },
+                      'workflow_event_persist_failed'
+                    );
+                  });
+                // falls through to re-execute the node with fresh dep output
+              } else {
+                getLog().info({ nodeId: node.id }, 'dag.node_skipped_prior_success');
+                await logNodeSkip(logDir, workflowRun.id, node.id, 'prior_success').catch(
+                  (err: Error) => {
+                    getLog().warn({ err, nodeId: node.id }, 'dag.node_skip_log_write_failed');
+                  }
+                );
+                deps.store
+                  .createWorkflowEvent({
+                    workflow_run_id: workflowRun.id,
+                    event_type: 'node_skipped_prior_success',
+                    step_name: stepNamePrefix + node.id,
+                    data: {
+                      reason: 'prior_success',
+                      node_output: priorCompletedNodes.get(node.id)?.output ?? '',
+                      // Copy the logical value forward (#2637) so a SECOND resume's
+                      // snapshot still sees it — this re-emit is that resume's source.
+                      ...(priorCompletedNodes.get(node.id)?.structuredOutput !== undefined
+                        ? { structured_output: priorCompletedNodes.get(node.id)?.structuredOutput }
+                        : {}),
+                    },
+                  })
+                  .catch((err: Error) => {
+                    getLog().error(
+                      {
+                        err,
+                        workflowRunId: workflowRun.id,
+                        eventType: 'node_skipped_prior_success',
+                      },
+                      'workflow_event_persist_failed'
+                    );
+                  });
+                const emitterPrior = getWorkflowEventEmitter();
+                emitterPrior.emit({
+                  type: 'node_skipped',
+                  runId: workflowRun.id,
+                  nodeId: node.id,
+                  nodeName: node.command ?? node.id,
+                  reason: 'prior_success',
                 });
-              const emitterPrior = getWorkflowEventEmitter();
-              emitterPrior.emit({
-                type: 'node_skipped',
-                runId: workflowRun.id,
-                nodeId: node.id,
-                nodeName: node.command ?? node.id,
-                reason: 'prior_success',
-              });
-              // Return the pre-populated output (already in nodeOutputs)
-              return {
-                nodeId: node.id,
-                output: ctx.nodeOutputs.get(node.id) ?? { state: 'skipped' as const, output: '' },
-              };
+                // Return the pre-populated output (already in nodeOutputs)
+                return {
+                  nodeId: node.id,
+                  output: ctx.nodeOutputs.get(node.id) ?? { state: 'skipped' as const, output: '' },
+                };
+              }
             }
           }
 

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -7958,7 +7958,13 @@ interface RunLayersContext {
  *
  * 1. The dep was never in `priorCompletedNodes` at all (never completed in the
  *    prior run, or never reached) and is now `completed` in `nodeOutputs` — it
- *    re-ran this resume with no prior cache to honour.
+ *    re-ran this resume with no prior cache to honour. A dep that re-ran and
+ *    landed in `state: 'failed'` is treated identically: the cached downstream
+ *    carries synthesis built against the prior run's view, and silently
+ *    consuming it would report success over a fresh failure (the #2402 bug
+ *    surface on the failure path). `'skipped'` is intentionally left out: its
+ *    `output: ''` is semantically equivalent to the absent prior, so honouring
+ *    the cache is safe.
  * 2. The dep's `prior.output` differs from `nodeOutputs.get(dep).output` —
  *    either an `always_run` upstream that re-executed, or any dep the engine
  *    re-ran with new content. The per-layer aggregation is the only writer of
@@ -7988,9 +7994,15 @@ function getStaleCachedDependencies(
   for (const depId of deps) {
     const prior = priorCompletedNodes.get(depId);
     const current = nodeOutputs.get(depId);
-    // Case 1: dep was never cached; if it is now complete it ran fresh this resume.
+    // Case 1: dep was never cached; if it is now complete or failed it ran fresh this
+    // resume. `'skipped'` and missing-current (the dep is still pending or running) are
+    // intentionally left out: skipped has `output: ''` semantically equal to the absent
+    // prior, and pending/running cannot reach this helper via the resume-skip arm in
+    // executeDagWorkflow (`priorCompletedNodes?.has(node.id)` only fires when the
+    // CONSUMER itself was cached, but its dep would be addressed by case 2/3 once it
+    // finishes).
     if (prior === undefined) {
-      if (current?.state === 'completed') {
+      if (current?.state === 'completed' || current?.state === 'failed') {
         stale.push(depId);
       }
       continue;

--- a/packages/workflows/src/store.ts
+++ b/packages/workflows/src/store.ts
@@ -58,6 +58,14 @@ export const WORKFLOW_EVENT_TYPES = [
   'node_failed',
   'node_skipped',
   'node_skipped_prior_success',
+  // #2402 — written when a cached prior-success node is invalidated because a
+  // dependency re-executed during the current resume (e.g. an `always_run: true`
+  // upstream, or any dep that re-ran with fresh output). `data.prior_output` is the
+  // stale cached value being thrown away; `data.invalidating_deps` lists the
+  // upstream node ids whose current output no longer matches the prior snapshot.
+  // The audit counterpart to the resume cache invalidation; absence never implies
+  // the cache was honored — a skipped node only writes `node_skipped_prior_success`.
+  'node_prior_cache_invalidated',
   'node_always_run_reset',
   'loop_iteration_started',
   'loop_iteration_completed',


### PR DESCRIPTION
## Problem and outcome

A resumed workflow run that re-executes an upstream producer (e.g. `test-coverage`) silently keeps a downstream consumer's (`synthesize`) prior-success entry in the resume cache, even though the consumer was computed against the OLD producer output. From run `7f392748` in [#2402](https://github.com/coleam00/Archon/issues/2402): the resume executed `test-coverage`, then `node_skipped_prior_success`'d `synthesize`, and the final completion report quoted synthesis that was missing a review the artifact on disk now contained.

- **Outcome:** when a downstream node is in `priorCompletedNodes` and any of its dependencies re-ran during the current resume (text differs, structured value differs, or the dep was not in the prior snapshot and is now complete or failed), the cached entry is invalidated and the node re-executes against the fresh dependency values. A new `node_prior_cache_invalidated` audit event records the invalidating deps and the discarded cached output so the timeline shows exactly why the cache was not honoured.
- **Invariant:** the existing genuine-cache skip (deps unchanged) is unchanged — `node_skipped_prior_success` semantics and the `always_run: true` opt-out both still work. The fix is local to the resume-skip branch in `dag-executor.ts`, plus one supporting fix in `getDagResumeSnapshot` (see "Review round 2" under Validation) — this PR's own invalidate-and-re-execute mechanism is the first thing that can produce a `node_completed → node_failed` sequence for the same step, and that sequence needed to be handled at the snapshot layer too.
- **Scope boundary:** the in-process "ran this resume" detection is derived from a comparison of `priorCompletedNodes` and `nodeOutputs` (which is pre-populated from prior snapshot, then overwritten by per-layer aggregation only). No new persistent state, no new column, no schema migration. The `node_skipped_prior_success` event continues to be the audit signal for the genuine cache case; the new event is the audit signal for the invalidation case only.
- **Root cause:** the resume-skip branch at `packages/workflows/src/dag-executor.ts` keyed solely on `priorCompletedNodes?.has(node.id)` and ignored whether the node's dependencies had re-executed since the cached completion. There is no `node_started`-in-this-resume or completion-generation counter anywhere in the engine, so a diff between the dep's prior snapshot and its current `nodeOutputs` value is the only signal the engine already has without a new persistent state.

## Review guidance

- **Feedback requested:** correctness of the cache-invalidation contract, the audit-event shape (`prior_output` / `prior_structured_output` / `invalidating_deps`), and the conservative comparison (byte-identical re-run is intentionally not flagged as stale). Reviewers should form their own view on whether `Relates to #2402` is the right linkage given the issue comment's reframing (see Links).
- **Start here:** `packages/workflows/src/dag-executor.ts` — `getStaleCachedDependencies` (the new helper) and the modified branch in `runLayers` around the existing `node_skipped_prior_success` arm. The audit-event addition at `packages/workflows/src/store.ts` is a one-line addition to a closed `as const` tuple. Review round 2 also touches `packages/core/src/db/workflow-events.ts` — `getDagResumeSnapshot`'s `node_failed` handling (R2, see Validation).
- **Review order:**
  1. `getStaleCachedDependencies`: the unconditional failed-state check, then the three value-based cases it surfaces (never-prior / text-differs / structured-differs).
  2. The branch in `runLayers`: when `staleDeps.length > 0`, fall through to fresh execution (mirrors the `always_run: true` arm) instead of the skip arm.
  3. The audit event shape and its presence in `WORKFLOW_EVENT_TYPES`.
  4. `getDagResumeSnapshot`'s `node_failed` handling in `packages/core/src/db/workflow-events.ts`.
  5. The seven tests in the `#2402` describe block in `packages/workflows/src/dag-executor.test.ts`, plus the two new tests in `packages/core/src/db/workflow-events.test.ts`.
- **Lower-attention areas:** the existing `node_skipped_prior_success` payload and emit path are unchanged; the `always_run: true` arm upstream of the new branch is unchanged. The new event is filtered out of usage aggregation by virtue of carrying no `node_output` or `cost_usd`.
- **Known risk or uncertainty:** the comparison is intentionally lenient in the "no change" direction — a dep that re-runs with byte-identical text AND structured output is NOT flagged stale. The cached downstream is semantically equivalent in that case (over-run is the safe-but-costly direction to err in, not the cheap-but-wrong one). This is pinned by one of the new tests. If a stricter generation-counter contract is wanted later, that is a separate change.

## Solution

A dep-re-ran check sits between the existing `composedBoundaryDecision === 'run'` branch and the prior-success emit. Before honouring the cache, the engine asks: did any of this node's dependencies produce different output during the current resume? It can answer that without new persistence because `nodeOutputs` is pre-populated from `priorCompletedNodes` and then overwritten by the per-layer aggregation — a diff is proof of fresh execution.

Two helpers carry the comparison:

- `getStaleCachedDependencies` walks `node.depends_on` and returns the subset of dep ids in three states: (1) the dep was never in `priorCompletedNodes` and is now `completed` or `failed`; (2) the dep's text output differs from the prior snapshot; (3) the dep's structured output differs even though text did not (the surface introduced by #2637). Case 3 matters because `$dep.output.field` consumers would otherwise silently read stale structured data through a text-stable cached downstream. `JSON.stringify` is sufficient because structured outputs are persisted to JSONB.
- `structuredOutputsEqual` is the structured comparator — strict-equal for the trivial case, JSON-stringified equal otherwise, with `undefined` normalised to absent.

When any dep is stale, the cached node is invalidated: a `node_prior_cache_invalidated` event is persisted (carrying `invalidating_deps`, `prior_output`, and `prior_structured_output` when set), the log branch writes `dag.node_prior_cache_invalidated`, and execution falls through to a fresh re-execution against the new dep values. When no dep is stale, the existing `node_skipped_prior_success` arm runs untouched.

This is the smallest coherent fix because the engine already carries everything the comparison needs. The main alternative — a per-node completion-generation counter or a per-resume "executed this run" `Set` — would be exactly as ephemeral as `ctx.nodeOutputs`, so it would not actually require new persistence; its real cost is a larger blast radius, since the per-layer aggregation path is shared by every node type's many dispatch return points (bash/script/prompt/command/loop/approval, etc.), and threading a clean "did this node actually dispatch fresh work" signal through all of them is a materially bigger change than the value-diffing approach shipped here — which also still needs the conservative "byte-identical re-run" handling either way.

## Behavior change

| | Before | After |
|---|---|---|
| **Resume with re-ran upstream and cached downstream** | Downstream is `node_skipped_prior_success`'d; the prior (stale) output is repeated verbatim in the run's completion report, which can describe gaps that no longer exist. | Downstream is invalidated: `node_prior_cache_invalidated` is emitted with `invalidating_deps` and `prior_output`, then the downstream re-executes against the fresh dep values. The completion report reflects the new state. |
| **Resume with unchanged deps and cached downstream** | Cached value is reused as before. | Unchanged: the genuine-cache path continues to emit `node_skipped_prior_success` and skip the node. The new branch is consulted only and falls through to the unchanged skip arm. |
| **`always_run: true` nodes** | `node_always_run_reset` is emitted and the node re-runs; downstream consumers are still membership-skipped. | Unchanged for the upstream itself; downstream consumers are now also subject to the dep-re-ran check above, so a consumer over an `always_run: true` producer re-runs against the freshly-reset producer on every resume (the desired behaviour). |

### User flow

```mermaid
flowchart LR
  subgraph Before
    P1[Producer re-runs on resume] --> S1[synthesize skipped via prior_success]
    S1 --> R1[Run reports success over stale synthesis]
  end

  subgraph After
    P2[Producer re-runs on resume] --> C2{Any dep stale vs. prior snapshot?}
    C2 -- Yes --> I2[node_prior_cache_invalidated]
    I2 --> E2[synthesize re-executes against fresh producer]
    E2 --> R2[Run reports correct synthesis]
    C2 -- No --> S2[synthesize skipped via prior_success unchanged]
  end
```

## Architecture

```mermaid
flowchart LR
  A[runLayers resume-skip branch] --> B{priorCompletedNodes.has<br/>and composedBoundaryDecision run}
  B --> C[getStaleCachedDependencies]
  C --> D{any dep differs from<br/>priorCompletedNodes snapshot?}
  D -- Yes --> E[persist node_prior_cache_invalidated<br/>+ fall through to fresh execute]
  D -- No --> F[emit node_skipped_prior_success<br/>and reuse cache unchanged]
  E --> G[executeNodeInternal / executeBashNode / etc.]
  F --> H[Continued layered walk]
  G --> H
```

The `priorCompletedNodes` snapshot read at `packages/core/src/db/workflow-events.ts` gained one targeted fix (review round 2, R2 — see Validation); the engine does not gain a "ran in this resume" persistent set. The new event matches `node_skipped_prior_success`'s shape on the discard side (`prior_output` / `prior_structured_output`) so a future #2393 audit that pairs cache events with their invalidations can render them adjacently without a per-event special case.

### Changed seams

| Boundary or contract | Change | Evidence |
|---|---|---|
| Resume-skip membership check (consumer-of-prior-output) | New dep-staleness check before the skip arm; invalidates and re-executes when any dep changed. | `packages/workflows/src/dag-executor.ts` `getStaleCachedDependencies` + `runLayers`; `executeDagWorkflow -- prior-success cache invalidated by dep re-execution (#2402)` describe block in `packages/workflows/src/dag-executor.test.ts`. |
| `WORKFLOW_EVENT_TYPES` | Added `node_prior_cache_invalidated`. | `packages/workflows/src/store.ts`; closed `as const` tuple so `createWorkflowEvent` and the CLI's event-type validator cover it. |
| `priorCompletedNodes` snapshot read | `getDagResumeSnapshot` now deletes a step's `completedNodeOutputs` entry when a later `node_failed` row lands for that same step, so a later failure supersedes an earlier completion instead of being silently outvoted by it (review round 2, R2). | `packages/core/src/db/workflow-events.ts`. |
| `node_skipped_prior_success` semantics for the genuine cache case | Unchanged. | Same emit path; payload unchanged. |
| `always_run: true` arm | Unchanged. | Still emits `node_always_run_reset` upstream of the new check. |
| `node_output` / usage aggregation | Unchanged. | The new event carries no `node_output` or `cost_usd`, so it filters out of usage totals by construction. |
| UI event mapping (`packages/web/src/experiments/console/primitives/event.ts`) | Unchanged. | The new event is an audit signal, not a UI transition; `node_started` / `node_completed` / `node_failed` follow when the node actually re-executes. |

## Validation

- `bun test packages/workflows/src/dag-executor.test.ts` — **590 pass, 0 fail** (583 pre-existing + 7 in the `#2402` describe block, one added in review round 2). The describe block `executeDagWorkflow -- prior-success cache invalidated by dep re-execution (#2402)`:
  - `invalidates a cached downstream when an always_run dep re-runs with fresh output` — bug-shape reproducer; verifies the consumer sees the fresh producer output, that no `node_skipped_prior_success` is emitted for the consumer, and that `node_prior_cache_invalidated` carries `invalidating_deps: ['producer']` and the discarded `prior_output`.
  - `does NOT invalidate when a cached dep actually re-runs and produces text-identical output` — pins the conservative comparison contract with a dep that genuinely re-executes (`always_run: true`) and lands identical output; the consumer stays cached and no invalidation event fires. (Rewritten in review round 2 — R3: the original version's producer had no `depends_on` and was itself skipped via the ordinary prior-cache path, so the comparison it claimed to pin was never reached.)
  - `invalidates a cached downstream when a dep that was never cached completes fresh this resume` — covers case 1 of `getStaleCachedDependencies`.
  - `invalidates a cached downstream when a dep that re-ran fresh failed (case 1 "failed" arm)` — the dep had NO prior cache entry and fails fresh this resume.
  - `invalidates a cached downstream when a PREVIOUSLY-CACHED dep fails fresh with output matching its prior success (#2705 R1)` — new in review round 2. The dep WAS cached from a prior success whose output was `''`, and fails fresh this resume with the same `''` output (the shape every failure arm in the executor produces) — pins that a fresh failure is never masked by value equality against a prior success.
  - `invalidates when a dep's structured output changes even though text is stable` — covers case 3; pins that `prior_structured_output` is populated.
  - `invalidates a cached downstream when ONE of its multiple deps re-ran (any-stale triggers re-execution)` — pins the "any stale dep invalidates" trigger for cached consumers with ≥ 2 deps; verifies `invalidating_deps` lists only the actually-stale deps (length 1, not 2) and that the stable sibling still emits `node_skipped_prior_success`.
- `bun test packages/core/src/db/workflow-events.test.ts` — **34 pass, 0 fail**, including two new tests added in review round 2 (R2): a `node_completed → node_failed` sequence for the same step no longer leaves the stale completion in `completedNodeOutputs`, and the symmetric `node_failed → node_completed` sequence still honours the later success (no permanent tombstone).
- `bun run --filter @archon/workflows test` (full package suite) — exit code 0.
- `bun run --filter @archon/core test` (full package suite) — exit code 0.
- `bun run type-check` — all packages pass.
- `bun run lint` — clean.
- `bun run format:check` — clean.

Pre-existing cross-file mock-pollution issues (e.g. `subrun.test.ts` together with `dag-executor.test.ts` produces failures that also reproduce on the unmodified `dev`) are not caused by this change; `CONTRIBUTING.md` already documents `bun run test` for isolation, and each affected file passes 100% when run on its own.

- **Not verified:** No live reproduction of run `7f392748` end-to-end; the fix is proven against current code via fixtures in the same describe block as the existing `always_run` opt-out tests, but is not regressed through a real LangSmith / production trace. Nothing material in the closure of the dep-re-ran surface requires that.

### Review round 2 (2026-08-22)

[prp-review](https://github.com/coleam00/Archon/pull/2705#issuecomment-5379798172) returned NEEDS FIXES against `ba1de703`, with two blocking findings (five independent reviewers converged on R1; two independently reproduced both R1 and R2 against the live head):

- **R1 (blocking, fixed):** `getStaleCachedDependencies` only re-checked a dependency's terminal *state* when that dependency had no prior cache entry at all. Once a dependency WAS cached — the ordinary shape for an `always_run: true` gate on a second-or-later resume — staleness was judged purely by output-value equality, and every failure arm in the executor returns `output: ''`. A dependency that succeeded with `''` and then genuinely failed on this resume with `''` again looked unchanged, so its cached downstream was skipped via `node_skipped_prior_success` before `checkTriggerRule` ever ran. Fixed by hoisting a `current?.state === 'failed'` check to run unconditionally, before the prior-cache lookup, in `getStaleCachedDependencies` (`packages/workflows/src/dag-executor.ts`).
- **R2 (blocking, fixed):** `getDagResumeSnapshot` (outside this PR's original diff, but newly reachable because of it) never cleared an earlier `node_completed` map entry when a later `node_failed` row landed for the same step. Before this PR, a non-`always_run` node that had already completed could never be re-attempted, so that sequence was impossible; this PR's own invalidate-and-re-execute mechanism is the first thing that can produce it. Fixed by deleting the step's `completedNodeOutputs` entry when a `node_failed` row is processed (`packages/core/src/db/workflow-events.ts`).
- **R3 (non-blocking, fixed):** the "does NOT invalidate... identical output" test's producer never actually re-executed, so the conservative contract it claimed to pin was never reached. Rewritten so the producer is `always_run: true` and genuinely re-runs with identical output.
- **R4 (non-blocking, fixed):** corrected the Solution section's inaccurate claim that the rejected "executed this run" `Set` alternative "would require new persistence" — it would be exactly as ephemeral as `ctx.nodeOutputs`; the real cost is the blast radius of threading a new signal through every node type's dispatch return points.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | None. No new persisted state, no migration, no event-name schema change for events other than the additive `node_prior_cache_invalidated`. | `packages/workflows/src/store.ts` is an additive change to a closed tuple. |
| Security / permissions / data | None. The change reads only what `priorCompletedNodes` and `nodeOutputs` already carry; no new process boundary, no new I/O. | Helper is a pure local function over the existing context maps. |
| Rollout / rollback | Reverse-merge is safe: removing the helper call restores the prior behaviour exactly. The new event type would then stop being persisted; downstream consumers that filter by `node_skipped_prior_success` are unaffected. | One branch in `runLayers`; one helper. |
| Observability | A new audit event (`node_prior_cache_invalidated`) carries `invalidating_deps`, `prior_output`, and `prior_structured_output`. When #2393 (workflow_events schema audit) lands, this event is the concrete "show the discarded cache next to the fresh completion" hook. Filtered out of usage totals by carrying no `node_output` or `cost_usd`. | `packages/workflows/src/store.ts`; `packages/workflows/src/dag-executor.ts` invalidation branch. |
| Documentation / communication | None required for this PR. #2327 remains the upstream root for the case where `priorCompletedNodes` itself contains a false `node_completed`; #2393 remains the substrate to measure cache-invalidation frequency. Both are independent of this change. | Per the issue comment and the triage notes in the run record. |

## Links

- Related #2402
- Related #2327 — a node that reports itself blocked is recorded `node_completed`. Per the issue comment, #2402 is downstream of #2327: this PR closes the dep-re-ran amplifier surface in #2402 (a producer that genuinely re-runs with new output invalidates the consumer's cache). It does not address the #2327 case where a producer was falsely recorded `node_completed` in a prior attempt and therefore never re-runs. That remains a separate decision.
- Related #2393 — workflow_events schema audit. The new `node_prior_cache_invalidated` event is sized to pair with `node_skipped_prior_success` so the audit can render cache invalidations next to cache honours.
- Related #2637 — value transport. The case-3 detection in `getStaleCachedDependencies` exists because `$dep.output.field` consumers would otherwise silently read stale structured data through a text-stable cache.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved workflow resume behavior by re-running previously successful steps when dependencies or outputs have changed.
  - Added tracking for invalidated cached steps, including affected dependencies and prior output details.
  - Preserved structured output when safely skipping cached steps.

- **Bug Fixes**
  - Prevented stale cached results from being reused after dependency updates or failures.
  - Ensured downstream prompts and results are refreshed when upstream data changes.
  - Corrected resume handling so later failures remove earlier success states, while subsequent successes restore them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

