### PR TITLE
fix(workflows): loop_group warns when its pause escalation can't reach a nested interactive loop

### DIFF
--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -6766,10 +6766,14 @@ nodes:
     });
 
     it('warns on a gate/interactive loop_group nested inside a loop_group body', async () => {
-      // Exercises the recursion into loop_group.nodes — the outer group is
-      // clean, only the inner body nodes carry deprecated fields. 'inner-gate' also
-      // has a dependent ('inner-loop'), so it additionally trips the terminal-sink
-      // placement warning below — three warnings on one gate/loop pair, not two.
+      // Exercises the recursion into loop_group.nodes — the outer group's own
+      // body-terminal sink is 'inner-loop' (a plain interactive `loop:` node,
+      // since 'inner-gate' has a dependent and so is NOT the sole terminal
+      // sink). That makes four warnings: the two deprecation notices on
+      // 'inner-gate'/'inner-loop', the terminal-sink placement warning on
+      // 'inner-gate', and — #2753 — 'outer' itself, whose only escalatable
+      // sink is an interactive loop and therefore can't stop on a pause inside
+      // it.
       const pw = await warningsFor([
         'name: test',
         'description: test',
@@ -6794,12 +6798,94 @@ nodes:
         '            gate_message: continue?',
         '          depends_on: [inner-gate]',
       ]);
-      expect(pw).toHaveLength(3);
+      expect(pw).toHaveLength(4);
       expect(pw.some(w => w.includes("Node 'inner-gate'") && w.includes('on_reject'))).toBe(true);
       expect(pw.some(w => w.includes("Node 'inner-loop'") && w.includes('interactive'))).toBe(true);
       expect(pw.some(w => w.includes("Node 'inner-gate'") && w.includes('terminal sink'))).toBe(
         true
       );
+      expect(
+        pw.some(w => w.includes("Node 'outer'") && w.includes('inner-loop') && w.includes('#2753'))
+      ).toBe(true);
+    });
+
+    it('warns on a loop_group whose sole terminal sink is a gate-terminated nested loop_group (#2753)', async () => {
+      const pw = await warningsFor([
+        'name: test',
+        'description: test',
+        'interactive: true',
+        'nodes:',
+        '  - id: outer',
+        '    loop_group:',
+        '      until_bash: "exit 0"',
+        '      max_iterations: 2',
+        '      nodes:',
+        '        - id: inner',
+        '          loop_group:',
+        '            until_bash: test "$review.output.decision" = approve',
+        '            max_iterations: 3',
+        '            nodes:',
+        '              - id: review',
+        '                approval:',
+        '                  message: ok?',
+      ]);
+      expect(pw).toHaveLength(1);
+      expect(pw[0]).toContain("Node 'outer'");
+      expect(pw[0]).toContain("'inner'");
+      expect(pw[0]).toContain('#2753');
+    });
+
+    it('warns at every level of a 3-deep nested loop_group chain (#2753)', async () => {
+      const pw = await warningsFor([
+        'name: test',
+        'description: test',
+        'interactive: true',
+        'nodes:',
+        '  - id: grandparent',
+        '    loop_group:',
+        '      until_bash: "exit 0"',
+        '      max_iterations: 2',
+        '      nodes:',
+        '        - id: middle',
+        '          loop_group:',
+        '            until_bash: "exit 0"',
+        '            max_iterations: 2',
+        '            nodes:',
+        '              - id: inner',
+        '                loop_group:',
+        '                  until_bash: test "$review.output.decision" = approve',
+        '                  max_iterations: 3',
+        '                  nodes:',
+        '                    - id: review',
+        '                      approval:',
+        '                        message: ok?',
+      ]);
+      expect(pw).toHaveLength(2);
+      expect(pw.every(w => w.includes('#2753'))).toBe(true);
+      expect(pw.some(w => w.includes("Node 'grandparent'") && w.includes("'middle'"))).toBe(true);
+      expect(pw.some(w => w.includes("Node 'middle'") && w.includes("'inner'"))).toBe(true);
+    });
+
+    it('does not warn when a nested loop_group has nothing interactive to escalate (#2753)', async () => {
+      const pw = await warningsFor([
+        'name: test',
+        'description: test',
+        'interactive: true',
+        'nodes:',
+        '  - id: outer',
+        '    loop_group:',
+        '      until_bash: "exit 0"',
+        '      max_iterations: 2',
+        '      nodes:',
+        '        - id: inner',
+        '          loop_group:',
+        '            until_bash: "exit 0"',
+        '            max_iterations: 3',
+        '            nodes:',
+        '              - id: work',
+        '                prompt: do work',
+      ]);
+      expect(pw).toEqual([]);
     });
 
     it('warns on a gate node with a dependent inside a loop_group body (not a terminal sink)', async () => {

--- a/packages/workflows/src/loader.ts
+++ b/packages/workflows/src/loader.ts
@@ -378,10 +378,14 @@ function collectUnknownNodeKeys(raw: unknown, id: string, label: string, warning
  * enclosing loop_group, but that escalation is bounded to that one level) or
  * transitively (a `loop:` node with `interactive: true`, the legacy mechanism,
  * or a `loop_group:` node that is itself `interactive: true` or whose own sole
- * terminal sink recurses into this same case, at any nesting depth). Mirrors
- * `findLoopGroupTerminalGate`'s doc comment (dag-executor.ts:4153-4164): the
- * runtime has no unambiguous way to escalate a pause through a sink that isn't
- * a bare gate, so this only makes that gap visible at load time.
+ * terminal sink recurses into this same case, following a chain of well-formed
+ * sole-terminal-sink nesting to any depth). A gate that is mid-body or
+ * co-terminal with another sink breaks the chain here too — the placement
+ * check in `collectGateAndLoopDeprecationWarnings` below already warns about
+ * that misplacement on its own. Mirrors `findLoopGroupTerminalGate`'s doc comment
+ * (dag-executor.ts:4153-4164): the runtime has no unambiguous way to escalate
+ * a pause through a sink that isn't a bare gate, so this only makes that gap
+ * visible at load time.
  */
 function isUnescalatableInteractiveSink(node: DagNode | IncludeDirective): boolean {
   if (isIncludeDirective(node)) return false;
@@ -557,7 +561,7 @@ function collectGateAndLoopDeprecationWarnings(
         const message =
           `Node '${id}': this loop_group's terminal sink ('${sink.id}') is itself an ` +
           'interactive loop/loop_group — a pause inside it does not escalate to stop ' +
-          `'${id}''s own iteration (#2753). The outer loop can run further iterations ` +
+          "this loop_group's own iteration (#2753). The outer loop can run further iterations " +
           "while a human's answer to the inner pause is still pending. Only a gate node " +
           'directly as the terminal sink correctly stops the enclosing loop_group ' +
           '(#2707 step 3).';

--- a/packages/workflows/src/loader.ts
+++ b/packages/workflows/src/loader.ts
@@ -372,6 +372,29 @@ function collectUnknownNodeKeys(raw: unknown, id: string, label: string, warning
 }
 
 /**
+ * True when `node`, used as a loop_group's body-terminal sink, can itself pause
+ * in a way that is invisible one level up (#2753) — either directly (a `gate:`
+ * node — the pattern #2707 step 3's escalation handles correctly for its OWN
+ * enclosing loop_group, but that escalation is bounded to that one level) or
+ * transitively (a `loop:` node with `interactive: true`, the legacy mechanism,
+ * or a `loop_group:` node that is itself `interactive: true` or whose own sole
+ * terminal sink recurses into this same case, at any nesting depth). Mirrors
+ * `findLoopGroupTerminalGate`'s doc comment (dag-executor.ts:4153-4164): the
+ * runtime has no unambiguous way to escalate a pause through a sink that isn't
+ * a bare gate, so this only makes that gap visible at load time.
+ */
+function isUnescalatableInteractiveSink(node: DagNode | IncludeDirective): boolean {
+  if (isIncludeDirective(node)) return false;
+  if (isGateNode(node)) return true;
+  if (isLoopNode(node)) return node.loop.interactive === true;
+  if (!isLoopGroupNode(node)) return false;
+  if (node.loop_group.interactive === true) return true;
+  const dependedOn = new Set(node.loop_group.nodes.flatMap(n => n.depends_on ?? []));
+  const sinks = node.loop_group.nodes.filter(n => !dependedOn.has(n.id));
+  return sinks.length === 1 && isUnescalatableInteractiveSink(sinks[0]);
+}
+
+/**
  * #2707 step 1 grow-then-deprecate warnings: `approval.capture_response`,
  * `approval.on_reject`, and node-level loop `interactive:` still parse and
  * function exactly as before (Migration section — these become load errors
@@ -521,6 +544,28 @@ function collectGateAndLoopDeprecationWarnings(
             'loop_group_gate_completion_not_referenced'
           );
         }
+      }
+    }
+
+    // A body-terminal sink that is itself an interactive loop/loop_group can pause
+    // without stopping THIS group (#2753) — a bare gate sink is excluded here since
+    // that case is already correctly handled above (and by #2707 step 3 at runtime);
+    // this covers a sink whose own pause is trapped one level down instead.
+    if (bodySinks.length === 1) {
+      const sink = bodySinks[0];
+      if (!isIncludeDirective(sink) && !isGateNode(sink) && isUnescalatableInteractiveSink(sink)) {
+        const message =
+          `Node '${id}': this loop_group's terminal sink ('${sink.id}') is itself an ` +
+          'interactive loop/loop_group — a pause inside it does not escalate to stop ' +
+          `'${id}''s own iteration (#2753). The outer loop can run further iterations ` +
+          "while a human's answer to the inner pause is still pending. Only a gate node " +
+          'directly as the terminal sink correctly stops the enclosing loop_group ' +
+          '(#2707 step 3).';
+        warnings.push(message);
+        getLog().warn(
+          { id, sinkId: sink.id, warning: message },
+          'loop_group_nested_pause_not_escalated'
+        );
       }
     }
   }


### PR DESCRIPTION
## Problem and outcome

PR #2749 (#2707 step 3) fixed pause escalation for a `loop_group` whose body-terminal sink is a native `gate:` node — the gate's pause now correctly stops the enclosing loop instead of the loop tolerating the pause and barreling into another iteration. That fix doesn't reach a nested case: a `loop_group` whose body-terminal sink is itself another interactive `loop_group` (or a legacy interactive `loop:` node) has no way to escalate that inner pause, so the exact bug #2749 fixed recurs one level down, unfixed.

- **Outcome:** Loading a workflow with this nesting pattern now produces a `parseWarnings` entry naming the outer `loop_group` and explaining that a pause inside its terminal-sink loop won't stop it. The workflow still loads and runs — this is advisory guidance, matching every other check in the function it extends.
- **Invariant:** No workflow that loads successfully today is rejected by this change. The warning fires only when a `loop_group`'s sole body-terminal sink is itself an interactive-class node whose own pause can't escalate.
- **Scope boundary:** Load-time only. `dag-executor.ts` and `NodeOutput` are untouched — no runtime pause-propagation mechanism was built.
- **Root cause:** `findLoopGroupTerminalGate` (`packages/workflows/src/dag-executor.ts:4165`) only recognizes a bare `gate:` node as an escalatable terminal sink. When the sink is instead a nested `loop_group`/interactive `loop`, that inner node's own pause escalation only rewrites its own `ApprovalContext` — it never touches `workflow_runs.status`, which stays `'paused'`. The outer group tolerates that status (by design, for sibling-gate cases), can't find its own terminal gate, and treats the inner node's phantom `{state:'completed'}` as a real iteration result — then loops again, re-invoking the inner node from a stale in-memory snapshot that doesn't see its own pending pause.

## Review guidance

- **Feedback requested:** Whether the load-time-warning direction (vs. building real runtime pause propagation) is the right call for this codebase's current maturity, and whether the recursive predicate's scope (covering both nested `loop_group` and the legacy interactive `loop:` node) is correctly bounded.
- **Start here:** `packages/workflows/src/loader.ts:374-395` — the new `isUnescalatableInteractiveSink` predicate; everything else follows from it.
- **Review order:** `loader.ts:374-395` (predicate) → `loader.ts:549-570` (call site) → `loader.test.ts:6768-6803` (existing test now asserting 4 warnings instead of 3 — proof the gap was real and untested) → the three new test cases below it.
- **Lower-attention areas:** None — this is a small, self-contained change.
- **Known risk or uncertainty:** None identified. The recursion has no depth cap, matching the existing unbounded recursion this function already does when walking nested `loop_group` bodies.

## Solution

Extends the existing `collectGateAndLoopDeprecationWarnings` in `packages/workflows/src/loader.ts`, which already computes each `loop_group`'s body-terminal sink and warns when a `gate:` node is misplaced there (#2707 step 3a). Adds one recursive predicate, `isUnescalatableInteractiveSink`: true for a `gate:` node, a `loop:` node with `interactive: true`, or a `loop_group:` node that is itself `interactive: true` or whose own sole terminal sink recursively satisfies the same predicate (any nesting depth). The existing block gets one new branch: when an outer group's sole body-terminal sink is a `loop`/`loop_group` node (not a bare gate — that's already correctly handled) satisfying the predicate, push a warning naming the outer group.

This is deliberately the smaller of the two options the source issue names. `NodeOutput` (`packages/workflows/src/schemas/workflow-run.ts:102-128`) has no `'paused'` state — pause is modeled everywhere in this codebase as `workflow_runs.status`, never a per-node output. Building real propagation would mean adding that state and updating every `.state` switch/if across the executor, resume snapshotting, and any API/console consumer — a lot of new surface on a mechanism (#2749) that just shipped. #2749 itself already declined full generality for a similar edge case (a gate that's mid-body or co-terminal with another sink) and documented it as a known limitation instead of building it out (`dag-executor.ts:4153-4164`) — this PR applies the same posture one level deeper.

## Validation

- `cd packages/workflows && bun test src/loader.test.ts` — passed (341 pass, 0 fail, 924 expect() calls) — proves the warning fires correctly at 1, 2, and 3+ nesting levels and does not false-positive on a bare gate sink or a non-interactive nested sink.
- `bun run validate` (full repo gate: bundled/schema checks, type-check across all 13 packages, lint, format, and the complete test suite) — passed, exit 0.
- **Not verified:** No live end-to-end runtime repro (an actual paused nested-loop workflow run) — the fix is load-time only with zero runtime behavior change, so a runtime repro would only re-prove the pre-existing bug rather than verify what this PR does. The causal chain is established by direct code tracing, cited above and in the linked issue/plan.

## Links

- Closes #2753
- Plan: https://github.com/coleam00/Archon/issues/2753#issuecomment-5383413132


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added warnings for workflow configurations where interactive loops or nested loop groups cannot properly escalate pauses.
  * Improved detection of terminal nested loop groups, including gate-terminated scenarios.
  * Extended warning propagation across deeply nested loop groups.
  * Avoided unnecessary warnings for non-interactive nested groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->