### PR TITLE
fix(providers): surface Claude tool-scoped hook activity in the audit stream

### DIFF
--- a/packages/providers/src/claude/provider.test.ts
+++ b/packages/providers/src/claude/provider.test.ts
@@ -926,6 +926,112 @@ describe('ClaudeProvider', () => {
       expect(callArgs.options).not.toHaveProperty('agentProgressSummaries');
     });
 
+    // --- Issue #2324 — tool-scoped hook frames must reach the audit stream -----
+
+    test('opts the SDK into lifecycle hook events for every surface (#2324)', async () => {
+      mockQuery.mockImplementation(async function* () {
+        // Empty
+      });
+
+      for await (const _ of client.sendQuery('test', '/workspace')) {
+        // consume
+      }
+
+      const callArgs = mockQuery.mock.calls[0][0] as { options: Record<string, unknown> };
+      // The SDK defaults `includeHookEvents` to false, which suppresses
+      // `hook_started` / `hook_response` for every hook type except
+      // SessionStart and Setup. Without an explicit opt-in, a node-level
+      // `PreToolUse` hook that denies Bash never reaches the workflow
+      // `hook_activity` stream.
+      expect(callArgs.options).toMatchObject({ includeHookEvents: true });
+    });
+
+    test('forwards a denied PreToolUse hook through the chunk pipeline (#2324)', async () => {
+      mockQuery.mockImplementation(async function* () {
+        yield {
+          type: 'system',
+          subtype: 'hook_started',
+          hook_id: 'h-1',
+          hook_name: 'Bash',
+          hook_event: 'PreToolUse',
+        };
+        yield {
+          type: 'system',
+          subtype: 'hook_response',
+          hook_id: 'h-1',
+          hook_name: 'Bash',
+          hook_event: 'PreToolUse',
+          outcome: 'error',
+          exit_code: 2,
+        };
+      });
+
+      const chunks = [];
+      for await (const chunk of client.sendQuery('test', '/workspace')) {
+        chunks.push(chunk);
+      }
+
+      expect(chunks).toEqual([
+        {
+          type: 'hook_started',
+          hookId: 'h-1',
+          hookName: 'Bash',
+          hookEvent: 'PreToolUse',
+        },
+        {
+          type: 'hook_response',
+          hookId: 'h-1',
+          hookName: 'Bash',
+          hookEvent: 'PreToolUse',
+          outcome: 'error',
+          exitCode: 2,
+        },
+      ]);
+    });
+
+    test('forwards a PostToolUse hook lifecycle (#2324)', async () => {
+      mockQuery.mockImplementation(async function* () {
+        yield {
+          type: 'system',
+          subtype: 'hook_started',
+          hook_id: 'h-2',
+          hook_name: 'Edit',
+          hook_event: 'PostToolUse',
+        };
+        yield {
+          type: 'system',
+          subtype: 'hook_response',
+          hook_id: 'h-2',
+          hook_name: 'Edit',
+          hook_event: 'PostToolUse',
+          outcome: 'success',
+          exit_code: 0,
+        };
+      });
+
+      const chunks = [];
+      for await (const chunk of client.sendQuery('test', '/workspace')) {
+        chunks.push(chunk);
+      }
+
+      expect(chunks).toEqual([
+        {
+          type: 'hook_started',
+          hookId: 'h-2',
+          hookName: 'Edit',
+          hookEvent: 'PostToolUse',
+        },
+        {
+          type: 'hook_response',
+          hookId: 'h-2',
+          hookName: 'Edit',
+          hookEvent: 'PostToolUse',
+          outcome: 'success',
+          exitCode: 0,
+        },
+      ]);
+    });
+
     test('handles tool_use with empty input', async () => {
       mockQuery.mockImplementation(async function* () {
         yield {

--- a/packages/providers/src/claude/provider.test.ts
+++ b/packages/providers/src/claude/provider.test.ts
@@ -1032,6 +1032,37 @@ describe('ClaudeProvider', () => {
       ]);
     });
 
+    test('drops hook_progress frames (only emitted for async hooks — none registered) (#2324)', async () => {
+      mockQuery.mockImplementation(async function* () {
+        yield {
+          type: 'system',
+          subtype: 'hook_progress',
+          hook_id: 'h-3',
+          hook_name: 'Bash',
+          hook_event: 'PreToolUse',
+          stdout: 'still running...',
+          stderr: '',
+          output: '',
+        };
+        yield {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'text', text: 'Real response' }],
+          },
+        };
+      });
+
+      const chunks = [];
+      for await (const chunk of client.sendQuery('test', '/workspace')) {
+        chunks.push(chunk);
+      }
+
+      // The hook_progress frame is intentionally not surfaced: Archon
+      // registers only synchronous hooks, and the hooks guide documents
+      // the carve-out. Only the assistant message reaches the stream.
+      expect(chunks).toEqual([{ type: 'assistant', content: 'Real response' }]);
+    });
+
     test('handles tool_use with empty input', async () => {
       mockQuery.mockImplementation(async function* () {
         yield {

--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -847,8 +847,10 @@ function buildBaseClaudeOptions(
     // Opt into the SDK's hook lifecycle frames so that tool-scoped hooks
     // (PreToolUse / PostToolUse / Stop / etc.) reach the workflow audit
     // stream as `hook_activity` (#2324). SessionStart and Setup remain
-    // emitted regardless. The downstream `hook_started` / `hook_response`
-    // normalization already handles every frame this enables.
+    // emitted regardless. The downstream normalization surfaces
+    // `hook_started` and `hook_response`; the third subtype the SDK
+    // enables (`hook_progress`) falls through — it is only emitted for
+    // async hooks, which Archon does not register today.
     includeHookEvents: true,
     hooks: buildToolCaptureHooks(toolResultQueue),
     stderr: (data: string): void => {

--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -844,6 +844,12 @@ function buildBaseClaudeOptions(
     // Per-node override wins over the assistant-level default; the final
     // fallback stays ['project', 'user'] (the SDK-loading default Archon ships).
     settingSources,
+    // Opt into the SDK's hook lifecycle frames so that tool-scoped hooks
+    // (PreToolUse / PostToolUse / Stop / etc.) reach the workflow audit
+    // stream as `hook_activity` (#2324). SessionStart and Setup remain
+    // emitted regardless. The downstream `hook_started` / `hook_response`
+    // normalization already handles every frame this enables.
+    includeHookEvents: true,
     hooks: buildToolCaptureHooks(toolResultQueue),
     stderr: (data: string): void => {
       const output = data.trim();


### PR DESCRIPTION
## Problem and outcome

`hook_activity` only ever carried `SessionStart` rows. Tool-scoped hooks (`PreToolUse`, `PostToolUse`, `Stop`, …) fired inside nodes but left no trace, so the audit stream could not distinguish "hook did not run" from "hook ran and was denied" — and an operator's `PreToolUse` guard that actively blocks Bash was invisible. Issue #2324 documents the symptom and shows a deterministic reproduction (a node-level `PreToolUse(Bash)` hook that denies the tool, while every `hook_activity` row is still `SessionStart`).

- **Outcome:** Tool-scoped Claude hooks now reach the existing workflow `hook_activity` audit stream as `hook_started` / `hook_response` frames, with `hook_event` and the response's outcome intact, matching the contract #1939 established against #975.
- **Invariant:** `SessionStart` and `Setup` behavior is unchanged; the existing `hook_started` / `hook_response` normalization in `provider.ts` and the DAG persistence path in `dag-executor.ts` already model the lifecycle frames Archon surfaces, so their shape is unchanged.
- **Scope boundary:** No event-schema change, no UI change, no SDK upgrade, no new audit surface. The locked SDK already supports the flag.
- **Root cause:** `buildBaseClaudeOptions` did not set `includeHookEvents`, so the SDK defaulted to `false` and suppressed lifecycle frames for every hook type except `SessionStart` and `Setup`.

## Review guidance

- **Feedback requested:** Correctness of the opt-in placement and whether the regression coverage pins both the SDK option and the chunk-pipeline shape enough to prevent a future regression.
- **Start here:** `packages/providers/src/claude/provider.ts:854` — the single new SDK option that closes the audit gap.
- **Review order:** `provider.ts:786-854` (the base options builder and the new flag), then `provider.ts:1115-1134` (the existing normalization the tests exercise), then `provider.test.ts:929-1064` (the four regression tests).
- **Lower-attention areas:** The four new tests are mechanical assertions on the mocked SDK options and the resulting chunk shape; no new public API.
- **Known risk or uncertainty:** None. The other failing tests under `packages/providers` (sub-run e2e, Pi `withCustomProviderRequestEnv`) reproduce on the unpatched `69adee5d` commit and are unrelated.

## Solution

`buildBaseClaudeOptions` now returns `includeHookEvents: true`, the SDK opt-in the locked `@anthropic-ai/claude-agent-sdk` already documents. With the flag on, the SDK can emit `hook_started` / `hook_progress` / `hook_response`; the existing `provider.ts` system-message handler converts `hook_started` and `hook_response` into Archon chunks at the same boundary as before, while `hook_progress` falls through because it is only emitted for async hooks, which Archon does not register. The DAG executor's `hook_activity` persistence path (`dag-executor.ts:2608-2666`) already models every field needed for those surfaced frames — `hook_event`, `hook_name`, outcome, exit code — so the audit stream starts receiving the tool-scoped rows with no schema or persistence work.

This is the smallest coherent solution because every other layer (normalization of the surfaced lifecycle frames, persistence, UI display names) already targets this contract; the only missing handoff was the SDK option itself.

### Changed seams

| Boundary or contract | Change | Evidence |
|---|---|---|
| Claude provider → SDK | New `includeHookEvents: true` opt-in on every `query({ prompt, options })` call | `packages/providers/src/claude/provider.ts:854` |
| SDK → provider chunks | Existing `hook_started` / `hook_response` normalization now reaches tool-scoped frames | `packages/providers/src/claude/provider.test.ts:949-1021` |
| Workflow `hook_activity` audit | Tool-scoped frames flow into the DAG executor's existing persistence boundary with no edits | `packages/providers/src/claude/provider.test.ts:975-1021` covers both deny and success paths |

## Validation

- `bun test src/claude/provider.test.ts` — 142 pass, 0 fail — proves the SDK opt-in is asserted and both a denied `PreToolUse(Bash)` and a successful `PostToolUse(Edit)` lifecycle reach the chunk pipeline with `hook_event` and outcome intact.
- `bun --filter '*' type-check` — clean across every workspace — proves the new SDK option is supported by the locked `@anthropic-ai/claude-agent-sdk` and does not regress any other workspace.
- `bun test src/dag-executor.test.ts` (workflows package) — 598 pass, 0 fail — proves the `hook_activity` persistence path remains green against the new emitter behavior.
- `bun x prettier --check packages/providers/src/claude/provider.ts packages/providers/src/claude/provider.test.ts` — both files conform.
- `bun x eslint packages/providers/src/claude/ --max-warnings 0` — clean.
- **Not verified:** A live end-to-end probe against a real Claude Code CLI was not re-run; the mocked regression tests cover the `includeHookEvents` opt-in, the surfaced `hook_started` / `hook_response` chunk shape, and the deliberately dropped `hook_progress` path, and the issue's reproduction (a denied `PreToolUse(Bash)`) is mirrored exactly by the second regression test.

## Links

- Closes #2324


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added visibility into tool hook activity, including hook start and completion events.
  - Hook events now include details such as hook name, event type, outcome, and exit code.
- **Bug Fixes**
  - Tool-scoped hook activity is now forwarded to the workflow activity stream.
  - Unsupported asynchronous hook progress events are excluded from the stream to prevent misleading activity records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->