### PR TITLE
fix(workflows): bash loop_group body nodes now receive $LOOP_USER_INPUT

### DIFF
--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -19735,6 +19735,85 @@ describe('executeDagWorkflow -- loop_group node', () => {
     }
   });
 
+  it('delivers $LOOP_USER_INPUT to a resumed body bash node via env (#2725)', async () => {
+    // A body bash node's literal "$LOOP_USER_INPUT" token is already resolved by the
+    // loop_group-level shell-quoted splice (applyLoopPrevToBodyNode) before executeBashNode
+    // ever runs, so a script using that exact literal form is not a regression test for
+    // this fix. This test targets a script that reads the variable WITHOUT that literal
+    // token — `printenv`, matching how `${LOOP_USER_INPUT}` (braced form) or any other
+    // indirect env read behaves — which the splice cannot touch and which previously read
+    // as empty because executeBashNode's subprocess env hardcoded LOOP_USER_INPUT: ''.
+    const feedback = 'looks good, ship it';
+    const execSpy = spyOn(git, 'execFileAsync').mockResolvedValue({ stdout: 'DONE\n', stderr: '' });
+    try {
+      const mockDeps = createMockDeps();
+      const platform = createMockPlatform();
+      const workflowRun = makeWorkflowRun('lg-userinput-bash', {
+        metadata: {
+          approval: {
+            type: 'interactive_loop',
+            nodeId: 'grp',
+            iteration: 0,
+            message: 'Review and provide feedback.',
+          },
+          loop_user_input: feedback,
+          loop_feedback_given: true,
+        },
+      });
+
+      const nodes: DagNode[] = [
+        {
+          id: 'grp',
+          kind: 'loop_group',
+          loop_group: {
+            until: 'DONE',
+            max_iterations: 3,
+            fresh_context: true,
+            interactive: true,
+            gate_message: 'Review and provide feedback.',
+            nodes: [
+              {
+                id: 'emit',
+                kind: 'exec',
+                script: 'printenv LOOP_USER_INPUT; echo "DONE"',
+                runtime: 'sh',
+                depends_on: [],
+              },
+            ],
+          },
+          depends_on: [],
+        },
+      ];
+
+      await executeDagWorkflow(
+        mockDeps,
+        platform,
+        'conv-lg-userinput-bash',
+        testDir,
+        { name: 'lg-userinput-bash', nodes },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'state'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+
+      const bashCall = execSpy.mock.calls.find(
+        c => (c[0] as string) === 'bash' && (c[1] as string[])[0] === '-c'
+      ) as [string, string[], { env: NodeJS.ProcessEnv }] | undefined;
+      expect(bashCall).toBeDefined();
+      // The per-iteration feedback reaches the bash node through the environment —
+      // previously always '' regardless of what the reviewer typed at the gate.
+      expect(bashCall?.[2].env.LOOP_USER_INPUT).toBe(feedback);
+    } finally {
+      execSpy.mockRestore();
+    }
+  });
+
   it('fails the loop_group when max_iterations is exceeded without the until signal', async () => {
     let callCount = 0;
     mockSendQueryDag.mockImplementation(async function* () {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -19803,7 +19803,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
       );
 
       const bashCall = execSpy.mock.calls.find(
-        c => (c[0] as string) === 'bash' && (c[1] as string[])[0] === '-c'
+        c => (c[0] as string) === git.resolveBashPath() && (c[1] as string[])[0] === '-c'
       ) as [string, string[], { env: NodeJS.ProcessEnv }] | undefined;
       expect(bashCall).toBeDefined();
       // The per-iteration feedback reaches the bash node through the environment —

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -3304,6 +3304,10 @@ async function executeBashNode(
   envVars?: Record<string, string>,
   stepNamePrefix = '',
   iteration?: number,
+  // Per-iteration $LOOP_USER_INPUT free-text for loop_group body bash nodes, delivered via
+  // env (never spliced into source — #2115). '' for top-level bash nodes and non-first
+  // iterations (mirrors executeScriptNode, #2725).
+  loopUserInput = '',
   execContext: ExecutionContext = { kind: 'host' }
 ): Promise<NodeOutput> {
   const nodeStartTime = Date.now();
@@ -3387,7 +3391,7 @@ async function executeBashNode(
     BASE_BRANCH: baseBranch,
     USER_MESSAGE: workflowRun.user_message,
     ARGUMENTS: workflowRun.user_message,
-    LOOP_USER_INPUT: '',
+    LOOP_USER_INPUT: loopUserInput,
     LOOP_PREV_OUTPUT: '',
     REJECTION_REASON: '',
     CONTEXT: issueContext ?? '',
@@ -8559,6 +8563,7 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
                       config.envVars,
                       stepNamePrefix,
                       iteration,
+                      ctx.bodyLoopUserInput ?? '',
                       execContext
                     )
                 );

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -3305,8 +3305,11 @@ async function executeBashNode(
   stepNamePrefix = '',
   iteration?: number,
   // Per-iteration $LOOP_USER_INPUT free-text for loop_group body bash nodes, delivered via
-  // env (never spliced into source — #2115). '' for top-level bash nodes and non-first
-  // iterations (mirrors executeScriptNode, #2725).
+  // env (#2725). This is bash's SECOND delivery channel — the literal "$LOOP_USER_INPUT"
+  // token is already shell-quoted and spliced into the script source by
+  // applyLoopPrevToBodyNode before this function runs; this env var is what a script that
+  // reads the variable indirectly (${LOOP_USER_INPUT}, printenv, env) actually sees. ''
+  // for top-level bash nodes and non-first iterations.
   loopUserInput = '',
   execContext: ExecutionContext = { kind: 'host' }
 ): Promise<NodeOutput> {
@@ -3583,7 +3586,10 @@ async function executeScriptNode(
   iteration?: number,
   // Per-iteration $LOOP_USER_INPUT free-text for loop_group body scripts, delivered via
   // env (never spliced into source — #2115). '' for top-level scripts and non-first
-  // iterations (mirrors executeBashNode, which delivers loop input via quoted splice).
+  // iterations. This is script's ONLY delivery channel; executeBashNode also uses this
+  // same env-var parameter (#2725), but additionally has the literal "$LOOP_USER_INPUT"
+  // token pre-spliced (shell-quoted) into its script source by applyLoopPrevToBodyNode
+  // before it runs — a channel script deliberately has no equivalent of.
   loopUserInput = '',
   execContext: ExecutionContext = { kind: 'host' },
   /** Roots named scripts resolve under; always supplied from RunLayersContext. */
@@ -4354,8 +4360,12 @@ async function executeLoopGroupNode(
       totalLoopIterations: 0,
       stepNamePrefix: bodyStepNamePrefix,
       loopGroupPath: [...enclosingLoopGroupPath, { groupId: node.id, iteration: i }],
-      // Deliver this iteration's approval-gate free-text to body script: nodes via env
-      // (never spliced into source — #2115); matches applyLoopPrevToBodyNode's skip.
+      // Deliver this iteration's approval-gate free-text to body exec: nodes via env
+      // (#2115, #2725). Script bodies use this as their ONLY channel (applyLoopPrevToBodyNode
+      // skips their literal token, unsafe to splice into TS/Python source). Bash bodies get
+      // it as a SECOND channel — applyLoopPrevToBodyNode already spliced the literal
+      // "$LOOP_USER_INPUT" token into the script source; this env var covers indirect reads
+      // (${LOOP_USER_INPUT}, printenv, env) that splice can't reach.
       bodyLoopUserInput: userInputForIter,
     };
     await runLayers(iterCtx);
@@ -8042,10 +8052,14 @@ interface RunLayersContext {
   /** Complete runtime loop_group lineage for typed body artifacts; empty at top level. */
   loopGroupPath: NodeArtifactLoopFrame[];
   /**
-   * Per-iteration `$LOOP_USER_INPUT` free-text for loop_group body `script:` nodes,
-   * delivered into the subprocess as an env var (never spliced into TS/Python source —
-   * #2115). Only non-empty on the first resumed iteration of an interactive group;
-   * undefined for the top-level DAG (top-level scripts have no loop user input).
+   * Per-iteration `$LOOP_USER_INPUT` free-text for loop_group body `exec:` nodes, delivered
+   * into the subprocess as an env var (#2115, #2725). `script:` nodes never splice this into
+   * source (unsafe for TS/Python) and rely on this env var exclusively. `bash:` nodes get it
+   * as a second channel alongside `applyLoopPrevToBodyNode`'s pre-existing shell-quoted
+   * splice of the literal `$LOOP_USER_INPUT` token — this env var is what covers an indirect
+   * read (`${LOOP_USER_INPUT}`, `printenv`, `env`) that splice can't reach. Only non-empty on
+   * the first resumed iteration of an interactive group; undefined for the top-level DAG
+   * (top-level exec nodes have no loop user input).
    */
   bodyLoopUserInput?: string;
 }

--- a/packages/workflows/src/schemas/dag-node.ts
+++ b/packages/workflows/src/schemas/dag-node.ts
@@ -382,17 +382,23 @@ export type AgentNode = z.infer<typeof agentNodeSchema>;
  * side-by-side read of both, 222 + 323 = 545 lines). The two are not thin
  * wrappers around one shell-out — real, non-superficial differences: output-ref
  * substitution (shell-escaped + artifacts-dir-aware for bash vs. raw splice for
- * script), env-delivered `$LOOP_USER_INPUT`/`deps:`/named-script-file resolution
- * (script-only), and per-runtime error diagnostics. A "merge but keep behavior
- * byte-identical" refactor would relocate rather than remove that complexity,
- * while unifying the ~230 lines of near-identical scaffolding (event
+ * script), `deps:`/named-script-file resolution (script-only), and per-runtime
+ * error diagnostics. `$LOOP_USER_INPUT` delivery is NOT a script-only concept —
+ * both runtimes deliver it via env (#2725); bash additionally gets the literal
+ * `$LOOP_USER_INPUT` token pre-spliced (shell-quoted) into its source by
+ * `applyLoopPrevToBodyNode`, a channel script has no equivalent of. A "merge but
+ * keep behavior byte-identical" refactor would relocate rather than remove that
+ * complexity, while unifying the ~230 lines of near-identical scaffolding (event
  * emission/persistence, retry wiring, error formatting) into one function risks
  * a regression that touches every deterministic node in every workflow at once —
  * today a bug in one runtime's path can't touch the other. Two bugs the read
- * surfaced along the way (`$LOOP_USER_INPUT` never reaching a `bash:` loop_group
- * body node, and `script:` node output never getting the truncation cap `bash:`
- * gets) are real independently-evolved drift, not evidence for merging — they're
- * filed as their own fixes, #2725 and #2726, rather than folded into this call.
+ * surfaced along the way (`executeBashNode`'s own env channel for
+ * `$LOOP_USER_INPUT` was unwired, so a `bash:` loop_group body node reading it
+ * indirectly — `${LOOP_USER_INPUT}`, `printenv`, `env` — always saw an empty
+ * value even though the literal-token splice worked; and `script:` node output
+ * never getting the truncation cap `bash:` gets) are real independently-evolved
+ * drift, not evidence for merging — they're filed as their own fixes, #2725 and
+ * #2726, rather than folded into this call.
  */
 export const execNodeSchema = dagNodeBaseSchema.extend({
   kind: z.literal('exec'),


### PR DESCRIPTION
## Problem and outcome

`executeBashNode`'s subprocess environment hardcoded `LOOP_USER_INPUT` to `''`, unlike its sibling `executeScriptNode`, which threads the resumed loop_group gate's free-text feedback through a `loopUserInput` parameter into the same env var. A `bash:` node inside an interactive `loop_group` body that reads `$LOOP_USER_INPUT` through any indirect form — `${LOOP_USER_INPUT}` braced syntax, `printenv`, `env` — always saw an empty value regardless of what the reviewer typed at the gate.

- **Outcome:** A `bash:` node inside an interactive loop_group body sees `$LOOP_USER_INPUT` in its subprocess env whenever a `script:` node in the same position already would.
- **Invariant:** A `bash:` or `script:` `exec` node's subprocess environment carries the current iteration's `LOOP_USER_INPUT` value whenever one is available, regardless of how the script reads it.
- **Scope boundary:** No change to `executeScriptNode`, to the top-level (non-loop_group) bash/script env delivery, or to issue #2726 (unrelated `script:` node output truncation, delivered separately).
- **Root cause:** The engine already computes `ctx.bodyLoopUserInput` per resumed iteration and threads it into the `case 'exec':` dispatch. The script branch forwards it into `executeScriptNode`. The bash branch had no corresponding parameter or call-site argument, so `executeBashNode` always used its own hardcoded `''`.

**Correction to the originally filed issue:** the issue's own example — a bash node doing `echo "$LOOP_USER_INPUT"` (the bare literal token) — does not actually reproduce this failure on `dev`. Verified by test: a separate, pre-existing mechanism (`applyLoopPrevToBodyNode`, `packages/workflows/src/dag-executor.ts:4931-4939`, present since well before this issue was filed) already shell-quotes and splices that exact literal substring into bash script source before `executeBashNode` ever runs. The residual gap this PR fixes is real but narrower: any bash script that reads the variable a different way — because the splice's regex `/\$LOOP_USER_INPUT/g` only matches that exact literal substring, not `${LOOP_USER_INPUT}` or an indirect env read — never received the value. This PR closes that gap and brings `executeBashNode` to full parity with `executeScriptNode`'s env channel.

## Review guidance

- **Feedback requested:** Correctness of the parameter threading, and whether the corrected root-cause framing above is accurate.
- **Start here:** `packages/workflows/src/dag-executor.ts:3307` — the new `loopUserInput` parameter, positioned identically to `executeScriptNode`'s existing one.
- **Review order:** `dag-executor.ts:3307` (parameter) → `dag-executor.ts:3394` (env wiring) → `dag-executor.ts:8566` (call site) → the new test in `dag-executor.test.ts`.
- **Lower-attention areas:** None — this is a three-line change plus one test.
- **Known risk or uncertainty:** None.

## Solution

`executeBashNode` now takes a `loopUserInput = ''` parameter in the same relative position `executeScriptNode` already uses (immediately before `execContext`), and its `subprocessEnv.LOOP_USER_INPUT` uses that parameter instead of a hardcoded `''`. The `case 'exec':` bash call site now passes `ctx.bodyLoopUserInput ?? ''`, exactly matching how the script call site already does. No new abstraction — this converges `executeBashNode` onto a pattern that already existed, working, one function away.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | A `bash:` loop_group body node reading `$LOOP_USER_INPUT` via `printenv`/`${LOOP_USER_INPUT}`/`env` always sees `''` | Sees the reviewer's actual feedback text, on the first iteration of a resumed interactive loop_group |
| **Failure behavior** | N/A (silent empty value, no error) | N/A (no failure mode introduced) |

## Validation

- `cd packages/workflows && bun test src/dag-executor.test.ts -t "LOOP_USER_INPUT"` — 4 pass, 0 fail — proves the new bash-side test and existing script-side test both pass.
- New test verified failing against pre-fix code (`Received: ""`) and passing after the fix (`Received: "looks good, ship it"`) — proves this is a genuine regression test, not a vacuous one.
- `cd packages/workflows && bun test src/dag-executor.test.ts` (full file) — 599 pass, 0 fail — proves no regression to existing bash/script behavior.
- `cd packages/workflows && bun run type-check` — passed.
- `bun run validate` — exit 0, all per-package suites green.
- **Not verified:** No manual end-to-end run against a live workflow — the mocked-`execFileAsync` unit test directly asserts the subprocess env contents, which is the authoritative observable point for this fix.

## Links

- Closes #2725
- Plan: https://github.com/coleam00/Archon/issues/2725#issuecomment-5381908622


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resumed interactive workflow loops now correctly pass reviewer feedback to Bash and script steps.
  * Bash commands can access the latest loop input through the subprocess environment or inline substitution.
  * Clarified how loop input is provided during Bash and script execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->