### PR TITLE
fix(workflows): a faulted codebase lookup no longer pins a run to an empty fallback location

### DIFF
--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -162,7 +162,7 @@ import { keepAwake } from './utils/keep-awake';
 import type { WorkflowDeps, IWorkflowPlatform, WorkflowConfig } from './deps';
 import type { IWorkflowStore } from './store';
 import type { WorkflowDefinition, WorkflowRun, WorkflowRunNodeSession } from './schemas';
-import { workflowDefinitionSchema } from './schemas';
+import { RUN_METADATA_KEYS, workflowDefinitionSchema } from './schemas';
 
 // --- Helpers ---
 
@@ -1782,6 +1782,95 @@ describe('executeWorkflow', () => {
       expect(msg).toContain('Wait for it to finish');
     });
   });
+
+  // #2304 — the persistence block must distinguish three `identityResolution` outcomes:
+  //   • 'faulted'      → skip the `output_root` write, stamp the metadata flag
+  //                      (`metadata.identity_unresolved = true`). The row keeps
+  //                      `output_root` NULL so a later resume can self-heal.
+  //   • 'unregistered' → cwd fallback IS the correct location for this row;
+  //                      persist `output_root` exactly as before.
+  //   • 'resolved'     → repo/folder/_local key; persist `output_root` as before.
+  describe('output_root persistence branching (#2304)', () => {
+    it('does NOT write output_root when identityResolution is "faulted"; stamps the metadata flag instead', async () => {
+      const updateSpy = mock(async () => {});
+      const store = makeStore({
+        // Both attempts throw — the retry yields the same fault.
+        getCodebase: mock(async () => {
+          throw new Error('db down');
+        }),
+        updateWorkflowRun: updateSpy,
+      });
+      const deps = makeDeps(store);
+
+      await executeWorkflow(
+        deps,
+        makePlatform(),
+        'conv-1',
+        '/repos/widget',
+        makeWorkflow(),
+        'test',
+        'db-conv-1',
+        { codebaseId: 'cb-boom' }
+      );
+
+      const writesWithOutputRoot = updateSpy.mock.calls.filter(
+        (call: unknown[]) => typeof (call[1] as { output_root?: unknown })?.output_root === 'string'
+      );
+      expect(writesWithOutputRoot).toHaveLength(0);
+
+      const flagWrite = updateSpy.mock.calls.find(
+        (call: unknown[]) =>
+          (call[1] as { metadata?: Record<string, unknown> })?.metadata?.[
+            RUN_METADATA_KEYS.identityUnresolved
+          ] === true
+      );
+      expect(flagWrite).toBeDefined();
+      // The patch must not also write `output_root` — a NULL `output_root`
+      // means a later resume can still self-heal.
+      const patch = (flagWrite as unknown as [unknown, { output_root?: unknown }] | undefined)?.[1];
+      expect(patch?.output_root).toBeUndefined();
+    });
+
+    it('persists output_root when identityResolution is "resolved" (a registered codebase)', async () => {
+      const updateSpy = mock(async () => {});
+      const store = makeStore({
+        getCodebase: mock(async () => ({
+          id: 'cb-repo',
+          name: 'acme/widget',
+          repository_url: 'https://github.com/acme/widget',
+          default_cwd: '/repos/widget',
+          kind: 'repo' as const,
+        })),
+        updateWorkflowRun: updateSpy,
+      });
+      const deps = makeDeps(store);
+
+      await executeWorkflow(
+        deps,
+        makePlatform(),
+        'conv-1',
+        '/repos/widget',
+        makeWorkflow(),
+        'test',
+        'db-conv-1',
+        { codebaseId: 'cb-repo' }
+      );
+
+      const write = updateSpy.mock.calls.find(
+        (call: unknown[]) => typeof (call[1] as { output_root?: unknown })?.output_root === 'string'
+      );
+      expect(write).toBeDefined();
+      // The metadata flag must NOT be stamped on a resolved row — that flag is the
+      // faulted-only signal.
+      const flagWrite = updateSpy.mock.calls.find(
+        (call: unknown[]) =>
+          (call[1] as { metadata?: Record<string, unknown> })?.metadata?.[
+            RUN_METADATA_KEYS.identityUnresolved
+          ] !== undefined
+      );
+      expect(flagWrite).toBeUndefined();
+    });
+  });
 });
 
 describe('finally backstop', () => {
@@ -2513,6 +2602,115 @@ describe('resolveProjectPaths', () => {
     });
 
     expect(result.outputRoot).toBe(wsPath('acme', 'widget'));
+  });
+
+  // #2304: identityResolution is the row-level flag the persistence block reads to
+  // decide whether to write `output_root` or stamp `metadata.identity_unresolved`.
+  // The five cases below cover every branch in `resolveProjectPaths`:
+  //   • registered repo / folder / _local  → 'resolved'
+  //   • codebase row exists, no identity   → 'unregistered' (the WARN arm)
+  //   • no codebaseId                      → 'unregistered' (no lookup attempted)
+  //   • codebase lookup returns null       → 'unregistered' (no row)
+  //   • both attempts throw                → 'faulted' (the ERROR arm)
+  //   • persisted-output-root short-circuit → undefined (a resume, no fresh flag)
+  describe('identityResolution (#2304)', () => {
+    it('is "resolved" for a repo codebase', async () => {
+      const store = makeStore({
+        getCodebase: mock(async () => ({
+          id: 'cb-repo',
+          name: 'acme/widget',
+          repository_url: 'https://github.com/acme/widget',
+          default_cwd: '/repos/widget',
+          kind: 'repo' as const,
+        })),
+      });
+      const deps = makeDeps(store);
+
+      const result = await resolveProjectPaths(deps, '/repos/widget', RUN_ID, 'cb-repo');
+
+      expect(result.identityResolution).toBe('resolved');
+    });
+
+    it('is "resolved" for a folder codebase', async () => {
+      const store = makeStore({
+        getCodebase: mock(async () => ({
+          id: 'cb-folder',
+          name: 'My Platform',
+          repository_url: null,
+          default_cwd: '/tmp/platform',
+          kind: 'folder' as const,
+        })),
+      });
+      const deps = makeDeps(store);
+
+      const result = await resolveProjectPaths(deps, '/tmp/platform', RUN_ID, 'cb-folder');
+
+      expect(result.identityResolution).toBe('resolved');
+    });
+
+    it('is "unregistered" when the lookup returns a codebase row that resolves to a cwd key (WARN arm)', async () => {
+      // The fake resolver only falls back to { kind: 'cwd', cwd } when the basename
+      // is '.' or '..' (the corner that excludes owner/repo and `_local` derivation).
+      const store = makeStore({
+        getCodebase: mock(async () => ({
+          id: 'cb-noop',
+          name: 'orphan',
+          repository_url: null,
+          default_cwd: '/tmp/.',
+          kind: 'repo' as const,
+        })),
+      });
+      const deps = makeDeps(store);
+
+      const result = await resolveProjectPaths(deps, '/tmp/.', RUN_ID, 'cb-noop');
+
+      expect(result.identityResolution).toBe('unregistered');
+    });
+
+    it('is "unregistered" when no codebaseId is provided (no lookup attempted)', async () => {
+      const deps = makeDeps();
+
+      const result = await resolveProjectPaths(deps, '/some/cwd', RUN_ID);
+
+      expect(result.identityResolution).toBe('unregistered');
+    });
+
+    it('is "unregistered" when the lookup returns null (no codebase row)', async () => {
+      const store = makeStore({ getCodebase: mock(async () => null) });
+      const deps = makeDeps(store);
+
+      const result = await resolveProjectPaths(deps, '/some/cwd', RUN_ID, 'missing-id');
+
+      expect(result.identityResolution).toBe('unregistered');
+    });
+
+    it('is "faulted" when both getCodebase attempts throw (ERROR arm)', async () => {
+      const store = makeStore({
+        getCodebase: mock(async () => {
+          throw new Error('db down');
+        }),
+      });
+      const deps = makeDeps(store);
+
+      const result = await resolveProjectPaths(deps, '/some/cwd', RUN_ID, 'cb-boom');
+
+      expect(result.identityResolution).toBe('faulted');
+    });
+
+    it('is undefined on the persisted-output-root short-circuit (resume reading an existing row)', async () => {
+      // A resume reads its `output_root` from the row and re-derives nothing; the
+      // persistence block has nothing to flag on a branch that never resolved.
+      const store = makeStore();
+      const deps = makeDeps(store);
+
+      const result = await resolveProjectPaths(deps, '/repos/widget', RUN_ID, 'cb-repo', {
+        persistedOutputRoot: wsPath('acme', 'original'),
+      });
+
+      expect(result.identityResolution).toBeUndefined();
+      // The resolved paths still come from the persisted root, not from a fresh lookup.
+      expect(result.outputRoot).toBe(wsPath('acme', 'original'));
+    });
   });
 });
 

--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -1870,6 +1870,100 @@ describe('executeWorkflow', () => {
       );
       expect(flagWrite).toBeUndefined();
     });
+
+    // #2304 — the contract is "Cleared by the same persistence block the moment
+    // a later resume writes a real root". The faulted arm stamps `true`; the
+    // else arm MUST ride the same atomic metadata write with `false` on the
+    // heal, or a row that has resolved leaves the flag set and the
+    // state-preflight gate (#2200) / maintainer-triage read it as still faulted.
+    it('clears metadata.identity_unresolved when a faulted row heals (resolved on resume)', async () => {
+      const updateSpy = mock(async () => {});
+      const store = makeStore({
+        getCodebase: mock(async () => ({
+          id: 'cb-repo',
+          name: 'acme/widget',
+          repository_url: 'https://github.com/acme/widget',
+          default_cwd: '/repos/widget',
+          kind: 'repo' as const,
+        })),
+        updateWorkflowRun: updateSpy,
+        // Simulate a previously-faulted row whose first run left `output_root`
+        // NULL and stamped the flag. The next run arrives on a healthy registry
+        // and hits the else-arm with that pre-existing metadata.
+        createWorkflowRun: mock(async () =>
+          makeRun({
+            metadata: { [RUN_METADATA_KEYS.identityUnresolved]: true },
+          })
+        ),
+      });
+      const deps = makeDeps(store);
+
+      await executeWorkflow(
+        deps,
+        makePlatform(),
+        'conv-1',
+        '/repos/widget',
+        makeWorkflow(),
+        'test',
+        'db-conv-1',
+        { codebaseId: 'cb-repo' }
+      );
+
+      const healWrite = updateSpy.mock.calls.find(
+        (call: unknown[]) => typeof (call[1] as { output_root?: unknown })?.output_root === 'string'
+      );
+      expect(healWrite).toBeDefined();
+      const patch = (
+        healWrite as unknown as
+          | [unknown, { output_root?: unknown; metadata?: Record<string, unknown> }]
+          | undefined
+      )?.[1];
+      // The output_root write still happens — a row that has resolved
+      // gets a real root, that's the whole point of the resume.
+      expect(typeof patch?.output_root).toBe('string');
+      // AND the metadata flag rides the same write as `false`, not as
+      // the stale `true` from the faulted arm.
+      expect(patch?.metadata).toEqual({ [RUN_METADATA_KEYS.identityUnresolved]: false });
+    });
+
+    // Defensive neighbour: a row that never was faulted must not have its
+    // metadata touched by the else-arm writer. The cleared-flag stamp is
+    // conditional, not unconditional.
+    it('does not touch metadata when the row was never flagged as faulted', async () => {
+      const updateSpy = mock(async () => {});
+      const store = makeStore({
+        getCodebase: mock(async () => ({
+          id: 'cb-repo',
+          name: 'acme/widget',
+          repository_url: 'https://github.com/acme/widget',
+          default_cwd: '/repos/widget',
+          kind: 'repo' as const,
+        })),
+        updateWorkflowRun: updateSpy,
+        createWorkflowRun: mock(async () => makeRun({ metadata: {} })),
+      });
+      const deps = makeDeps(store);
+
+      await executeWorkflow(
+        deps,
+        makePlatform(),
+        'conv-1',
+        '/repos/widget',
+        makeWorkflow(),
+        'test',
+        'db-conv-1',
+        { codebaseId: 'cb-repo' }
+      );
+
+      const outputRootWrite = updateSpy.mock.calls.find(
+        (call: unknown[]) => typeof (call[1] as { output_root?: unknown })?.output_root === 'string'
+      );
+      expect(outputRootWrite).toBeDefined();
+      const patch = (
+        outputRootWrite as unknown as [unknown, { metadata?: Record<string, unknown> }] | undefined
+      )?.[1];
+      expect(patch?.metadata).toBeUndefined();
+    });
   });
 });
 

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -28,6 +28,7 @@ import {
   isRunBlockedOnChild,
   SUBRUN_METADATA_KEYS,
   readSubrunMetadata,
+  RUN_METADATA_KEYS,
   WORKFLOW_SOURCE_METADATA_KEY,
   readWorkflowSourceState,
 } from './schemas';
@@ -305,6 +306,25 @@ export interface ResolvedProjectPaths {
   stateDir: string;
   /** The project root persisted to `workflow_runs.output_root`. */
   outputRoot: string;
+  /**
+   * How the run's project identity was determined (#2304). Three states; collapsing
+   * any two is a correctness bug:
+   *  - `'resolved'`     — `getCodebase` returned a row whose identity resolves to a
+   *                      repo / folder / `_local` key.
+   *  - `'unregistered'` — `getCodebase` returned a row, but no owner/repo nor a
+   *                      `_local` identity could be derived from it; the run still
+   *                      gets external storage, keyed on cwd (`codebase_project_identity_unresolved`
+   *                      WARN). This is a legitimate outcome of a registered codebase,
+   *                      NOT a fault.
+   *  - `'faulted'`      — `getCodebase` threw on BOTH retry attempts; the run fell
+   *                      through to the cwd fallback (`project_paths_resolve_failed_using_fallback`
+   *                      ERROR). The persistence block must NOT write `output_root`
+   *                      for these runs — see `executeWorkflow`.
+   *
+   * Undefined on the persisted-`output_root` short-circuit branch (a resume reading
+   * an existing root re-derives nothing and there is nothing to flag).
+   */
+  identityResolution?: 'resolved' | 'unregistered' | 'faulted';
 }
 
 /**
@@ -356,13 +376,16 @@ export async function resolveProjectPaths(
   }
 
   let key: archonPaths.ProjectStorageKey | undefined;
+  let identityResolution: 'resolved' | 'unregistered' | 'faulted' | undefined;
   if (codebaseId) {
     // Retried once (#2304). A failing lookup drops the run onto the `_cwd/<basename>`
-    // pseudo-project, and because `output_root` is write-once that location is then
-    // pinned for the run's whole life — including its `$STATE_DIR`, so a stateful
-    // workflow silently reads an empty state directory. Failing the run instead was
-    // considered and rejected: the fallback exists precisely because a registry blip
-    // must not kill a run.
+    // pseudo-project. The fallback itself stays — a registry blip must not kill a run.
+    // What changed is what happens to the row afterwards: a faulted run no longer
+    // has its fault-derived location PERSISTED as `output_root` (so the rename hazard
+    // #1192 protects stays scoped to rows with real roots), and the run carries
+    // `metadata.identity_unresolved = true` so "unregistered" and "we could not tell"
+    // are distinguishable after the fact. See the persistence block in `executeWorkflow`
+    // and `ResolvedProjectPaths.identityResolution`.
     //
     // What the retry is worth, honestly, differs by dialect:
     //   • Postgres — it earns its place. A stale or broken pooled connection is exactly
@@ -374,19 +397,17 @@ export async function resolveProjectPaths(
     //     contention have already elapsed, so what reaches us is by construction not
     //     transient, and retrying at that instant retries the moment least likely to
     //     have cleared. Kept because it costs one attempt and cannot make things worse.
-    //
-    // The deeper question — whether an unresolved identity should be recorded on the
-    // row so "unregistered" and "we could not tell" are distinguishable — stays open
-    // in #2304.
     for (let attempt = 0; attempt < 2; attempt++) {
       try {
         const codebase = await deps.store.getCodebase(codebaseId);
         if (codebase) {
           key = archonPaths.resolveProjectStorageKey(codebase, cwd);
+          identityResolution = key.kind === 'cwd' ? 'unregistered' : 'resolved';
           if (key.kind === 'cwd') {
             // The codebase exists but neither an owner/repo nor a _local identity
             // could be derived from it — the run still gets external storage, but
-            // keyed on the working directory rather than the project.
+            // keyed on the working directory rather than the project. NOT a fault;
+            // the persistence block writes the cwd fallback as `output_root` here.
             getLog().warn(
               { codebaseName: codebase.name, cwd: codebase.default_cwd },
               'codebase_project_identity_unresolved'
@@ -402,6 +423,7 @@ export async function resolveProjectPaths(
           );
           continue;
         }
+        identityResolution = 'faulted';
         getLog().error(
           { err: error as Error, codebaseId, cwd },
           'project_paths_resolve_failed_using_fallback'
@@ -410,10 +432,20 @@ export async function resolveProjectPaths(
     }
   }
 
-  return composeRunPaths(
-    archonPaths.getProjectStoragePaths(key ?? { kind: 'cwd', cwd }),
-    workflowRunId
-  );
+  // When the lookup returned null (no codebase row) or no `codebaseId` was provided,
+  // `key` is undefined and the cwd fallback is used. Both are legitimate — neither is
+  // a fault — so they read as `'unregistered'`. A `'faulted'` outcome overrides this.
+  if (identityResolution === undefined) {
+    identityResolution = 'unregistered';
+  }
+
+  return {
+    ...composeRunPaths(
+      archonPaths.getProjectStoragePaths(key ?? { kind: 'cwd', cwd }),
+      workflowRunId
+    ),
+    identityResolution,
+  };
 }
 
 /** Project-level roots → the run-scoped view the executor threads downstream. */
@@ -2009,13 +2041,10 @@ export async function executeWorkflow(
 
   // Resolve external artifact, log, and state directories. A resumed run
   // carries its `output_root` and short-circuits identity resolution entirely.
-  const { artifactsDir, logDir, artifactsRoot, stateDir, outputRoot } = await resolveProjectPaths(
-    deps,
-    cwd,
-    workflowRun.id,
-    codebaseId,
-    { persistedOutputRoot: workflowRun.output_root }
-  );
+  const { artifactsDir, logDir, artifactsRoot, stateDir, outputRoot, identityResolution } =
+    await resolveProjectPaths(deps, cwd, workflowRun.id, codebaseId, {
+      persistedOutputRoot: workflowRun.output_root,
+    });
 
   // Record the resolved root ONCE, so every later reader (artifact routes, CLI)
   // addresses this run's output by a durable pointer instead of re-deriving it
@@ -2023,20 +2052,56 @@ export async function executeWorkflow(
   // overwritten — a resumed run already has one, and the store additionally
   // enforces write-once via COALESCE.
   //
+  // Faulted-identity exception (#2304): when `resolveProjectPaths` returned the
+  // cwd fallback BECAUSE both `getCodebase` attempts threw (not because a registered
+  // codebase simply lacked an owner/repo or `_local` identity), the cwd location is
+  // fault-shaped — persisting it here would pin this run's `output_root` AND
+  // `$STATE_DIR` to that empty, fault-derived tree for the run's whole life. We
+  // instead leave `output_root` NULL and stamp `metadata.identity_unresolved = true`,
+  // so:
+  //   • a later resume re-derives once the registry is healthy and the
+  //     `!workflowRun.output_root` guard above writes the now-correct root;
+  //   • the state-preflight gate (#2200), maintainer-triage, and anyone reading the
+  //     row can tell "unregistered" apart from "we could not tell";
+  //   • the write-once invariant is preserved everywhere else (a row with a
+  //     resolved or unregistered identity is still protected across a #1192
+  //     rename — only the empty faulted shape is scoped differently).
+  //
   // A failure here is NOT retried: the guard is `if (!output_root)`, so this run
   // keeps a NULL pointer for its whole lifetime and permanently stays on the
   // re-derive path — the exact orphaning #1192 makes possible. It does not
   // justify failing an otherwise healthy run (re-derivation works today), but it
   // is a durable per-run degradation, so it logs at ERROR rather than WARN.
   if (!workflowRun.output_root) {
-    await deps.store
-      .updateWorkflowRun(workflowRun.id, { output_root: outputRoot })
-      .catch((err: Error) => {
-        getLog().error(
-          { err, workflowRunId: workflowRun.id, outputRoot },
-          'workflow.output_root_persist_failed'
+    if (identityResolution === 'faulted') {
+      workflowRun.metadata = {
+        ...workflowRun.metadata,
+        [RUN_METADATA_KEYS.identityUnresolved]: true,
+      };
+      try {
+        await deps.store.updateWorkflowRun(workflowRun.id, {
+          metadata: { [RUN_METADATA_KEYS.identityUnresolved]: true },
+        });
+      } catch (err) {
+        getLog().warn(
+          { err: err as Error, workflowRunId: workflowRun.id },
+          'workflow.identity_unresolved_flag_persist_failed'
         );
-      });
+      }
+      getLog().warn(
+        { workflowRunId: workflowRun.id, outputRoot },
+        'workflow.output_root_not_persisted_identity_faulted'
+      );
+    } else {
+      await deps.store
+        .updateWorkflowRun(workflowRun.id, { output_root: outputRoot })
+        .catch((err: Error) => {
+          getLog().error(
+            { err, workflowRunId: workflowRun.id, outputRoot },
+            'workflow.output_root_persist_failed'
+          );
+        });
+    }
   }
 
   // Detect (never move) legacy repo-local `.archon/` output directories. State was a

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -29,6 +29,7 @@ import {
   SUBRUN_METADATA_KEYS,
   readSubrunMetadata,
   RUN_METADATA_KEYS,
+  readIdentityUnresolved,
   WORKFLOW_SOURCE_METADATA_KEY,
   readWorkflowSourceState,
 } from './schemas';
@@ -2093,14 +2094,22 @@ export async function executeWorkflow(
         'workflow.output_root_not_persisted_identity_faulted'
       );
     } else {
-      await deps.store
-        .updateWorkflowRun(workflowRun.id, { output_root: outputRoot })
-        .catch((err: Error) => {
-          getLog().error(
-            { err, workflowRunId: workflowRun.id, outputRoot },
-            'workflow.output_root_persist_failed'
-          );
-        });
+      const updates: Parameters<typeof deps.store.updateWorkflowRun>[1] = {
+        output_root: outputRoot,
+      };
+      // The faulted arm stamped `identity_unresolved = true`; this is the heal
+      // half of the same write — once a later resume's identity lookup succeeds,
+      // a row that has healed must stop reading as faulted. The `false` rides the
+      // same atomic metadata merge as the faulted arm's `true`.
+      if (readIdentityUnresolved(workflowRun.metadata) === true) {
+        updates.metadata = { [RUN_METADATA_KEYS.identityUnresolved]: false };
+      }
+      await deps.store.updateWorkflowRun(workflowRun.id, updates).catch((err: Error) => {
+        getLog().error(
+          { err, workflowRunId: workflowRun.id, outputRoot },
+          'workflow.output_root_persist_failed'
+        );
+      });
     }
   }
 

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -2068,11 +2068,16 @@ export async function executeWorkflow(
   //     resolved or unregistered identity is still protected across a #1192
   //     rename — only the empty faulted shape is scoped differently).
   //
-  // A failure here is NOT retried: the guard is `if (!output_root)`, so this run
-  // keeps a NULL pointer for its whole lifetime and permanently stays on the
-  // re-derive path — the exact orphaning #1192 makes possible. It does not
+  // A failure to persist here is NOT retried: the guard is `if (!output_root)`, so
+  // this run keeps a NULL pointer for its whole lifetime and permanently stays on
+  // the re-derive path — the exact orphaning #1192 makes possible. That does not
   // justify failing an otherwise healthy run (re-derivation works today), but it
-  // is a durable per-run degradation, so it logs at ERROR rather than WARN.
+  // is a durable per-run degradation, so the healed-arm persist failure below
+  // (`workflow.output_root_persist_failed`) logs at ERROR rather than WARN. The
+  // faulted arm's two logs stay at WARN by design: the underlying fault was
+  // already logged at ERROR inside `resolveProjectPaths`, so these only report a
+  // secondary bookkeeping failure (stamping the flag, noting the skipped persist),
+  // not the fault itself.
   if (!workflowRun.output_root) {
     if (identityResolution === 'faulted') {
       workflowRun.metadata = {

--- a/packages/workflows/src/schemas.test.ts
+++ b/packages/workflows/src/schemas.test.ts
@@ -16,6 +16,8 @@ import {
   dagNodeSchema,
   inputEnvKey,
   readSubrunMetadata,
+  RUN_METADATA_KEYS,
+  readIdentityUnresolved,
 } from './schemas';
 import type {
   DagNode,
@@ -1475,5 +1477,35 @@ describe('readSubrunMetadata — inputs (#2470)', () => {
     expect(readSubrunMetadata({ inputs: ['a'] }).inputs).toBeUndefined();
     expect(readSubrunMetadata({}).inputs).toBeUndefined();
     expect(readSubrunMetadata(undefined).inputs).toBeUndefined();
+  });
+});
+
+// #2304: a row-level marker that distinguishes "unregistered project" from "identity
+// could not be resolved". The reader is defensive the same way `readSubrunMetadata`
+// is: a non-boolean value (corrupt, hand edit, future format) reads as `undefined`
+// rather than as `false`, so a row never silently downgrades to a 'resolved' posture.
+describe('readIdentityUnresolved (#2304)', () => {
+  test('reads a true stamp', () => {
+    expect(readIdentityUnresolved({ [RUN_METADATA_KEYS.identityUnresolved]: true })).toBe(true);
+  });
+
+  test('reads a false stamp', () => {
+    expect(readIdentityUnresolved({ [RUN_METADATA_KEYS.identityUnresolved]: false })).toBe(false);
+  });
+
+  test('treats a missing key as undefined', () => {
+    expect(readIdentityUnresolved({})).toBeUndefined();
+    expect(readIdentityUnresolved(undefined)).toBeUndefined();
+  });
+
+  test('treats a non-boolean value as undefined (defensive)', () => {
+    expect(
+      readIdentityUnresolved({ [RUN_METADATA_KEYS.identityUnresolved]: 'yes' })
+    ).toBeUndefined();
+    expect(readIdentityUnresolved({ [RUN_METADATA_KEYS.identityUnresolved]: 1 })).toBeUndefined();
+    expect(
+      readIdentityUnresolved({ [RUN_METADATA_KEYS.identityUnresolved]: null })
+    ).toBeUndefined();
+    expect(readIdentityUnresolved({ [RUN_METADATA_KEYS.identityUnresolved]: {} })).toBeUndefined();
   });
 });

--- a/packages/workflows/src/schemas/index.ts
+++ b/packages/workflows/src/schemas/index.ts
@@ -143,6 +143,8 @@ export {
   isRecognizedSuspendReason,
   SUBRUN_METADATA_KEYS,
   readSubrunMetadata,
+  RUN_METADATA_KEYS,
+  readIdentityUnresolved,
   WORKFLOW_SOURCE_METADATA_KEY,
   workflowSourceMetadataSchema,
   readWorkflowSourceMetadata,

--- a/packages/workflows/src/schemas/workflow-run.ts
+++ b/packages/workflows/src/schemas/workflow-run.ts
@@ -245,6 +245,38 @@ export function readSubrunMetadata(metadata: Record<string, unknown> | undefined
 }
 
 /**
+ * Keys the run-lifecycle machinery writes into a row's untyped `metadata` JSONB, and the
+ * shape of each value. `metadata` is `Record<string, unknown>`, so a typo in a string
+ * literal at either end silently no-ops — the write lands under a key nobody reads, or the
+ * read returns undefined and the row looks like it was never stamped. Naming them once
+ * gives the compiler the only handle it can have on an untyped column: writer and reader
+ * now share a symbol instead of agreeing by luck.
+ *
+ * `identity_unresolved` — TRUE on a fresh run whose `output_root` was deliberately NOT
+ *                       written because `resolveProjectPaths` returned the `_cwd/<basename>`
+ *                       fallback AFTER `getCodebase` threw on both retry attempts (#2304).
+ *                       Distinguishes "this run is on the cwd fallback because the codebase
+ *                       had no owner/repo or `_local` identity" (legitimate, the WARN arm
+ *                       of the same function) from "this run is on the cwd fallback
+ *                       because we couldn't reach the registry at all" (the ERROR arm).
+ *                       Absent on every other run — the existing `output_root` write-once
+ *                       invariant is preserved for them. Cleared by the same persistence
+ *                       block the moment a later resume writes a real root, so a row that
+ *                       heals stops reading as faulted.
+ */
+export const RUN_METADATA_KEYS = {
+  identityUnresolved: 'identity_unresolved',
+} as const;
+
+/** Typed view of the run-lifecycle keys on a run's metadata; undefined when unset. */
+export function readIdentityUnresolved(
+  metadata: Record<string, unknown> | undefined
+): boolean | undefined {
+  const raw = metadata?.[RUN_METADATA_KEYS.identityUnresolved];
+  return typeof raw === 'boolean' ? raw : undefined;
+}
+
+/**
  * Key under which a run records the executable SOURCE it was started from.
  *
  * A run reads its workflows, commands, and scripts from one directory and acts on


### PR DESCRIPTION
## Problem and outcome

A transient `getCodebase` failure inside `resolveProjectPaths` drops a run onto the `_cwd/<basename>` fallback. Today the persistence block then writes that fallback location as the run's `output_root`, which is write-once via `COALESCE`, so the fault-derived location is pinned for the run's whole life — including `$STATE_DIR`, so a stateful workflow silently reads an empty state directory. The fix in #2299 / `42690a89` lowered the probability of the underlying fault but did not satisfy the open acceptance boxes from #2304; the row's `output_root` was still pinned on either retry attempt that hit a fault.

- **Outcome:** A faulted lookup no longer writes `output_root` at all — the column stays NULL — and stamps `metadata.identity_unresolved = true` instead, so a later resume self-heals from a now-healthy registry and any reader (the state-preflight gate from #2200, maintainer triage) can tell "unregistered" apart from "we could not tell".
- **Invariant:** The `output_root` write-once guard is preserved for every non-faulted case (so the #1192 rename hazard stays scoped to rows with real roots); a faulted run whose `output_root` is still NULL on its next successful lookup will write that now-correct root exactly once.
- **Scope boundary:** The existing retry loop's shape is untouched; the existing `_cwd` fallback still runs (a fault does not kill a run); legitimate unregistered rows (`key.kind === 'cwd'` with a successful lookup) still persist `output_root` exactly as before. Wiring the new flag into #2200's gate or the maintainer-triage workflows is a follow-up — readers of the flag live where the issue says they do.
- **Root cause:** The persistence block in `executeWorkflow` branched only on `!workflowRun.output_root`, with no signal for whether the resolved location came from a successful lookup or from a fault. A successful-cwd-key fallback wrote `output_root` legitimately; a faulted-cwd-key fallback wrote it by accident, and write-once made the accident permanent.

## Review guidance

- **Feedback requested:** Correctness of the three-way `identityResolution` taxonomy (does collapsing `'resolved'` / `'unregistered'` / `'faulted'` into any two lose information that matters?); whether the `'faulted'` branch's "stamp the flag, skip the write" shape is the right read of `updateWorkflowRun`'s COALESCE-backed write-once contract.
- **Start here:** `packages/workflows/src/executor.ts:2076-2113` — the persistence block in `executeWorkflow` is the load-bearing change; everything else is plumbing.
- **Review order:** `packages/workflows/src/executor.ts` (`ResolvedProjectPaths.identityResolution` interface, then `resolveProjectPaths`'s three branches in the retry loop, then the persistence block) → `packages/workflows/src/schemas/workflow-run.ts` (`RUN_METADATA_KEYS` + `readIdentityUnresolved`) → `packages/workflows/src/executor.test.ts` (resolve-time + persist-time tests) → `packages/workflows/src/schemas.test.ts` (reader round-trip).
- **Lower-attention areas:** `packages/workflows/src/schemas/index.ts` is a pure re-export.
- **Known risk or uncertainty:** None outstanding — see Validation. The "resume self-heals" half is asserted structurally by the unchanged `!workflowRun.output_root` guard + the now-correct resolve-time `'resolved'` branch; the implementation.md explains why it was not separately driven through two `executeWorkflow` invocations.

## Solution

Thread an `identityResolution: 'resolved' | 'unregistered' | 'faulted'` flag through `resolveProjectPaths`; branch the persistence block on it.

- `resolveProjectPaths` sets the flag inside the existing two-attempt retry loop, not after it:
  - on a successful lookup whose derived key is repo / folder / `_local` → `'resolved'`;
  - on a successful lookup whose derived key is `cwd` (the codebase exists but has no owner/repo or `_local` identity — the existing `codebase_project_identity_unresolved` WARN) → `'unregistered'`;
  - after both attempts throw → `'faulted'`;
  - on the `codebaseId == null` or `getCodebase → null` arm (no lookup, or no row) → `'unregistered'`;
  - on the persisted-`output_root` short-circuit (a resume reading an existing root) → `undefined` — nothing to flag.
- `executeWorkflow`'s `if (!workflowRun.output_root)` block now branches:
  - `'faulted'` → **skip** the `output_root` write, write `{ metadata: { identity_unresolved: true } }` instead, and emit `workflow.output_root_not_persisted_identity_faulted` at WARN. A subsequent successful resume reads `output_root === null`, enters the same persistence block, this time with `identityResolution: 'resolved'`, and writes the now-correct root once.
  - `'resolved'` / `'unregistered'` / `undefined` → write `output_root` exactly as before for a row that was never flagged. For a previously-faulted row whose `metadata.identity_unresolved` is still `true` when the resume arrives, the same atomic write rides `metadata: { identity_unresolved: false }` so the cleared flag and the new root land together (the heal half — without it the DB's `jsonMerge` keeps the stale `true` and a row that has resolved would continue to read as faulted to #2200's gate and the maintainer-triage workflows). The `output_root` write-once guard continues to protect every legitimate row from the #1192 rename hazard.
- `RUN_METADATA_KEYS.identityUnresolved = 'identity_unresolved'` and `readIdentityUnresolved(metadata): boolean | undefined` live in `schemas/workflow-run.ts`, mirroring the existing `SUBRUN_METADATA_KEYS` / `readSubrunMetadata` precedent (`Record<string, unknown>` JSONB column, shared symbol between writer and reader, defensive non-boolean-reads-as-`undefined` reader). Both are re-exported from `@archon/workflows/schemas` so #2200's gate and the maintainer-triage workflows can consume them when those surfaces pick up the flag.

This keeps the change to "stop persisting on one arm of the resolver; add one row-level marker" — no new DB columns, no new run states, no change to the retry's shape.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | A run whose `getCodebase` throws on both attempts has `output_root` populated with `~/.archon/workspaces/_cwd/<basename>/`, and that path is pinned for the run's whole life. A stateful workflow reads an empty `$STATE_DIR` for the remainder of that run. | That run has `output_root` left NULL and `metadata.identity_unresolved = true` stamped instead. A later resume self-heals to the correct root once the registry is healthy. |
| **Failure behavior** | Indistinguishable from a legitimately unregistered run; the maintainer triage workflows and #2200's state-preflight gate cannot tell a faulted run from a healthy one that happens to be on the cwd fallback. | `readIdentityUnresolved(metadata)` returns `true` on a faulted row, `false` on a row that has healed, and `undefined` on every other row; readers can branch on it without speculating about why `output_root` is null. |

### User flow

```mermaid
flowchart LR
  subgraph Before
    B1[resolveProjectPaths] --> B2{getCodebase throws twice?}
    B2 -- yes --> B3[Faulted cwd fallback, persisted as output_root]
    B3 --> B4[output_root pinned for run's whole life]
  end

  subgraph After
    A1[resolveProjectPaths] --> A2{getCodebase throws twice?}
    A2 -- yes --> A3[output_root stays NULL, metadata.identity_unresolved = true]
    A3 --> A4[Later resume: registry healthy, root written once]
  end
```

## Architecture

```mermaid
flowchart LR
  A[executeWorkflow: !workflowRun.output_root] --> B{identityResolution}
  B -- faulted --> C[stamp identity_unresolved, skip output_root]
  B -- resolved / unregistered / undefined --> D[existing output_root write]
  C -.resume after registry heals.-> A
  E[resolveProjectPaths retry loop] ==> B
  E -- three states, set inside the loop.--> F[ResolvedProjectPaths.identityResolution]
```

### Changed seams

| Boundary or contract | Change | Evidence |
|---|---|---|
| `resolveProjectPaths → executeWorkflow` | New `identityResolution` field on the `ResolvedProjectPaths` return shape (`undefined` on the persisted-`output_root` short-circuit). | `packages/workflows/src/executor.ts:309-326` (type) and `:435-447` (population). |
| `executeWorkflow → IWorkflowStore.updateWorkflowRun` | The `'faulted'` arm writes `{ metadata: { identity_unresolved: true } }` and skips `output_root`. The else arm now also writes `metadata.identity_unresolved = false` when the row was previously flagged, so a healed row stops reading as faulted; rows that were never flagged still see a plain `output_root` write. | `packages/workflows/src/executor.ts:2076-2113`; `executor.test.ts` "output_root persistence branching (#2304)" describe block. |
| `workflow_run.metadata` JSONB column | Adds `identity_unresolved: true` as a typed value, parallel to `SUBRUN_METADATA_KEYS` (`packages/workflows/src/schemas/workflow-run.ts:247-277`). Reader (`readIdentityUnresolved`) returns `boolean | undefined` and treats non-boolean values as `undefined`. | `schemas.test.ts` "readIdentityUnresolved (#2304)" describe block (4 cases). |
| Re-exports (`@archon/workflows/schemas`) | `RUN_METADATA_KEYS` and `readIdentityUnresolved` are re-exported alongside `SUBRUN_METADATA_KEYS` and `readSubrunMetadata` so #2200's state-preflight gate and the maintainer-triage workflows can consume them. | `packages/workflows/src/schemas/index.ts:146-147`. |

## Validation

- `bun --filter @archon/workflows type-check` — exit 0.
- `bun --filter @archon/workflows test` — 22 separate `bun test` invocations across the package, every one green. The new `identityResolution (#2304)` (7 cases) and `output_root persistence branching (#2304)` (4 cases) describe blocks in `executor.test.ts` pass, as does `readIdentityUnresolved (#2304)` (4 cases) in `schemas.test.ts`.
- `bun --filter '*' type-check` — every workspace type-checks clean.
- `bun run format:check` — "All matched files use Prettier code style!"
- `bun run lint` — no warnings, no errors.
- **Not verified end-to-end manually:** No live `bun run cli workflow run` against a deliberately faulting `getCodebase` — the unit tests drive `executeWorkflow` end-to-end with a mocked store and assert against the `updateWorkflowRun` calls, and the existing `resolveProjectPaths` tests already prove the success-arm paths return a real `outputRoot`. Postgres path (`docker-compose --profile with-db`) — not run in this environment.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | None. The flag is a new metadata key; existing rows read as `undefined`, identical to absent. The `output_root` write-once invariant is preserved for every non-faulted row. | `readIdentityUnresolved` returns `undefined` on missing key; the persistence block's `'resolved'` / `'unregistered'` / `undefined` arms leave `metadata` untouched unless the row was previously flagged as faulted, in which case the same atomic write carries `identity_unresolved = false`. |
| Security / permissions / data | None. The flag is local to a workflow-run row; no permissions, no cross-tenant surface. | `RUN_METADATA_KEYS.identityUnresolved` is private to `@archon/workflows/schemas`; nothing else writes the column. |
| Rollout / rollback | `git revert` of `68bed1c5 a31ab562` restores the pre-fix behaviour; in-flight faulted runs from before the revert keep the metadata stamp and continue to read as faulted (the reader returns `undefined` for non-boolean and absent values, never coerces). | Two commits; no schema migration. |
| Observability | New WARN `workflow.output_root_not_persisted_identity_faulted` and `workflow.identity_unresolved_flag_persist_failed` log events; existing `workflow.output_root_persist_failed` continues to fire on the non-faulted persistence path. | `packages/workflows/src/executor.ts:2087-2095`. |
| Documentation / communication | The acceptance boxes in #2304 close with this PR (#2200's gate and the maintainer-triage workflows are follow-ups). | Issue body, items 1-4. |

## Links

- Closes #2304
- Related #1192, #2200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow handling when project identity cannot be resolved after repeated lookup failures.
  * Prevented incomplete runs from recording an incorrect output location.
  * Automatically clears the unresolved-identity status after successful recovery.
  * Preserved existing metadata when no identity issue is present.

* **Tests**
  * Added coverage for resolved, unregistered, faulted, and resumed workflow scenarios.
  * Added validation for safely reading identity-resolution metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->