### PR TITLE
fix(workflows): a failed loop_group's binding now fails its consumer

### DIFF
--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -945,8 +945,9 @@ binding, producer, and fix named — a binding never silently resolves to `''`.
 **failed** always fails the binding too, whether or not `if_skipped` is declared — a
 `loop_group`'s failure paths in particular can leave real, non-empty output behind (its last
 completed iteration's text), so this is an explicit check, not an accident of empty output.
-Declaring `if_skipped` never papers over a real failure; guard the consumer with `when:`
-instead if it should tolerate that branch.
+There is no way to opt a binding out of this: declaring `if_skipped` never papers over a real
+failure, and `when:` cannot substitute for it either — it reads the same output text, which is
+indistinguishable from a success for a `loop_group` that failed mid-run.
 
 Two guarantees the loader enforces: every bound producer must be reachable through
 `depends_on` (a binding can never race its producer), and two binding names may not fold to

--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -941,6 +941,13 @@ is the [constitution's](/reference/workflow-language-constitution/) YAML-coordin
 code-computes split. A skipped producer with **no** `if_skipped` fails the node with the
 binding, producer, and fix named — a binding never silently resolves to `''`.
 
+`if_skipped` only ever covers a producer that **did not run**. A producer that ran and
+**failed** always fails the binding too, whether or not `if_skipped` is declared — a
+`loop_group`'s failure paths in particular can leave real, non-empty output behind (its last
+completed iteration's text), so this is an explicit check, not an accident of empty output.
+Declaring `if_skipped` never papers over a real failure; guard the consumer with `when:`
+instead if it should tolerate that branch.
+
 Two guarantees the loader enforces: every bound producer must be reachable through
 `depends_on` (a binding can never race its producer), and two binding names may not fold to
 the same `INPUTS_*` env key. At runtime, node-local bindings are the **nearest** input

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -25427,4 +25427,168 @@ describe('value transport (#2637): persistence, resume, and node-local bindings'
     await runDag(deliverWorkflow('iteration'), 'transport-deliver-iteration');
     expect(checkPrompts).toEqual(['joined [initial=false|iteration=true]']);
   });
+
+  // --- loop_group producer bindings, the real deliver topology (#2696) ---
+  //
+  // `deliver`'s `gate-ready` binds `{ from: '$corrections.output', if_skipped: null }`
+  // on a `loop_group` (not a plain node), joined via `trigger_rule: all_done`. Three
+  // cases: the group completes, the group is skipped, and the group fails. All three
+  // build the same shape — a bash-only `corrections` loop_group feeding a `gate-ready`
+  // script node — so each test constructs its own `nodes` array inline rather than a
+  // shared builder, keeping every producer state (completed/skipped/failed) visible at
+  // its call site.
+
+  it("loop_group binding (#2696): a completed group's output resolves through an all_done join, not the if_skipped default", async () => {
+    const nodes: DagNode[] = [
+      dagNodeSchema.parse({
+        id: 'corrections',
+        loop_group: {
+          until_bash: 'exit 0',
+          max_iterations: 1,
+          fresh_context: false,
+          nodes: [{ id: 'apply', bash: "printf 'CORRECTIONS_APPLIED'", depends_on: [] }],
+        },
+        depends_on: [],
+      }),
+      dagNodeSchema.parse({
+        id: 'gate-ready',
+        script: 'console.log(process.env.INPUTS_CORRECTIONS);',
+        runtime: 'bun',
+        depends_on: ['corrections'],
+        trigger_rule: 'all_done',
+        with: {
+          corrections: { from: '$corrections.output', if_skipped: 'NO_CORRECTIONS_RAN' },
+        },
+      }),
+    ];
+
+    const result = await executeDagWorkflow(
+      createMockDeps(),
+      createMockPlatform(),
+      'conv-lg-binding',
+      testDir,
+      { name: 'lg-binding-completed', nodes },
+      makeWorkflowRun('lg-binding-completed'),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    // The group's real whole-ref output resolved — the `if_skipped` default never fired.
+    expect(result).toBe('CORRECTIONS_APPLIED');
+  });
+
+  it("loop_group binding (#2696): a skipped group's binding takes if_skipped", async () => {
+    const nodes: DagNode[] = [
+      dagNodeSchema.parse({ id: 'gate', bash: "printf 'skip'", depends_on: [] }),
+      dagNodeSchema.parse({
+        id: 'corrections',
+        loop_group: {
+          until_bash: 'exit 0',
+          max_iterations: 1,
+          fresh_context: false,
+          nodes: [{ id: 'apply', bash: "printf 'CORRECTIONS_APPLIED'", depends_on: [] }],
+        },
+        depends_on: ['gate'],
+        when: "$gate.output == 'run'",
+      }),
+      dagNodeSchema.parse({
+        id: 'gate-ready',
+        script: 'console.log(process.env.INPUTS_CORRECTIONS);',
+        runtime: 'bun',
+        depends_on: ['corrections'],
+        trigger_rule: 'all_done',
+        with: {
+          corrections: { from: '$corrections.output', if_skipped: 'NO_CORRECTIONS_RAN' },
+        },
+      }),
+    ];
+
+    const result = await executeDagWorkflow(
+      createMockDeps(),
+      createMockPlatform(),
+      'conv-lg-binding',
+      testDir,
+      { name: 'lg-binding-skipped', nodes },
+      makeWorkflowRun('lg-binding-skipped'),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    // The group never ran — the binding took its declared default, unchanged by #2696.
+    expect(result).toBe('NO_CORRECTIONS_RAN');
+  });
+
+  it("loop_group binding (#2696): a failed group's binding fails the consumer instead of resolving stale output", async () => {
+    // Reproduces run 6607bf20 (issue #2696): the group fails via max_iterations
+    // exhaustion, but its one completed iteration left real, non-empty output behind
+    // (captured as `lastIterationOutput` before the completion check that then failed).
+    // Before the fix, `gate-ready` would resolve that stale text as if the group had
+    // succeeded and run its own body on it — the split-brain that flipped PR #2705.
+    const markerPath = join(testDir, 'gate-ready-ran.marker');
+
+    const nodes: DagNode[] = [
+      dagNodeSchema.parse({
+        id: 'corrections',
+        loop_group: {
+          until_bash: 'exit 1',
+          max_iterations: 1,
+          fresh_context: false,
+          nodes: [{ id: 'apply', bash: "printf 'CORRECTIONS_APPLIED'", depends_on: [] }],
+        },
+        depends_on: [],
+      }),
+      dagNodeSchema.parse({
+        id: 'gate-ready',
+        // A stand-in for `flip-ready`'s real public write: proves whether the
+        // consumer's own body ever ran, independent of the run's overall status.
+        script: `require('fs').writeFileSync(${JSON.stringify(markerPath)}, process.env.INPUTS_CORRECTIONS ?? '');`,
+        runtime: 'bun',
+        depends_on: ['corrections'],
+        trigger_rule: 'all_done',
+        with: {
+          corrections: { from: '$corrections.output', if_skipped: null },
+        },
+      }),
+    ];
+
+    const platform = createMockPlatform();
+    await executeDagWorkflow(
+      createMockDeps(),
+      platform,
+      'conv-lg-binding',
+      testDir,
+      { name: 'lg-binding-failed', nodes },
+      makeWorkflowRun('lg-binding-failed'),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    // gate-ready's body never executed — no public-write consequence from a failed group.
+    expect(await Bun.file(markerPath).exists()).toBe(false);
+
+    // The failure names both the failed producer and the node whose binding rejected it.
+    const sent = (platform.sendMessage as Mock<(...args: unknown[]) => Promise<void>>).mock.calls
+      .map(c => String(c[1]))
+      .join('\n');
+    expect(sent).toContain("Node 'gate-ready'");
+    expect(sent).toContain("'corrections' failed");
+  });
 });

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -429,6 +429,20 @@ function resolveBindingDirective(
         `guard '${consumerId}' with a 'when:' condition.`
     );
   }
+  // A failed producer never falls back to `if_skipped` (#2696): that default exists for
+  // a branch that legitimately didn't run, not for a run that ran and produced a result
+  // that can't be trusted (a loop_group's failure paths carry the last completed
+  // iteration's real output text — non-empty, often valid JSON — which would otherwise
+  // resolve here as if the group had succeeded).
+  if (producer.state === 'failed') {
+    throw new Error(
+      `Node '${consumerId}' binding '${name}' reads '${directive.from}', but node ` +
+        `'${ref.nodeId}' failed (${producer.error}), so its output cannot be trusted. ` +
+        "A binding never falls back to 'if_skipped' for a failed producer — fix the " +
+        `failure, or guard '${consumerId}' with a 'when:' condition that excludes the ` +
+        'failed branch.'
+    );
+  }
   return wholeRefLogicalValue(producer, ref.nodeId, ref.field);
 }
 

--- a/packages/workflows/src/dry-run.test.ts
+++ b/packages/workflows/src/dry-run.test.ts
@@ -1459,6 +1459,38 @@ describe('dryRunWorkflow — node-local with: bindings (#2637)', () => {
     expect(result.outcome).toBe('completed');
     expect(result.trace.find(t => t.nodeId === 'gate')?.output).toBe('ready=false');
   });
+
+  test('a directive on a failed producer fails the consumer, never taking if_skipped (#2696)', async () => {
+    // Preview and the real run share resolveNodeBindings (see this file's docblock),
+    // so the failed-producer guard added for #2696 must behave identically here.
+    const workflow = makeTestWorkflow({
+      name: 'binding-failed',
+      nodes: [
+        { id: 'corrections', bash: 'echo boom >&2; exit 1' },
+        {
+          id: 'gate-ready',
+          script: 'console.log(`ready=${process.env.INPUTS_READY ?? "unset"}`)',
+          runtime: 'bun' as const,
+          depends_on: ['corrections'],
+          trigger_rule: 'all_done' as const,
+          with: { ready: { from: '$corrections.output', if_skipped: 'default' } },
+        },
+      ],
+    });
+
+    const result = await dryRunWorkflow({
+      workflow,
+      userMessage: '',
+      cwd: process.cwd(),
+      execCode: true,
+    });
+
+    expect(result.outcome).toBe('failed');
+    const gate = result.trace.find(t => t.nodeId === 'gate-ready');
+    // The binding rejected the failed producer outright — it never took if_skipped's default.
+    expect(gate?.state).toBe('failed');
+    expect(gate?.reason).toContain("'corrections' failed");
+  });
 });
 
 describe('dryRunWorkflow — effective provider/model per node', () => {


### PR DESCRIPTION
## Problem and outcome

A `{ from: '$node.output', if_skipped }` binding directive on a failed producer resolved instead of failing. For a plain node this rarely showed up, since ordinary failure paths return `output: ''` and the binding's fielded reads accidentally choke on the empty string — but a `loop_group`'s failure paths (body-node failure, `max_iterations` exhaustion, cancellation) all preserve the last completed iteration's real, non-empty output text. A binding joined via `trigger_rule: all_done` onto a failed `loop_group` therefore silently resolved that stale text as if the group had succeeded, and the consumer ran its own body on it.

This reproduced live (issue #2696, run `6607bf20`): a corrections `loop_group` failed after its recheck lenses exhausted retries under provider rate-limiting. The downstream `gate-ready` script node — bound via `{ from: '$corrections.output', if_skipped: null }` — resolved against the failed group's stale output, inferred `ready:true`, and a later `flip-ready` node flipped a PR to ready with its final correction commit unreviewed, while the workflow run itself finished `failed`. A split-brain terminal: the run reported failure, but a public, hard-to-reverse side effect fired anyway.

- **Outcome:** A binding on a failed producer — plain node or `loop_group` — now always fails the consuming node. `if_skipped` never applies to a failed producer, regardless of what text happens to be stored as its output.
- **Invariant:** `resolveBindingDirective` never returns a value, real or defaulted, for a producer whose state is `'failed'`.
- **Scope boundary:** No change to `wholeRefLogicalValue`, `resolveNodeOutputField`, the plain-string whole-ref tier of `resolveWorkflowValue`, `checkTriggerRule`'s `all_done` semantics, or how a `loop_group`'s failure paths compute their stored output. Those are separate, unrequested surfaces.
- **Root cause:** `resolveBindingDirective`'s only state guard checked `undefined | 'skipped' | 'pending'`; `'failed'` fell through to an unconditional value lookup with no state check at all.

## Review guidance

- **Feedback requested:** Correctness of the new guard's placement and error message; whether the marker-file idiom in the third test is a convincing proxy for "the consumer's real body never ran."
- **Start here:** `packages/workflows/src/dag-executor.ts:433` — the new `producer.state === 'failed'` branch, the entire fix.
- **Review order:** `dag-executor.ts` (the fix) → `dag-executor.test.ts`, the three new tests immediately after the "deliver pattern (PR #2627)" test (search `#2696`).
- **Lower-attention areas:** None — this is a two-file, single-behavior change.
- **Known risk or uncertainty:** None.

## Solution

One explicit branch in `resolveBindingDirective`, ordered after the existing skipped/pending guard and before the value lookup: if the producer's state is `'failed'`, throw unconditionally, naming both the failed producer and its real error. The branch applies uniformly to any producer type — no `loop_group`-specific code — because the existing bug was never about `loop_group` specifically, only exposed by it (a `loop_group`'s failure paths happen to leave real output text behind, where a plain node's usually don't).

Three tests build the real `deliver` topology — a bash-only `corrections` loop_group feeding a `gate-ready` script consumer joined via `all_done` — across all three producer states the issue named: completed (resolves to the real output), skipped (takes the declared default), and failed (fails the consumer, whose body never executes). The failed-group test is the reproduction: temporarily reverting the fix makes it fail exactly as run `6607bf20` did (the consumer's marker-file write happens), confirming it is a real regression guard.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | A binding on a failed `loop_group` resolved its last-completed-iteration output as if the group had succeeded; the consumer ran normally. | A binding on a failed producer (any node type) always throws; the consumer never runs its body. |
| **Failure behavior** | Silent: the consumer succeeded on stale data, and only the unrelated `loop_group` node showed as failed. | Explicit: the consumer itself fails, with an error naming the failed producer and its cause. |

## Validation

- `bun test src/dag-executor.test.ts -t "loop_group binding \(#2696\)"` (from `packages/workflows/`) — 3 pass, 0 fail — proves all three cases.
- Regression check: stashed the fix and reran the same three tests — case 3 failed (`Expected: false / Received: true`, the marker file existed), cases 1 and 2 still passed. Confirms the third test is a genuine guard, not vacuous, and that the fix doesn't change already-correct behavior.
- `bun test src/dag-executor.test.ts` (full file) — 586 pass, 0 fail — no regressions in the existing suite.
- `bun --filter @archon/workflows test` — exit code 0, every constituent suite `0 fail`.
- `bun run validate` — exit code 0. Type-check, lint (`--max-warnings 0`), format, the full per-package test suite, build, and all `check:bundled*`/`check:pi-vendor-map`/`check:capability-matrix` generators all passed; 148 individual `bun test` invocations across the monorepo each reported `0 fail`.
- **Not verified:** A real-run reproduction on top of the fix (rerunning the sdlc pack's `deliver` workflow through the exact `6607bf20` failure shape) — outside this PR's scope, which is engine-level coverage; the issue's own dogfood evidence already established the completed/skipped cases empirically, and the fix directly targets the diagnosed code path.

## Links

- Closes #2696
- Plan: https://github.com/coleam00/Archon/issues/2696#issuecomment-5379799060


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Failed workflow producers now correctly block dependent steps instead of being treated as skipped.
  * Prevents downstream steps from consuming invalid output from failed producers, including failed loop groups.
  * Added coverage for completed, skipped, and failed loop-group scenarios, including dry runs.

* **Documentation**
  * Clarified that `if_skipped` applies only when a producer does not run; producer failures always fail dependent bindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->