### PR TITLE
fix(workflows): bash and script exec nodes now match on loop input delivery and output truncation

### DIFF
--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -1029,7 +1029,7 @@ load-time `<include>__<node>` ID in metadata and as the sanitized body suffix.
 
 This works on **every** node type (`bash`/`script` produce typed outputs too, just without a `sessionId`). The write is **best-effort** — if it fails, the node still succeeds and a warning is logged; the typed sidecar may simply be absent. `output_type` is an open set of labels (`plan`, `findings`, `code`, `summary`, …) — pick a convention and keep casing consistent, since lookup is case-sensitive.
 
-Successful bash stdout is retained by default on the completed run as a bounded audit preview in `node_completed.data.node_output`. Output over 32 KiB (32,768 UTF-8 bytes) ends with a truncation marker, and the event also includes `node_output_truncated: true` plus `node_output_original_bytes`. Because stdout is persisted, never print secrets or credentials from bash nodes. This preview is separate from `output_type`: declaring `output_type` opts into a best-effort file sidecar that may contain the full output and is not required for ordinary bash audit retention.
+Successful `bash`/`script` stdout is retained by default on the completed run as a bounded audit preview in `node_completed.data.node_output`. Output over 32 KiB (32,768 UTF-8 bytes) ends with a truncation marker, and the event also includes `node_output_truncated: true` plus `node_output_original_bytes`. Because stdout is persisted, never print secrets or credentials from a bash or script node. This preview is separate from `output_type`: declaring `output_type` opts into a best-effort file sidecar that may contain the full output and is not required for ordinary audit retention.
 
 ---
 

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -6015,6 +6015,107 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     // complete cross-process output requires a separately managed artifact.
   });
 
+  it('caps over-limit persisted script output with a marker and byte metadata (#2726)', async () => {
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const workflowRun = makeWorkflowRun('script-output-over-cap');
+
+    await executeDagWorkflow(
+      mockDeps,
+      createMockPlatform(),
+      'conv-script-over-cap',
+      testDir,
+      {
+        name: 'script-output-over-cap',
+        nodes: [
+          {
+            id: 'over-cap',
+            kind: 'exec',
+            runtime: 'bun',
+            script: 'console.log("x".repeat(32769))',
+          },
+        ],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+    const completedEvent = eventCalls.find(
+      (call: unknown[]) =>
+        (call[0] as { event_type: string }).event_type === 'node_completed' &&
+        (call[0] as { step_name: string }).step_name === 'over-cap'
+    );
+    const data = (
+      completedEvent![0] as {
+        data: {
+          node_output: string;
+          node_output_truncated: boolean;
+          node_output_original_bytes: number;
+        };
+      }
+    ).data;
+    expect(Buffer.byteLength(data.node_output, 'utf8')).toBeLessThanOrEqual(32_768);
+    expect(data.node_output).toEndWith('\n\n… [truncated; original output was 32769 bytes]');
+    expect(data.node_output_truncated).toBe(true);
+    expect(data.node_output_original_bytes).toBe(32_769);
+  });
+
+  it('persists script output at or below the byte cap unchanged without truncation metadata', async () => {
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const workflowRun = makeWorkflowRun('script-output-below-cap');
+
+    await executeDagWorkflow(
+      mockDeps,
+      createMockPlatform(),
+      'conv-script-below-cap',
+      testDir,
+      {
+        name: 'script-output-below-cap',
+        nodes: [
+          {
+            id: 'below-cap',
+            kind: 'exec',
+            runtime: 'bun',
+            script: 'console.log("x".repeat(32767))',
+          },
+        ],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+    const completedEvent = eventCalls.find(
+      (call: unknown[]) =>
+        (call[0] as { event_type: string }).event_type === 'node_completed' &&
+        (call[0] as { step_name: string }).step_name === 'below-cap'
+    );
+    const data = (
+      completedEvent![0] as {
+        data: Record<string, unknown> & { node_output: string };
+      }
+    ).data;
+    expect(data.node_output).toBe('x'.repeat(32767));
+    expect(data.node_output_truncated).toBeUndefined();
+    expect(data.node_output_original_bytes).toBeUndefined();
+  });
+
   it('keeps a persisted UTF-8 preview valid when the byte cap splits a code point', async () => {
     const store = createMockStore();
     const mockDeps = createMockDeps(store);
@@ -19730,6 +19831,84 @@ describe('executeDagWorkflow -- loop_group node', () => {
       expect(scriptCall?.[1][2]).not.toContain('process.exit');
       // The per-iteration feedback reaches the script through the environment.
       expect(scriptCall?.[2].env.LOOP_USER_INPUT).toBe(injection);
+    } finally {
+      execSpy.mockRestore();
+    }
+  });
+
+  it('delivers $LOOP_USER_INPUT to a resumed body bash node via env (#2725)', async () => {
+    // A `${VAR}` (braced) reference is NOT matched by applyLoopPrevToBodyNode's literal
+    // `$LOOP_USER_INPUT` splice — bash resolves it from the subprocess environment at
+    // runtime instead, so this specifically proves the env-delivery channel this fix adds
+    // (a plain unbraced `$LOOP_USER_INPUT` reference was already spliced pre-fix and is
+    // not a regression risk here).
+    const feedback = 'looks good, ship it';
+    const execSpy = spyOn(git, 'execFileAsync').mockResolvedValue({ stdout: 'DONE\n', stderr: '' });
+    try {
+      const mockDeps = createMockDeps();
+      const platform = createMockPlatform();
+      const workflowRun = makeWorkflowRun('lg-userinput-bash', {
+        metadata: {
+          approval: {
+            type: 'interactive_loop',
+            nodeId: 'grp',
+            iteration: 0,
+            message: 'Review and provide feedback.',
+          },
+          loop_user_input: feedback,
+          loop_feedback_given: true,
+        },
+      });
+
+      const nodes: DagNode[] = [
+        {
+          id: 'grp',
+          kind: 'loop_group',
+          loop_group: {
+            until: 'DONE',
+            max_iterations: 3,
+            fresh_context: true,
+            interactive: true,
+            gate_message: 'Review and provide feedback.',
+            nodes: [
+              {
+                id: 'emit',
+                kind: 'exec',
+                script: 'echo "${LOOP_USER_INPUT}"; echo DONE',
+                runtime: 'sh',
+                depends_on: [],
+              },
+            ],
+          },
+          depends_on: [],
+        },
+      ];
+
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-lg-userinput-bash',
+        testDir,
+        { name: 'lg-userinput-bash', nodes },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'state'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+
+      const bashCall = execSpy.mock.calls.find(
+        c => (c[0] as string) === git.resolveBashPath() && (c[1] as string[])[0] === '-c'
+      ) as [string, string[], { env: NodeJS.ProcessEnv }] | undefined;
+      expect(bashCall).toBeDefined();
+      // The braced reference is left untouched by the source-splice pass...
+      expect(bashCall?.[1][1]).toBe('echo "${LOOP_USER_INPUT}"; echo DONE');
+      // ...so the subprocess environment is the only channel that can deliver it.
+      expect(bashCall?.[2].env.LOOP_USER_INPUT).toBe(feedback);
     } finally {
       execSpy.mockRestore();
     }

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -6069,51 +6069,56 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
   });
 
   it('persists script output at or below the byte cap unchanged without truncation metadata', async () => {
-    const store = createMockStore();
-    const mockDeps = createMockDeps(store);
-    const workflowRun = makeWorkflowRun('script-output-below-cap');
+    for (const [nodeId, byteCount] of [
+      ['below-cap', 32_767],
+      ['exact-cap', 32_768],
+    ] as const) {
+      const store = createMockStore();
+      const mockDeps = createMockDeps(store);
+      const workflowRun = makeWorkflowRun(`script-output-${nodeId}`);
 
-    await executeDagWorkflow(
-      mockDeps,
-      createMockPlatform(),
-      'conv-script-below-cap',
-      testDir,
-      {
-        name: 'script-output-below-cap',
-        nodes: [
-          {
-            id: 'below-cap',
-            kind: 'exec',
-            runtime: 'bun',
-            script: 'console.log("x".repeat(32767))',
-          },
-        ],
-      },
-      workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      await executeDagWorkflow(
+        mockDeps,
+        createMockPlatform(),
+        `conv-script-${nodeId}`,
+        testDir,
+        {
+          name: `script-output-${nodeId}`,
+          nodes: [
+            {
+              id: nodeId,
+              kind: 'exec',
+              runtime: 'bun',
+              script: `console.log("x".repeat(${String(byteCount)}))`,
+            },
+          ],
+        },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'state'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
 
-    const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
-    const completedEvent = eventCalls.find(
-      (call: unknown[]) =>
-        (call[0] as { event_type: string }).event_type === 'node_completed' &&
-        (call[0] as { step_name: string }).step_name === 'below-cap'
-    );
-    const data = (
-      completedEvent![0] as {
-        data: Record<string, unknown> & { node_output: string };
-      }
-    ).data;
-    expect(data.node_output).toBe('x'.repeat(32767));
-    expect(data.node_output_truncated).toBeUndefined();
-    expect(data.node_output_original_bytes).toBeUndefined();
+      const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+      const completedEvent = eventCalls.find(
+        (call: unknown[]) =>
+          (call[0] as { event_type: string }).event_type === 'node_completed' &&
+          (call[0] as { step_name: string }).step_name === nodeId
+      );
+      const data = (
+        completedEvent![0] as {
+          data: Record<string, unknown> & { node_output: string };
+        }
+      ).data;
+      expect(data.node_output).toBe('x'.repeat(byteCount));
+      expect(data.node_output_truncated).toBeUndefined();
+      expect(data.node_output_original_bytes).toBeUndefined();
+    }
   });
 
   it('keeps a persisted UTF-8 preview valid when the byte cap splits a code point', async () => {

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -3307,8 +3307,10 @@ async function executeBashNode(
   stepNamePrefix = '',
   iteration?: number,
   // Per-iteration $LOOP_USER_INPUT free-text for loop_group body bash nodes, delivered via
-  // env (never spliced into source — #2115). '' for top-level bash nodes and non-first
-  // iterations (mirrors executeScriptNode, #2725).
+  // env — the channel a braced ${LOOP_USER_INPUT} read or a nested subprocess needs. An
+  // unbraced $LOOP_USER_INPUT literal is separately shell-quoted and spliced into the
+  // script source by applyLoopPrevToBodyNode before this function ever runs (#2725).
+  // '' for top-level bash nodes and non-first iterations (mirrors executeScriptNode).
   loopUserInput = '',
   execContext: ExecutionContext = { kind: 'host' }
 ): Promise<NodeOutput> {
@@ -3584,8 +3586,10 @@ async function executeScriptNode(
   stepNamePrefix = '',
   iteration?: number,
   // Per-iteration $LOOP_USER_INPUT free-text for loop_group body scripts, delivered via
-  // env (never spliced into source — #2115). '' for top-level scripts and non-first
-  // iterations (mirrors executeBashNode, which delivers loop input via quoted splice).
+  // env — TS/Python source can't be safely shell-quoted the way bash can, so unlike bash
+  // this is the ONLY delivery channel here (#2115). '' for top-level scripts and non-first
+  // iterations (executeBashNode also delivers this via env now, alongside its separate
+  // splice path for an unbraced $LOOP_USER_INPUT literal — #2725).
   loopUserInput = '',
   execContext: ExecutionContext = { kind: 'host' },
   /** Roots named scripts resolve under; always supplied from RunLayersContext. */
@@ -4369,8 +4373,10 @@ async function executeLoopGroupNode(
       totalLoopIterations: 0,
       stepNamePrefix: bodyStepNamePrefix,
       loopGroupPath: [...enclosingLoopGroupPath, { groupId: node.id, iteration: i }],
-      // Deliver this iteration's approval-gate free-text to body script: nodes via env
-      // (never spliced into source — #2115); matches applyLoopPrevToBodyNode's skip.
+      // Deliver this iteration's approval-gate free-text to body bash:/script: nodes via
+      // env (#2115/#2725) — script's only channel, and bash's channel for a braced
+      // ${LOOP_USER_INPUT} read or a nested subprocess; an unbraced bash literal is
+      // separately spliced by applyLoopPrevToBodyNode above.
       bodyLoopUserInput: userInputForIter,
     };
     await runLayers(iterCtx);
@@ -8057,10 +8063,13 @@ interface RunLayersContext {
   /** Complete runtime loop_group lineage for typed body artifacts; empty at top level. */
   loopGroupPath: NodeArtifactLoopFrame[];
   /**
-   * Per-iteration `$LOOP_USER_INPUT` free-text for loop_group body `script:` nodes,
-   * delivered into the subprocess as an env var (never spliced into TS/Python source —
-   * #2115). Only non-empty on the first resumed iteration of an interactive group;
-   * undefined for the top-level DAG (top-level scripts have no loop user input).
+   * Per-iteration `$LOOP_USER_INPUT` free-text for loop_group body `bash:`/`script:` nodes,
+   * delivered into the subprocess as an env var (#2115/#2725) — TS/Python source can't be
+   * shell-quoted the way bash can, so this is script's only channel; for bash it covers a
+   * braced `${LOOP_USER_INPUT}` read or a nested subprocess (an unbraced literal is
+   * separately spliced into the bash source by `applyLoopPrevToBodyNode`). Only non-empty
+   * on the first resumed iteration of an interactive group; undefined for the top-level
+   * DAG (top-level nodes have no loop user input).
    */
   bodyLoopUserInput?: string;
 }

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -3239,8 +3239,8 @@ async function runSubprocess(
  *  instead of inlined as bash -c arguments, to avoid silent data corruption. */
 const NODE_OUTPUT_FILE_THRESHOLD = 32_768;
 
-/** Maximum UTF-8 bytes retained for successful bash stdout in workflow events. */
-const PERSISTED_BASH_OUTPUT_MAX_BYTES = 32 * 1024;
+/** Maximum UTF-8 bytes retained for successful bash/script stdout in workflow events. */
+const PERSISTED_NODE_OUTPUT_MAX_BYTES = 32 * 1024;
 
 function utf8SequenceLength(leadByte: number): number {
   if (leadByte < 0x80) return 1;
@@ -3249,19 +3249,21 @@ function utf8SequenceLength(leadByte: number): number {
   return 4;
 }
 
-function formatPersistedBashOutput(output: string): {
+/** Shared by executeBashNode and executeScriptNode — both persist deterministic
+ *  node stdout through this same UTF-8-safe cap (#2726). */
+function formatPersistedNodeOutput(output: string): {
   nodeOutput: string;
   truncated: boolean;
   originalBytes?: number;
 } {
   const outputBytes = Buffer.from(output, 'utf8');
-  if (outputBytes.byteLength <= PERSISTED_BASH_OUTPUT_MAX_BYTES) {
+  if (outputBytes.byteLength <= PERSISTED_NODE_OUTPUT_MAX_BYTES) {
     return { nodeOutput: output, truncated: false };
   }
 
   const marker = buildTruncationMarker(outputBytes.byteLength);
   const markerBytes = Buffer.byteLength(marker, 'utf8');
-  let headEnd = PERSISTED_BASH_OUTPUT_MAX_BYTES - markerBytes;
+  let headEnd = PERSISTED_NODE_OUTPUT_MAX_BYTES - markerBytes;
 
   // The byte cap can land inside a multi-byte code point. Inspect the final
   // sequence in the prefix and drop it when it is incomplete before decoding.
@@ -3304,6 +3306,10 @@ async function executeBashNode(
   envVars?: Record<string, string>,
   stepNamePrefix = '',
   iteration?: number,
+  // Per-iteration $LOOP_USER_INPUT free-text for loop_group body bash nodes, delivered via
+  // env (never spliced into source — #2115). '' for top-level bash nodes and non-first
+  // iterations (mirrors executeScriptNode, #2725).
+  loopUserInput = '',
   execContext: ExecutionContext = { kind: 'host' }
 ): Promise<NodeOutput> {
   const nodeStartTime = Date.now();
@@ -3387,7 +3393,7 @@ async function executeBashNode(
     BASE_BRANCH: baseBranch,
     USER_MESSAGE: workflowRun.user_message,
     ARGUMENTS: workflowRun.user_message,
-    LOOP_USER_INPUT: '',
+    LOOP_USER_INPUT: loopUserInput,
     LOOP_PREV_OUTPUT: '',
     REJECTION_REASON: '',
     CONTEXT: issueContext ?? '',
@@ -3420,7 +3426,7 @@ async function executeBashNode(
     getLog().info({ nodeId: node.id, durationMs: duration }, 'dag_node_completed');
     await logNodeComplete(logDir, workflowRun.id, node.id, '<bash>', { durationMs: duration });
 
-    const persistedOutput = formatPersistedBashOutput(output);
+    const persistedOutput = formatPersistedNodeOutput(output);
 
     deps.store
       .createWorkflowEvent({
@@ -3810,12 +3816,25 @@ async function executeScriptNode(
     getLog().info({ nodeId: node.id, durationMs: duration }, 'dag_node_completed');
     await logNodeComplete(logDir, workflowRun.id, node.id, '<script>', { durationMs: duration });
 
+    const persistedOutput = formatPersistedNodeOutput(output);
+
     deps.store
       .createWorkflowEvent({
         workflow_run_id: workflowRun.id,
         event_type: 'node_completed',
         step_name: stepName,
-        data: { duration_ms: duration, type: 'script', node_output: output, ...iterationData },
+        data: {
+          duration_ms: duration,
+          type: 'script',
+          node_output: persistedOutput.nodeOutput,
+          ...(persistedOutput.truncated
+            ? {
+                node_output_truncated: true,
+                node_output_original_bytes: persistedOutput.originalBytes,
+              }
+            : {}),
+          ...iterationData,
+        },
       })
       .catch((err: Error) => {
         getLog().error(
@@ -8554,6 +8573,7 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
                       config.envVars,
                       stepNamePrefix,
                       iteration,
+                      ctx.bodyLoopUserInput ?? '',
                       execContext
                     )
                 );

--- a/packages/workflows/src/utils/output-truncation.ts
+++ b/packages/workflows/src/utils/output-truncation.ts
@@ -3,17 +3,17 @@
  *
  * Two sides must agree on this string, so it lives in one place rather than
  * being written by one and pattern-matched by the other:
- *   - `formatPersistedBashOutput` (dag-executor) WRITES it when successful bash
- *     stdout exceeds the persisted-event byte cap.
+ *   - `formatPersistedNodeOutput` (dag-executor) WRITES it when successful bash
+ *     or script stdout exceeds the persisted-event byte cap.
  *   - `resolveNodeOutputField` (output-ref) RECOGNISES it so a resumed run can
  *     explain why an output it cannot parse was nonetheless emitted correctly.
  *
  * That second case is not hypothetical. `output_format` is declared on
- * `dagNodeBaseSchema`, so a bash node may carry one; the fresh path holds the
- * full stdout in memory and parses fine, while a resumed run rehydrates the
- * clipped text and cannot. Without this marker the failure reads "output is not
- * a JSON object — emit JSON containing 'x'", which sends the author to fix a
- * producer that was already correct.
+ * `dagNodeBaseSchema`, so a bash or script node may carry one; the fresh path
+ * holds the full stdout in memory and parses fine, while a resumed run
+ * rehydrates the clipped text and cannot. Without this marker the failure
+ * reads "output is not a JSON object — emit JSON containing 'x'", which sends
+ * the author to fix a producer that was already correct.
  */
 
 /** Build the marker for an output clipped from `originalBytes` UTF-8 bytes. */


### PR DESCRIPTION
## Problem and outcome

`executeBashNode` and `executeScriptNode` in `dag-executor.ts` are sibling implementations of the same `exec` node kind (bash vs. script runtime) that had drifted apart on two behaviors.

- **Outcome:** A `bash:` node inside an interactive `loop_group` body now receives the reviewer's resumed feedback text through its subprocess environment, matching `script:` nodes. A `script:` node's persisted output is now capped at the same 32KB boundary as `bash:` nodes, with the same truncation metadata.
- **Invariant:** `bash:` and `script:` `exec` nodes behave identically with respect to which loop-scoped variables reach their subprocess environment and how their successful stdout is capped before persistence.
- **Scope boundary:** No change to `executeScriptNode`'s existing loop-input behavior (it was already correct), the truncation marker format or byte cap value, or the reader side (`output-ref.ts`) — both were already runtime-agnostic.
- **Root cause:**
  - `#2725` — `executeBashNode` hardcoded `LOOP_USER_INPUT: ''` in its subprocess env and its call site never passed the computed per-iteration value, while `executeScriptNode` already had a `loopUserInput` parameter wired from `ctx.bodyLoopUserInput`. Note: a *plain* `$LOOP_USER_INPUT` reference in a bash body script already worked pre-fix through a separate, pre-existing mechanism (`applyLoopPrevToBodyNode` shell-quotes and splices it directly into the script source before dispatch). The env var this PR adds is what a `${LOOP_USER_INPUT}` (braced) reference or a nested subprocess reading the inherited environment needs — that path was genuinely broken.
  - `#2726` — `executeScriptNode` persisted its full, unbounded stdout into the `node_completed` event, while `executeBashNode` already ran output through a 32KB UTF-8-safe truncation helper before persisting.

## Review guidance

- **Feedback requested:** Correctness of the two fixes and whether the parity they establish is complete.
- **Start here:** `packages/workflows/src/dag-executor.ts:3290` (`executeBashNode`) — the loop-input parameter and env wiring.
- **Review order:** `executeBashNode` signature/env (loop input) → `case 'exec':` call site → shared truncation helper rename → `executeScriptNode`'s new truncation call → new tests.
- **Lower-attention areas:** The helper/constant rename (`formatPersistedBashOutput`/`PERSISTED_BASH_OUTPUT_MAX_BYTES` → `formatPersistedNodeOutput`/`PERSISTED_NODE_OUTPUT_MAX_BYTES`) is mechanical — logic unchanged, just no longer bash-specific since it now serves both call sites.
- **Known risk or uncertainty:** None.

## Solution

`executeBashNode` gains a `loopUserInput = ''` parameter positioned identically to `executeScriptNode`'s (immediately before `execContext`), used in place of the hardcoded `''` in `subprocessEnv.LOOP_USER_INPUT`. The `case 'exec':` dispatch's bash branch now passes `ctx.bodyLoopUserInput ?? ''`, exactly mirroring the existing script branch.

The truncation helper (`formatPersistedBashOutput`) and its byte-cap constant (`PERSISTED_BASH_OUTPUT_MAX_BYTES`) are renamed to runtime-neutral names since a second caller now exists, and `executeScriptNode` calls it before building its `node_completed` event, adding the same conditional `node_output_truncated`/`node_output_original_bytes` fields `executeBashNode` already emits. No truncation logic is duplicated — both node types share the one helper. The shared-marker doc comment in `utils/output-truncation.ts` is updated to name the new writer and both node types.

## Validation

- `bun test src/dag-executor.test.ts -t "resumed body bash node via env"` — passed — proves #2725: a bash body node's `${LOOP_USER_INPUT}` env read now carries the resumed reviewer feedback. Verified this test fails on pre-fix code (`Expected: "looks good, ship it" / Received: ""`).
- `bun test src/dag-executor.test.ts -t "caps over-limit persisted script output"` — passed — proves #2726: a script node's persisted output is capped at 32,768 bytes with the correct truncation metadata. Verified this test fails on pre-fix code (`Expected: <= 32768 / Received: 32769`).
- `bun test src/dag-executor.test.ts` (full file) — 601 pass, 0 fail — no regressions in the existing suite, including the pre-existing bash truncation and script loop-input tests these fixes converge onto.
- `bun run type-check` — passed — renamed identifiers and the new parameter type-check cleanly.
- `bun run validate` — exit 0 — full repository gate (lint, format, type-check, complete test suite) green.
- **Not verified:** Nothing material — both fixes are covered by regression tests proven to fail before the fix and pass after it.

## Links

- Closes #2725
- Closes #2726


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Limited persisted Bash and script output to 32 KiB while preserving valid UTF-8 and indicating when content was truncated.
  * Ensured output at or below the limit remains unchanged.
  * Preserved loop input when resuming Bash workflow nodes.

* **Documentation**
  * Clarified truncation behavior and audit-preview retention for Bash and script output.
  * Updated security guidance for persisted execution output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->