### PR TITLE
fix(cli): workflow reject and the Slack reject button now default empty text to 'Rejected'

### DIFF
--- a/packages/adapters/src/chat/slack/workflow-bridge.test.ts
+++ b/packages/adapters/src/chat/slack/workflow-bridge.test.ts
@@ -354,6 +354,10 @@ describe('SlackWorkflowBridge', () => {
     });
 
     expect(mockRejectWorkflow).toHaveBeenCalledTimes(1);
+    // The reject button has no text-entry affordance, so it can never supply a
+    // reason — the bridge must default it to 'Rejected' itself (#2740),
+    // otherwise a new-mode gate's structured output.text records ''.
+    expect(mockRejectWorkflow).toHaveBeenCalledWith('r1', 'Rejected');
     const text = (updated[0]?.blocks?.[0] as { text?: { text?: string } } | undefined)?.text?.text;
     expect(text).toContain('Rejected');
     expect(text).toContain('will retry');

--- a/packages/adapters/src/chat/slack/workflow-bridge.ts
+++ b/packages/adapters/src/chat/slack/workflow-bridge.ts
@@ -479,7 +479,7 @@ export class SlackWorkflowBridge {
               ? 'recorded — finalizes if the gate paused after a completion condition was met, otherwise the loop runs another iteration on resume'
               : 'workflow resumed';
         } else {
-          const result = await workflowOperations.rejectWorkflow(runId);
+          const result = await workflowOperations.rejectWorkflow(runId, 'Rejected');
           outcomeNote = result.cancelled
             ? result.maxAttemptsReached
               ? 'cancelled — max reject attempts reached'

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -6420,6 +6420,114 @@ describe('workflowRejectCommand', () => {
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Rejected and cancelled'));
   });
 
+  it('plain mode: rejecting with no reason defaults structured output text to "Rejected" (#2740)', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'run-new-mode',
+      workflow_name: 'new-mode-wf',
+      status: 'paused',
+      user_message: 'build it',
+      working_path: '/repo',
+      codebase_id: null,
+      metadata: {
+        approval: {
+          type: 'approval',
+          nodeId: 'gate',
+          message: 'Approve?',
+          decisions: [{ id: 'approve' }, { id: 'reject' }],
+          decisionsAuthored: true,
+        },
+      },
+    });
+
+    try {
+      await workflowRejectCommand('run-new-mode');
+    } catch {
+      // A new-mode reject stays resumable and auto-resumes inline; the
+      // downstream workflowRunCommand failure (no workflow discovered in this
+      // unit test's fake cwd) is acceptable here — this test only cares about
+      // what was recorded before that point.
+    }
+
+    // No `reason` argument at all — the CLI must default it to 'Rejected'
+    // before it reaches rejectWorkflow, otherwise the new-mode structured
+    // output (#2707) records an empty string instead (#2740).
+    const structuredOutput = { decision: 'reject', text: 'Rejected' };
+    expect(workflowDb.resolveApprovalGate).toHaveBeenCalledWith(
+      'run-new-mode',
+      {
+        approval: {
+          type: 'approval',
+          nodeId: 'gate',
+          message: 'Approve?',
+          decisions: [{ id: 'approve' }, { id: 'reject' }],
+          decisionsAuthored: true,
+          resolved: 'rejected',
+        },
+      },
+      [
+        {
+          event_type: 'node_completed',
+          step_name: 'gate',
+          data: {
+            node_output: JSON.stringify(structuredOutput),
+            approval_decision: 'rejected',
+            structured_output: structuredOutput,
+          },
+        },
+        {
+          event_type: 'approval_received',
+          step_name: 'gate',
+          data: { decision: 'rejected', reason: 'Rejected' },
+        },
+      ]
+    );
+  });
+
+  it('--json mode: rejecting with no reason defaults structured output text to "Rejected" (#2740)', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const jsonStdoutSpy = spyOnJsonStdout();
+
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'run-new-mode-json',
+      workflow_name: 'new-mode-wf',
+      status: 'paused',
+      user_message: 'build it',
+      working_path: '/repo',
+      codebase_id: null,
+      metadata: {
+        approval: {
+          type: 'approval',
+          nodeId: 'gate',
+          message: 'Approve?',
+          decisions: [{ id: 'approve' }, { id: 'reject' }],
+          decisionsAuthored: true,
+        },
+      },
+    });
+
+    await workflowRejectCommand('run-new-mode-json', undefined, true);
+
+    const structuredOutput = { decision: 'reject', text: 'Rejected' };
+    expect(workflowDb.resolveApprovalGate).toHaveBeenCalledWith(
+      'run-new-mode-json',
+      expect.objectContaining({
+        approval: expect.objectContaining({ resolved: 'rejected' }),
+      }),
+      expect.arrayContaining([
+        expect.objectContaining({
+          event_type: 'node_completed',
+          step_name: 'gate',
+          data: expect.objectContaining({ structured_output: structuredOutput }),
+        }),
+      ])
+    );
+    const parsed = JSON.parse(firstJsonPayload(jsonStdoutSpy)) as Record<string, unknown>;
+    expect(parsed).toMatchObject({ ok: true, runId: 'run-new-mode-json', action: 'reject' });
+    jsonStdoutSpy.mockRestore();
+  });
+
   it('updates metadata and auto-resumes when on_reject configured and under limit', async () => {
     const workflowDb = await import('@archon/core/db/workflows');
 

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -6601,6 +6601,114 @@ describe('workflowRejectCommand', () => {
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Rejected and cancelled'));
   });
 
+  it('plain mode: rejecting with no reason defaults structured output text to "Rejected" (#2740)', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'run-new-mode',
+      workflow_name: 'new-mode-wf',
+      status: 'paused',
+      user_message: 'build it',
+      working_path: '/repo',
+      codebase_id: null,
+      metadata: {
+        approval: {
+          type: 'approval',
+          nodeId: 'gate',
+          message: 'Approve?',
+          decisions: [{ id: 'approve' }, { id: 'reject' }],
+          decisionsAuthored: true,
+        },
+      },
+    });
+
+    try {
+      await workflowRejectCommand('run-new-mode');
+    } catch {
+      // A new-mode reject stays resumable and auto-resumes inline; the
+      // downstream workflowRunCommand failure (no workflow discovered in this
+      // unit test's fake cwd) is acceptable here — this test only cares about
+      // what was recorded before that point.
+    }
+
+    // No `reason` argument at all — the CLI must default it to 'Rejected'
+    // before it reaches rejectWorkflow, otherwise the new-mode structured
+    // output (#2707) records an empty string instead (#2740).
+    const structuredOutput = { decision: 'reject', text: 'Rejected' };
+    expect(workflowDb.resolveApprovalGate).toHaveBeenCalledWith(
+      'run-new-mode',
+      {
+        approval: {
+          type: 'approval',
+          nodeId: 'gate',
+          message: 'Approve?',
+          decisions: [{ id: 'approve' }, { id: 'reject' }],
+          decisionsAuthored: true,
+          resolved: 'rejected',
+        },
+      },
+      [
+        {
+          event_type: 'node_completed',
+          step_name: 'gate',
+          data: {
+            node_output: JSON.stringify(structuredOutput),
+            approval_decision: 'rejected',
+            structured_output: structuredOutput,
+          },
+        },
+        {
+          event_type: 'approval_received',
+          step_name: 'gate',
+          data: { decision: 'rejected', reason: 'Rejected' },
+        },
+      ]
+    );
+  });
+
+  it('--json mode: rejecting with no reason defaults structured output text to "Rejected" (#2740)', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const jsonStdoutSpy = spyOnJsonStdout();
+
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'run-new-mode-json',
+      workflow_name: 'new-mode-wf',
+      status: 'paused',
+      user_message: 'build it',
+      working_path: '/repo',
+      codebase_id: null,
+      metadata: {
+        approval: {
+          type: 'approval',
+          nodeId: 'gate',
+          message: 'Approve?',
+          decisions: [{ id: 'approve' }, { id: 'reject' }],
+          decisionsAuthored: true,
+        },
+      },
+    });
+
+    await workflowRejectCommand('run-new-mode-json', undefined, true);
+
+    const structuredOutput = { decision: 'reject', text: 'Rejected' };
+    expect(workflowDb.resolveApprovalGate).toHaveBeenCalledWith(
+      'run-new-mode-json',
+      expect.objectContaining({
+        approval: expect.objectContaining({ resolved: 'rejected' }),
+      }),
+      expect.arrayContaining([
+        expect.objectContaining({
+          event_type: 'node_completed',
+          step_name: 'gate',
+          data: expect.objectContaining({ structured_output: structuredOutput }),
+        }),
+      ])
+    );
+    const parsed = JSON.parse(firstJsonPayload(jsonStdoutSpy)) as Record<string, unknown>;
+    expect(parsed).toMatchObject({ ok: true, runId: 'run-new-mode-json', action: 'reject' });
+    jsonStdoutSpy.mockRestore();
+  });
+
   it('updates metadata and auto-resumes when on_reject configured and under limit', async () => {
     const workflowDb = await import('@archon/core/db/workflows');
 

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -3312,7 +3312,8 @@ export async function workflowRejectCommand(
   if (json) {
     try {
       const resolvedId = await resolveRunIdArg(runId, cwd);
-      const result = await rejectWorkflow(resolvedId, reason);
+      const rejectText = reason && reason.length > 0 ? reason : 'Rejected';
+      const result = await rejectWorkflow(resolvedId, rejectText);
       await writeJsonLine({
         ok: true,
         runId: resolvedId,
@@ -3329,7 +3330,8 @@ export async function workflowRejectCommand(
   }
 
   const resolvedId = await resolveRunIdArg(runId, cwd);
-  const result = await rejectWorkflow(resolvedId, reason);
+  const rejectText = reason && reason.length > 0 ? reason : 'Rejected';
+  const result = await rejectWorkflow(resolvedId, rejectText);
 
   if (result.cancelled) {
     const suffix = result.maxAttemptsReached ? ' (max attempts reached)' : '';

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -3351,6 +3351,11 @@ export async function workflowRejectCommand(
     return;
   }
 
+  // An empty or omitted reason still needs a meaningful value on the new-mode
+  // structured-output path (#2740) — rejectWorkflow's own internal default
+  // only covers the audit event and legacy rework/cancel path.
+  const rejectText = reason && reason.length > 0 ? reason : 'Rejected';
+
   // JSON mode records the rejection and returns a structured ack WITHOUT the
   // inline auto-resume (an on_reject rework executes the workflow and streams
   // to stdout, corrupting the JSON contract). When `cancelled` is false the run
@@ -3358,7 +3363,6 @@ export async function workflowRejectCommand(
   if (json) {
     try {
       const resolvedId = await resolveRunIdArg(runId, cwd);
-      const rejectText = reason && reason.length > 0 ? reason : 'Rejected';
       const result = await rejectWorkflow(resolvedId, rejectText);
       await writeJsonLine({
         ok: true,
@@ -3376,7 +3380,6 @@ export async function workflowRejectCommand(
   }
 
   const resolvedId = await resolveRunIdArg(runId, cwd);
-  const rejectText = reason && reason.length > 0 ? reason : 'Rejected';
   const result = await rejectWorkflow(resolvedId, rejectText);
 
   if (result.cancelled) {

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -3305,6 +3305,11 @@ export async function workflowRejectCommand(
     return;
   }
 
+  // An empty or omitted reason still needs a meaningful value on the new-mode
+  // structured-output path (#2740) — rejectWorkflow's own internal default
+  // only covers the audit event and legacy rework/cancel path.
+  const rejectText = reason && reason.length > 0 ? reason : 'Rejected';
+
   // JSON mode records the rejection and returns a structured ack WITHOUT the
   // inline auto-resume (an on_reject rework executes the workflow and streams
   // to stdout, corrupting the JSON contract). When `cancelled` is false the run
@@ -3312,7 +3317,6 @@ export async function workflowRejectCommand(
   if (json) {
     try {
       const resolvedId = await resolveRunIdArg(runId, cwd);
-      const rejectText = reason && reason.length > 0 ? reason : 'Rejected';
       const result = await rejectWorkflow(resolvedId, rejectText);
       await writeJsonLine({
         ok: true,
@@ -3330,7 +3334,6 @@ export async function workflowRejectCommand(
   }
 
   const resolvedId = await resolveRunIdArg(runId, cwd);
-  const rejectText = reason && reason.length > 0 ? reason : 'Rejected';
   const result = await rejectWorkflow(resolvedId, rejectText);
 
   if (result.cancelled) {

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -3358,7 +3358,8 @@ export async function workflowRejectCommand(
   if (json) {
     try {
       const resolvedId = await resolveRunIdArg(runId, cwd);
-      const result = await rejectWorkflow(resolvedId, reason);
+      const rejectText = reason && reason.length > 0 ? reason : 'Rejected';
+      const result = await rejectWorkflow(resolvedId, rejectText);
       await writeJsonLine({
         ok: true,
         runId: resolvedId,
@@ -3375,7 +3376,8 @@ export async function workflowRejectCommand(
   }
 
   const resolvedId = await resolveRunIdArg(runId, cwd);
-  const result = await rejectWorkflow(resolvedId, reason);
+  const rejectText = reason && reason.length > 0 ? reason : 'Rejected';
+  const result = await rejectWorkflow(resolvedId, rejectText);
 
   if (result.cancelled) {
     const suffix = result.maxAttemptsReached ? ' (max attempts reached)' : '';


### PR DESCRIPTION
## Problem and outcome

PR #2739 fixed `manage_run`'s `reject` action to default an empty rejection message to `'Rejected'` before calling `rejectWorkflow`, matching the pattern already used in `command-handler.ts`'s `/workflow reject` and `api.ts`'s REST reject route. That fix was deliberately scoped to its one call site, leaving two more with the identical gap: the CLI's `archon workflow reject` and the Slack reject button.

- **Outcome:** `archon workflow reject <run-id>` with no reason (`--json`, plain, and `--detach`) and every Slack reject-button click now record `structured_output.text: 'Rejected'` on a gate authored with `approval.decisions:`, instead of `''`.
- **Invariant:** An empty or omitted rejection reason never reaches `structured_output.text` as `''`.
- **Scope boundary:** No change to `rejectWorkflow`, `respondToWorkflow`, or any other call site — only these two call-site defaults. `rejectWorkflow`'s `reason` parameter stays optional (see Review guidance).
- **Root cause:** `rejectWorkflow`'s new-mode structured-output path (`packages/core/src/operations/workflow-operations.ts:697`) computes `text: reason ?? ''`. Its own internal default (`rejectReason = reason ?? 'Rejected'`, line 644) only feeds the audit event and the legacy stage-rework/cancel path, not this field — so a caller that passes `undefined` reaches `''` here. `workflow.ts`'s two `rejectWorkflow` calls passed `reason` straight through (`string | undefined`), and `workflow-bridge.ts`'s Slack call passed no second argument at all — Slack's reject button has no text-entry affordance, so it can never supply one.

## Review guidance

- **Feedback requested:** Correctness only — this is a narrow, well-precedented fix identical in shape to #2739.
- **Start here:** `packages/cli/src/commands/workflow.ts:3316` and `:3334` — the two fixed `rejectWorkflow` calls.
- **Review order:** `workflow.ts` diff → `workflow-bridge.ts` diff → the two new regression tests in `workflow.test.ts` → the one new assertion in `workflow-bridge.test.ts`.
- **Lower-attention areas:** None — the whole diff is small and mechanical.
- **Known risk or uncertainty:** The issue raised an optional follow-up: making `rejectWorkflow`'s `reason` parameter non-optional (`reason: string`) to collapse the repeated `x.length > 0 ? x : 'Rejected'` guard into one place. Declined here — `workflow-operations.test.ts` has four existing call sites (`rejectWorkflow('run-1')`, no second arg) that intentionally exercise the function's own internal default; making the parameter required would force rewriting those tests to pass `'Rejected'` explicitly, turning a runtime-tested default into a compile-time-enforced-but-no-longer-exercised one. The issue itself scoped this as skippable if it adds risk, and #2739 set the precedent of touching only the call site.

## Solution

Mirror #2739's exact pattern at the two remaining call sites:

- `workflow.ts`, both `rejectWorkflow` call sites (`--json` at line 3315-3316, plain at 3333-3334): compute `const rejectText = reason && reason.length > 0 ? reason : 'Rejected';` and pass `rejectText` instead of `reason`. The `--detach` branch needed no separate change — it never calls `rejectWorkflow` itself, it re-spawns a detached child that re-invokes the same CLI argv (`runDetachedControlCommand`, `workflow.ts:2893-2941`), and that child re-enters `workflowRejectCommand`, hitting one of these two now-fixed lines.
- `workflow-bridge.ts:482`: `workflowOperations.rejectWorkflow(runId)` → `workflowOperations.rejectWorkflow(runId, 'Rejected')`. No conditional needed — this call site never has a reason to preserve.

## Validation

- `bun test packages/cli/src/commands/workflow.test.ts` — 258 pass, 0 fail — proves both fixed lines (two new regression tests assert `resolveApprovalGate` receives `structured_output.text: 'Rejected'` for `--json` and plain mode with no reason given) and every existing reject test (all passing an explicit non-empty reason) still holds.
- `bun test packages/adapters/src/chat/slack/workflow-bridge.test.ts` — 11 pass, 0 fail — proves the Slack fix (new assertion: `mockRejectWorkflow` called with `('r1', 'Rejected')` when the reject button is clicked with no text).
- `bun run type-check` — passed, all packages.
- `bun run lint --max-warnings 0` — passed, no warnings.
- `bun run format:check` — passed.
- `bun run test` (full suite, every package) — 0 fail across the monorepo.
- `bun run validate` (all remaining gates: `check:bundled`, `check:bundled-skill`, `check:bundled-schema`, `check:pi-vendor-map`, `check:capability-matrix`, `test:install`) — all passed.
- **Not verified:** Nothing material — this is a pure call-site default fix fully covered by the added unit tests, matching #2739's validation shape.

## Links

- Closes #2740
- Plan: https://github.com/coleam00/Archon/issues/2740#issuecomment-5382534342


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for responding to arbitrary workflow decisions from the command line, including detached and inline responses.
  - Improved handling of detached workflows with interactive approval steps.

- **Bug Fixes**
  - Rejection actions now consistently record “Rejected” when no feedback is provided across Slack and command-line workflows.
  - Improved workflow resource cleanup after failures, interruptions, and completion.

- **Tests**
  - Added coverage for workflow responses, detached execution, cleanup, and default rejection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->