### PR TITLE
feat(workflows): a gate-terminated loop_group body now works — load-time guidance and runtime pause/resume (#2707 step 3)

### DIFF
--- a/packages/core/src/operations/workflow-operations.test.ts
+++ b/packages/core/src/operations/workflow-operations.test.ts
@@ -64,6 +64,7 @@ mock.module('@archon/paths', () => ({
 const {
   approveWorkflow,
   rejectWorkflow,
+  respondToWorkflow,
   getWorkflowStatus,
   resumeWorkflow,
   abandonWorkflow,
@@ -193,6 +194,37 @@ describe('approveWorkflow', () => {
         structured_output: { decision: 'approve', text: 'Looks good' },
       },
     });
+  });
+
+  test('approves an escalated body-terminal-gate pause — node_completed lands under the namespaced <nodeId>.<bodyGateId> step_name (#2707 step 3)', async () => {
+    // nodeId is the enclosing loop_group's own id (so top-level resume routing
+    // finds it); bodyGateId carries the gate's own id — the namespaced write is
+    // what #2748's outerNodeOutputs pre-population keys on to find this decision
+    // again after a resume.
+    mockGetWorkflowRun.mockResolvedValueOnce(
+      makePausedRun({
+        metadata: {
+          approval: {
+            nodeId: 'grp',
+            message: 'Continue?',
+            type: 'approval',
+            bodyGateId: 'check',
+            decisions: [{ id: 'approve' }, { id: 'revise' }],
+            decisionsAuthored: true,
+          },
+        },
+      })
+    );
+
+    await approveWorkflow('run-1', 'looks good');
+
+    const casEvents = mockResolveApprovalGate.mock.calls[0][2] as Array<Record<string, unknown>>;
+    const nodeCompleted = casEvents.find(e => e.event_type === 'node_completed');
+    expect(nodeCompleted).toMatchObject({ step_name: 'grp.check' });
+    // The OTHER audit event (approval_received) is untouched — only node_completed,
+    // the one #2748's pre-population reads, needs the namespaced form.
+    const approvalReceived = casEvents.find(e => e.event_type === 'approval_received');
+    expect(approvalReceived).toMatchObject({ step_name: 'grp' });
   });
 
   test('approves legacy on_reject-configured gate — plain text output, unaffected by #2707', async () => {
@@ -792,6 +824,30 @@ describe('rejectWorkflow', () => {
     expect(mockCaptureApprovalResolved).toHaveBeenCalledWith({ resolution: 'rejected' });
   });
 
+  test('rejects an escalated body-terminal-gate pause — node_completed lands under the namespaced <nodeId>.<bodyGateId> step_name (#2707 step 3)', async () => {
+    const run = makePausedRun({
+      metadata: {
+        approval: {
+          nodeId: 'grp',
+          message: 'Continue?',
+          type: 'approval',
+          bodyGateId: 'check',
+          decisions: [{ id: 'approve' }, { id: 'reject' }],
+          decisionsAuthored: true,
+        },
+      },
+    });
+    mockGetWorkflowRun.mockResolvedValueOnce(run);
+
+    await rejectWorkflow('run-1', 'needs changes');
+
+    const casEvents = mockResolveApprovalGate.mock.calls[0][2] as Array<Record<string, unknown>>;
+    const nodeCompleted = casEvents.find(e => e.event_type === 'node_completed');
+    expect(nodeCompleted).toMatchObject({ step_name: 'grp.check' });
+    const approvalReceived = casEvents.find(e => e.event_type === 'approval_received');
+    expect(approvalReceived).toMatchObject({ step_name: 'grp' });
+  });
+
   test('new-mode approve-only gate rejects — no reject decision declared, cancels (no unreachable decision)', async () => {
     const run = makePausedRun({
       metadata: {
@@ -913,6 +969,60 @@ describe('rejectWorkflow', () => {
     expect(mockResolveApprovalGate).not.toHaveBeenCalled();
     expect(mockResolveAndCancelApprovalGate).not.toHaveBeenCalled();
     expect(mockCancelWorkflowRun).not.toHaveBeenCalled();
+  });
+});
+
+describe('respondToWorkflow', () => {
+  beforeEach(() => {
+    mockCaptureApprovalResolved.mockClear();
+    mockGetWorkflowRun.mockClear();
+    mockResolveApprovalGate.mockClear();
+    mockResolveApprovalGate.mockResolvedValue({ resolved: true });
+  });
+
+  test('resolves a custom decision on an escalated body-terminal-gate pause — node_completed lands under the namespaced <nodeId>.<bodyGateId> step_name (#2707 step 3)', async () => {
+    mockGetWorkflowRun.mockResolvedValueOnce(
+      makePausedRun({
+        metadata: {
+          approval: {
+            nodeId: 'grp',
+            message: 'Continue?',
+            type: 'approval',
+            bodyGateId: 'check',
+            decisions: [{ id: 'approve' }, { id: 'revise' }],
+            decisionsAuthored: true,
+          },
+        },
+      })
+    );
+
+    await respondToWorkflow('run-1', 'revise', 'please improve X');
+
+    const [, metadataPayload, events] = mockResolveApprovalGate.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+      Array<Record<string, unknown>>,
+    ];
+    expect(metadataPayload).toMatchObject({
+      approval: { nodeId: 'grp', bodyGateId: 'check', resolved: 'approved' },
+    });
+    const nodeCompleted = events.find(e => e.event_type === 'node_completed');
+    expect(nodeCompleted).toMatchObject({
+      step_name: 'grp.check',
+      data: {
+        node_output: JSON.stringify({ decision: 'revise', text: 'please improve X' }),
+        structured_output: { decision: 'revise', text: 'please improve X' },
+      },
+    });
+    const approvalReceived = events.find(e => e.event_type === 'approval_received');
+    expect(approvalReceived).toMatchObject({ step_name: 'grp' });
+  });
+
+  test('delegates approve/reject to the dedicated functions unchanged', async () => {
+    mockGetWorkflowRun.mockResolvedValue(makePausedRun());
+    await respondToWorkflow('run-1', 'approve', 'looks good');
+    expect(mockResolveApprovalGate).toHaveBeenCalledTimes(1);
+    expect(mockCaptureApprovalResolved).toHaveBeenCalledWith({ resolution: 'approved' });
   });
 });
 

--- a/packages/core/src/operations/workflow-operations.ts
+++ b/packages/core/src/operations/workflow-operations.ts
@@ -197,6 +197,24 @@ async function getRunOrThrow(runId: string, logEvent: string): Promise<WorkflowR
  * Returns the validated context so callers keep today's narrowing — `nodeId` is a
  * required field on ApprovalContext, so no intersection type is needed.
  */
+/**
+ * The `step_name` a gate resolution's `node_completed` event should be written
+ * under. Ordinarily just `approval.nodeId`. On an ESCALATED body-terminal-gate
+ * pause (#2707 step 3), `nodeId` holds the ENCLOSING loop_group's id instead —
+ * required so the top-level DAG's resume walk finds it — and `bodyGateId`
+ * carries the actual gate's own id. Namespacing the write as `<nodeId>.
+ * <bodyGateId>` matches the exact `<groupId>.<bodyId>` step name #2748's
+ * `outerNodeOutputs` pre-population already keys on, so the gate's own
+ * resolved decision is findable again after a resume the same way any other
+ * body node's output is. Every other pause kind has no `bodyGateId`, so this
+ * is a no-op there.
+ */
+function resolvedNodeCompletedStepName(approval: ApprovalContext): string {
+  return approval.bodyGateId !== undefined
+    ? `${approval.nodeId}.${approval.bodyGateId}`
+    : approval.nodeId;
+}
+
 export function assertApprovable(run: WorkflowRun): ApprovalContext {
   if (run.status !== 'paused') {
     throw new Error(
@@ -510,7 +528,7 @@ export async function approveWorkflow(
       events = [
         {
           event_type: 'node_completed',
-          step_name: approval.nodeId,
+          step_name: resolvedNodeCompletedStepName(approval),
           data: {
             node_output: nodeOutput,
             approval_decision: 'approved',
@@ -697,7 +715,7 @@ export async function rejectWorkflow(
     const structuredOutput = { decision: 'reject', text: reason ?? '' };
     const nodeCompletedEvent: workflowDb.GateResolutionEvent = {
       event_type: 'node_completed',
-      step_name: approval.nodeId,
+      step_name: resolvedNodeCompletedStepName(approval),
       data: {
         node_output: JSON.stringify(structuredOutput),
         approval_decision: 'rejected',
@@ -804,7 +822,7 @@ async function respondToWorkflowWithDeclaredDecision(
   const events: workflowDb.GateResolutionEvent[] = [
     {
       event_type: 'node_completed',
-      step_name: approval.nodeId,
+      step_name: resolvedNodeCompletedStepName(approval),
       data: {
         node_output: JSON.stringify(structuredOutput),
         approval_decision: decision,

--- a/packages/core/src/workflows/store-adapter.test.ts
+++ b/packages/core/src/workflows/store-adapter.test.ts
@@ -15,6 +15,11 @@ const mockCompleteWorkflowRun = mock(() => Promise.resolve());
 const mockFailWorkflowRun = mock(() => Promise.resolve());
 const mockCancelWorkflowRun = mock(() => Promise.resolve());
 const mockPauseWorkflowRun = mock(() => Promise.resolve());
+// Backs createWorkflowStore()'s rewriteApprovalContext (#2707 step 3 pause
+// escalation) — per AGENTS.md's mock.module rule, an export the factory omits
+// keeps its REAL implementation, so this must be listed even though no test
+// here calls rewriteApprovalContext yet.
+const mockResolveApprovalGate = mock(() => Promise.resolve({ resolved: true }));
 
 mock.module('../db/workflows', () => ({
   createWorkflowRun: mockCreateWorkflowRun,
@@ -30,6 +35,7 @@ mock.module('../db/workflows', () => ({
   failWorkflowRun: mockFailWorkflowRun,
   cancelWorkflowRun: mockCancelWorkflowRun,
   pauseWorkflowRun: mockPauseWorkflowRun,
+  resolveApprovalGate: mockResolveApprovalGate,
   claimWriteback: mock(() => Promise.resolve({ claimed: true })),
   releaseWritebackClaim: mock(() => Promise.resolve()),
 }));

--- a/packages/core/src/workflows/store-adapter.ts
+++ b/packages/core/src/workflows/store-adapter.ts
@@ -63,6 +63,8 @@ export function createWorkflowStore(): IWorkflowStore {
     completeWorkflowRun: workflowDb.completeWorkflowRun,
     failWorkflowRun: workflowDb.failWorkflowRun,
     pauseWorkflowRun: workflowDb.pauseWorkflowRun,
+    rewriteApprovalContext: (id, approvalContext) =>
+      workflowDb.resolveApprovalGate(id, { approval: approvalContext }, []),
     claimWriteback: workflowDb.claimWriteback,
     releaseWritebackClaim: workflowDb.releaseWritebackClaim,
     cancelWorkflowRun: workflowDb.cancelWorkflowRun,

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -97,6 +97,7 @@ import type {
   WorkflowRunNodeSession,
   WorkflowDefinition,
   WorkflowRunStatus,
+  ApprovalContext,
 } from './schemas';
 import { dagNodeSchema, workflowDefinitionSchema } from './schemas';
 import { discoverWorkflows } from './workflow-discovery';
@@ -171,6 +172,9 @@ function createMockStore(): MockWorkflowStore {
     failWorkflowRun: mock<IWorkflowStore['failWorkflowRun']>(async (_id, _error) => {}),
     pauseWorkflowRun: mock<IWorkflowStore['pauseWorkflowRun']>(
       async (_id, _approvalContext, _extraMetadata) => {}
+    ),
+    rewriteApprovalContext: mock<IWorkflowStore['rewriteApprovalContext']>(
+      async (_id, _approvalContext) => ({ resolved: true })
     ),
     claimWriteback: mock<IWorkflowStore['claimWriteback']>(async _id => ({ claimed: true })),
     releaseWritebackClaim: mock<IWorkflowStore['releaseWritebackClaim']>(async _id => {}),
@@ -28853,5 +28857,447 @@ describe('value transport (#2637): persistence, resume, and node-local bindings'
       .join('\n');
     expect(sent).toContain("node 'corrections'");
     expect(sent).toContain('failed');
+  });
+});
+
+// ─── #2707 step 3: gate-terminated loop_group pause escalation ─────────────
+
+/**
+ * A stateful (not static) IWorkflowStore for exercising the pause-escalation /
+ * resume-completion-recheck round trip: `pauseWorkflowRun`/`rewriteApprovalContext`
+ * actually mutate an in-memory status/metadata pair that `getWorkflowRunStatus`/
+ * `getWorkflowRun` subsequently observe — required because the escalation code
+ * under test reads status/metadata BACK after the body gate's own generic pause,
+ * which the file's default static mocks (always 'running') can never satisfy.
+ */
+function createEscalationStore(runId: string): MockWorkflowStore & {
+  getState: () => { status: WorkflowRunStatus; metadata: Record<string, unknown> };
+} {
+  const base = createMockStore();
+  let status: WorkflowRunStatus = 'running';
+  let metadata: Record<string, unknown> = {};
+  return {
+    ...base,
+    getWorkflowRunStatus: mock<IWorkflowStore['getWorkflowRunStatus']>(async _id => status),
+    getWorkflowRun: mock<IWorkflowStore['getWorkflowRun']>(async _id => ({
+      ...mockWorkflowRun(runId),
+      status,
+      metadata,
+    })),
+    pauseWorkflowRun: mock<IWorkflowStore['pauseWorkflowRun']>(
+      async (_id, approvalContext, extraMetadata) => {
+        status = 'paused';
+        metadata = { ...metadata, ...(extraMetadata ?? {}), approval: { ...approvalContext } };
+      }
+    ),
+    rewriteApprovalContext: mock<IWorkflowStore['rewriteApprovalContext']>(
+      async (_id, approvalContext) => {
+        const currentApproval = metadata.approval as { resolved?: string } | undefined;
+        if (status !== 'paused' || currentApproval?.resolved != null) {
+          return { resolved: false };
+        }
+        metadata = { ...metadata, approval: { ...approvalContext } };
+        return { resolved: true };
+      }
+    ),
+    getState: () => ({ status, metadata }),
+  };
+}
+
+/** A loop_group whose body ends in a gate — the canonical Design A shape. */
+function gateTerminatedLoopGroupWorkflow(): WorkflowDefinition {
+  return {
+    name: 'gate-terminated-loop-group',
+    description: 'Design A canonical shape',
+    interactive: true,
+    nodes: [
+      dagNodeSchema.parse({
+        id: 'grp',
+        loop_group: {
+          // NOT '[ "$check.output.decision" = "approve" ]' — substituteNodeOutputRefs
+          // already shell-quotes the substituted value (e.g. 'approve'), so wrapping
+          // the ref in ITS OWN double quotes compares the literal string 'approve'
+          // (with embedded quote characters) against "approve" and never matches.
+          until_bash: '[ $check.output.decision = "approve" ]',
+          max_iterations: 5,
+          nodes: [
+            { id: 'work', prompt: 'do work. Prior feedback: $LOOP_PREV.check.output.text' },
+            {
+              id: 'check',
+              depends_on: ['work'],
+              approval: {
+                message: 'Continue?',
+                decisions: [{ id: 'approve' }, { id: 'revise' }],
+              },
+            },
+          ],
+        },
+      }),
+    ],
+  };
+}
+
+describe('#2707 step 3: gate-terminated loop_group pause escalation', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = join(
+      tmpdir(),
+      `dag-gate-escalation-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    await mkdir(testDir, { recursive: true });
+    mockSendQueryDag.mockClear();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(testDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  it('pauses correctly instead of barreling through remaining iterations', async () => {
+    mockSendQueryDag.mockImplementation(async function* () {
+      yield { type: 'assistant', content: 'work done' };
+      yield { type: 'result', sessionId: 'work-session' };
+    });
+
+    const store = createEscalationStore('run-escalation-1');
+    const platform = createMockPlatform();
+
+    await executeDagWorkflow(
+      createMockDeps(store),
+      platform,
+      'conv-dag',
+      testDir,
+      ready(gateTerminatedLoopGroupWorkflow()),
+      makeWorkflowRun('run-escalation-1'),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    // Only 'work' ran once — proves the loop did NOT barrel through remaining
+    // iterations re-running the body every time the gate re-paused.
+    expect(mockSendQueryDag.mock.calls.length).toBe(1);
+    expect(store.getState().status).toBe('paused');
+
+    // The escalation rewrote the pause to point at the enclosing group, carrying
+    // the body gate's own id.
+    const rewriteCalls = (
+      store.rewriteApprovalContext as Mock<IWorkflowStore['rewriteApprovalContext']>
+    ).mock.calls;
+    expect(rewriteCalls.length).toBe(1);
+    expect(rewriteCalls[0][1]).toMatchObject({
+      nodeId: 'grp',
+      bodyGateId: 'check',
+      type: 'approval',
+      iteration: 1,
+    });
+    expect(store.getState().status).toBe('paused');
+  });
+
+  it('resuming after "approve" completes the group without re-running the body', async () => {
+    mockSendQueryDag.mockClear();
+    mockSendQueryDag.mockImplementation(async function* () {
+      yield { type: 'assistant', content: 'should not run' };
+      yield { type: 'result', sessionId: 'unexpected-session' };
+    });
+
+    const store = createEscalationStore('run-escalation-2');
+    const platform = createMockPlatform();
+    const approvedDecision = { decision: 'approve', text: '' };
+    const priorCompletedNodes = new Map<string, PersistedNodeOutput>([
+      ['grp.work', { output: 'work output' }],
+      [
+        'grp.check',
+        { output: JSON.stringify(approvedDecision), structuredOutput: approvedDecision },
+      ],
+    ]);
+    const workflowRun = makeWorkflowRun('run-escalation-2', {
+      metadata: {
+        approval: {
+          nodeId: 'grp',
+          message: 'Continue?',
+          type: 'approval',
+          bodyGateId: 'check',
+          iteration: 1,
+          decisions: [{ id: 'approve' }, { id: 'revise' }],
+          decisionsAuthored: true,
+        } satisfies ApprovalContext,
+      },
+    });
+
+    await executeDagWorkflow(
+      createMockDeps(store),
+      platform,
+      'conv-dag',
+      testDir,
+      ready(gateTerminatedLoopGroupWorkflow()),
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      priorCompletedNodes
+    );
+
+    // No fresh iteration ran — the resumed iteration's completion was decided
+    // from the reconstructed data, not by re-running the body.
+    expect(mockSendQueryDag.mock.calls.length).toBe(0);
+    expect(
+      (store.completeWorkflowRun as Mock<IWorkflowStore['completeWorkflowRun']>).mock.calls.length
+    ).toBe(1);
+
+    const completedEvents = (
+      store.createWorkflowEvent as Mock<IWorkflowStore['createWorkflowEvent']>
+    ).mock.calls
+      .map(call => call[0])
+      .filter(data => data.event_type === 'node_completed' && data.step_name === 'grp');
+    expect(completedEvents.length).toBe(1);
+    expect(completedEvents[0].data).toMatchObject({
+      structured_output: approvedDecision,
+    });
+  });
+
+  it('resuming after a non-completing decision advances to a fresh iteration, with the text available via $LOOP_PREV', async () => {
+    mockSendQueryDag.mockClear();
+    let seenPrompt: string | undefined;
+    mockSendQueryDag.mockImplementation(async function* (prompt: string) {
+      seenPrompt = prompt;
+      yield { type: 'assistant', content: 'revised work' };
+      yield { type: 'result', sessionId: 'revised-session' };
+    });
+
+    const store = createEscalationStore('run-escalation-3');
+    const platform = createMockPlatform();
+    const revisedDecision = { decision: 'revise', text: 'please improve X' };
+    const priorCompletedNodes = new Map<string, PersistedNodeOutput>([
+      ['grp.work', { output: 'work output' }],
+      ['grp.check', { output: JSON.stringify(revisedDecision), structuredOutput: revisedDecision }],
+    ]);
+    const workflowRun = makeWorkflowRun('run-escalation-3', {
+      metadata: {
+        approval: {
+          nodeId: 'grp',
+          message: 'Continue?',
+          type: 'approval',
+          bodyGateId: 'check',
+          iteration: 1,
+          decisions: [{ id: 'approve' }, { id: 'revise' }],
+          decisionsAuthored: true,
+        } satisfies ApprovalContext,
+      },
+    });
+
+    await executeDagWorkflow(
+      createMockDeps(store),
+      platform,
+      'conv-dag',
+      testDir,
+      ready(gateTerminatedLoopGroupWorkflow()),
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      priorCompletedNodes
+    );
+
+    // A genuinely fresh iteration 2 ran (the "revise" decision did not satisfy
+    // until_bash), seeded with the human's feedback via the ordinary $LOOP_PREV
+    // channel — not the retired $LOOP_USER_INPUT.
+    expect(mockSendQueryDag.mock.calls.length).toBe(1);
+    expect(seenPrompt).toContain('please improve X');
+  });
+
+  it('resume completion recheck resolves an outer-DAG ref inside until_bash, not just the gate decision', async () => {
+    mockSendQueryDag.mockClear();
+    mockSendQueryDag.mockImplementation(async function* () {
+      yield { type: 'assistant', content: 'should not run' };
+      yield { type: 'result', sessionId: 'unexpected-session' };
+    });
+
+    const store = createEscalationStore('run-escalation-5');
+    const platform = createMockPlatform();
+    const approvedDecision = { decision: 'approve', text: '' };
+    // 'outer' is a bare top-level id (not namespaced) — it reaches the resumed
+    // until_bash only via outerNodeOutputs, exactly the path the merge fix covers.
+    const priorCompletedNodes = new Map<string, PersistedNodeOutput>([
+      ['outer', { output: 'ok' }],
+      ['grp.work', { output: 'work output' }],
+      [
+        'grp.check',
+        { output: JSON.stringify(approvedDecision), structuredOutput: approvedDecision },
+      ],
+    ]);
+    const workflowRun = makeWorkflowRun('run-escalation-5', {
+      metadata: {
+        approval: {
+          nodeId: 'grp',
+          message: 'Continue?',
+          type: 'approval',
+          bodyGateId: 'check',
+          iteration: 1,
+          decisions: [{ id: 'approve' }, { id: 'revise' }],
+          decisionsAuthored: true,
+        } satisfies ApprovalContext,
+      },
+    });
+
+    const outerRefWorkflow: WorkflowDefinition = {
+      ...gateTerminatedLoopGroupWorkflow(),
+      nodes: [
+        dagNodeSchema.parse({ id: 'outer', bash: 'echo ok' }),
+        dagNodeSchema.parse({
+          id: 'grp',
+          depends_on: ['outer'],
+          loop_group: {
+            // Combines an outer-scope ref with the gate's own decision — the
+            // outer ref only resolves if resumedScope includes outerNodeOutputs.
+            until_bash: '[ $outer.output = "ok" ] && [ $check.output.decision = "approve" ]',
+            max_iterations: 5,
+            nodes: [
+              { id: 'work', prompt: 'do work' },
+              {
+                id: 'check',
+                depends_on: ['work'],
+                approval: {
+                  message: 'Continue?',
+                  decisions: [{ id: 'approve' }, { id: 'revise' }],
+                },
+              },
+            ],
+          },
+        }),
+      ],
+    };
+
+    await executeDagWorkflow(
+      createMockDeps(store),
+      platform,
+      'conv-dag',
+      testDir,
+      ready(outerRefWorkflow),
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      priorCompletedNodes
+    );
+
+    // No fresh iteration ran — the outer ref resolved correctly on resume, so
+    // until_bash saw both halves satisfied and completed without re-running the body.
+    expect(mockSendQueryDag.mock.calls.length).toBe(0);
+    expect(
+      (store.completeWorkflowRun as Mock<IWorkflowStore['completeWorkflowRun']>).mock.calls.length
+    ).toBe(1);
+  });
+
+  it('falls through without erroring when a human resolves the original pause before the rewrite lands (CAS loss)', async () => {
+    mockSendQueryDag.mockImplementation(async function* () {
+      yield { type: 'assistant', content: 'work done' };
+      yield { type: 'result', sessionId: 'work-session' };
+    });
+
+    const store = createEscalationStore('run-escalation-4');
+    // Simulate an astronomically narrow race: a human resolved the ORIGINAL
+    // bare-gate-id pause in the window between its own write and the
+    // escalation's rewrite attempt — resolveApprovalGate's real CAS guard
+    // (unresolvedGateClause) would report exactly this outcome.
+    (
+      store.rewriteApprovalContext as Mock<IWorkflowStore['rewriteApprovalContext']>
+    ).mockResolvedValue({ resolved: false });
+    const platform = createMockPlatform();
+
+    // max_iterations: 1 makes the fallthrough's outcome deterministic and
+    // assertable: without the escalation applying, the group's own terminal-
+    // sink selection finds no non-empty output (a gate's own output is always
+    // ''), so it never detects completion and exhausts max_iterations — a
+    // clean, expected failure, not a hang, crash, or corrupted state.
+    const singleIterationWorkflow: WorkflowDefinition = {
+      ...gateTerminatedLoopGroupWorkflow(),
+      nodes: [
+        dagNodeSchema.parse({
+          id: 'grp',
+          loop_group: {
+            until_bash: '[ $check.output.decision = "approve" ]',
+            max_iterations: 1,
+            nodes: [
+              { id: 'work', prompt: 'do work' },
+              {
+                id: 'check',
+                depends_on: ['work'],
+                approval: {
+                  message: 'Continue?',
+                  decisions: [{ id: 'approve' }, { id: 'revise' }],
+                },
+              },
+            ],
+          },
+        }),
+      ],
+    };
+
+    // Must not throw — the fallthrough path is a normal, tolerated outcome.
+    await expect(
+      executeDagWorkflow(
+        createMockDeps(store),
+        platform,
+        'conv-dag',
+        testDir,
+        ready(singleIterationWorkflow),
+        makeWorkflowRun('run-escalation-4'),
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'state'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      )
+    ).resolves.toBeUndefined();
+
+    // The escalation was attempted and correctly observed the lost race.
+    expect(
+      (store.rewriteApprovalContext as Mock<IWorkflowStore['rewriteApprovalContext']>).mock.calls
+        .length
+    ).toBe(1);
+    // No corrupted state: the run stays exactly as the human's own resolution
+    // left it — 'paused' — never force-completed by the loop_group's own
+    // "max iterations exceeded" failure (the run being non-'running' by the
+    // time that failure is reported is what stops the top-level executor from
+    // clobbering the human's already-in-flight resolution with a 'failed'
+    // status).
+    expect(store.getState().status).toBe('paused');
+    expect(
+      (store.completeWorkflowRun as Mock<IWorkflowStore['completeWorkflowRun']>).mock.calls.length
+    ).toBe(0);
   });
 });

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -4728,11 +4728,15 @@ async function executeLoopGroupNode(
           };
         }
         // A human resolved the ORIGINAL bare-gate pause before the rewrite landed
-        // (an astronomically narrow race) — fall through to the normal per-
-        // iteration path below, which observes whatever state that resolution
-        // left and behaves correctly for it, same as any other externally-
-        // resolved gate. (The postBodyStatus tolerance above already let a
-        // 'paused' status through; nothing here re-checks it.)
+        // (an astronomically narrow race) — fall through rather than error or
+        // corrupt state. This does NOT behave the same as a normal resolved gate,
+        // though: the resolution was written under the bare gate id, with
+        // bodyGateId still unset, so it's unreachable by the namespaced restore
+        // path this mechanism depends on — the loop proceeds toward
+        // max_iterations instead of honoring the human's answer. Accepted for
+        // this race's vanishingly narrow window rather than built out further.
+        // (The postBodyStatus tolerance above already let a 'paused' status
+        // through; nothing here re-checks it.)
       }
     }
 

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -4151,6 +4151,24 @@ async function finalizeLoopFromSignal(
 }
 
 /**
+ * The body's designated pause node for #2707 step 3's gate-terminated pattern: a
+ * `gate:` node that is the body's SOLE terminal sink (nothing depends on it, and
+ * it is the only node nothing else depends on) — mirrors the placement rule
+ * `loader.ts`'s `collectGateAndLoopDeprecationWarnings` already checks at load
+ * time. Returns `undefined` for a body with no gate, or one that is misplaced
+ * (mid-body, or co-terminal with another sink) — 3a already warns on that at
+ * load time; this runtime code makes no special attempt to handle it, and such
+ * a gate simply keeps behaving as it does today (silently ignored for
+ * escalation purposes, since there is no unambiguous single pause node to
+ * escalate).
+ */
+function findLoopGroupTerminalGate(bodyNodes: readonly DagNode[]): GateNode | undefined {
+  const dependedOn = new Set(bodyNodes.flatMap(n => n.depends_on ?? []));
+  const sinks = bodyNodes.filter(n => !dependedOn.has(n.id));
+  return sinks.length === 1 && isGateNode(sinks[0]) ? sinks[0] : undefined;
+}
+
+/**
  * Execute a loop-group node — runs a multi-node sub-DAG body repeatedly until a
  * completion condition (`until` signal in the body's terminal-node output, and/or
  * `until_bash` exit code) or `max_iterations`.
@@ -4232,13 +4250,29 @@ async function executeLoopGroupNode(
   const knownBodyIds = collectLoopBodyNodeIds(group.nodes);
   const directBodyIds = new Set(group.nodes.map(n => n.id));
 
-  // Detect interactive loop resume (mirrors executeLoopNode).
+  // Detect loop resume (mirrors executeLoopNode). Two shapes recognized:
+  //  - the ORIGINAL interactive_loop gate (group.interactive + gate_message).
+  //  - the #2707 step 3 ESCALATED shape — a gate node that is the body's sole
+  //    terminal sink paused generically as an ordinary 'approval' gate, then
+  //    rewritten (see the post-runLayers escalation below) so nodeId points at
+  //    THIS group and bodyGateId carries the gate's own id. `$LOOP_USER_INPUT`
+  //    does not apply to this shape — the human's text flows via the ordinary
+  //    $LOOP_PREV.<gateId>.output.text channel instead, like any other body
+  //    node's output — so `loopUserInput` below stays scoped to the legacy shape.
   const rawApproval = workflowRun.metadata?.approval;
   const loopGateMeta = isApprovalContext(rawApproval) ? rawApproval : undefined;
-  const isLoopResume = loopGateMeta?.type === 'interactive_loop' && loopGateMeta.nodeId === node.id;
+  const isLegacyInteractiveLoopResume =
+    loopGateMeta?.type === 'interactive_loop' && loopGateMeta.nodeId === node.id;
+  const isEscalatedGateResume =
+    loopGateMeta?.type === 'approval' &&
+    loopGateMeta.nodeId === node.id &&
+    loopGateMeta.bodyGateId !== undefined;
+  const isLoopResume = isLegacyInteractiveLoopResume || isEscalatedGateResume;
   const startIteration = isLoopResume ? (loopGateMeta.iteration ?? 0) + 1 : 1;
   const loopGateRunMeta = (workflowRun.metadata ?? {}) as LoopGateRunMetadata;
-  const loopUserInput = isLoopResume ? (loopGateRunMeta.loop_user_input ?? '') : '';
+  const loopUserInput = isLegacyInteractiveLoopResume
+    ? (loopGateRunMeta.loop_user_input ?? '')
+    : '';
 
   // Finalize-on-approve (#2074): mirrors executeLoopNode — a completion-bearing gate
   // resumed WITHOUT feedback completes the group from the persisted output instead
@@ -4315,6 +4349,158 @@ async function executeLoopGroupNode(
     // to every consumer; this has no behavioral effect either way.
     if (restoredLoopPrevOutputs.size > 0) loopPrevOutputs = restoredLoopPrevOutputs;
   }
+
+  // #2707 step 3: an escalated gate-terminated-body resume might already be
+  // "done" — the human's answer, just reconstructed above (the SAME restoration
+  // #2748 built for $LOOP_PREV, now also finding the gate's own resolution
+  // thanks to the namespaced write-path fix), may satisfy the group's own
+  // until_bash. The legacy interactive_loop resume always advances blindly to
+  // iteration+1; that would be WRONG here — it would silently start a whole new
+  // iteration (re-running the body's pre-gate work) while ignoring an answer
+  // that already meant "stop". Re-run the same completion check the normal
+  // per-iteration path runs below, fed from the reconstructed data instead of a
+  // fresh runLayers call — decision (b) settled that resume re-enters at the
+  // iteration boundary, so the pre-gate body nodes' already-produced outputs are
+  // safe to reuse as-is; only the gate's own answer needed reconstructing.
+  if (isEscalatedGateResume && loopPrevOutputs !== undefined) {
+    const terminalGate = findLoopGroupTerminalGate(group.nodes as DagNode[]);
+    const terminalSink = terminalGate ? loopPrevOutputs.get(terminalGate.id) : undefined;
+    if (terminalSink !== undefined) {
+      const resumedIteration = loopGateMeta.iteration ?? 0;
+      const rawIterationOutput = terminalSink.output;
+      const resumedSignalDetected =
+        group.until !== undefined && detectCompletionSignal(rawIterationOutput, group.until);
+      let resumedBashComplete = false;
+      if (group.until_bash && !resumedSignalDetected) {
+        // No $LOOP_PREV history survives a resume beyond the single reconstructed
+        // iteration above — #2748 restores only the LATEST persisted body outputs,
+        // not a full history — so an until_bash referencing $LOOP_PREV from the
+        // iteration BEFORE this one resolves empty here, same as a fresh
+        // iteration 1. Not expected to matter in practice: Design A's canonical
+        // pattern reads only $<gateId>.output inside until_bash, never $LOOP_PREV.
+        const { prompt: resumedBashPrompt } = substituteWorkflowVariables(
+          group.until_bash,
+          workflowRun.id,
+          workflowRun.user_message,
+          artifactsDir,
+          baseBranch,
+          docsDir,
+          issueContext,
+          undefined,
+          undefined,
+          undefined,
+          { shellSafe: true, stateDir }
+        );
+        // Merge outer-DAG outputs underneath the reconstructed body outputs —
+        // mirrors how a normal (non-resumed) iteration seeds scopedNodeOutputs
+        // (`new Map(outerNodeOutputs)`, then overwritten by this iteration's own
+        // body results) — so an until_bash combining an outer-scope ref with the
+        // gate's own decision resolves the outer ref correctly on resume too,
+        // not just mid-loop. outerNodeOutputs is already an in-scope parameter;
+        // no new reconstruction needed.
+        const resumedScope = new Map([...outerNodeOutputs, ...loopPrevOutputs]);
+        const resumedSubstitutedBash = substituteNodeOutputRefs(
+          resumedBashPrompt,
+          resumedScope,
+          true, // escapedForBash
+          artifactsDir
+        );
+        const resumedBashPath = resolveBashPath();
+        try {
+          await runSubprocess(execContext, resumedBashPath, ['-c', resumedSubstitutedBash], {
+            cwd,
+            timeout: SUBPROCESS_DEFAULT_TIMEOUT,
+            env: {
+              ...(config.envVars ?? {}),
+              USER_MESSAGE: workflowRun.user_message,
+              ARGUMENTS: workflowRun.user_message,
+              LOOP_USER_INPUT: '',
+              LOOP_PREV_OUTPUT: '',
+              REJECTION_REASON: '',
+              CONTEXT: issueContext ?? '',
+              EXTERNAL_CONTEXT: issueContext ?? '',
+              ISSUE_CONTEXT: issueContext ?? '',
+            },
+          });
+          resumedBashComplete = true;
+        } catch (e) {
+          const bashErr = e as NodeJS.ErrnoException;
+          if (
+            bashErr.code === 'ENOENT' ||
+            bashErr.code === 'EACCES' ||
+            bashErr.code === 'ENOTDIR'
+          ) {
+            getLog().error(
+              { err: bashErr, nodeId: node.id, iteration: resumedIteration },
+              'loop_group.until_bash_failed'
+            );
+            throw new Error(
+              `Loop group '${node.id}' until_bash failed: cannot execute bash at ` +
+                `'${resumedBashPath}' (${bashErr.code}). Set ARCHON_BASH_PATH if Git Bash ` +
+                'is installed elsewhere.'
+            );
+          }
+          if (typeof bashErr.code !== 'number') {
+            getLog().error(
+              { err: bashErr, nodeId: node.id, iteration: resumedIteration },
+              'loop_group.until_bash_unexpected_error'
+            );
+            throw bashErr;
+          }
+          resumedBashComplete = false;
+        }
+      }
+      if (resumedSignalDetected || resumedBashComplete) {
+        const resumedOutput = stripCompletionTags(rawIterationOutput, group.until);
+        const resumedStructuredOutput =
+          'structuredOutput' in terminalSink ? terminalSink.structuredOutput : undefined;
+        await safeSendMessage(
+          platform,
+          conversationId,
+          `Loop-group node '${node.id}' completed after ${String(resumedIteration)} iteration${resumedIteration > 1 ? 's' : ''}`,
+          msgContext
+        );
+        deps.store
+          .createWorkflowEvent({
+            workflow_run_id: workflowRun.id,
+            event_type: 'node_completed',
+            step_name: stepName,
+            data: {
+              node_output: resumedOutput,
+              ...(resumedStructuredOutput !== undefined
+                ? { structured_output: resumedStructuredOutput }
+                : {}),
+              aggregate: true,
+            },
+          })
+          .catch((err: Error) => {
+            getLog().error(
+              { err, workflowRunId: workflowRun.id, eventType: 'node_completed' },
+              'workflow_event_persist_failed'
+            );
+          });
+        getWorkflowEventEmitter().emit({
+          type: 'node_completed',
+          runId: workflowRun.id,
+          nodeId: node.id,
+          nodeName: node.id,
+          duration: 0,
+        });
+        return {
+          state: 'completed',
+          output: resumedOutput,
+          loopIterations: resumedIteration,
+          ...(resumedStructuredOutput !== undefined
+            ? { structuredOutput: resumedStructuredOutput }
+            : {}),
+        };
+      }
+      // Not complete — fall through. startIteration is already iteration+1 (set
+      // above from loopGateMeta.iteration), so the for loop below proceeds into a
+      // genuinely fresh iteration, exactly as it would for any other resume.
+    }
+  }
+
   let lastIterationOutput = '';
   // The terminal sink's structured payload for the same iteration (#2637) — tracked
   // beside the text so the group's completed NodeOutput carries the logical value
@@ -4474,6 +4660,7 @@ async function executeLoopGroupNode(
       bodyLoopUserInput: userInputForIter,
     };
     await runLayers(iterCtx);
+
     // A body approval/cancel node may have paused or cancelled the run mid-iteration.
     // `paused` is tolerated (a sibling gate in the same iteration layer) — mirror
     // executeLoopNode's between-iteration tolerance — but a terminal/cancelled state
@@ -4496,6 +4683,57 @@ async function executeLoopGroupNode(
         [...(loopTotalTokens !== undefined ? [loopTotalTokens] : []), iterCtx.totalTokens],
         { nodeId: node.id, iteration: i }
       );
+    }
+
+    // #2707 step 3: pause escalation. A gate node that is the body's sole terminal
+    // sink pauses generically via executeApprovalNode (called through runLayers,
+    // like any other body node) — that pause alone does NOT stop this loop: the
+    // `paused` tolerance above (needed for a genuinely unrelated sibling gate
+    // pausing in the same layer) would otherwise let the loop barrel straight into
+    // the next iteration, immediately re-pausing and burning cost every time. This
+    // detects THAT specific pause and escalates it: rewrite the ApprovalContext so
+    // it points at THIS group (the top-level DAG only knows top-level node ids,
+    // never a nested body id — mirrors exactly how the interactive_loop gate below
+    // already works) and return the same "paused" shape that path uses. Placed
+    // AFTER the usage accumulation above (not right after runLayers) so this
+    // iteration's own spend — the 'work' node plus the gate check that just ran —
+    // is already folded into loopTotalCostUsd/loopTotalTokens by the time the
+    // escalation return reads them; reading them any earlier would silently drop
+    // this iteration's cost from the run's live totals for the whole pause window.
+    const terminalGate = findLoopGroupTerminalGate(iterBodyNodes);
+    if (terminalGate && postBodyStatus === 'paused') {
+      // Fresh read — workflowRun is this call's stale snapshot from before
+      // runLayers ran; the gate's own pause just wrote metadata.approval.
+      const freshRun = await deps.store.getWorkflowRun(workflowRun.id);
+      const freshApproval = isApprovalContext(freshRun?.metadata?.approval)
+        ? freshRun.metadata.approval
+        : undefined;
+      if (freshApproval?.nodeId === terminalGate.id) {
+        const rewritten: ApprovalContext = {
+          ...freshApproval,
+          nodeId: node.id,
+          bodyGateId: terminalGate.id,
+          iteration: i,
+          sessionId: loopLastSequentialSession?.sessionId ?? null,
+          sessionProvider: loopLastSequentialSession?.provider ?? null,
+        };
+        const { resolved } = await deps.store.rewriteApprovalContext(workflowRun.id, rewritten);
+        if (resolved) {
+          return {
+            state: 'completed',
+            output: lastIterationOutput,
+            costUsd: loopTotalCostUsd,
+            ...(loopTotalTokens !== undefined ? { tokens: loopTotalTokens } : {}),
+            loopIterations: i,
+          };
+        }
+        // A human resolved the ORIGINAL bare-gate pause before the rewrite landed
+        // (an astronomically narrow race) — fall through to the normal per-
+        // iteration path below, which observes whatever state that resolution
+        // left and behaves correctly for it, same as any other externally-
+        // resolved gate. (The postBodyStatus tolerance above already let a
+        // 'paused' status through; nothing here re-checks it.)
+      }
     }
 
     // A failed body node fails the group immediately — mirrors the top-level DAG

--- a/packages/workflows/src/executor-preamble.test.ts
+++ b/packages/workflows/src/executor-preamble.test.ts
@@ -113,6 +113,7 @@ function makeStore(overrides: Partial<IWorkflowStore> = {}): IWorkflowStore {
     updateWorkflowActivity: mock(async () => {}),
     completeWorkflowRun: mock(async () => {}),
     pauseWorkflowRun: mock(async () => {}),
+    rewriteApprovalContext: mock(async () => ({ resolved: true })),
     claimWriteback: mock(async () => ({ claimed: true })),
     releaseWritebackClaim: mock(async () => {}),
     cancelWorkflowRun: mock(async () => ({ cancelled: false })),

--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -190,6 +190,7 @@ function makeStore(overrides: Partial<IWorkflowStore> = {}): IWorkflowStore {
     updateWorkflowActivity: mock(async () => {}),
     completeWorkflowRun: mock(async () => {}),
     pauseWorkflowRun: mock(async () => {}),
+    rewriteApprovalContext: mock(async () => ({ resolved: true })),
     claimWriteback: mock(async () => ({ claimed: true })),
     releaseWritebackClaim: mock(async () => {}),
     cancelWorkflowRun: mock(async () => ({ cancelled: false })),

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -4102,6 +4102,148 @@ nodes:
       expect(pw.some(w => w.includes('does not reference'))).toBe(false);
     });
 
+    it('checks EVERY gate in a body, not just the first (review fix)', async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+
+      // 'first-gate' is not terminal (has a dependent, 'work'). 'second-gate' IS
+      // the body's true terminal sink, but until_bash never references it. Before
+      // the fix, `.find()` stopped at 'first-gate' and 'second-gate' was never
+      // checked at all — its completion-not-referenced footgun went undetected.
+      await writeFile(
+        join(workflowDir, 'loop-group-multiple-gates.yaml'),
+        `
+name: loop-group-multiple-gates
+description: Two gates in one body — each needs its own verdict
+interactive: true
+nodes:
+  - id: grp
+    loop_group:
+      until_bash: "exit 0"
+      max_iterations: 3
+      nodes:
+        - id: first-gate
+          approval:
+            message: "Start?"
+        - id: work
+          depends_on: [first-gate]
+          prompt: "do work"
+        - id: second-gate
+          depends_on: [work]
+          approval:
+            message: "Continue?"
+`
+      );
+
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      const pw = result.workflows[0].parseWarnings ?? [];
+      expect(pw).toHaveLength(2);
+      expect(pw.some(w => w.includes("Node 'first-gate'") && w.includes('terminal sink'))).toBe(
+        true
+      );
+      expect(
+        pw.some(w => w.includes("Node 'second-gate'") && w.includes('does not reference'))
+      ).toBe(true);
+    });
+
+    it("counts an include: directive's own depends_on when computing terminal-sink status (review fix)", async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+
+      await writeFile(
+        join(workflowDir, 'block.yaml'),
+        `
+name: block
+description: Reusable step
+nodes:
+  - id: step
+    prompt: do the reusable thing
+`
+      );
+      // 'check' has a dependent — the included 'review' node — so it is NOT the
+      // body's terminal sink. Before the fix, an include directive's own
+      // depends_on was excluded from the dependency set, so 'check' was silently
+      // misclassified as terminal (no warning at all, and a factually wrong
+      // "sole terminal sink" verdict).
+      await writeFile(
+        join(workflowDir, 'loop-group-gate-include-dependent.yaml'),
+        `
+name: loop-group-gate-include-dependent
+description: A downstream include node depends on the gate
+interactive: true
+nodes:
+  - id: grp
+    loop_group:
+      until_bash: "exit 0"
+      max_iterations: 3
+      nodes:
+        - id: check
+          approval:
+            message: "Continue?"
+        - id: review
+          include: block
+          depends_on: [check]
+`
+      );
+
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      // 'block.yaml' is itself a discoverable workflow, so it's also in
+      // result.workflows — select by name rather than assuming index 0.
+      const target = result.workflows.find(
+        w => w.workflow.name === 'loop-group-gate-include-dependent'
+      );
+      const pw = target?.parseWarnings ?? [];
+      expect(pw.some(w => w.includes("Node 'check'") && w.includes('terminal sink'))).toBe(true);
+    });
+
+    it('counts an include: directive as a co-terminal sink (review fix)', async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+
+      await writeFile(
+        join(workflowDir, 'block.yaml'),
+        `
+name: block
+description: Reusable step
+nodes:
+  - id: step
+    prompt: do the reusable thing
+`
+      );
+      // 'independent-include' has no dependents and nothing depends on it — a
+      // second, genuine terminal sink alongside the gate. Before the fix, include
+      // directives were excluded from the sink set entirely, so this second sink
+      // was invisible and 'check' was wrongly treated as the sole terminal node.
+      await writeFile(
+        join(workflowDir, 'loop-group-gate-include-co-terminal.yaml'),
+        `
+name: loop-group-gate-include-co-terminal
+description: An independent include node is a second terminal sink
+interactive: true
+nodes:
+  - id: grp
+    loop_group:
+      until_bash: "exit 0"
+      max_iterations: 3
+      nodes:
+        - id: check
+          approval:
+            message: "Continue?"
+        - id: independent-include
+          include: block
+`
+      );
+
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      // 'block.yaml' is itself a discoverable workflow, so it's also in
+      // result.workflows — select by name rather than assuming index 0.
+      const target = result.workflows.find(
+        w => w.workflow.name === 'loop-group-gate-include-co-terminal'
+      );
+      const pw = target?.parseWarnings ?? [];
+      expect(pw.some(w => w.includes("Node 'check'") && w.includes('terminal sink'))).toBe(true);
+    });
+
     it('should accept a well-formed loop_group', async () => {
       const workflowDir = join(testDir, '.archon', 'workflows');
       await mkdir(workflowDir, { recursive: true });

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -3999,6 +3999,109 @@ nodes:
       expect(result.errors[0].error).toContain('unknown node');
     });
 
+    // --- gate placement inside a loop_group body (#2707 step 3) -------------------
+    // Guidance only (parseWarnings), not a load error — a mid-body/co-terminal gate
+    // predates this pattern (e.g. via the legacy `on_reject` mechanism) and must keep
+    // loading; see the '#2707 step 1 gate/loop deprecation warnings' describe block
+    // below for the equivalent warning-content assertions.
+
+    it('should accept the canonical Design A gate-terminated loop_group, with no warning', async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+
+      await writeFile(
+        join(workflowDir, 'loop-group-gate-terminal.yaml'),
+        `
+name: loop-group-gate-terminal
+description: A gate as the body's sole terminal sink, completion reading its decision
+interactive: true
+nodes:
+  - id: grp
+    loop_group:
+      until_bash: '[ "$check.output.decision" = "approve" ]'
+      max_iterations: 3
+      nodes:
+        - id: work
+          prompt: "do work"
+        - id: check
+          depends_on: [work]
+          approval:
+            message: "Continue?"
+`
+      );
+
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      expect(result.errors).toHaveLength(0);
+      expect(result.workflows).toHaveLength(1);
+      expect(result.workflows[0].parseWarnings ?? []).toEqual([]);
+    });
+
+    it("warns when a gate-terminated loop_group's until_bash does not reference the gate", async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+
+      await writeFile(
+        join(workflowDir, 'loop-group-gate-completion-not-referenced.yaml'),
+        `
+name: loop-group-gate-completion-not-referenced
+description: A gate-terminated body whose completion channel ignores the gate
+interactive: true
+nodes:
+  - id: grp
+    loop_group:
+      until_bash: "exit 0"
+      max_iterations: 3
+      nodes:
+        - id: work
+          prompt: "do work"
+        - id: check
+          depends_on: [work]
+          approval:
+            message: "Continue?"
+`
+      );
+
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      expect(result.errors).toHaveLength(0);
+      const pw = result.workflows[0].parseWarnings ?? [];
+      expect(pw).toHaveLength(1);
+      expect(pw[0]).toContain("Node 'check'");
+      expect(pw[0]).toContain('does not reference');
+      expect(pw[0]).toContain('$check.output');
+    });
+
+    it('does NOT warn about completion-not-referenced when the gate is not the terminal sink (avoids piling on)', async () => {
+      const workflowDir = join(testDir, '.archon', 'workflows');
+      await mkdir(workflowDir, { recursive: true });
+
+      await writeFile(
+        join(workflowDir, 'loop-group-gate-mid-body-no-pileup.yaml'),
+        `
+name: loop-group-gate-mid-body-no-pileup
+description: A non-terminal gate — only the placement warning should fire
+interactive: true
+nodes:
+  - id: grp
+    loop_group:
+      until_bash: "exit 0"
+      max_iterations: 3
+      nodes:
+        - id: check
+          approval:
+            message: "Continue?"
+        - id: after
+          depends_on: [check]
+          prompt: "do more work"
+`
+      );
+
+      const result = await discoverWorkflows(testDir, { loadDefaults: false });
+      const pw = result.workflows[0].parseWarnings ?? [];
+      expect(pw).toHaveLength(1);
+      expect(pw[0]).toContain('terminal sink');
+      expect(pw.some(w => w.includes('does not reference'))).toBe(false);
+    });
+
     it('should accept a well-formed loop_group', async () => {
       const workflowDir = join(testDir, '.archon', 'workflows');
       await mkdir(workflowDir, { recursive: true });
@@ -6126,7 +6229,7 @@ nodes:
         'nodes:',
         '  - id: refine',
         '    loop_group:',
-        '      until: DONE',
+        '      until_bash: "exit 0"',
         '      max_iterations: 3',
         '      nodes:',
         '        - id: check',
@@ -6147,7 +6250,7 @@ nodes:
         'nodes:',
         '  - id: refine',
         '    loop_group:',
-        '      until: DONE',
+        '      until_bash: "exit 0"',
         '      max_iterations: 3',
         '      max_attempts: 4', // not a loop control field
         '      nodes:',
@@ -6204,15 +6307,16 @@ nodes:
         '        max_attempts: 2',
       ]);
       // Every key used here IS valid — none should trip the unknown-key check
-      // this describe block covers. `loop.interactive`/`on_reject` are also
-      // deliberately deprecated (#2707 step 1), so this fixture now
-      // legitimately produces THOSE warnings too — asserted separately below,
-      // not conflated with "unknown key" false positives. `capture_response`
-      // combined with `on_reject` (no `decisions:` authored) is still fully
-      // functional (R4 fix), so it does NOT warn here.
+      // this describe block covers. `loop.interactive`/`on_reject`/the prose
+      // `until:` channel are also deliberately deprecated (#2707 steps 1 and 3),
+      // so this fixture now legitimately produces THOSE warnings too — asserted
+      // separately below, not conflated with "unknown key" false positives.
+      // `capture_response` combined with `on_reject` (no `decisions:` authored)
+      // is still fully functional (R4 fix), so it does NOT warn here.
       expect(pw.some(w => w.includes('unknown key'))).toBe(false);
       expect(pw).toEqual([
         "Node 'refine': node-level loop 'interactive:' is deprecated. A future release re-expresses the interactive loop as a gate + loop_group composition (#2707 step 3). Continue using it for now.",
+        "Node 'refine': the prose 'loop_group.until' completion signal is deprecated. Declare 'loop_group.until_bash' instead — it can read a body node's structured output (e.g. 'test \"$body-node.output.field\" = true') (#2707 step 3). Continue using it for now.",
         "Node 'gate': 'approval.on_reject' is deprecated. Declare 'approval.decisions' and wire a rework node with \"when: \\\"$gate.output.decision == 'reject'\\\"\" instead (loop it with loop_group if it should iterate). This gate keeps running via the legacy mechanism until migrated.",
       ]);
     });
@@ -6402,6 +6506,15 @@ nodes:
       // Remove from this list once #2123's defaults rewrite migrates them.
       'archon-interactive-prd',
       'archon-piv-loop',
+      // #2707 step 3: these bundled workflows declare the now-deprecated prose
+      // 'until:' completion channel on a loop/loop_group — still fully
+      // functional (grow-then-deprecate); the warning is expected, not a false
+      // positive. Remove from this list once #2123's defaults rewrite migrates
+      // them to 'until_bash'/'until_field'.
+      'archon-adversarial-dev',
+      'archon-test-loop-dag',
+      'archon-ralph-dag',
+      't1-fix-issue',
     ]);
 
     it('warns only on workflows already known to carry unknown keys', async () => {
@@ -6501,7 +6614,7 @@ nodes:
         '  - id: iterate',
         '    loop:',
         '      prompt: work',
-        '      until: DONE',
+        '      until_bash: "exit 0"',
         '      max_iterations: 5',
         '      interactive: true',
         '      gate_message: continue?',
@@ -6512,7 +6625,9 @@ nodes:
 
     it('warns on a gate/interactive loop_group nested inside a loop_group body', async () => {
       // Exercises the recursion into loop_group.nodes — the outer group is
-      // clean, only the inner body nodes carry deprecated fields.
+      // clean, only the inner body nodes carry deprecated fields. 'inner-gate' also
+      // has a dependent ('inner-loop'), so it additionally trips the terminal-sink
+      // placement warning below — three warnings on one gate/loop pair, not two.
       const pw = await warningsFor([
         'name: test',
         'description: test',
@@ -6520,7 +6635,7 @@ nodes:
         'nodes:',
         '  - id: outer',
         '    loop_group:',
-        '      until: DONE',
+        '      until_bash: "exit 0"',
         '      max_iterations: 2',
         '      nodes:',
         '        - id: inner-gate',
@@ -6531,15 +6646,125 @@ nodes:
         '        - id: inner-loop',
         '          loop:',
         '            prompt: work',
-        '            until: DONE',
+        '            until_bash: "exit 0"',
         '            max_iterations: 5',
         '            interactive: true',
         '            gate_message: continue?',
         '          depends_on: [inner-gate]',
       ]);
-      expect(pw).toHaveLength(2);
+      expect(pw).toHaveLength(3);
       expect(pw.some(w => w.includes("Node 'inner-gate'") && w.includes('on_reject'))).toBe(true);
       expect(pw.some(w => w.includes("Node 'inner-loop'") && w.includes('interactive'))).toBe(true);
+      expect(pw.some(w => w.includes("Node 'inner-gate'") && w.includes('terminal sink'))).toBe(
+        true
+      );
+    });
+
+    it('warns on a gate node with a dependent inside a loop_group body (not a terminal sink)', async () => {
+      const pw = await warningsFor([
+        'name: test',
+        'description: test',
+        'interactive: true',
+        'nodes:',
+        '  - id: grp',
+        '    loop_group:',
+        '      until_bash: "exit 0"',
+        '      max_iterations: 3',
+        '      nodes:',
+        '        - id: check',
+        '          approval:',
+        '            message: ok?',
+        '        - id: after',
+        '          depends_on: [check]',
+        '          prompt: do more work',
+      ]);
+      expect(pw).toHaveLength(1);
+      expect(pw[0]).toContain("Node 'check'");
+      expect(pw[0]).toContain('terminal sink');
+    });
+
+    it('warns on a gate node sharing terminal-sink status with another body node', async () => {
+      const pw = await warningsFor([
+        'name: test',
+        'description: test',
+        'interactive: true',
+        'nodes:',
+        '  - id: grp',
+        '    loop_group:',
+        '      until_bash: "exit 0"',
+        '      max_iterations: 3',
+        '      nodes:',
+        '        - id: check',
+        '          approval:',
+        '            message: ok?',
+        '        - id: also-terminal',
+        '          prompt: an independent branch',
+      ]);
+      expect(pw).toHaveLength(1);
+      expect(pw[0]).toContain("Node 'check'");
+      expect(pw[0]).toContain('terminal sink');
+    });
+
+    it('warns on the prose until: channel on a loop node', async () => {
+      const pw = await warningsFor([
+        'name: test',
+        'description: test',
+        'nodes:',
+        '  - id: iterate',
+        '    loop:',
+        '      prompt: work',
+        '      until: DONE',
+        '      max_iterations: 5',
+      ]);
+      expect(pw).toHaveLength(1);
+      expect(pw[0]).toContain(
+        "Node 'iterate': the prose 'loop.until' completion signal is deprecated"
+      );
+      expect(pw[0]).toContain('until_bash');
+      expect(pw[0]).toContain('until_field');
+    });
+
+    it('warns on the prose until: channel on a loop_group node, with loop_group-specific guidance (no until_field)', async () => {
+      const pw = await warningsFor([
+        'name: test',
+        'description: test',
+        'nodes:',
+        '  - id: grp',
+        '    loop_group:',
+        '      until: DONE',
+        '      max_iterations: 3',
+        '      nodes:',
+        '        - id: work',
+        '          prompt: do work',
+      ]);
+      expect(pw).toHaveLength(1);
+      expect(pw[0]).toContain(
+        "Node 'grp': the prose 'loop_group.until' completion signal is deprecated"
+      );
+      expect(pw[0]).toContain('loop_group.until_bash');
+      expect(pw[0]).not.toContain('until_field');
+    });
+
+    it('does NOT warn on until_bash or until_field alone', async () => {
+      const pw = await warningsFor([
+        'name: test',
+        'description: test',
+        'nodes:',
+        '  - id: iterate',
+        '    loop:',
+        '      prompt: work',
+        '      until_bash: "exit 0"',
+        '      max_iterations: 5',
+        '  - id: grp',
+        '    depends_on: [iterate]',
+        '    loop_group:',
+        '      until_bash: "exit 0"',
+        '      max_iterations: 3',
+        '      nodes:',
+        '        - id: work',
+        '          prompt: do work',
+      ]);
+      expect(pw).toEqual([]);
     });
 
     it('warns on a typo inside a decisions: entry (R5 fix — array typo protection)', async () => {

--- a/packages/workflows/src/loader.ts
+++ b/packages/workflows/src/loader.ts
@@ -433,6 +433,91 @@ function collectGateAndLoopDeprecationWarnings(
     getLog().warn({ id, warning: message }, 'node_loop_interactive_deprecated');
   }
 
+  // The prose `until:` completion channel is deprecated for EVERY loop/loop_group,
+  // not only interactive ones (#2707 step 3, "What gets deleted"): its one stated
+  // reason to exist — "the iteration output is a message a human reads at an
+  // interactive gate" (#2563) — evaporates once that human interaction is a gate
+  // node with structured decision output rather than a prose sentinel. `until_bash`
+  // and (loop: only) `until_field` are the declared, structured replacements. This
+  // keeps running exactly as before; only the guidance is new.
+  if (isLoopNode(node) && node.loop.until !== undefined) {
+    const message =
+      `Node '${id}': the prose 'loop.until' completion signal is deprecated. Declare ` +
+      "'loop.until_bash' (deterministic check) or 'loop.until_field' (a declared boolean " +
+      'in output_format) instead (#2707 step 3). Continue using it for now.';
+    warnings.push(message);
+    getLog().warn({ id, warning: message }, 'node_loop_until_deprecated');
+  } else if (isLoopGroupNode(node) && node.loop_group.until !== undefined) {
+    const message =
+      `Node '${id}': the prose 'loop_group.until' completion signal is deprecated. ` +
+      "Declare 'loop_group.until_bash' instead — it can read a body node's structured " +
+      'output (e.g. \'test "$body-node.output.field" = true\') (#2707 step 3). Continue ' +
+      'using it for now.';
+    warnings.push(message);
+    getLog().warn({ id, warning: message }, 'node_loop_group_until_deprecated');
+  }
+
+  // A gate node inside a loop_group body only pauses the enclosing loop when it is
+  // the body's SOLE terminal sink (#2707 step 3, target-model decision (b)) — a
+  // mid-body or co-terminal gate has no defined resume semantics and silently does
+  // not stop iteration (mid-body resume-to-node is deferred to #2708). This is
+  // guidance for the new authoring pattern, not a rejection: the file keeps loading
+  // either way, matching the grow-then-deprecate posture used throughout this
+  // function — including for a gate placed here via the legacy `on_reject`
+  // mechanism, which predates and is unrelated to this pattern but is equally
+  // unable to stop the loop from this position.
+  if (isLoopGroupNode(node)) {
+    const bodyDependedOn = new Set(
+      node.loop_group.nodes.flatMap(n => (isIncludeDirective(n) ? [] : (n.depends_on ?? [])))
+    );
+    const gateInBody = node.loop_group.nodes.find(n => !isIncludeDirective(n) && isGateNode(n));
+    if (gateInBody && !isIncludeDirective(gateInBody)) {
+      const bodySinks = node.loop_group.nodes.filter(
+        n => !isIncludeDirective(n) && !bodyDependedOn.has(n.id)
+      );
+      if (bodyDependedOn.has(gateInBody.id) || bodySinks.length > 1) {
+        const message =
+          `Node '${gateInBody.id}': a gate node inside a loop_group body must be the ` +
+          "body's sole terminal sink to pause the enclosing loop (#2707 step 3) — this " +
+          'gate is not, so it will not stop loop iteration. Move it to the end of the ' +
+          'body with nothing else depending on it, and no other node left un-depended-on.';
+        warnings.push(message);
+        getLog().warn({ id: gateInBody.id, warning: message }, 'loop_group_gate_not_terminal_sink');
+      } else {
+        // Gate is validly the sole terminal sink. Design A (#2707 step 3) is
+        // deliberately unopinionated about what a decision means — the group's own
+        // 'until_bash' is the completion channel, and it either reads the gate's
+        // '$<gateId>.output.decision'/'.text' or it doesn't. If it doesn't, the
+        // human's answer is captured (every resolution still writes node_completed)
+        // but never consulted for completion — the loop just runs to max_iterations,
+        // silently ignoring every response. Structural check (does the until_bash
+        // string reference the gate's node id), not prose-sniffing — no judgment
+        // about what the check DOES with it, only whether it looks at it at all.
+        const untilBash = node.loop_group.until_bash;
+        const untilBashRefsGate =
+          untilBash !== undefined &&
+          Array.from(untilBash.matchAll(new RegExp(OUTPUT_REF_SOURCE, 'g'))).some(
+            m => m[1] === gateInBody.id
+          );
+        if (!untilBashRefsGate) {
+          const gateRef = `$${gateInBody.id}.output`;
+          const message =
+            `Node '${gateInBody.id}': this gate is the loop_group's terminal sink, but ` +
+            `'loop_group.until_bash' does not reference '${gateRef}' — the human's ` +
+            'decision is captured but never consulted for completion, so the loop only ' +
+            `ends via max_iterations. Declare 'until_bash' checking '${gateRef}.decision' ` +
+            `(e.g. '[ "${gateRef}.decision" = "approve" ]') so the gate's answer actually ` +
+            'drives completion (#2707 step 3).';
+          warnings.push(message);
+          getLog().warn(
+            { id: gateInBody.id, warning: message },
+            'loop_group_gate_completion_not_referenced'
+          );
+        }
+      }
+    }
+  }
+
   // Recurse into a loop_group body — mirrors collectUnknownNodeKeys's own body
   // recursion. Resolved and raw body arrays share index order (Zod arrays
   // preserve it), so they're zipped by position rather than by id.

--- a/packages/workflows/src/loader.ts
+++ b/packages/workflows/src/loader.ts
@@ -467,22 +467,29 @@ function collectGateAndLoopDeprecationWarnings(
   // mechanism, which predates and is unrelated to this pattern but is equally
   // unable to stop the loop from this position.
   if (isLoopGroupNode(node)) {
-    const bodyDependedOn = new Set(
-      node.loop_group.nodes.flatMap(n => (isIncludeDirective(n) ? [] : (n.depends_on ?? [])))
-    );
-    const gateInBody = node.loop_group.nodes.find(n => !isIncludeDirective(n) && isGateNode(n));
-    if (gateInBody && !isIncludeDirective(gateInBody)) {
-      const bodySinks = node.loop_group.nodes.filter(
-        n => !isIncludeDirective(n) && !bodyDependedOn.has(n.id)
-      );
-      if (bodyDependedOn.has(gateInBody.id) || bodySinks.length > 1) {
+    // Every body entry — including an unexpanded `include:` directive, which has
+    // the identical `depends_on` shape (both extend dagNodeBaseSchema) and is a
+    // real graph participant here, not yet inlined — contributes to and can BE a
+    // terminal sink. Excluding it would silently misclassify a gate a downstream
+    // include node depends on as "terminal", and miss an include node that is
+    // itself a second, co-terminal sink.
+    const bodyDependedOn = new Set(node.loop_group.nodes.flatMap(n => n.depends_on ?? []));
+    const bodySinks = node.loop_group.nodes.filter(n => !bodyDependedOn.has(n.id));
+    // Every gate in the body, not just the first: a body may legitimately contain
+    // more than one (e.g. an "approve to start" gate followed by work followed by
+    // a "review the result" gate) — only ONE can validly be the sole terminal sink,
+    // but each needs its own placement/completion-reference verdict, not just the
+    // first one found.
+    const gatesInBody = node.loop_group.nodes.filter(n => !isIncludeDirective(n) && isGateNode(n));
+    for (const gate of gatesInBody) {
+      if (bodyDependedOn.has(gate.id) || bodySinks.length > 1) {
         const message =
-          `Node '${gateInBody.id}': a gate node inside a loop_group body must be the ` +
+          `Node '${gate.id}': a gate node inside a loop_group body must be the ` +
           "body's sole terminal sink to pause the enclosing loop (#2707 step 3) — this " +
           'gate is not, so it will not stop loop iteration. Move it to the end of the ' +
           'body with nothing else depending on it, and no other node left un-depended-on.';
         warnings.push(message);
-        getLog().warn({ id: gateInBody.id, warning: message }, 'loop_group_gate_not_terminal_sink');
+        getLog().warn({ id: gate.id, warning: message }, 'loop_group_gate_not_terminal_sink');
       } else {
         // Gate is validly the sole terminal sink. Design A (#2707 step 3) is
         // deliberately unopinionated about what a decision means — the group's own
@@ -497,12 +504,12 @@ function collectGateAndLoopDeprecationWarnings(
         const untilBashRefsGate =
           untilBash !== undefined &&
           Array.from(untilBash.matchAll(new RegExp(OUTPUT_REF_SOURCE, 'g'))).some(
-            m => m[1] === gateInBody.id
+            m => m[1] === gate.id
           );
         if (!untilBashRefsGate) {
-          const gateRef = `$${gateInBody.id}.output`;
+          const gateRef = `$${gate.id}.output`;
           const message =
-            `Node '${gateInBody.id}': this gate is the loop_group's terminal sink, but ` +
+            `Node '${gate.id}': this gate is the loop_group's terminal sink, but ` +
             `'loop_group.until_bash' does not reference '${gateRef}' — the human's ` +
             'decision is captured but never consulted for completion, so the loop only ' +
             `ends via max_iterations. Declare 'until_bash' checking '${gateRef}.decision' ` +
@@ -510,7 +517,7 @@ function collectGateAndLoopDeprecationWarnings(
             'drives completion (#2707 step 3).';
           warnings.push(message);
           getLog().warn(
-            { id: gateInBody.id, warning: message },
+            { id: gate.id, warning: message },
             'loop_group_gate_completion_not_referenced'
           );
         }

--- a/packages/workflows/src/schemas/workflow-run.ts
+++ b/packages/workflows/src/schemas/workflow-run.ts
@@ -435,6 +435,21 @@ export interface ApprovalContext {
    * child of the same parent can't trigger the wrong re-entry.
    */
   childRunId?: string;
+  /**
+   * Set only on an ESCALATED pause: a `gate:` node that is the sole terminal sink
+   * of a `loop_group` body (#2707 step 3), still `type: 'approval'`. The enclosing
+   * loop_group's own id occupies `nodeId` — required for the top-level DAG's
+   * resume walk to find it (it only knows top-level node ids, never a nested body
+   * id) — so this field carries the body gate's own bare id, the one piece the
+   * rewrite would otherwise lose. `approveWorkflow`/`rejectWorkflow`/
+   * `respondToWorkflowWithDeclaredDecision` read it to namespace the resolution's
+   * `node_completed` event as `<nodeId>.<bodyGateId>` instead of bare `nodeId` —
+   * the exact `<groupId>.<bodyId>` step name #2748's `outerNodeOutputs`
+   * pre-population already keys on, so the gate's own resolved decision is
+   * findable again after a resume the same way any other body node's output is.
+   * Absent for every other pause kind, including an ordinary top-level gate.
+   */
+  bodyGateId?: string;
   /** Current loop iteration when paused (interactive loops only). */
   iteration?: number;
   /**

--- a/packages/workflows/src/script-node-deps.test.ts
+++ b/packages/workflows/src/script-node-deps.test.ts
@@ -106,6 +106,7 @@ function createMockStore(): IWorkflowStore {
     completeWorkflowRun: mock(() => Promise.resolve()),
     failWorkflowRun: mock(() => Promise.resolve()),
     pauseWorkflowRun: mock(() => Promise.resolve()),
+    rewriteApprovalContext: mock(() => Promise.resolve({ resolved: true })),
     claimWriteback: mock(() => Promise.resolve({ claimed: true })),
     releaseWritebackClaim: mock(() => Promise.resolve()),
     cancelWorkflowRun: mock(() => Promise.resolve({ cancelled: false })),

--- a/packages/workflows/src/store.ts
+++ b/packages/workflows/src/store.ts
@@ -225,6 +225,26 @@ export interface IWorkflowStore extends IRunTreeStore, IWorkflowRunNodeSessionSt
   ): Promise<void>;
 
   /**
+   * Rewrite the approval context of an ALREADY-paused, still-open gate — unlike
+   * `pauseWorkflowRun`, which requires the run to currently be `'running'` and so
+   * cannot be used once a pause has already landed. CAS-guarded on the gate still
+   * being unresolved: a human who resolves the gate first wins the race, and this
+   * returns `resolved: false` instead of clobbering their resolution.
+   *
+   * Built for #2707 step 3's pause escalation: a `loop_group` body gate pauses
+   * generically (via `pauseWorkflowRun`, `nodeId` = the gate's own bare id), and
+   * this then rewrites `nodeId` to the enclosing loop_group's id (so the
+   * top-level DAG's resume walk finds it) and adds `bodyGateId` (the gate's
+   * original id, otherwise lost). Pass the COMPLETE rewritten `ApprovalContext`,
+   * not a partial one — the write merges into stored metadata, and an omitted
+   * field can survive from the prior context on one dialect and not the other.
+   */
+  rewriteApprovalContext(
+    id: string,
+    approvalContext: ApprovalContext
+  ): Promise<{ resolved: boolean }>;
+
+  /**
    * Atomically CLAIM the container write-back apply before the live root is mutated
    * (retry-safe apply). Sets `metadata.writeback_apply_claimed` only while unset;
    * returns whether THIS caller won. Apply the overlay only when `claimed`.

--- a/packages/workflows/src/subrun.test.ts
+++ b/packages/workflows/src/subrun.test.ts
@@ -213,6 +213,18 @@ class InMemoryStore implements IWorkflowStore {
     return Promise.resolve();
   };
 
+  rewriteApprovalContext: IWorkflowStore['rewriteApprovalContext'] = (id, approvalContext) => {
+    const r = this.runs.get(id);
+    // Mirrors the real store's CAS guard (unresolvedGateClause): only while still
+    // paused and unresolved — a human resolving the gate first wins the race.
+    const approval = r?.metadata?.approval as { resolved?: string } | undefined;
+    if (r && r.status === 'paused' && approval?.resolved == null) {
+      r.metadata = { ...r.metadata, approval: { ...approvalContext } };
+      return Promise.resolve({ resolved: true });
+    }
+    return Promise.resolve({ resolved: false });
+  };
+
   claimWriteback = (): Promise<{ claimed: boolean }> => Promise.resolve({ claimed: true });
   releaseWritebackClaim = (): Promise<void> => Promise.resolve();
 


### PR DESCRIPTION
## Problem and outcome

#2707 step 3 re-expresses the interactive loop as a `loop_group` whose body ends in a gate node, replacing the node-level `loop.interactive` + `gate_message` mechanism (steps 1 and 2, already merged, shipped the structured gate output and class-enforcement halves this builds on). This PR delivers step 3 in full: 3a (schema/loader guidance) and 3b (the runtime mechanism that makes the pattern actually work), landed as two commits on one PR since they share a branch.

- **Outcome:** A gate node can now be authored as a `loop_group` body's terminal sink and it genuinely pauses the loop for human input, then resumes correctly — completing immediately when the human's answer means "done" (per an author-declared `until_bash` check), or advancing to a real next iteration otherwise, with the human's text available to that next iteration via the existing `$LOOP_PREV` channel.
- **Invariant:** The old `loop_group.interactive` + `gate_message` mechanism is completely untouched — byte-for-byte unchanged behavior, unchanged tests. Every new load-time check is a warning, not a load error; nothing that loads today stops loading.
- **Scope boundary:** The single-node `loop:` type is out of scope (no body to place a gate in — an interactive `loop:` still uses the old mechanism, to be migrated by #2123's `archon-piv-loop` rewrite). Mid-body pause/resume (a gate anywhere other than the body's terminal sink) is deferred to #2708 per the design's settled decision (b).

## Review guidance

- **Feedback requested:** Correctness of the pause-escalation/resume mechanism (3b) — this is genuinely novel engine surgery with a non-obvious CAS interaction; the placement/completion-reference load-time checks (3a) are lower-risk and already independently reviewed once.
- **Start here:** `packages/workflows/src/dag-executor.ts` — `executeLoopGroupNode`, specifically the `findLoopGroupTerminalGate` pause-escalation block (search `#2707 step 3: pause escalation`) and the resume-time completion re-check (search `isEscalatedGateResume`).
- **Review order:** 3a commit first (`packages/workflows/src/loader.ts` + `loader.test.ts`), then 3b commit (`dag-executor.ts` + `dag-executor.test.ts`, then the smaller `workflow-operations.ts`/`store.ts`/`store-adapter.ts` write-path changes).
- **Lower-attention areas:** The one-line `rewriteApprovalContext` mock additions across `executor-preamble.test.ts`/`executor.test.ts`/`script-node-deps.test.ts`/`subrun.test.ts` — mechanical additions required because `IWorkflowStore` gained a method; `subrun.test.ts`'s version does simulate the real CAS guard, the others just stub success.
- **Known risk or uncertainty:** The resume-time `until_bash` re-check restores only the single most-recent iteration's body outputs (matching #2748's own restoration scope), not a full history — an `until_bash` referencing `$LOOP_PREV` from *before* the resumed iteration would resolve empty on resume. Judged acceptable: Design A's canonical pattern only ever reads `$<gateId>.output` inside `until_bash`, never `$LOOP_PREV`.

## Solution

### 3a — load-time guidance

**Placement.** Per the design's settled decision (b), a pause node must be the body's terminal sink — resume re-enters at the iteration boundary, not mid-body. Warns when a gate has a dependent, or shares terminal-sink status with another body node (checks every gate in a body, and correctly counts `include:` directives in the dependency/sink graph — both fixed after an independent review caught them checking only the first gate and excluding includes).

**Completion reachability, Design A** (confirmed with the operator — supersedes the "approve-empty finalizes" convention from the original plan). No new schema. A gate-terminated group's completion is expressed through the *existing* `until_bash` channel reading the gate's own structured output — `$<gateId>.output.decision`/`.text` — exactly like any other loop_group body node's `output_format`. No decision id gets hardcoded meaning; the author's own check is the definition of "done." Canonical two-decision shape (what #2123's `archon-piv-loop` rewrite will use):

```yaml
loop_group:
  until_bash: '[ $check.output.decision = "approve" ]'
  max_iterations: 5
  nodes:
    - id: work
      prompt: "..."
    - id: check
      depends_on: [work]
      approval:
        message: "Continue?"
        decisions:
          - id: approve
          - id: revise
```

(The ref is not manually quoted — `substituteNodeOutputRefs` already shell-quotes it; wrapping it again compares a quoted literal to an unquoted one and never matches. Found and fixed this while building 3b.)

`approve` completes; `revise` with text iterates, with the text flowing to the next iteration via the existing `$LOOP_PREV.<gateId>.output.text` channel — a considered *replacement* for #2074's approve-empty/approve-with-text convention, not a silent drop.

Because this reuses `until_bash` verbatim, the schema's existing "at least one completion channel" rule already covers reachability. What *is* new: a structural (non-prose-sniffing) warning when a gate-terminated group's `until_bash` never references the gate's own node id — the real footgun: a group relying on an unrelated `until_bash` would ask the human every iteration and silently ignore every answer, ending only via `max_iterations`.

**Reject semantics** (stated precisely per the operator's correction, verified against `packages/core/src/operations/workflow-operations.ts:696-724`). A bare gate (no `decisions:` authored) rejecting inside a loop_group body does **not** fail the node or propagate through loop_group's "failed body node fails the group" rule — `rejectWorkflow`'s legacy branch calls `resolveAndCancelApprovalGate`, which cancels the *run* directly, no `node_completed`/`node_failed` event ever written for that gate. Everything stops (more emphatically than a group-failure would), but the mechanism is direct run cancellation, not dependency-failure propagation.

**`until:` deprecation, widened.** The prose `until:` channel's one stated reason to exist — "the iteration output is a message a human reads at an interactive gate" (#2563) — evaporates once that interaction is a gate node with structured output. Warns on every loop/loop_group declaring `until:`, not only interactive ones.

### 3b — runtime pause/resume

**Pause escalation.** A body-terminal gate pauses generically today (gate nodes are ordinary body nodes, run through the same `runLayers` path as anything else) — but the enclosing loop_group's between-iteration status check tolerates `'paused'` (correctly, for a genuinely unrelated sibling gate pausing in the same layer), so without this change the loop barrels straight into the next iteration, immediately re-pausing and burning AI cost every time, never letting the human's answer take effect. Right after `runLayers()` returns, the code now detects when the iteration's designated terminal gate is what just paused the run and rewrites the persisted `ApprovalContext` so `nodeId` points at the enclosing loop_group's own id — required because the outer DAG's resume routing finds a paused loop_group via that loop_group re-checking its *own* id, and the top-level DAG never sees nested body ids — while recording the gate's actual bare id in a new `bodyGateId` field.

This can't reuse the ordinary pause call: `pauseWorkflowRun` requires `status='running'`, already false by the time this runs (the inner gate's own pause already flipped it) — reusing it would silently no-op through the "external transition, skip" branch and never apply the rewrite. It uses `resolveApprovalGate`'s CAS instead (gated on the gate still being unresolved, not on run status), which correctly no-ops without corrupting state on the astronomically narrow race where a human resolves the original bare-gate pause before the rewrite lands.

**Write-path fix.** `approveWorkflow`/`rejectWorkflow`/`respondToWorkflowWithDeclaredDecision` write their `node_completed` event's `step_name` as `<nodeId>.<bodyGateId>` when `bodyGateId` is present, instead of bare `nodeId` — otherwise the gate's real resolved decision is never findable at the namespaced key #2748's `outerNodeOutputs` resume pre-population depends on, and Design A's `until_bash` completion check would resolve against nothing on resume.

**Resume-time completion re-check.** The old `interactive_loop` mechanism always skips blindly to iteration+1 on resume. That's wrong here: if the human's answer means "done" per the group's own `until_bash`, the group must complete immediately from this iteration, not silently start a new one while ignoring the answer. On resume, the code reconstructs the paused iteration's data (reusing #2748's restoration, extended to also carry the gate's own now-correctly-namespaced resolution, and merged with `outerNodeOutputs` so an `until_bash` combining an outer-scope ref with the gate's decision resolves correctly too) and re-runs the same `until`/`until_bash` check the normal per-iteration path runs — without re-invoking `runLayers` — completing now, or falling through to a genuine fresh iteration.

## Validation

- `bun run --filter @archon/workflows type-check` / `bun run --filter @archon/core type-check` — clean.
- `bun x eslint <changed files> --max-warnings 0` (both packages, non-test files) — clean.
- `bun run --filter @archon/workflows test` — full package suite (24 files), 0 fail; `dag-executor.test.ts` alone 614 pass including 5 new `#2707 step 3` tests (pause-and-complete, resume-and-iterate with `$LOOP_PREV` text delivery, the CAS-race fallthrough, an outer-DAG-ref-in-`until_bash` regression, and loader-level placement/reachability coverage).
- `bun run --filter @archon/core test` — full package suite, 0 fail; `workflow-operations.test.ts` covers the namespaced `step_name` write for approve/reject/respond; `store-adapter.test.ts` covers the new `rewriteApprovalContext` wiring.
- Two rounds of independent review (`prp-core:code-reviewer`) before this was pushed — round 1 on 3a found and fixed 2 real bugs (only the first gate in a body was checked; `include:` directives were wrongly excluded from the sink graph); round 2 on 3b found and fixed 4 issues (a real cost/token-accounting bug where a paused iteration's own AI spend was dropped from the run's live total; a missing mock-factory update for a new store method; a missing test for the CAS-race branch; a narrow outer-DAG-ref gap in the resume recheck, fixed outright rather than just documented).
- **Not verified:** End-to-end manual validation through a running server/CLI (this PR's tests exercise the mechanism through the public `executeDagWorkflow` entry point with mocked platform/deps, not a live run against a real database).

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | Grow-then-deprecate throughout. 3a's warnings are additive; 3b's mechanism is strictly opt-in to the new "gate is the body's sole terminal sink" shape and leaves the old `loop_group.interactive` mechanism fully intact. `archon-piv-loop.yaml` (the one bundled workflow using the old mechanism) is unaffected — it uses single-node `loop:`, which has no body. | `loader.test.ts`'s real-corpus test + `KNOWN_BAD` allowlist; `dag-executor.test.ts`'s isolation between `isLegacyInteractiveLoopResume`/`isEscalatedGateResume` |
| Documentation / communication | No docs-site pages added — this PR makes the pattern *work*; authoring-guide content is 3c's job. The canonical example above is captured here for that follow-up and for #2123's `archon-piv-loop` migration. | This PR description |

## Links

- Related #2707


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Escalated approval gates in loop workflows can resume and complete without repeating prior work.
  * Revised decisions and feedback can trigger additional iterations while preserving workflow context.
  * Custom responses are supported for escalated gate pauses.

* **Bug Fixes**
  * Improved validation for multiple gates and included steps in loop bodies.
  * Corrected event tracking for nested gate resolutions.
  * Added safeguards for concurrent approval-resolution races.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->