### PR TITLE
fix(workflows): interactive loop_group resume now restores $LOOP_PREV body outputs

### DIFF
--- a/packages/docs-web/src/content/docs/guides/loop-nodes.md
+++ b/packages/docs-web/src/content/docs/guides/loop-nodes.md
@@ -738,10 +738,10 @@ Two distinct cases:
 - **Interactive-gate resume** (`/workflow approve <id>`): the loop continues
   with the **next** iteration's whole body. With `fresh_context: false`, the
   body's AI session continues from where it paused (the session cursor is
-  persisted across the gate). `$LOOP_PREV.*` refs, however, resolve to an empty
-  string on the first resumed iteration — the prior iteration's body-output
-  snapshot is **not** carried across the gate (same caveat as
-  [`$LOOP_PREV_OUTPUT`](#retry-on-failure-with-loop_prev_output)).
+  persisted across the gate). `$LOOP_PREV.*` refs on the first resumed
+  iteration resolve to the prior iteration's real body outputs, restored from
+  the persisted run history — the same as an un-paused next iteration would
+  have seen.
 - **Failure resume** (`/workflow resume <id>` after a crash/failure): there is
   no persisted iteration cursor — the loop_group node restarts from
   **iteration 1**. Per-body-node resume granularity is not supported in v1.
@@ -758,8 +758,6 @@ Two distinct cases:
 - Per-body-node resume (skip-to-failed-body-node) — the whole iteration re-runs.
 - `$LOOP_PREV.<id>.output[N]` history indexing — only the immediately prior
   iteration is reachable.
-- `$LOOP_PREV.*` across an interactive pause/resume boundary — resolves to an
-  empty string on the resumed iteration.
 
 Nested `loop_group` inside a `loop_group` body is supported by construction
 (the body is a normal `nodes` array), but is not hardened in v1.

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -22564,12 +22564,13 @@ describe('executeDagWorkflow -- loop_group node', () => {
     expect(pauseCalls2.length).toBe(0);
   });
 
-  it('INTERACTIVE resume: $LOOP_PREV is NOT preserved across the pause/resume boundary (v1 known limitation)', async () => {
-    // v1 behavior: on interactive resume, loopPrevOutputs resets to undefined (the prior
-    // process's body-output snapshot is not persisted in ApprovalContext). So the resumed
-    // iteration's $LOOP_PREV.<bodyNode>.output resolves to '' — NOT to the paused run's
-    // iteration-1 output. This test locks the current behavior; persisting $LOOP_PREV
-    // across resume is a tracked follow-up (CodeRabbit finding #5).
+  it('INTERACTIVE resume: $LOOP_PREV resolves to the prior iteration real body output (#2748)', async () => {
+    // On interactive resume, executeLoopGroupNode is a fresh call whose local
+    // loopPrevOutputs starts undefined — but the paused run's iteration-1 body output
+    // was already persisted as a `refine.work` node_completed row. The resumed
+    // executeDagWorkflow call re-derives loopPrevOutputs from that persisted row (via
+    // outerNodeOutputs, pre-populated from the priorCompletedNodes snapshot passed in
+    // below), so $LOOP_PREV.<bodyNode>.output resolves to the real prior output, not ''.
     mockSendQueryDag.mockImplementationOnce(async function* () {
       yield { type: 'assistant', content: 'iter1 body output XYZ' };
       yield { type: 'result', sessionId: 'lg-prev-sess-1' };
@@ -22626,7 +22627,11 @@ describe('executeDagWorkflow -- loop_group node', () => {
     const iter1Prompt = mockSendQueryDag.mock.calls[0][0] as string;
     expect(iter1Prompt).toContain('PREV=<<>>');
 
-    // ---- Resume: iteration 2.
+    // ---- Resume: iteration 2. priorCompletedNodes carries the persisted iteration-1
+    // body row (the `refine.work` node_completed row a real DB would return from
+    // getDagResumeSnapshot) — this is what a real resume threads in via
+    // hydrateResumableRun before calling executeDagWorkflow.
+    const priorCompletedNodes = new Map([['refine.work', { output: 'iter1 body output XYZ' }]]);
     mockSendQueryDag.mockImplementationOnce(async function* () {
       yield { type: 'assistant', content: 'final\nAPPROVED' };
       yield { type: 'result', sessionId: 'lg-prev-sess-2' };
@@ -22656,15 +22661,158 @@ describe('executeDagWorkflow -- loop_group node', () => {
       join(testDir, 'logs'),
       'main',
       'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      priorCompletedNodes
+    );
+
+    // Resumed iteration 2: $LOOP_PREV resolves to the real persisted iteration-1 output.
+    const resumePrompt = mockSendQueryDag.mock.calls[1][0] as string;
+    expect(resumePrompt).toContain('PREV=<<iter1 body output XYZ>>');
+    expect(resumePrompt).toContain('USER=ok');
+  });
+
+  it('INTERACTIVE resume: $LOOP_PREV resolves an oversized (>32KB) prior body output via the spill path (#2748)', async () => {
+    // Mirrors 'reads oversized $LOOP_PREV output from the run-owned spill directory'
+    // (same file, in-process case) but crosses a real pause/resume boundary: a bash
+    // body node spills a real oversized output on iteration 1, the group pauses, then
+    // a SEPARATE resumed executeDagWorkflow call — seeded with priorCompletedNodes the
+    // way a real resume threads it in via hydrateResumableRun — reads
+    // $LOOP_PREV.work.output back and proves the full byte length survived the pause.
+    const artifactsDir = join(testDir, 'lg-prev-large-artifacts');
+    const logDir = join(testDir, 'lg-prev-large-logs');
+    const paddingBytes = 40_000;
+    const freshStore = createMockStore();
+
+    const freshWorkflow = {
+      name: 'lg-resume-prev-large',
+      nodes: [
+        {
+          id: 'refine',
+          kind: 'loop_group',
+          loop_group: {
+            until: 'DONE',
+            max_iterations: 5,
+            fresh_context: false,
+            interactive: true,
+            gate_message: 'Review.',
+            nodes: [
+              {
+                id: 'work',
+                kind: 'exec',
+                runtime: 'sh',
+                script: `head -c ${String(paddingBytes)} /dev/zero | tr "\\0" x`,
+                depends_on: [],
+              },
+            ],
+          },
+          depends_on: [],
+        },
+      ] as DagNode[],
+    };
+
+    await executeDagWorkflow(
+      createMockDeps(freshStore),
+      createMockPlatform(),
+      'conv-lg-large',
+      testDir,
+      freshWorkflow,
+      makeWorkflowRun('lg-prev-large-fresh'),
+      'claude',
+      undefined,
+      artifactsDir,
+      join(testDir, 'state'),
+      logDir,
+      'main',
+      'docs/',
       minimalConfig
     );
 
-    // Resumed iteration 2: $LOOP_PREV is '' (v1 does not persist the prior body snapshot
-    // across resume), NOT 'iter1 body output XYZ'.
-    const resumePrompt = mockSendQueryDag.mock.calls[1][0] as string;
-    expect(resumePrompt).toContain('PREV=<<>>');
-    expect(resumePrompt).not.toContain('iter1 body output XYZ');
-    expect(resumePrompt).toContain('USER=ok');
+    const freshEventCalls = (freshStore.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+    const bodyEvent = freshEventCalls.find(
+      (call: unknown[]) =>
+        (call[0] as { event_type: string }).event_type === 'node_completed' &&
+        (call[0] as { step_name: string }).step_name === 'refine.work'
+    );
+    expect(bodyEvent).toBeDefined();
+    if (!bodyEvent) throw new Error('Expected refine.work to complete on the fresh pass');
+    const bodyData = bodyEvent[0].data as {
+      node_output_truncated: boolean;
+      node_output_spill_path: string;
+    };
+    expect(bodyData.node_output_truncated).toBe(true);
+    const spilledFullOutput = await readFile(bodyData.node_output_spill_path, 'utf8');
+    expect(spilledFullOutput.length).toBe(paddingBytes);
+
+    // The group paused after iteration 1 (interactive: true, no 'DONE' signal yet).
+    const pauseCalls = (freshStore.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>)
+      .mock.calls;
+    expect(pauseCalls.length).toBe(1);
+
+    // ---- Resume: seed priorCompletedNodes with the REAL spilled bytes (not a
+    // hand-authored string) and prove the resumed body script sees the full value.
+    const priorCompletedNodes = new Map([['refine.work', { output: spilledFullOutput }]]);
+    const resumedWorkflow = {
+      name: 'lg-resume-prev-large',
+      nodes: [
+        {
+          id: 'refine',
+          kind: 'loop_group',
+          loop_group: {
+            until: 'DONE',
+            max_iterations: 5,
+            fresh_context: false,
+            interactive: true,
+            gate_message: 'Review.',
+            nodes: [
+              {
+                id: 'work',
+                kind: 'exec',
+                runtime: 'sh',
+                script: 'previous=$LOOP_PREV.work.output; printf "%s\\nDONE\\n" "${#previous}"',
+                depends_on: [],
+              },
+            ],
+          },
+          depends_on: [],
+        },
+      ] as DagNode[],
+    };
+    const result = await executeDagWorkflow(
+      createMockDeps(createMockStore()),
+      createMockPlatform(),
+      'conv-lg-large-resume',
+      testDir,
+      resumedWorkflow,
+      makeWorkflowRun('lg-prev-large-resume', {
+        metadata: {
+          approval: {
+            type: 'interactive_loop',
+            nodeId: 'refine',
+            iteration: 1,
+            message: 'Review.',
+          },
+          loop_user_input: '',
+        },
+      }),
+      'claude',
+      undefined,
+      artifactsDir,
+      join(testDir, 'state'),
+      logDir,
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      priorCompletedNodes
+    );
+
+    // The resumed body script measured $LOOP_PREV.work.output's length as the FULL
+    // padding size — proving the real spilled bytes (not a truncated preview) survived
+    // the pause/resume boundary.
+    expect(result).toContain(String(paddingBytes));
   });
 
   // --- Dimension 3: cost/token accumulation across iterations ---

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -22673,6 +22673,110 @@ describe('executeDagWorkflow -- loop_group node', () => {
     expect(resumePrompt).toContain('USER=ok');
   });
 
+  it('INTERACTIVE resume: re-derives declaredFields so an undeclared $LOOP_PREV field fails the consumer (not-in-schema) (#2748 R1)', async () => {
+    // Mirrors the top-level 're-derives declaredFields on resume...' test (this file,
+    // ~line 5876) at the loop_group body level: a resumed body node's restored NodeOutput
+    // must keep the SAME schema-typo strictness a live in-process iteration has. Without
+    // re-deriving declaredFields from the body node's own current output_format, an
+    // undeclared field silently resolves to '' instead of throwing.
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+
+    // Prior iteration's persisted body output carries an `extra` key the schema does
+    // NOT declare.
+    const priorCompletedNodes = new Map([
+      ['refine.work', { output: '{"type":"BUG","extra":"x"}' }],
+    ]);
+
+    const workflow = {
+      name: 'lg-resume-declared-fields',
+      nodes: [
+        {
+          id: 'refine',
+          kind: 'loop_group',
+          loop_group: {
+            until: 'DONE',
+            max_iterations: 5,
+            fresh_context: false,
+            interactive: true,
+            gate_message: 'Review.',
+            nodes: [
+              {
+                id: 'work',
+                kind: 'agent',
+                source: { kind: 'inline', prompt: 'produce json' },
+                output_format: {
+                  type: 'object',
+                  properties: { type: { type: 'string' } },
+                  required: ['type'],
+                },
+                depends_on: [],
+              },
+              {
+                id: 'consumer',
+                kind: 'agent',
+                source: {
+                  kind: 'inline',
+                  prompt: 'extra=[$LOOP_PREV.work.output.extra]',
+                },
+                depends_on: ['work'],
+              },
+            ],
+          },
+          depends_on: [],
+        },
+      ] as DagNode[],
+    };
+
+    mockSendQueryDag.mockImplementationOnce(async function* () {
+      yield { type: 'assistant', content: '{"type":"BUG"}' };
+      yield { type: 'result', sessionId: 'lg-declared-fields-sess' };
+    });
+
+    await executeDagWorkflow(
+      mockDeps,
+      createMockPlatform(),
+      'conv-lg-declared-fields',
+      testDir,
+      workflow,
+      makeWorkflowRun('lg-resume-declared-fields', {
+        metadata: {
+          approval: {
+            type: 'interactive_loop',
+            nodeId: 'refine',
+            iteration: 1,
+            message: 'Review.',
+          },
+          loop_user_input: '',
+        },
+      }),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      priorCompletedNodes
+    );
+
+    // The undeclared `extra` field must fail loudly (not-in-schema) on the resumed
+    // iteration — exactly as it would fail an in-process iteration — instead of
+    // silently resolving to '' the way a genuinely schemaless body node's absent
+    // field would.
+    const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
+    const failedEvent = eventCalls.find((call: unknown[]) => {
+      const event = call[0] as { event_type: string; data?: { error?: string } };
+      return (
+        event.event_type === 'node_failed' && event.data?.error?.includes('is not declared in node')
+      );
+    });
+    expect(failedEvent).toBeDefined();
+  });
+
   it('INTERACTIVE resume: $LOOP_PREV resolves an oversized (>32KB) prior body output via the spill path (#2748)', async () => {
     // Mirrors 'reads oversized $LOOP_PREV output from the run-owned spill directory'
     // (same file, in-process case) but crosses a real pause/resume boundary: a bash

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -4289,10 +4289,30 @@ async function executeLoopGroupNode(
   // substituteLoopPrevRefs finds them exactly as it would mid-loop.
   if (isLoopResume) {
     const restoredLoopPrevOutputs = new Map<string, NodeOutput>();
+    const bodyNodesById = new Map((group.nodes as DagNode[]).map(n => [n.id, n]));
     for (const id of directBodyIds) {
       const prior = outerNodeOutputs.get(bodyStepNamePrefix + id);
-      if (prior) restoredLoopPrevOutputs.set(id, prior);
+      if (!prior) continue;
+      // The persisted row's dotted `<groupId>.<bodyId>` step name never matches a
+      // TOP-LEVEL node id, so the pre-population `prior` came from (dag-executor.ts
+      // ~10037-10052) always drops declaredFields for it. Re-derive it from the body
+      // node's OWN current definition — the same source the in-process per-iteration
+      // path uses (~line 3111) — so a resumed $LOOP_PREV.<id>.output.<field> ref keeps
+      // the same schema-typo strictness a live iteration has, instead of silently
+      // degrading to lenient '' for a genuinely undeclared field.
+      const bodyNodeDef = bodyNodesById.get(id);
+      const declaredFields =
+        bodyNodeDef !== undefined && !isLoopGroupNode(bodyNodeDef)
+          ? declaredFieldsFromSchema(bodyNodeDef.output_format)
+          : undefined;
+      restoredLoopPrevOutputs.set(id, {
+        ...prior,
+        ...(declaredFields !== undefined ? { declaredFields } : {}),
+      });
     }
+    // Kept as an empty-map guard for clarity only — substituteLoopPrevRefs reads via
+    // `loopPrevOutputs?.get(id)`, so an empty Map and undefined are indistinguishable
+    // to every consumer; this has no behavioral effect either way.
     if (restoredLoopPrevOutputs.size > 0) loopPrevOutputs = restoredLoopPrevOutputs;
   }
   let lastIterationOutput = '';

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -4279,6 +4279,22 @@ async function executeLoopGroupNode(
   }
 
   let loopPrevOutputs: Map<string, NodeOutput> | undefined; // undefined on iteration 1
+  // Restore the body-output snapshot $LOOP_PREV.* reads, for the resumed iteration
+  // (#2748). The pause boundary discards this function's local state, but the last
+  // iteration's direct body-node outputs already survive as persisted
+  // `<groupId>.<bodyId>` node_completed rows — `outerNodeOutputs` was ALREADY
+  // pre-populated from them (executeDagWorkflow's resume pre-population, itself
+  // sourced from getDagResumeSnapshot's #2726/#2732 bounded-rows + spill/rehydrate
+  // read), keyed by that full step name. Re-key to the bare body id so
+  // substituteLoopPrevRefs finds them exactly as it would mid-loop.
+  if (isLoopResume) {
+    const restoredLoopPrevOutputs = new Map<string, NodeOutput>();
+    for (const id of directBodyIds) {
+      const prior = outerNodeOutputs.get(bodyStepNamePrefix + id);
+      if (prior) restoredLoopPrevOutputs.set(id, prior);
+    }
+    if (restoredLoopPrevOutputs.size > 0) loopPrevOutputs = restoredLoopPrevOutputs;
+  }
   let lastIterationOutput = '';
   // The terminal sink's structured payload for the same iteration (#2637) — tracked
   // beside the text so the group's completed NodeOutput carries the logical value


### PR DESCRIPTION
## Problem and outcome

An interactive `loop_group`'s pause/resume didn't preserve `$LOOP_PREV.*` — the body-output map that lets an iteration reference what a sibling (or itself) produced last time. On resume, the first iteration processed always saw every `$LOOP_PREV.<bodyId>.output` as `''`, even though the real prior output existed and was already persisted. A draft/review/refine loop resumed after human feedback effectively asked the model to improve on work it could no longer see.

- **Outcome:** `$LOOP_PREV.*` on the first iteration after an interactive-gate resume now resolves to the real previous iteration's body output — identical to what an un-paused next iteration would have seen — for any output size, including outputs large enough to spill to disk.
- **Invariant:** `$LOOP_PREV.<bodyId>.output[.field]` on the resumed iteration must equal what it would have resolved to without the intervening pause.
- **Scope boundary:** Only the single-level interactive `loop_group` case the issue reproduces. A nested interactive `loop_group` (gate inside an inner group's body, itself inside an outer group's body) has broader pre-existing resume semantics beyond `$LOOP_PREV` and is already documented as "not hardened in v1" — untouched here. The identical structural gap in the single-node `loop:`'s `$LOOP_PREV_OUTPUT` is a different code path, not raised by this issue, and also untouched.
- **Root cause:** `loopPrevOutputs` is a local variable scoped to one `executeLoopGroupNode` call, populated only from in-process iterations. The interactive-gate pause payload (`ApprovalContext`) persists the session cursor and completion-signal state, but never a body-output snapshot. Resume re-enters `executeLoopGroupNode` as a brand-new call, so `loopPrevOutputs` starts `undefined` again and every `$LOOP_PREV.*` ref resolves via the same "no prior output" branch a genuine iteration 1 hits.

## Review guidance

- **Feedback requested:** Correctness of the reconstruction (does `outerNodeOutputs` really already carry what I claim on every production resume path, not just in the test harness), and whether the oversized-output test convincingly proves the spill path.
- **Start here:** `packages/workflows/src/dag-executor.ts:4281` — the fix itself, ~16 lines.
- **Review order:** `dag-executor.ts:4281` (fix) → `dag-executor.ts:10015-10059` (the existing, unrelated top-level pre-population the fix depends on — unchanged, cited for context) → `dag-executor.test.ts` (the two updated/new tests) → `loop-nodes.md` (doc caveat removal).
- **Lower-attention areas:** The doc change is a mechanical removal of a now-false caveat; no new claims added.
- **Known risk or uncertainty:** None identified. The reconstruction reuses data (`outerNodeOutputs`) that was already being computed and threaded through for an unrelated reason (top-level `$node.output` resume support), so this fix adds no new state, query, or persisted field.

## Solution

`executeDagWorkflow` already pre-populates its top-level `nodeOutputs` map from every persisted `node_completed` row on a resume (`dag-executor.ts:10015-10059`), unconditionally — it doesn't filter by whether a row's `step_name` matches a top-level node id, so a loop_group body node's `<groupId>.<bodyId>`-keyed row lands there too. That map is exactly the `outerNodeOutputs` parameter `executeLoopGroupNode` already receives.

The fix reads those entries back: on `isLoopResume`, for each of this group's direct body ids, look up `outerNodeOutputs.get(bodyStepNamePrefix + id)` and re-key it to the bare id `substituteLoopPrevRefs` looks up. This also resolves the "which iteration's row" question for free — a loop_group body node's persisted `step_name` is the *same* string across every iteration, and the underlying `getDagResumeSnapshot` read already folds chronologically-ordered rows per `step_name`, so the last (latest) iteration's row is what survives. No new `ApprovalContext` field, no new DB query, and it inherits the existing #2726/#2732 spill/rehydrate machinery (a large prior output already reads back its full spilled bytes, not a truncated preview) with no extra code.

## Validation

- `cd packages/workflows && bun test src/dag-executor.test.ts -t "LOOP_PREV"` — 14 pass, 0 fail — proves both the inverted regression test (general resume case) and the new oversized/spill regression test.
- `cd packages/workflows && bun test src/dag-executor.test.ts` — 608 pass, 0 fail — proves no regression across the full loop_group/loop/DAG-executor suite, including the sibling resume test covering session-cursor and `$LOOP_USER_INPUT` restoration.
- `bun run validate` — full repo gate green (type-check, lint, format, all package test suites, bundled/schema/capability-matrix checks).
- **Not verified:** No live end-to-end manual run against a real Archon server/CLI (approve a paused run and observe the resumed prompt). The unit-level harness constructs `priorCompletedNodes` the same way `hydrateResumableRun` does for a real resume (confirmed by reading its production callers in the orchestrator and CLI), so this is considered adequately covered without a manual run.

## Links

- Closes #2748
- Plan: https://github.com/coleam00/Archon/issues/2748#issuecomment-5382807363


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Interactive loop resumes now correctly restore outputs from the previous iteration.
  * `$LOOP_PREV.*` references continue working after a pause and resume.
  * Undeclared `$LOOP_PREV` fields are properly rejected after resuming.
  * Large outputs remain available in full after resuming an interactive loop.

* **Documentation**
  * Updated loop guidance to reflect restored previous-iteration outputs after interactive resumes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->