### PR TITLE
fix(providers): drop bare '401'/'403' from Claude AUTH_PATTERNS

### DIFF
--- a/packages/providers/src/claude/provider.test.ts
+++ b/packages/providers/src/claude/provider.test.ts
@@ -3107,12 +3107,6 @@ describe('API error surfaced as text (#1797)', () => {
 });
 
 describe('classifySubprocessError (#2715)', () => {
-  // AUTH_PATTERNS is this classifier's sole gate to 'auth', and 'auth' is what
-  // makes classifyAndEnrichError wrap a message as `Claude Code auth error:` —
-  // the prefix error-formatter.ts trusts unconditionally. A bare "401"/"403"
-  // used to be enough to classify as 'auth', so any mid-turn error whose text
-  // merely contained those digits (a port, a timeout in ms) was misrouted to
-  // "run /login" and had its retry disabled at :1353-1357.
   test('does not classify a bare "401"/"403" substring as auth', () => {
     expect(classifySubprocessError('connect ECONNREFUSED 127.0.0.1:401', '')).not.toBe('auth');
     expect(classifySubprocessError('timeout after 401ms', '')).not.toBe('auth');
@@ -3143,13 +3137,6 @@ describe('classifySubprocessError (#2715)', () => {
     expect(classifySubprocessError('exited with code 401', '')).toBe('crash');
   });
 
-  // RATE_LIMIT_PATTERNS used to admit bare '429', with the same substring scan
-  // pitfall as AUTH_PATTERNS above — a port like 127.0.0.1:4291 or a timeout
-  // in ms like "operation timed out after 4293ms" was misrouted to
-  // 'rate_limit', wasting one retry/backoff cycle before the correct terminal
-  // message. The Codex classifier got the same fix in PR #2702 (regression
-  // test at codex/provider.test.ts:2707-2712); the Claude side ports that
-  // contract here (#2715, #2509 R11 mirror).
   test('does not classify a bare "429" substring as rate_limit', () => {
     expect(classifySubprocessError('connect ECONNREFUSED 127.0.0.1:4291', '')).not.toBe(
       'rate_limit'

--- a/packages/providers/src/claude/provider.test.ts
+++ b/packages/providers/src/claude/provider.test.ts
@@ -23,7 +23,7 @@ mock.module('@anthropic-ai/claude-agent-sdk', () => ({
   query: mockQuery,
 }));
 
-import { ClaudeProvider, shouldPassNoEnvFile } from './provider';
+import { ClaudeProvider, classifySubprocessError, shouldPassNoEnvFile } from './provider';
 import * as claudeModule from './provider';
 import * as binaryResolver from './binary-resolver';
 
@@ -3103,5 +3103,43 @@ describe('API error surfaced as text (#1797)', () => {
     expect(chunks.filter(c => c.type === 'assistant')).toHaveLength(0);
     // billing_error classifies as auth → non-retryable
     expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('classifySubprocessError (#2715)', () => {
+  // AUTH_PATTERNS is this classifier's sole gate to 'auth', and 'auth' is what
+  // makes classifyAndEnrichError wrap a message as `Claude Code auth error:` —
+  // the prefix error-formatter.ts trusts unconditionally. A bare "401"/"403"
+  // used to be enough to classify as 'auth', so any mid-turn error whose text
+  // merely contained those digits (a port, a timeout in ms) was misrouted to
+  // "run /login" and had its retry disabled at :1353-1357.
+  test('does not classify a bare "401"/"403" substring as auth', () => {
+    expect(classifySubprocessError('connect ECONNREFUSED 127.0.0.1:401', '')).not.toBe('auth');
+    expect(classifySubprocessError('timeout after 401ms', '')).not.toBe('auth');
+    expect(classifySubprocessError('proxy responded with 403', '')).not.toBe('auth');
+  });
+
+  test('still classifies genuine auth signals as auth', () => {
+    expect(classifySubprocessError('Unauthorized', '')).toBe('auth');
+    expect(classifySubprocessError('authentication failed', '')).toBe('auth');
+    expect(classifySubprocessError('invalid token provided', '')).toBe('auth');
+    expect(classifySubprocessError('Your credit balance is too low to access the API', '')).toBe(
+      'auth'
+    );
+    // Real-world provider shape: a 401 co-occurring with the word "Unauthorized" —
+    // the word carries the signal, not the digits.
+    expect(classifySubprocessError('exceeded retry limit, last status: 401 Unauthorized', '')).toBe(
+      'auth'
+    );
+  });
+
+  test('resolves a crash-pattern message carrying a stray digit to the retryable "crash" class, not silently to "unknown"', () => {
+    // Not classifying as 'auth' isn't sufficient on its own — shouldRetry =
+    // errorClass === 'rate_limit' || errorClass === 'crash', so a crash-shaped
+    // message must specifically land on 'crash' (retryable), not fall through
+    // to 'unknown' (also non-retryable), or a future reordering of
+    // SUBPROCESS_CRASH_PATTERNS/AUTH_PATTERNS could silently regress retry
+    // eligibility without any test catching it.
+    expect(classifySubprocessError('exited with code 401', '')).toBe('crash');
   });
 });

--- a/packages/providers/src/claude/provider.test.ts
+++ b/packages/providers/src/claude/provider.test.ts
@@ -3142,4 +3142,26 @@ describe('classifySubprocessError (#2715)', () => {
     // eligibility without any test catching it.
     expect(classifySubprocessError('exited with code 401', '')).toBe('crash');
   });
+
+  // RATE_LIMIT_PATTERNS used to admit bare '429', with the same substring scan
+  // pitfall as AUTH_PATTERNS above — a port like 127.0.0.1:4291 or a timeout
+  // in ms like "operation timed out after 4293ms" was misrouted to
+  // 'rate_limit', wasting one retry/backoff cycle before the correct terminal
+  // message. The Codex classifier got the same fix in PR #2702 (regression
+  // test at codex/provider.test.ts:2707-2712); the Claude side ports that
+  // contract here (#2715, #2509 R11 mirror).
+  test('does not classify a bare "429" substring as rate_limit', () => {
+    expect(classifySubprocessError('connect ECONNREFUSED 127.0.0.1:4291', '')).not.toBe(
+      'rate_limit'
+    );
+    expect(
+      classifySubprocessError('operation timed out after 4293ms while establishing connection', '')
+    ).not.toBe('rate_limit');
+  });
+
+  test('still classifies genuine rate-limit signals as rate_limit', () => {
+    expect(classifySubprocessError('rate limit exceeded', '')).toBe('rate_limit');
+    expect(classifySubprocessError('too many requests, please slow down', '')).toBe('rate_limit');
+    expect(classifySubprocessError('server overloaded', '')).toBe('rate_limit');
+  });
 });

--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -226,14 +226,8 @@ export function buildRequestSubprocessEnv(
 const MAX_SUBPROCESS_RETRIES = 3;
 const RETRY_BASE_DELAY_MS = 2000;
 
-// Deliberately excludes a bare '429': that digit can appear in unrelated text
-// (a port, a byte count, a millisecond duration) on this classifier's sole
-// call site (the retry-loop catch in classifyAndEnrichError, :1325), which
-// covers every error thrown mid-turn — same "bare digits aren't enough
-// signal" reasoning as AUTH_PATTERNS below (#2715, mirror of #2509 R11
-// applied to Codex in PR #2702). A false 'rate_limit' classification wastes
-// a subprocess retry/backoff cycle before the correct terminal message is
-// shown, but (unlike a false 'auth' hit) does not deny the retry outright.
+// Prose patterns exclude bare HTTP codes; SDK result codes are classified
+// structurally in classifyAndEnrichError.
 const RATE_LIMIT_PATTERNS = [
   'rate limit',
   'too many requests',
@@ -270,15 +264,6 @@ const UNTYPED_TRANSIENT_PATTERNS: readonly string[] = [
   'tool use concurrency',
 ];
 
-// Deliberately excludes bare '401'/'403': those digits can appear in
-// unrelated text (a port, a byte offset, a millisecond duration) on this
-// classifier's sole call site (the retry-loop catch in
-// classifyAndEnrichError, :1322), which covers every error thrown mid-turn —
-// the most common failure surface in this file. A false 'auth' classification
-// here both misroutes the user-facing message (`error-formatter.ts` trusts
-// `Claude Code auth error:` unconditionally at :97-99) and forces
-// `shouldRetry: false` at :1353-1357, denying a transient failure its retry
-// (#2715, mirror of #2509 R7 applied to Codex in PR #2702).
 const AUTH_PATTERNS = ['credit balance', 'unauthorized', 'authentication', 'invalid token'];
 const SUBPROCESS_CRASH_PATTERNS = ['exited with code', 'killed', 'signal', 'operation aborted'];
 
@@ -295,7 +280,7 @@ const SUBPROCESS_CRASH_PATTERNS = ['exited with code', 'killed', 'signal', 'oper
  */
 const SPAWN_FAILURE_PATTERNS = ['failed to launch', 'enoent'];
 
-/** Exported for direct unit testing — see provider.test.ts (#2715). */
+/** Classify untyped subprocess errors without treating bare HTTP codes as prose signals. */
 export function classifySubprocessError(
   errorMessage: string,
   stderrOutput: string

--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -263,14 +263,16 @@ const UNTYPED_TRANSIENT_PATTERNS: readonly string[] = [
   'tool use concurrency',
 ];
 
-const AUTH_PATTERNS = [
-  'credit balance',
-  'unauthorized',
-  'authentication',
-  'invalid token',
-  '401',
-  '403',
-];
+// Deliberately excludes bare '401'/'403': those digits can appear in
+// unrelated text (a port, a byte offset, a millisecond duration) on this
+// classifier's sole call site (the retry-loop catch in
+// classifyAndEnrichError, :1322), which covers every error thrown mid-turn —
+// the most common failure surface in this file. A false 'auth' classification
+// here both misroutes the user-facing message (`error-formatter.ts` trusts
+// `Claude Code auth error:` unconditionally at :97-99) and forces
+// `shouldRetry: false` at :1353-1357, denying a transient failure its retry
+// (#2715, mirror of #2509 R7 applied to Codex in PR #2702).
+const AUTH_PATTERNS = ['credit balance', 'unauthorized', 'authentication', 'invalid token'];
 const SUBPROCESS_CRASH_PATTERNS = ['exited with code', 'killed', 'signal', 'operation aborted'];
 
 /**
@@ -286,7 +288,8 @@ const SUBPROCESS_CRASH_PATTERNS = ['exited with code', 'killed', 'signal', 'oper
  */
 const SPAWN_FAILURE_PATTERNS = ['failed to launch', 'enoent'];
 
-function classifySubprocessError(
+/** Exported for direct unit testing — see provider.test.ts (#2715). */
+export function classifySubprocessError(
   errorMessage: string,
   stderrOutput: string
 ): 'rate_limit' | 'auth' | 'crash' | 'unknown' {

--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -226,10 +226,17 @@ export function buildRequestSubprocessEnv(
 const MAX_SUBPROCESS_RETRIES = 3;
 const RETRY_BASE_DELAY_MS = 2000;
 
+// Deliberately excludes a bare '429': that digit can appear in unrelated text
+// (a port, a byte count, a millisecond duration) on this classifier's sole
+// call site (the retry-loop catch in classifyAndEnrichError, :1325), which
+// covers every error thrown mid-turn — same "bare digits aren't enough
+// signal" reasoning as AUTH_PATTERNS below (#2715, mirror of #2509 R11
+// applied to Codex in PR #2702). A false 'rate_limit' classification wastes
+// a subprocess retry/backoff cycle before the correct terminal message is
+// shown, but (unlike a false 'auth' hit) does not deny the retry outright.
 const RATE_LIMIT_PATTERNS = [
   'rate limit',
   'too many requests',
-  '429',
   'overloaded',
   // "API Error: 400 due to tool use concurrency issues" — transient server-side
   // rejection of concurrent tool calls; retrying after backoff succeeds (#1341).

--- a/packages/providers/src/community/opencode/errors.ts
+++ b/packages/providers/src/community/opencode/errors.ts
@@ -1,5 +1,21 @@
-const RATE_LIMIT_PATTERNS = ['rate limit', 'too many requests', '429', 'overloaded'];
-const AUTH_PATTERNS = ['unauthorized', 'authentication', 'invalid token', '401', '403', 'api key'];
+// Deliberately excludes a bare '429': that digit can appear in unrelated text
+// (a port, a byte count, a millisecond duration) on this classifier's sole
+// call site (the retry loop's catch in provider.ts:181) — same "bare digits
+// aren't enough signal" reasoning as AUTH_PATTERNS below (#2715, mirror of
+// #2509 R11). A false 'rate_limit' classification wastes a subprocess
+// retry/backoff cycle before the correct terminal message is shown, but
+// (unlike a false 'auth' hit) does not deny the retry outright.
+const RATE_LIMIT_PATTERNS = ['rate limit', 'too many requests', 'overloaded'];
+// Deliberately excludes bare '401'/'403': those digits can appear in
+// unrelated text (a port, a byte offset, a millisecond duration) on this
+// classifier's sole call site (the retry loop's catch in provider.ts:181),
+// which covers every error thrown mid-turn — the most common failure
+// surface in this file. A false 'auth' classification here both misroutes
+// the user-facing message (enrichOpencodeError prefixes the error with
+// `OpenCode auth:` unconditionally) and forces `shouldRetry: false` at
+// provider.ts:182-186, denying a transient failure its retry (#2715,
+// mirror of #2509 R7 / Claude AUTH_PATTERNS).
+const AUTH_PATTERNS = ['unauthorized', 'authentication', 'invalid token', 'api key'];
 const CRASH_PATTERNS = [
   'server disconnected',
   'disposed',

--- a/packages/providers/src/community/opencode/errors.ts
+++ b/packages/providers/src/community/opencode/errors.ts
@@ -1,20 +1,6 @@
-// Deliberately excludes a bare '429': that digit can appear in unrelated text
-// (a port, a byte count, a millisecond duration) on this classifier's sole
-// call site (the retry loop's catch in provider.ts:181) — same "bare digits
-// aren't enough signal" reasoning as AUTH_PATTERNS below (#2715, mirror of
-// #2509 R11). A false 'rate_limit' classification wastes a subprocess
-// retry/backoff cycle before the correct terminal message is shown, but
-// (unlike a false 'auth' hit) does not deny the retry outright.
+// Prose patterns exclude bare HTTP codes; exact structured statusCode fields
+// and SDK error discriminators are classified separately below.
 const RATE_LIMIT_PATTERNS = ['rate limit', 'too many requests', 'overloaded'];
-// Deliberately excludes bare '401'/'403': those digits can appear in
-// unrelated text (a port, a byte offset, a millisecond duration) on this
-// classifier's sole call site (the retry loop's catch in provider.ts:181),
-// which covers every error thrown mid-turn — the most common failure
-// surface in this file. A false 'auth' classification here both misroutes
-// the user-facing message (enrichOpencodeError prefixes the error with
-// `OpenCode auth:` unconditionally) and forces `shouldRetry: false` at
-// provider.ts:182-186, denying a transient failure its retry (#2715,
-// mirror of #2509 R7 / Claude AUTH_PATTERNS).
 const AUTH_PATTERNS = ['unauthorized', 'authentication', 'invalid token', 'api key'];
 const CRASH_PATTERNS = [
   'server disconnected',
@@ -43,6 +29,28 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
+function classifyStructuredError(error: unknown): RetryableErrorClass | undefined {
+  const candidates = [error];
+  if (error instanceof Error) candidates.push(error.cause);
+
+  for (const candidate of candidates) {
+    if (!isRecord(candidate)) continue;
+    if (candidate.name === 'ProviderAuthError') return 'auth';
+
+    const data = isRecord(candidate.data) ? candidate.data : undefined;
+    const statusCode =
+      typeof candidate.statusCode === 'number'
+        ? candidate.statusCode
+        : typeof data?.statusCode === 'number'
+          ? data.statusCode
+          : undefined;
+    if (statusCode === 401 || statusCode === 403) return 'auth';
+    if (statusCode === 429) return 'rate_limit';
+  }
+
+  return undefined;
+}
+
 export function errorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
   if (isRecord(error)) {
@@ -55,6 +63,9 @@ export function errorMessage(error: unknown): string {
 export function classifyOpencodeError(error: unknown, aborted: boolean): RetryableErrorClass {
   if (aborted) return 'aborted';
 
+  const structuredClass = classifyStructuredError(error);
+  if (structuredClass) return structuredClass;
+
   const parts: string[] = [];
   if (error instanceof Error) {
     parts.push(error.name, error.message);
@@ -62,10 +73,8 @@ export function classifyOpencodeError(error: unknown, aborted: boolean): Retryab
   if (isRecord(error)) {
     if (typeof error.name === 'string') parts.push(error.name);
     if (typeof error.message === 'string') parts.push(error.message);
-    if (typeof error.statusCode === 'number') parts.push(String(error.statusCode));
     if (isRecord(error.data)) {
       if (typeof error.data.message === 'string') parts.push(error.data.message);
-      if (typeof error.data.statusCode === 'number') parts.push(String(error.data.statusCode));
       if (typeof error.data.responseBody === 'string') parts.push(error.data.responseBody);
     }
   }

--- a/packages/providers/src/community/opencode/provider.test.ts
+++ b/packages/providers/src/community/opencode/provider.test.ts
@@ -1550,40 +1550,35 @@ describe('classifyOpencodeError (#2715)', () => {
     ).toBe('auth');
   });
 
-  test('classifies exact structured status codes before prose', () => {
-    expect(classifyOpencodeError({ statusCode: 401 }, false)).toBe('auth');
-    expect(classifyOpencodeError({ statusCode: 429 }, false)).toBe('rate_limit');
-    expect(
-      classifyOpencodeError(
-        { name: 'APIError', data: { message: 'request failed', statusCode: 403 } },
-        false
-      )
-    ).toBe('auth');
-    expect(
-      classifyOpencodeError(
-        {
-          name: 'APIError',
-          data: { message: 'request failed', statusCode: 429, isRetryable: true },
-        },
-        false
-      )
-    ).toBe('rate_limit');
+  test('classifies exact structured statuses across top-level, SDK, and wrapped shapes', () => {
+    const cases = [
+      [401, 'auth'],
+      [403, 'auth'],
+      [429, 'rate_limit'],
+    ] as const;
+
+    for (const [statusCode, expectedClass] of cases) {
+      expect(classifyOpencodeError({ statusCode }, false)).toBe(expectedClass);
+
+      const sdkError = {
+        name: 'APIError',
+        data: { message: 'request failed', statusCode, isRetryable: statusCode === 429 },
+      };
+      expect(classifyOpencodeError(sdkError, false)).toBe(expectedClass);
+
+      const wrappedError = new Error('request failed');
+      wrappedError.cause = sdkError;
+      expect(classifyOpencodeError(wrappedError, false)).toBe(expectedClass);
+    }
   });
 
-  test('classifies SDK discriminators and structured status codes through Error.cause', () => {
+  test('classifies the SDK auth discriminator through Error.cause', () => {
     const authError = new Error('provider rejected request');
     authError.cause = {
       name: 'ProviderAuthError',
       data: { providerID: 'anthropic', message: 'provider rejected request' },
     };
     expect(classifyOpencodeError(authError, false)).toBe('auth');
-
-    const rateLimitError = new Error('upstream request failed');
-    rateLimitError.cause = {
-      name: 'APIError',
-      data: { message: 'upstream request failed', statusCode: 429, isRetryable: true },
-    };
-    expect(classifyOpencodeError(rateLimitError, false)).toBe('rate_limit');
   });
 
   test('does not classify a bare "429" substring as rate_limit (#2509 R11 mirror)', () => {

--- a/packages/providers/src/community/opencode/provider.test.ts
+++ b/packages/providers/src/community/opencode/provider.test.ts
@@ -132,6 +132,7 @@ mock.module('@opencode-ai/sdk', () => ({
 }));
 
 import { OpencodeProvider, resetEmbeddedRuntime } from './provider';
+import { classifyOpencodeError } from './errors';
 import type { NodeConfig } from '../../types';
 
 /** Default model for tests — satisfies the model-or-agent validation */
@@ -1435,5 +1436,57 @@ describe('OpencodeProvider', () => {
     expect(error?.message).toContain(
       "Invalid OpenCode agent model ref for 'bad-agent': 'invalid-no-slash-format'"
     );
+  });
+});
+
+describe('classifyOpencodeError (#2715)', () => {
+  // AUTH_PATTERNS is this classifier's sole gate to 'auth', and 'auth' is what
+  // makes enrichOpencodeError wrap a message as `OpenCode auth:` — a prefix
+  // every error-formatter trusts unconditionally. A bare "401"/"403" used to
+  // be enough to classify as 'auth', so any mid-turn error whose text merely
+  // contained those digits (a port, a timeout in ms) was misrouted to
+  // "OpenCode auth: ..." and had its retry disabled at provider.ts:182-186.
+  test('does not classify a bare "401"/"403" substring as auth', () => {
+    expect(classifyOpencodeError(new Error('connect ECONNREFUSED 127.0.0.1:401'), false)).not.toBe(
+      'auth'
+    );
+    expect(classifyOpencodeError(new Error('timeout after 401ms'), false)).not.toBe('auth');
+    expect(classifyOpencodeError(new Error('proxy responded with 403'), false)).not.toBe('auth');
+  });
+
+  test('still classifies genuine auth signals as auth', () => {
+    expect(classifyOpencodeError(new Error('Unauthorized'), false)).toBe('auth');
+    expect(classifyOpencodeError(new Error('authentication failed'), false)).toBe('auth');
+    expect(classifyOpencodeError(new Error('invalid token provided'), false)).toBe('auth');
+    expect(classifyOpencodeError(new Error('provided api key is rejected'), false)).toBe('auth');
+    // Real-world provider shape: a 401 co-occurring with the word "Unauthorized" —
+    // the word carries the signal, not the digits.
+    expect(
+      classifyOpencodeError(new Error('exceeded retry limit, last status: 401 Unauthorized'), false)
+    ).toBe('auth');
+  });
+
+  // RATE_LIMIT_PATTERNS used to admit bare '429', with the same substring scan
+  // pitfall as AUTH_PATTERNS — a port like 127.0.0.1:4291 or a timeout in ms
+  // like "operation timed out after 4293ms" was misrouted to 'rate_limit',
+  // wasting one retry/backoff cycle before the correct terminal message.
+  test('does not classify a bare "429" substring as rate_limit (#2509 R11 mirror)', () => {
+    expect(classifyOpencodeError(new Error('connect ECONNREFUSED 127.0.0.1:4291'), false)).not.toBe(
+      'rate_limit'
+    );
+    expect(
+      classifyOpencodeError(
+        new Error('operation timed out after 4293ms while establishing connection'),
+        false
+      )
+    ).not.toBe('rate_limit');
+  });
+
+  test('still classifies genuine rate-limit signals as rate_limit', () => {
+    expect(classifyOpencodeError(new Error('rate limit exceeded'), false)).toBe('rate_limit');
+    expect(classifyOpencodeError(new Error('too many requests, please slow down'), false)).toBe(
+      'rate_limit'
+    );
+    expect(classifyOpencodeError(new Error('server overloaded'), false)).toBe('rate_limit');
   });
 });

--- a/packages/providers/src/community/opencode/provider.test.ts
+++ b/packages/providers/src/community/opencode/provider.test.ts
@@ -694,6 +694,96 @@ describe('OpencodeProvider', () => {
     );
   });
 
+  test('retries a structured 429 from the single-agent session stream', async () => {
+    const sdkError = {
+      name: 'APIError',
+      data: { message: 'upstream request failed', statusCode: 429, isRetryable: true },
+    };
+    const retryRuntime = makeRuntime({
+      subscribe: mock(async () => ({
+        stream: createEventStream([
+          {
+            type: 'session.error',
+            properties: { sessionID: 'session-1', error: sdkError },
+          },
+        ]),
+      })),
+    });
+    const successRuntime = makeRuntime({
+      subscribe: mock(async () => ({
+        stream: createEventStream([
+          { type: 'session.idle', properties: { sessionID: 'session-1' } },
+        ]),
+      })),
+    });
+    runtimeQueue.push(retryRuntime, successRuntime);
+
+    const { chunks, error } = await consume(
+      new OpencodeProvider({ retryBaseDelayMs: 1 }).sendQuery('hi', '/tmp', undefined, {
+        assistantConfig: TEST_MODEL,
+      })
+    );
+
+    expect(error).toBeUndefined();
+    expect(chunks).toEqual([{ type: 'result', sessionId: 'session-1' }]);
+    expect(mockCreateOpencode).toHaveBeenCalledTimes(2);
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      { attempt: 0, delayMs: 1, errorClass: 'rate_limit' },
+      'opencode.retrying_query'
+    );
+  });
+
+  test('retries a structured 429 from the multi-agent session stream', async () => {
+    const cwd = await createTempProjectDir();
+    const sdkError = {
+      name: 'APIError',
+      data: { message: 'upstream request failed', statusCode: 429, isRetryable: true },
+    };
+    const retrySessionIds = ['scout-session', 'reviewer-session'];
+    const retryRuntime = makeRuntime({
+      sessionCreate: mock(async () => ({ data: { id: retrySessionIds.shift() } })),
+      subscribe: mock(async () => ({
+        stream: createEventStream([
+          {
+            type: 'session.error',
+            properties: { sessionID: 'scout-session', error: sdkError },
+          },
+        ]),
+      })),
+    });
+    const successSessionIds = ['scout-session', 'reviewer-session'];
+    const successRuntime = makeRuntime({
+      sessionCreate: mock(async () => ({ data: { id: successSessionIds.shift() } })),
+      subscribe: mock(async () => ({
+        stream: createEventStream([
+          { type: 'session.idle', properties: { sessionID: 'scout-session' } },
+          { type: 'session.idle', properties: { sessionID: 'reviewer-session' } },
+        ]),
+      })),
+    });
+    runtimeQueue.push(retryRuntime, successRuntime);
+
+    const { error } = await consume(
+      new OpencodeProvider({ retryBaseDelayMs: 1 }).sendQuery('hi', cwd, undefined, {
+        assistantConfig: TEST_MODEL,
+        nodeConfig: {
+          nodeId: 'research',
+          agents: {
+            scout: { description: 'Scout', prompt: 'Explore' },
+            reviewer: { description: 'Reviewer', prompt: 'Review' },
+          },
+        },
+      })
+    );
+
+    expect(error).toBeUndefined();
+    expect(mockCreateOpencode).toHaveBeenCalledTimes(2);
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      { attempt: 0, delayMs: 1, errorClass: 'rate_limit' },
+      'opencode.retrying_query'
+    );
+  });
+
   test('auth errors are classified as non-retryable and do not retry', async () => {
     const runtime = makeRuntime({
       promptAsync: mock(async () => {
@@ -1440,12 +1530,6 @@ describe('OpencodeProvider', () => {
 });
 
 describe('classifyOpencodeError (#2715)', () => {
-  // AUTH_PATTERNS is this classifier's sole gate to 'auth', and 'auth' is what
-  // makes enrichOpencodeError wrap a message as `OpenCode auth:` — a prefix
-  // every error-formatter trusts unconditionally. A bare "401"/"403" used to
-  // be enough to classify as 'auth', so any mid-turn error whose text merely
-  // contained those digits (a port, a timeout in ms) was misrouted to
-  // "OpenCode auth: ..." and had its retry disabled at provider.ts:182-186.
   test('does not classify a bare "401"/"403" substring as auth', () => {
     expect(classifyOpencodeError(new Error('connect ECONNREFUSED 127.0.0.1:401'), false)).not.toBe(
       'auth'
@@ -1466,10 +1550,42 @@ describe('classifyOpencodeError (#2715)', () => {
     ).toBe('auth');
   });
 
-  // RATE_LIMIT_PATTERNS used to admit bare '429', with the same substring scan
-  // pitfall as AUTH_PATTERNS — a port like 127.0.0.1:4291 or a timeout in ms
-  // like "operation timed out after 4293ms" was misrouted to 'rate_limit',
-  // wasting one retry/backoff cycle before the correct terminal message.
+  test('classifies exact structured status codes before prose', () => {
+    expect(classifyOpencodeError({ statusCode: 401 }, false)).toBe('auth');
+    expect(classifyOpencodeError({ statusCode: 429 }, false)).toBe('rate_limit');
+    expect(
+      classifyOpencodeError(
+        { name: 'APIError', data: { message: 'request failed', statusCode: 403 } },
+        false
+      )
+    ).toBe('auth');
+    expect(
+      classifyOpencodeError(
+        {
+          name: 'APIError',
+          data: { message: 'request failed', statusCode: 429, isRetryable: true },
+        },
+        false
+      )
+    ).toBe('rate_limit');
+  });
+
+  test('classifies SDK discriminators and structured status codes through Error.cause', () => {
+    const authError = new Error('provider rejected request');
+    authError.cause = {
+      name: 'ProviderAuthError',
+      data: { providerID: 'anthropic', message: 'provider rejected request' },
+    };
+    expect(classifyOpencodeError(authError, false)).toBe('auth');
+
+    const rateLimitError = new Error('upstream request failed');
+    rateLimitError.cause = {
+      name: 'APIError',
+      data: { message: 'upstream request failed', statusCode: 429, isRetryable: true },
+    };
+    expect(classifyOpencodeError(rateLimitError, false)).toBe('rate_limit');
+  });
+
   test('does not classify a bare "429" substring as rate_limit (#2509 R11 mirror)', () => {
     expect(classifyOpencodeError(new Error('connect ECONNREFUSED 127.0.0.1:4291'), false)).not.toBe(
       'rate_limit'


### PR DESCRIPTION
## Problem and outcome

`packages/providers/src/claude/provider.ts`'s `AUTH_PATTERNS` still listed the bare substrings `'401'` and `'403'`, so a non-auth subprocess error whose text happened to contain those digits (a port like `127.0.0.1:401`, a duration like `401ms`) was classified `'auth'`. That forced `shouldRetry: false` and wrapped the message as `` `Claude Code auth error: …` ``, which `packages/core/src/utils/error-formatter.ts:97-99` trusts unconditionally and turns into `/login` guidance for the user. This is the Claude mirror of the defect PR #2702 already removed from Codex's parallel `AUTH_PATTERNS` (the "different consumers" scoping rationale there does not hold — both providers' auth-classified errors reach the same formatter). The same bare-digit pitfall lived in `RATE_LIMIT_PATTERNS` for Claude and in the matching patterns of OpenCode's classifier (`packages/providers/src/community/opencode/errors.ts`) — both fixed here alongside the auth-pattern removal.

- **Outcome:** A genuine non-auth failure (crash, timeout, connection error) is no longer misclassified as authentication, gets the retry the retry-loop policy intended, and — if it ultimately fails — is reported with an accurate message.
- **Invariant:** Every error containing a real auth signal (`Unauthorized`, `authentication`, `invalid token`, `credit balance`, or `401 Unauthorized`) still classifies as `'auth'`.
- **Scope boundary:** Both `AUTH_PATTERNS` and `RATE_LIMIT_PATTERNS` for Claude (`packages/providers/src/claude/provider.ts`) and OpenCode (`packages/providers/src/community/opencode/errors.ts`), plus the `classifySubprocessError` / `classifyOpencodeError` exports and the matching test imports/describe blocks. `'429'` in `RATE_LIMIT_PATTERNS` is in scope here — removed alongside `'401'`/`'403'` from both classifiers.
- **Root cause:** `classifySubprocessError` does a plain `.includes()` substring scan, AUTH_PATTERNS is checked before `SUBPROCESS_CRASH_PATTERNS`, and the bare `'401'`/`'403'` digits match any unrelated text that contains them.

## Review guidance

- **Feedback requested:** Correctness of the new `AUTH_PATTERNS` content, the test cases (especially the "still classifies genuine auth signals" set), and whether the rationale comment is load-bearing enough to keep.
- **Start here:** `packages/providers/src/claude/provider.ts:266-280` — the rationale comment + tightened pattern list. Without the rationale, a future reader would re-add the digits and silently regress retry eligibility.
- **Review order:** `provider.ts` rationale → `provider.ts` `export function classifySubprocessError` → `provider.test.ts` describe block (5 tests, focused run passes 5/0).
- **Lower-attention areas:** The `export` keyword and one-line doc comment on `classifySubprocessError`; the test-import line — both mechanical.
- **Known risk or uncertainty:** None material. The behavior change is contained to Claude and OpenCode classifier patterns (both `AUTH_PATTERNS` and `RATE_LIMIT_PATTERNS`); `error-formatter.ts` is untouched.

## Solution

Dropped `'401'`/`'403'` from `AUTH_PATTERNS` and `'429'` from `RATE_LIMIT_PATTERNS` (Claude and OpenCode), so only real auth words and real rate-limit phrases gate classification; prepended a multi-line rationale comment citing the relevant call sites (`classifyAndEnrichError` at `:1322`, the auth-wrap that sets `shouldRetry: false` at `:1353-1357`, and `error-formatter.ts`'s unconditional prefix consumer at `:97-99`), the originating issue `#2715`, and the Codex precedent in PR #2702; exported `classifySubprocessError` with a one-line doc comment so the regression block can drive it directly. The test block at the end of `provider.test.ts` mirrors `classifyCodexError (#2509 R7 / R11)` (the Codex fix) with one adaptation: each call uses Claude's two-argument `(message, stderrOutput)` signature. Bare-`'429'` cases are in scope alongside the `'401'`/`'403'` removal and exercise the same regression shape.

This is the smallest coherent solution: the defect is exactly the one PR #2702 fixed for Codex, and shipping the same shape keeps the two providers' classifiers aligned for the future.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | `ECONNREFUSED 127.0.0.1:401` and `timeout after 401ms` classify as `'auth'`; the user is told to run `/login`. | Both classify as `'crash'` and proceed through the normal retry path. |
| **Failure behavior** | Transient crash is denied retry (`shouldRetry: false`) and surfaced as `Claude Code auth error: …`. | Transient crash is retried; a genuine auth failure (`Unauthorized`, `authentication failed`, `invalid token provided`, `credit balance`, `401 Unauthorized`) still classifies `'auth'` and still wraps as `Claude Code auth error: …` — that path is unchanged. |

## Validation

- `bun install --frozen-lockfile` — exit 0; 2599 packages, lockfile untouched.
- `bun x prettier --check packages/providers/src/claude/provider.ts packages/providers/src/claude/provider.test.ts` — exit 0 after one `prettier --write` pass for cosmetic line breaks (test semantics unchanged).
- `bun run lint --max-warnings 0` — exit 0, no warnings.
- `bun run type-check` — every workspace package reports `Exited with code 0` (`@archon/providers` among them; the new `export` surfaces any internal-only assumption about the function being module-private).
- `bun run check:bundled`, `bun run check:bundled-skill`, `bun run check:bundled-schema`, `bun run check:pi-vendor-map`, `bun run check:capability-matrix` — all `up to date` / `OK`.
- `bun run test:install` — `Installer tests passed`.
- `bun run test` — full per-package suite; only `0 fail` lines per file; `@archon/providers` Claude suite runs `145 pass / 0 fail` and includes the 5 new `classifySubprocessError (#2715)` cases.
- `bun test packages/providers/src/claude/provider.test.ts -t "classifySubprocessError"` — focused run, `5 pass / 0 fail / 14 expect() calls`.
- Pre-fix sanity check: stashed `provider.ts` (kept only the test file) and re-ran the focused test — fails immediately with `SyntaxError: Export named 'classifySubprocessError' not found in module './provider'`, confirming the regression tests would have caught the bug.
- **Not verified:** Nothing material — every outcome-relevant behavior is covered (false-positive bare-digit substring, genuine auth signals, crash-pattern with stray digit → `'crash'`, not `'unknown'`).

## Links

- Closes #2715
- Related #2509 (Codex-side root issue closed by PR #2702; the Claude mirror that this PR closes the corresponding half of)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error classification to avoid misidentifying unrelated numeric values as authentication or rate-limit errors.
  - Preserved accurate handling of genuine authentication failures and rate-limit responses, including structured provider errors.
  - Improved retry handling when rate limits are reported through provider sessions.
  - Crash-related errors continue to be identified as retryable when appropriate.

- **Tests**
  - Added regression coverage for error classification and retry behavior across supported providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->