### PR TITLE
fix(core): manage_run's reject action now defaults empty text to 'Rejected'

### DIFF
--- a/packages/core/src/orchestrator/manage-run-tool.test.ts
+++ b/packages/core/src/orchestrator/manage-run-tool.test.ts
@@ -412,6 +412,18 @@ describe('manage_run — destructive confirmation gate', () => {
     expect(mockReject).toHaveBeenCalledWith('r1abcdef-1234', 'no');
   });
 
+  test('reject with no message defaults the rejection text to "Rejected"', async () => {
+    mockFindByPrefix.mockResolvedValue([makeRun({ status: 'paused' })]);
+    mockReject.mockResolvedValue({
+      workflowName: 'wf',
+      cancelled: true,
+      maxAttemptsReached: false,
+    });
+    const tool = buildManageRunTool({ codebaseId: CODEBASE_ID });
+    await tool.handler({ action: 'reject', runId: 'r1abcdef', confirm: true });
+    expect(mockReject).toHaveBeenCalledWith('r1abcdef-1234', 'Rejected');
+  });
+
   test('reject with confirm and an on-reject prompt reports rework, not cancellation', async () => {
     mockFindByPrefix.mockResolvedValue([makeRun({ status: 'paused' })]);
     mockReject.mockResolvedValue({

--- a/packages/core/src/orchestrator/manage-run-tool.ts
+++ b/packages/core/src/orchestrator/manage-run-tool.ts
@@ -386,7 +386,8 @@ async function handleWrite(
         : `Feedback recorded for ${result.workflowName} (${id.slice(0, 8)}); the loop runs another iteration with it.${continues}`;
     }
     case 'reject': {
-      const result = await rejectWorkflow(id, message.length > 0 ? message : undefined);
+      const rejectText = message.length > 0 ? message : 'Rejected';
+      const result = await rejectWorkflow(id, rejectText);
       if (result.cancelled) {
         const suffix = result.maxAttemptsReached ? ' (max attempts reached)' : '';
         return `Rejected and cancelled ${result.workflowName} (${id.slice(0, 8)})${suffix}. Nothing further runs.`;


### PR DESCRIPTION
## Problem and outcome

`manage_run`'s `reject` action passed `undefined` to `rejectWorkflow` when called with no message. On the new-mode structured-output path, that produced `structured_output.text: ''` instead of a meaningful default — the sibling `respond`-style default for this exact gap already exists elsewhere (`command-handler.ts`, `api.ts`), it just was never applied here.

- **Outcome:** Calling `manage_run action=reject` with no text now records `'Rejected'` as the structured output text, matching the same default already used by the `command-handler.ts` and `api.ts` reject/respond surfaces. (The CLI `workflow reject` and Slack reject-button call sites have the identical unfixed gap — tracked separately in #2740, deliberately out of this PR's scope, the same way #2734 itself was carved out of an earlier PR.)
- **Invariant:** An empty or whitespace-only rejection message never reaches `structured_output.text` as `''`.
- **Scope boundary:** No change to `rejectWorkflow`, `respondToWorkflow`, or any other `manage_run` action — only the `reject` case's call-site default.
- **Root cause:** `case 'reject':` in `manage-run-tool.ts` computed `message.length > 0 ? message : undefined` and passed that straight to `rejectWorkflow`, so an empty message became `undefined`, which the new-mode branch in `workflow-operations.ts` (`text: reason ?? ''`) turns into an empty string rather than a default.

## Review guidance

- **Feedback requested:** Correctness only — this is a narrow, well-precedented one-line fix.
- **Start here:** `packages/core/src/orchestrator/manage-run-tool.ts:388-390` — the fixed `case 'reject':` block.
- **Review order:** `manage-run-tool.ts` diff, then the new test in `manage-run-tool.test.ts`.
- **Lower-attention areas:** None — the whole diff is 14 lines.
- **Known risk or uncertainty:** None.

## Solution

Mirror the existing default pattern already used for the `respond` action: compute `rejectText = message.length > 0 ? message : 'Rejected'` and pass that to `rejectWorkflow` instead of `message.length > 0 ? message : undefined`. `rejectWorkflow`'s own internal default (`rejectReason = reason ?? 'Rejected'`) only feeds the audit event and the legacy stage-rework/cancel path — it doesn't cover the new-mode `structuredOutput.text` field, so the fix has to happen at this call site.

## Validation

- `bun test packages/core/src/orchestrator/manage-run-tool.test.ts` — passed (37 pass, 0 fail) — proves the new regression test (`reject with no message defaults the rejection text to "Rejected"`) and every existing reject/respond test still hold.
- `bun run test` — passed (0 fail across every package) — proves no regression elsewhere.
- `bun run validate` — passed (exit 0) — proves types, lint, format, and the full suite all pass.
- **Not verified:** Nothing material — this is a pure default-value fix fully covered by the added unit test.

## Links

- Closes #2734
- Plan: https://github.com/coleam00/Archon/issues/2734#issuecomment-5382407795
