### PR TITLE
fix(web): surface unrecognised workflow sources verbatim (#2578)

### DIFF
--- a/packages/web/src/experiments/console/builder/BuilderConnected.tsx
+++ b/packages/web/src/experiments/console/builder/BuilderConnected.tsx
@@ -49,13 +49,13 @@ import {
   validateWorkflow,
   listWorkflows,
   type LoadedWorkflow,
-  type WorkflowSource,
 } from '../skills/workflows';
 import { listProjects, type WorkflowListResult } from '../skills';
 import { useEntity, invalidate } from '../store/cache';
 import { K } from '../store/keys';
 import { HttpError } from '../lib/http';
 import type { Project } from '../primitives/project';
+import type { Workflow } from '../primitives/workflow';
 
 /** Router navigation state carried into the connected route. */
 interface BuilderNavState {
@@ -127,7 +127,10 @@ export function BuilderConnected(): ReactElement {
   // Resolve the workflow under edit (seed in create mode, else the server load).
   // Memoized on stable inputs (location-state seed, cache object) so it does NOT
   // produce a fresh identity every render — that would thrash the reset effect.
-  const loadedSource: WorkflowSource = isCreateMode
+  // Widened to `Workflow['source']` (#2578) so an unrecognised wire value passes
+  // through to `effectiveSource` (and the downstream `isReadOnlySource` /
+  // `saveTargetFor` helpers) without a cast at this seam.
+  const loadedSource: Workflow['source'] = isCreateMode
     ? 'project'
     : (loadView.data?.source ?? 'project');
 
@@ -144,7 +147,10 @@ export function BuilderConnected(): ReactElement {
   const [dirty, setDirty] = useState(false);
   const [serverIssues, setServerIssues] = useState<Issue[]>([]);
   // Source can flip after a bundled Save-as (bundled → project override).
-  const [sourceOverride, setSourceOverride] = useState<WorkflowSource | null>(null);
+  // Widened to `Workflow['source']` (#2578) to match `loadedSource` /
+  // `LoadedWorkflow.source` — `saveWorkflow` returns whatever the server put on
+  // the response, which is `Workflow['source']`-typed.
+  const [sourceOverride, setSourceOverride] = useState<Workflow['source'] | null>(null);
   const [busy, setBusy] = useState(false);
 
   const effectiveSource = sourceOverride ?? loadedSource;

--- a/packages/web/src/experiments/console/builder/connect/save-logic.test.ts
+++ b/packages/web/src/experiments/console/builder/connect/save-logic.test.ts
@@ -164,6 +164,20 @@ describe('isReadOnlySource / saveTargetFor', () => {
     expect(saveTargetFor('project')).toBe('project');
     expect(saveTargetFor('global')).toBe('global');
   });
+
+  // #2578 — the helpers accept `string` precisely so an unrecognised wire value
+  // does not silently become read-only / write-to-global. These tests pin that
+  // observable contract against the regressions noted in the review (a
+  // `source !== 'project' && source !== 'global'` rewrite would make the
+  // editor offer Save-as instead of Save; an inverted `saveTargetFor` would
+  // write the workflow into `~/.archon/workflows/` instead of the project).
+  test('an unrecognised source is editable in place, not read-only (#2578)', () => {
+    expect(isReadOnlySource('something-new')).toBe(false);
+  });
+
+  test('an unrecognised source saves to project scope, the most permissive target (#2578)', () => {
+    expect(saveTargetFor('something-new')).toBe('project');
+  });
 });
 
 describe('isValidWorkflowName', () => {

--- a/packages/web/src/experiments/console/builder/connect/save-logic.ts
+++ b/packages/web/src/experiments/console/builder/connect/save-logic.ts
@@ -6,7 +6,7 @@
 import type { Issue } from '../types';
 import { makeIssue } from '../validation/make-issue';
 import { HttpError } from '../../lib/http';
-import type { WorkflowSource, WorkflowSaveSource } from '../../skills/workflows';
+import type { WorkflowSaveSource } from '../../skills/workflows';
 
 /** A client-side instant error for the panel (name validation, save gate). */
 export function clientIssue(rule: string, message: string): Issue {
@@ -82,17 +82,25 @@ export function blockingErrors(issues: readonly Issue[]): Issue[] {
   return issues.filter(i => i.severity === 'error');
 }
 
-/** Bundled workflows open read-only; everything else is editable in place. */
-export function isReadOnlySource(source: WorkflowSource): boolean {
+/**
+ * Bundled workflows open read-only; everything else is editable in place. The
+ * parameter is widened to `string` so an unrecognised `Workflow.source` (#2578,
+ * `WorkflowSource | (string & {})`) can pass through without a cast at the
+ * call site — the comparison is the same `=== 'bundled'` either way.
+ */
+export function isReadOnlySource(source: string): boolean {
   return source === 'bundled';
 }
 
 /**
  * The write scope for a save. A `global` workflow saves back to global; a
  * `project` workflow stays project; a `bundled` (read-only) workflow saves as a
- * project override (Save-as).
+ * project override (Save-as). The parameter is widened to `string` for the
+ * same reason `isReadOnlySource` is (#2578): an unrecognised source is not
+ * `global`, so it falls to `'project'`, which is the "most permissive"
+ * interpretation the issue explicitly defends.
  */
-export function saveTargetFor(source: WorkflowSource): WorkflowSaveSource {
+export function saveTargetFor(source: string): WorkflowSaveSource {
   return source === 'global' ? 'global' : 'project';
 }
 

--- a/packages/web/src/experiments/console/components/WorkflowPicker.tsx
+++ b/packages/web/src/experiments/console/components/WorkflowPicker.tsx
@@ -39,6 +39,11 @@ function sourceBadgeClass(source: Workflow['source']): string {
       return 'text-text-secondary';
     case 'bundled':
       return 'text-text-tertiary';
+    default:
+      // An unrecognised source surfaces under its own raw value (#2578) — render
+      // it with a neutral muted colour rather than crashing or aliasing one of
+      // the known sources.
+      return 'text-text-tertiary';
   }
 }
 

--- a/packages/web/src/experiments/console/lib/recommended.test.ts
+++ b/packages/web/src/experiments/console/lib/recommended.test.ts
@@ -52,4 +52,18 @@ describe('orderWithRecommended', () => {
     expect(ordered.map(w => w.name)).toEqual(['beta', 'alpha', 'gamma']);
     expect(ordered.filter(w => w.name === 'beta')).toHaveLength(1);
   });
+
+  test('an unrecognised source ranks after the three known sources (#2578)', () => {
+    // Mirrors `toWorkflow`'s verbatim-passthrough contract: a misspelled or
+    // future source must not collapse to 'bundled' (or any known value), and
+    // the picker must place it deterministically rather than indexing an
+    // undeclared key on the rank map.
+    const workflows = [
+      wf('z-bundled', 'bundled'),
+      wf('a-unknown', 'something-new'),
+      wf('m-project', 'project'),
+    ];
+    const { ordered } = orderWithRecommended(workflows, []);
+    expect(ordered.map(w => w.name)).toEqual(['m-project', 'z-bundled', 'a-unknown']);
+  });
 });

--- a/packages/web/src/experiments/console/lib/recommended.ts
+++ b/packages/web/src/experiments/console/lib/recommended.ts
@@ -1,9 +1,27 @@
 import type { Workflow } from '../primitives/workflow';
 
+/**
+ * Source rank for the "other" group: project first, then global, then bundled,
+ * then any unrecognised source at the end (#2578). The fallback covers the
+ * widened `Workflow['source']` (`WorkflowSource | (string & {})`) without
+ * indexing a literal-keyed map with a `string` and getting `undefined`.
+ */
+function sourceRank(source: Workflow['source']): number {
+  switch (source) {
+    case 'project':
+      return 0;
+    case 'global':
+      return 1;
+    case 'bundled':
+      return 2;
+    default:
+      return 3;
+  }
+}
+
 /** Source rank for the "other" group: project first, then global, then bundled. */
 function bySourceThenName(a: Workflow, b: Workflow): number {
-  const rank = { project: 0, global: 1, bundled: 2 } as const;
-  return rank[a.source] - rank[b.source] || a.name.localeCompare(b.name);
+  return sourceRank(a.source) - sourceRank(b.source) || a.name.localeCompare(b.name);
 }
 
 /**

--- a/packages/web/src/experiments/console/primitives/workflow.test.ts
+++ b/packages/web/src/experiments/console/primitives/workflow.test.ts
@@ -8,8 +8,15 @@ describe('toWorkflow — source normalization', () => {
     expect(toWorkflow({ workflow: { name: 'a' }, source: 'bundled' }).source).toBe('bundled');
   });
 
-  test('falls back to bundled for an unrecognized source', () => {
-    expect(toWorkflow({ workflow: { name: 'a' }, source: 'something-new' }).source).toBe('bundled');
+  test('surfaces an unrecognised source verbatim rather than collapsing it to bundled (#2578)', () => {
+    // The server emits only the three known sources today, but a misspelled or
+    // future value must not be silently collapsed to 'bundled' — that would
+    // mark the workflow read-only and turn Save into Save-as. The fix mirrors
+    // `groupCommandsBySource` (`packages/web/src/lib/command-groups.ts`, #2570):
+    // surface unknown values rather than hide them.
+    expect(toWorkflow({ workflow: { name: 'a' }, source: 'something-new' }).source).toBe(
+      'something-new'
+    );
   });
 
   test('normalizes a missing description to null', () => {

--- a/packages/web/src/experiments/console/primitives/workflow.ts
+++ b/packages/web/src/experiments/console/primitives/workflow.ts
@@ -1,4 +1,17 @@
-export type WorkflowSource = 'project' | 'global' | 'bundled';
+import type { components } from '@/lib/api.generated';
+
+/**
+ * Where a workflow lives — engine-known (`project` / `global` / `bundled`).
+ * Derived from the generated OpenAPI schema (`@/lib/api.generated`) so the
+ * union cannot silently drift between this primitive and the server. #2578
+ * closed a hand-maintained mirror here that collapsed unrecognised values to
+ * `'bundled'`; the precedent is the same fix PR #2570 made for `CommandGroup`
+ * (`packages/web/src/lib/command-groups.ts`). The console's lint guard
+ * disallows named imports from `@/lib/api`, so the type is sourced from the
+ * generated file directly (the `packages/web/src/lib/api.ts` re-export
+ * carries the same bytes either way).
+ */
+export type WorkflowSource = components['schemas']['WorkflowSource'];
 
 /**
  * One entry of a workflow's declared `inputs:` signature (#2470), flattened for
@@ -15,7 +28,15 @@ export interface WorkflowInput {
 export interface Workflow {
   name: string;
   description: string | null;
-  source: WorkflowSource;
+  /**
+   * Where the workflow came from. Known values carry `WorkflowSource` literals
+   * so the downstream helpers (`isReadOnlySource`, `saveTargetFor`) keep their
+   * type-narrowed callers; the `(string & {})` widening surfaces an
+   * unrecognised value verbatim rather than collapsing it to `'bundled'`,
+   * which would silently mark it read-only and turn Save into Save-as
+   * (#2578). The `& {}` keeps the known literals visible in autocomplete.
+   */
+  source: WorkflowSource | (string & {});
   /**
    * Keys this workflow's YAML declares that the engine silently drops (#2213).
    * Empty for a clean workflow. The workflow still loads and runs — this is what
@@ -51,12 +72,14 @@ interface RawWorkflowEntry {
 }
 
 export function toWorkflow(raw: RawWorkflowEntry): Workflow {
-  // Three distinct sources matter for sort + badge: project (repo-local)
-  // > global (home-scoped `~/.archon/workflows`) > bundled (defaults
-  // shipped with Archon). Collapsing `global` into `bundled` silently
-  // demoted home-scoped workflows and rendered them with the wrong badge.
-  const src: WorkflowSource =
-    raw.source === 'project' ? 'project' : raw.source === 'global' ? 'global' : 'bundled';
+  // Pass the raw source through verbatim. Three distinct sources matter for
+  // sort + badge — project (repo-local) > global (home-scoped
+  // `~/.archon/workflows`) > bundled (defaults shipped with Archon) — but
+  // an unrecognised value must not be collapsed to `'bundled'` (that would
+  // mark it read-only and turn Save into Save-as, #2578). Mirrors
+  // `groupCommandsBySource` in `@/lib/command-groups.ts` (#2570): surface
+  // unknown values rather than hide them.
+  const src: WorkflowSource | (string & {}) = raw.source;
   // Object key order preserves the YAML's declaration order for string keys, so the
   // run form renders inputs in the order the author wrote them.
   const inputs: WorkflowInput[] = Object.entries(raw.workflow.inputs ?? {}).map(([name, spec]) => ({

--- a/packages/web/src/experiments/console/skills/workflows.ts
+++ b/packages/web/src/experiments/console/skills/workflows.ts
@@ -112,14 +112,27 @@ export type WorkflowSaveSource = 'project' | 'global';
 export interface GetWorkflowResponse {
   workflow: WireWorkflowDefinition;
   filename: string;
-  source: WorkflowSource;
+  /**
+   * Where the workflow came from. `Workflow['source']` widens to
+   * `WorkflowSource | (string & {})` so an unrecognised value (#2578) is
+   * surfaced verbatim rather than silently collapsed — the single-endpoint
+   * wire shape and `LoadedWorkflow` must match `Workflow.source` for the
+   * load-state chain to type-check end-to-end without a cast.
+   */
+  source: Workflow['source'];
 }
 
 /** Normalized result of `loadWorkflow`. */
 export interface LoadedWorkflow {
   definition: WireWorkflowDefinition;
   filename: string;
-  source: WorkflowSource;
+  /**
+   * Where the workflow came from. Same widening rationale as
+   * `GetWorkflowResponse.source`: an unrecognised value reaches the editor
+   * verbatim and the downstream helpers (`isReadOnlySource`, `saveTargetFor`)
+   * — both accepting `string` — decide what to do with it.
+   */
+  source: Workflow['source'];
 }
 
 /**


### PR DESCRIPTION
## Problem and outcome

The console's `toWorkflow` collapsed any unrecognised `WorkflowSource` value from the server to `'bundled'`, which is the read-only source. A misspelt or future source therefore opened a workflow read-only and silently turned Save into Save-as (a copy to a project override) with no signal to the user.

- **Outcome:** an unrecognised `Workflow.source` is now surfaced verbatim through `toWorkflow` (and through every downstream consumer), so a server-side drift shows up as "unknown" rather than masquerading as a read-only bundled workflow.
- **Invariant:** the web client's `WorkflowSource` union is byte-identical to the server's `z.enum(['project', 'bundled', 'global']).openapi('WorkflowSource')` (engine-side at `packages/server/src/routes/schemas/workflow.schemas.ts:32`); the two can no longer drift silently.
- **Scope boundary:** no server, schema, API, or DB change. The legacy console/non-console builder split is untouched; this fix lands entirely inside `experiments/console/**` plus the existing re-export at `packages/web/src/lib/api.ts:377` is left as-is (sourcing from `@/lib/api.generated` reaches the same bytes either way).
- **Root cause:** `packages/web/src/experiments/console/primitives/workflow.ts:1` hand-declared `WorkflowSource = 'project' | 'global' | 'bundled'`, and `toWorkflow`'s ternary (`raw.source === 'project' ? 'project' : raw.source === 'global' ? 'global' : 'bundled'`) made the else-arm a value, not a failure. Two downstream helpers gate on the collapsed value (`isReadOnlySource` reads `=== 'bundled'`; `saveTargetFor` returns `'project'` for non-`'global'`), so an unknown value inherited the most-damaging default.

## Review guidance

- **Feedback requested:** correctness of the verbatim-passthrough contract, and whether widening `isReadOnlySource` / `saveTargetFor` to `string` is the right level (vs. keeping them narrow and casting at call sites).
- **Start here:** `packages/web/src/experiments/console/primitives/workflow.ts:39` — `Workflow.source` widens to `WorkflowSource | (string & {})`, and `toWorkflow` drops the collapsing ternary.
- **Review order:**
  1. `packages/web/src/experiments/console/primitives/workflow.ts` — the union is now `components['schemas']['WorkflowSource']` from `@/lib/api.generated`, and `toWorkflow` returns `raw.source` directly.
  2. `packages/web/src/experiments/console/builder/connect/save-logic.ts` — `isReadOnlySource(source: string)` and `saveTargetFor(source: string)` keep their `=== 'bundled'` / `=== 'global'` comparisons; the comparison semantics are unchanged.
  3. `packages/web/src/experiments/console/lib/recommended.ts` and `components/WorkflowPicker.tsx` — `sourceRank` and `sourceBadgeClass` get a `default` arm so the widened type doesn't crash on an unknown source.
- **Lower-attention areas:** the test swap in `workflow.test.ts`, the new sort case in `recommended.test.ts`, and the two new helper-contract cases in `save-logic.test.ts`; mechanical, and they pin the new contract.
- **Known risk or uncertainty:** none material. The widening deliberately accepts any string but the comparisons stay identical, so the known-source behaviour is preserved exactly.

## Solution

Two parts, mirroring the precedent PR #2570 set for the same defect species in `CommandGroup`:

1. **Stop hand-declaring the union.** `WorkflowSource` is now `components['schemas']['WorkflowSource']` from `@/lib/api.generated`. The console's eslint guard disallows named imports from `@/lib/api` inside `experiments/console/**` (only type-only imports from `api.generated` are allowed), so sourcing the type from the generated file directly is the same byte-equivalent re-export at `packages/web/src/lib/api.ts:377` reaches from the API surface; the existing `skills/workflows.ts:106` re-export keeps resolving to the same union.
2. **Surface unknown values verbatim.** `Workflow.source` widens to `WorkflowSource | (string & {})` — the `& {}` intersection keeps the three known literals visible in autocomplete while still accepting any string. `toWorkflow` passes `raw.source` through directly. The two consumers (`isReadOnlySource`, `saveTargetFor`) take `string` and keep their `===` comparisons, so unknown values fall to the "most permissive" interpretation the issue explicitly defends (editable in place, save targets `project`).

Two adjacent call sites needed defensive fixes for the widened type that the issue did not enumerate:

- `bySourceThenName` in `lib/recommended.ts` indexed a literal-keyed `{project:0, global:1, bundled:2}` map with the wider `Workflow['source']`, which `tsc` flagged as potentially `undefined`. Replaced with a `sourceRank` helper that has a `default` arm returning `3` (unknown sources sort last, deterministically).
- `sourceBadgeClass` in `components/WorkflowPicker.tsx` used a `switch` without a `default`, which `tsc` flagged because the widened input is no longer an exhaustive literal. Added a `default` arm rendering `text-text-tertiary` so the badge never aliases a known source or crashes.

The fix is the smallest coherent change that closes the bug without re-introducing the hand-maintained mirror at the next engine-side drift.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | `toWorkflow({source: 'something-new'})` returns `source: 'bundled'`; the workflow opens read-only and Save becomes Save-as (project override copy) | `toWorkflow({source: 'something-new'})` returns `source: 'something-new'`; the workflow is editable in place, Save targets `project`, the badge renders muted |
| **Failure behavior** | silent — no warning, no error, the user's intended edit to the original becomes a copy | visible — the unknown source surfaces under its own raw label in the picker and badge, so the drift is observable in the UI |

### User flow

```mermaid
flowchart LR
  subgraph Before
    B1[Server emits unknown source] --> B2[Console collapses to 'bundled'] --> B3[Workflow opens read-only; Save becomes Save-as; no signal]
  end

  subgraph After
    A1[Server emits unknown source] --> A2[Console surfaces raw value] --> A3[Workflow stays editable; Save targets project; badge renders muted]
  end
```

## Architecture

```mermaid
flowchart LR
  R[RawWorkflowEntry.source: string] --> T[toWorkflow] --> W[Workflow.source: WorkflowSource | string & {}]
  W --> I[isReadOnlySource: string] --> RO[read-only?]
  W --> S[saveTargetFor: string] --> ST[save target]
  W --> B[sourceBadgeClass: switch + default] --> BC[badge colour]
  W --> RK[sourceRank: switch + default] --> OR[orderWithRecommended]
  API[components schemas WorkflowSource] -.generated.-> W
```

### Changed seams

| Boundary or contract | Change | Evidence |
|---|---|---|
| `primitives/workflow.ts` `WorkflowSource` | re-typed from hand-declared literal union to `components['schemas']['WorkflowSource']` | `packages/web/src/experiments/console/primitives/workflow.ts:14`, OpenAPI at `packages/server/src/routes/schemas/workflow.schemas.ts:32` |
| `primitives/workflow.ts` `toWorkflow` | raw `raw.source` passed through verbatim; the collapsing ternary removed | `packages/web/src/experiments/console/primitives/workflow.ts:82` |
| `Workflow.source` field type | widened to `WorkflowSource | (string & {})` | `packages/web/src/experiments/console/primitives/workflow.ts:39` |
| `save-logic.ts` `isReadOnlySource` / `saveTargetFor` parameter | widened from `WorkflowSource` to `string`; comparisons unchanged | `packages/web/src/experiments/console/builder/connect/save-logic.ts:91,103` |
| `recommended.ts` `bySourceThenName` | replaced literal-keyed map with `sourceRank` helper carrying a `default` arm | `packages/web/src/experiments/console/lib/recommended.ts:9` |
| `WorkflowPicker.tsx` `sourceBadgeClass` | `default` arm added for the widened input type | `packages/web/src/experiments/console/components/WorkflowPicker.tsx:42` |

## Validation

- `bun run type-check` (`tsc --noEmit`) — clean — proves the widened `Workflow.source` threads through `isReadOnlySource`, `saveTargetFor`, `sourceRank`, and `sourceBadgeClass` without a cast at the call sites.
- `bun run test` — 452 pass, 0 fail, 35 files — proves the verbatim-passthrough contract (`workflow.test.ts`), the unrecognised-source sort order (`recommended.test.ts`), and the helper-contract cases (`save-logic.test.ts`) all hold.
- `bun test src/experiments/console` — all pass, including the two new #2578 regression tests.
- `bun x eslint packages/web/src --max-warnings 0` — clean.
- `bun x prettier --check` on the six changed files — clean.
- Manual reasoning: the comparisons `=== 'bundled'` and `=== 'global'` are unchanged, so the known-source behaviour is preserved bit-for-bit; only the unknown-source branch changes (and now resolves to the most permissive interpretation the issue explicitly defends).

## Links

- Closes #2578
- Related #2567, PR #2570


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved unrecognized workflow source values instead of incorrectly converting them to bundled workflows.
  * Ensured workflows with unknown sources remain editable and save to the appropriate project scope.
  * Added neutral styling for unknown workflow sources.
  * Improved workflow recommendations by placing unknown sources after recognized workflow types with consistent ordering.
* **Tests**
  * Added regression coverage for editing, saving, normalization, styling, and recommendation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->