### PR TITLE
docs(workflows): record the decision to keep bash/script execution separate

### DIFF
--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -8530,6 +8530,11 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
               // deterministic node retries solely when it declares an explicit
               // `retry:` block (single attempt otherwise), so side-effectful scripts
               // aren't silently re-run (#2088).
+              //
+              // `executeBashNode`/`executeScriptNode` stay two separate functions
+              // rather than one `executeExecNode(node.runtime)` — deliberate, not an
+              // oversight (#2718). See the rationale on `execNodeSchema` in
+              // schemas/dag-node.ts.
               if (node.runtime === 'sh') {
                 const output = await runDeterministicNodeWithRetry(
                   node,

--- a/packages/workflows/src/schemas/dag-node.ts
+++ b/packages/workflows/src/schemas/dag-node.ts
@@ -379,7 +379,7 @@ export type AgentNode = z.infer<typeof agentNodeSchema>;
  * The EXECUTOR deliberately did not follow this collapse: `executeBashNode`/
  * `executeScriptNode` in dag-executor.ts stay two separate functions rather than
  * one `executeExecNode` branching on `runtime` (#2718, decided after a full
- * side-by-side read of both, 221 + 322 = 543 lines). The two are not thin
+ * side-by-side read of both, 222 + 323 = 545 lines). The two are not thin
  * wrappers around one shell-out — real, non-superficial differences: output-ref
  * substitution (shell-escaped + artifacts-dir-aware for bash vs. raw splice for
  * script), env-delivered `$LOOP_USER_INPUT`/`deps:`/named-script-file resolution

--- a/packages/workflows/src/schemas/dag-node.ts
+++ b/packages/workflows/src/schemas/dag-node.ts
@@ -369,13 +369,30 @@ export const agentNodeSchema = dagNodeBaseSchema.extend({
 export type AgentNode = z.infer<typeof agentNodeSchema>;
 
 /**
- * `bash:` + `script:` collapsed into one body kind (#2486) — 327 and 354 lines of
- * near-duplicate subprocess handling in dag-executor.ts differing only by
- * interpreter and a dependency-install step, both expressible as fields. `bash:`
- * becomes `runtime: 'sh'`; `deps`/`with` are only ever populated by the transform
- * for a `script:` input (a `bash:` input never sets them, matching today's
- * `BashNode` behavior — see `dagNodeSchema`'s transform).
+ * `bash:` + `script:` collapsed into one body kind (#2486) at the TYPE level —
+ * one `ExecNode` shape, discriminated by `runtime`. `bash:` becomes
+ * `runtime: 'sh'`; `deps`/`with` are only ever populated by the transform for a
+ * `script:` input (a `bash:` input never sets them, matching today's `BashNode`
+ * behavior — see `dagNodeSchema`'s transform).
  * AI-specific fields from the base are present in the type but ignored at runtime with a warning.
+ *
+ * The EXECUTOR deliberately did not follow this collapse: `executeBashNode`/
+ * `executeScriptNode` in dag-executor.ts stay two separate functions rather than
+ * one `executeExecNode` branching on `runtime` (#2718, decided after a full
+ * side-by-side read of both, 221 + 322 = 543 lines). The two are not thin
+ * wrappers around one shell-out — real, non-superficial differences: output-ref
+ * substitution (shell-escaped + artifacts-dir-aware for bash vs. raw splice for
+ * script), env-delivered `$LOOP_USER_INPUT`/`deps:`/named-script-file resolution
+ * (script-only), and per-runtime error diagnostics. A "merge but keep behavior
+ * byte-identical" refactor would relocate rather than remove that complexity,
+ * while unifying the ~230 lines of near-identical scaffolding (event
+ * emission/persistence, retry wiring, error formatting) into one function risks
+ * a regression that touches every deterministic node in every workflow at once —
+ * today a bug in one runtime's path can't touch the other. Two bugs the read
+ * surfaced along the way (`$LOOP_USER_INPUT` never reaching a `bash:` loop_group
+ * body node, and `script:` node output never getting the truncation cap `bash:`
+ * gets) are real independently-evolved drift, not evidence for merging — they're
+ * filed as their own fixes, #2725 and #2726, rather than folded into this call.
  */
 export const execNodeSchema = dagNodeBaseSchema.extend({
   kind: z.literal('exec'),


### PR DESCRIPTION
## Problem and outcome

#2716 collapsed `bash:`/`script:` into one type-level `ExecNode` (`kind: 'exec'`, discriminated by `runtime`), but deliberately left `executeBashNode`/`executeScriptNode` in `dag-executor.ts` as two separate functions rather than merging them behind the same discriminant. That call was made under #2716's own time/risk budget and tracked as a follow-up decision (#2718) rather than resolved on the merits — it needed someone to actually read both functions side by side and either merge them or record why not.

- **Outcome:** After that side-by-side read, keeping them separate is confirmed as the right call — not by rubber-stamping #2716's original framing, but by measuring it. Roughly a third of the combined 543 lines is genuinely runtime-specific (output-ref substitution differs in escaping and arguments passed; env-delivered `$LOOP_USER_INPUT` and `deps:` are script-only; named-script-file discovery has no bash analogue; error diagnostics are tailored per runtime), not superficial branching that a merge would simplify away. The rest (~230 lines) is near-identical scaffolding (event started/completed/failed persistence + emission, retry wiring via the caller, structured error formatting), so a merge would mostly relocate the real complexity into one function's runtime-conditional branches rather than remove it, while widening the blast radius of any regression in that shared scaffolding from one runtime to both at once.
- **Invariant:** No behavior change — this PR only adds documentation at the decision site.
- **Scope boundary:** Does not merge `executeBashNode`/`executeScriptNode`, and does not fix the two behavioral gaps described below — those are filed as independent, narrowly-scoped fixes (see Links) rather than folded into this decision.

The read also surfaced two real, currently-untested divergences between the two paths that aren't documented as intentional anywhere and read as accidental drift, not design:
- `$LOOP_USER_INPUT` never reaches a `bash:` node inside a `loop_group` body — the env var is hardcoded to `''` in `executeBashNode`, while `executeScriptNode` correctly threads `ctx.bodyLoopUserInput` through. Filed as #2725.
- `script:` node output is never truncated before being persisted to the `node_completed` workflow event, unlike `bash:` nodes which cap at 32KB via `formatPersistedBashOutput`. Filed as #2726.

Both are confirmed by test coverage asymmetry: the existing loop-input-to-loop_group-body test only exercises `runtime: 'bun'`, and all four truncation tests only exercise `runtime: 'sh'`.

## Review guidance

- **Feedback requested:** Whether the reasoning recorded here is convincing, or whether it undersells the case for merging.
- **Start here:** `packages/workflows/src/schemas/dag-node.ts` — the `execNodeSchema` docblock now carries the full rationale.
- **Review order:** `schemas/dag-node.ts` (rationale) → `dag-executor.ts:8528` (one-line pointer at the actual dispatch site).
- **Lower-attention areas:** None — this is a two-file, comment-only change.
- **Known risk or uncertainty:** None.

## Solution

Two comment-only edits: the `execNodeSchema` docblock in `schemas/dag-node.ts` now explains why the executor didn't follow the type-level collapse (superseding the docblock's previous, since-inaccurate "327 and 354 lines... differing only by interpreter and a dependency-install step" summary — the actual read found 222 + 323 = 545 lines with real per-runtime logic beyond interpreter selection). A short pointer comment at the `case 'exec':` dispatch site in `dag-executor.ts` links back to it, so a future reader hitting the split there isn't left wondering if it's an oversight.

## Validation

- `bun run --filter @archon/workflows type-check` — exit 0.
- `npx eslint packages/workflows/src/dag-executor.ts packages/workflows/src/schemas/dag-node.ts --max-warnings 0` — clean.
- `bun test src/dag-executor.test.ts src/schemas.test.ts` (from `packages/workflows/`) — 750 pass, 0 fail.
- **Not verified:** Nothing material — this PR changes only comments.

## Links

- Closes #2718
- Related #2725
- Related #2726

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how bash and script execution paths are handled.
  * Documented why bash and script execution remain separate.
  * Updated the combined line-count estimate for bash and script executors from 543 to 545 lines.
  * Added explanatory context linking execution behavior to the relevant validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->