### PR TITLE
fix(workflows): adopt the staged capture at the rename site (#2690)

### DIFF
--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -127,7 +127,19 @@ mock.module('@archon/workflows/workflow-discovery', () => ({
 const capturedSourceOwnerCalls: string[] = [];
 
 mock.module('@archon/workflows/executor', () => ({
-  executeWorkflow: mock(() => Promise.resolve({ success: true, workflowRunId: 'test-run-id' })),
+  // Mirrors the real executor's adopt site (#2690): rename happens, then the wrap's
+  // `capturedSourceOwner.adopt()` is called. For a continuation (no `preparedSource`)
+  // the executor takes the legacy branch and does not adopt, so the wrap reclaims.
+  executeWorkflow: mock((...args: unknown[]) => {
+    const opts = args[7] as
+      | {
+          preparedSource?: unknown;
+          capturedSourceOwner?: { adopt: () => void };
+        }
+      | undefined;
+    if (opts?.preparedSource) opts.capturedSourceOwner?.adopt();
+    return Promise.resolve({ success: true, workflowRunId: 'test-run-id' });
+  }),
   hydrateResumableRun: mock(() => Promise.resolve(null)),
   withCapturedSource: mock(
     (
@@ -1323,7 +1335,9 @@ describe('workflowRunCommand — continuation and capture ownership (#2646)', ()
   it('hands the capture to the run that starts, and keeps holding it when none does', async () => {
     // The wrapper only protects anything if the run path actually calls its owner. Assert
     // both edges: a dropped `adopt()` deletes a live run's source, and a missing `hold()`
-    // strands a full frozen tree under staged-source on every refusal.
+    // strands a full frozen tree under staged-source on every refusal. Under #2690 the
+    // run path passes `capturedSourceOwner` through and the (mocked) executor adopts;
+    // the implementation override below mirrors that.
     const { executeWorkflow } = await import('@archon/workflows/executor');
     const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
 
@@ -1331,9 +1345,15 @@ describe('workflowRunCommand — continuation and capture ownership (#2646)', ()
       workflows: [makeTestWorkflowWithSource({ name: 'assist' })],
       errors: [],
     });
-    (executeWorkflow as ReturnType<typeof mock>).mockResolvedValueOnce({
-      success: true,
-      workflowRunId: 'run-ok',
+    (executeWorkflow as ReturnType<typeof mock>).mockImplementationOnce((...args: unknown[]) => {
+      const opts = args[7] as
+        | {
+            preparedSource?: unknown;
+            capturedSourceOwner?: { adopt: () => void };
+          }
+        | undefined;
+      if (opts?.preparedSource) opts.capturedSourceOwner?.adopt();
+      return Promise.resolve({ success: true, workflowRunId: 'run-ok' });
     });
 
     await workflowRunCommand('/repo/root', 'assist', 'go', { noWorktree: true });

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -1004,9 +1004,6 @@ async function runWorkflowWithOwnedSource(
   const isContinuation = options.resume === true || continuationRun !== undefined;
 
   let preparedSource: PreparedWorkflowSource | undefined;
-  // Mirrors the owner's own flag, readable from the signal handler — which exits the
-  // process rather than returning, so it cannot consult the owner's closure.
-  let sourceAdopted = false;
   if (!isContinuation && !options.dryRun && !options.stubsInitPath) {
     try {
       preparedSource = await prepareWorkflowSource(createWorkflowDeps(), {
@@ -2065,9 +2062,10 @@ async function runWorkflowWithOwnedSource(
       // the forced exit below never returns up the stack, so the ownership `finally` —
       // whose whole premise is "whichever way we leave" — never runs. Ctrl-C during
       // isolation resolution or worktree creation would otherwise strand a complete
-      // frozen tree.
+      // frozen tree. `rm -rf` on the now-renamed capture root is a no-op once
+      // `executeWorkflow` has adopted it, so no separate guard is needed (#2690).
       .then(async () => {
-        if (preparedSource && !sourceAdopted) {
+        if (preparedSource) {
           await disposeWorkflowSource(preparedSource).catch(() => undefined);
         }
       })
@@ -2218,12 +2216,12 @@ async function runWorkflowWithOwnedSource(
           // The frozen source this run executes, captured before the workflow was even
           // selected. A resume ignores it and loads the source recorded on its own row.
           preparedSource,
+          // The wrap owns the capture until `executeWorkflow`'s rename succeeds; the
+          // executor adopts for us there (see #2690). Until then a rename failure
+          // leaves the staged directory un-adopted so the wrap reclaims it on the
+          // way out.
+          capturedSourceOwner: owner,
         };
-    // Handing the capture to a run: it now owns the bytes and their lifetime.
-    if (preparedSource) {
-      owner.adopt();
-      sourceAdopted = true;
-    }
     result = await executeWorkflow(
       deps,
       adapter,

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -40,7 +40,24 @@ const mockGetDefaultRemote = mock(() => Promise.resolve('origin' as string | nul
 const mockLoadRepoConfig = mock(() => Promise.resolve({} as Record<string, unknown>));
 const mockGetOrCreateConversation = mock(() => Promise.resolve(null as unknown));
 const mockGetCodebase = mock(() => Promise.resolve(null as unknown));
-const mockExecuteWorkflow = mock(() => Promise.resolve());
+// Simulates the rename-then-adopt order real `executeWorkflow` runs (#2690): adoption
+// happens INSIDE the executor at the rename success site, not from the caller. The
+// rename (and therefore the adopt) only runs for a non-continuation with a prepared
+// source — a continuation re-uses the capture its own row recorded and never re-adopts
+// here. Tests that observe `capturedSourceOwnerCalls` see the wrap finally behave the
+// same way the real one would.
+const mockExecuteWorkflow = mock((...args: unknown[]) => {
+  const opts = args[7] as
+    | {
+        preparedSource?: unknown;
+        capturedSourceOwner?: { adopt: () => void };
+      }
+    | undefined;
+  if (opts?.preparedSource) {
+    opts.capturedSourceOwner?.adopt();
+  }
+  return Promise.resolve();
+});
 const mockHandleCommand = mock(() =>
   Promise.resolve({ success: true, message: 'ok', workflow: undefined })
 );

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -827,12 +827,9 @@ async function dispatchOrchestratorWorkflowOwned(
   // For a fresh run: freeze, then re-resolve the workflow FROM the frozen copy, so the
   // definition executed and the resources beside it are one consistent set of bytes.
   const runCwd = conversation.cwd ?? codebase.default_cwd;
-  // `preparedSource` is the outer binding the resume branch's defensive guard reads
-  // (always undefined there — step 2 didn't run for a continuation). The two fresh
-  // dispatches read `freshCaptured` directly, so the helper's narrowed return type
-  // survives: a downstream `let` of type `PreparedWorkflowSource | undefined` would
-  // defeat the narrowing and leave the `if (preparedSource) owner.adopt();` guards
-  // structurally always-true at runtime.
+  // `preparedSource` is the outer binding the resume branch reads (always undefined
+  // there — step 2 didn't run for a continuation). The two fresh dispatches read
+  // `freshCaptured` directly, so the helper's narrowed return type survives.
   let preparedSource: PreparedWorkflowSource | undefined;
   let freshCaptured:
     | { preparedSource: PreparedWorkflowSource; workflow: WorkflowDefinition }
@@ -1094,8 +1091,9 @@ async function dispatchOrchestratorWorkflowOwned(
             `(\`/workflow abandon ${resumableRun.id}\`) and re-invoke.`
         );
       }
-      // Handing the capture to a run: it owns the bytes and their lifetime now.
-      if (preparedSource) owner.adopt();
+      // The wrap owns the capture until `executeWorkflow`'s rename succeeds; the
+      // executor adopts for us there (see #2690). Until then a rename failure leaves
+      // the staged directory un-adopted so the wrap reclaims it on the way out.
       await executeWorkflow(
         deps,
         platform,
@@ -1113,6 +1111,7 @@ async function dispatchOrchestratorWorkflowOwned(
           parseWarnings: options?.parseWarnings,
           baseBranch: codebaseBaseBranch,
           resolveChildIsolation,
+          capturedSourceOwner: owner,
           ...prepared,
         }
       );
@@ -1136,11 +1135,10 @@ async function dispatchOrchestratorWorkflowOwned(
         conversationId,
         `⚠️ Prior run for **${workflow.name}** had no completed nodes; starting fresh in the same worktree.`
       );
-      // Handing the capture to a run: it owns the bytes and their lifetime now. `captured`
-      // proves `preparedSource` is non-undefined via the helper's narrowed return type, so
-      // the previous outer-`let`-defeating `if (preparedSource) owner.adopt();` guard
-      // collapses to an unconditional adopt here.
-      owner.adopt();
+      // The wrap owns the capture until `executeWorkflow`'s rename succeeds; the
+      // executor adopts for us there (see #2690). `captured.preparedSource` proves
+      // the helper has already run `owner.hold`, which is the only thing the wrap
+      // needs to know to reclaim if the rename fails.
       await executeWorkflow(
         deps,
         platform,
@@ -1158,6 +1156,7 @@ async function dispatchOrchestratorWorkflowOwned(
           parseWarnings: options?.parseWarnings,
           baseBranch: codebaseBaseBranch,
           resolveChildIsolation,
+          capturedSourceOwner: owner,
           // This branch creates a FRESH run row (the prior run had nothing to resume),
           // so the supplied inputs still need stamping.
           inputs: resolvedInputs,
@@ -1204,9 +1203,7 @@ async function dispatchOrchestratorWorkflowOwned(
     // Fresh foreground execution: web interactive workflows + all chat platforms.
     // Reaching this branch means `resumableRun?.working_path` is falsy, which implies
     // `willContinueExistingRun` was false and step 2 above ran. `freshCaptured` is
-    // invariantly defined here — the previous outer-`let`-defeating
-    // `if (preparedSource) owner.adopt();` guard collapsed to an unconditional adopt
-    // by reading from the hoisted capture instead.
+    // invariantly defined here — the capture-flow helper ran before this branch.
     if (!freshCaptured) {
       // Should never trigger; the reasoning above is the invariant. If it does, the
       // dispatch returned a `preparedSource: undefined` to the executor and we are
@@ -1217,8 +1214,9 @@ async function dispatchOrchestratorWorkflowOwned(
         'orchestrator invariant violated: fresh-foreground dispatch reached without a captured source'
       );
     }
-    // Handing the capture to a run: it owns the bytes and their lifetime now.
-    owner.adopt();
+    // The wrap owns the capture until `executeWorkflow`'s rename succeeds; the
+    // executor adopts for us there (see #2690). `freshCaptured` proves the prior
+    // `captureFreshSource` call already ran `owner.hold`.
     await executeWorkflow(
       createWorkflowDeps(),
       platform,
@@ -1236,6 +1234,7 @@ async function dispatchOrchestratorWorkflowOwned(
         parseWarnings: options?.parseWarnings,
         baseBranch: codebaseBaseBranch,
         resolveChildIsolation,
+        capturedSourceOwner: owner,
         inputs: resolvedInputs,
       }
     );

--- a/packages/core/src/orchestrator/orchestrator-isolation.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-isolation.test.ts
@@ -153,7 +153,19 @@ mock.module('@archon/workflows/workflow-discovery', () => ({
 }));
 // Resolves to a paused result so dispatchBackgroundWorkflow's fire-and-forget
 // tail is a no-op (no result card is surfaced to the parent conversation).
-const mockExecuteWorkflow = mock(() => Promise.resolve({ paused: true }));
+// Mirrors the real executor's adopt site (#2690): rename happens, then the wrap's
+// `capturedSourceOwner.adopt()` is called. For a continuation (no `preparedSource`)
+// the executor takes the legacy branch and does not adopt, so the wrap reclaims.
+const mockExecuteWorkflow = mock((...args: unknown[]) => {
+  const opts = args[7] as
+    | {
+        preparedSource?: unknown;
+        capturedSourceOwner?: { adopt: () => void };
+      }
+    | undefined;
+  if (opts?.preparedSource) opts.capturedSourceOwner?.adopt();
+  return Promise.resolve({ paused: true });
+});
 /** Ownership calls the dispatch path makes on its capture, in order. */
 const capturedSourceOwnerCalls: string[] = [];
 

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -545,8 +545,9 @@ async function dispatchBackgroundWorkflowOwned(
   void (async (): Promise<void> => {
     try {
       try {
-        // Handing the capture to a run: it owns the bytes and their lifetime now.
-        if (preparedSource) owner.adopt();
+        // The wrap owns the capture until `executeWorkflow`'s rename succeeds; the
+        // executor adopts for us there (see #2690). Until then a rename failure leaves
+        // the staged directory un-adopted so the wrap reclaims it on the way out.
         const result = await executeWorkflow(
           workflowDeps,
           ctx.platform,
@@ -567,6 +568,7 @@ async function dispatchBackgroundWorkflowOwned(
             baseBranch: codebaseBaseBranch,
             resolveChildIsolation,
             preparedSource,
+            capturedSourceOwner: owner,
             // Only consumed when `preCreatedRun` is undefined (pre-creation failed and
             // the executor creates the row itself); otherwise the row above already
             // carries them.

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -1365,17 +1365,28 @@ async function runChildWorkflow(
   // 5. Run the child in-process (reuses the whole lifecycle) in its resolved cwd
   //    (its own worktree when isolated, else the parent's checkout). Its terminal
   //    output + cost + tokens land in the child run metadata on completion.
+  //
+  //    Wrapped in `withCapturedSource` so the staged capture above is reclaimed by
+  //    the wrap's `finally` if `executeWorkflow`'s move-into-artifacts rename fails
+  //    (#2690 recursive path). `failOutcome` already covers early-refusal paths
+  //    before this point; the rename failure inside the recursive call is the one
+  //    path the wrap is the only thing that can see — `executeWorkflow` returns
+  //    `{success: false}` from that branch rather than throwing, so without the
+  //    wrap the staged directory sits for the hourly age sweep.
   try {
-    await executeWorkflow(
-      deps,
-      platform,
-      conversationId,
-      childCwd,
-      childWorkflow,
-      input,
-      conversationDbId,
-      childOpts
-    );
+    await withCapturedSource(async owner => {
+      owner.hold(childSource);
+      await executeWorkflow(
+        deps,
+        platform,
+        conversationId,
+        childCwd,
+        childWorkflow,
+        input,
+        conversationDbId,
+        { ...childOpts, capturedSourceOwner: owner }
+      );
+    });
 
     // 6. Read the child back for the node-facing outcome (status + summary + cost +
     //    tokens). Works for synchronous completion AND a child paused at its gate.

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -632,6 +632,16 @@ export type ExecuteWorkflowOptions = ResumePayload & {
    * Ignored on a resume: the run resolves the source it recorded at start.
    */
   preparedSource?: PreparedWorkflowSource;
+  /**
+   * The owner's adopt/hold handle from the surrounding `withCapturedSource`. When set,
+   * `executeWorkflow` calls `adopt()` itself — at the rename success site — so a rename
+   * failure leaves the staged directory un-adopted and the wrap's `finally` reclaims
+   * it. Optional: omitting it preserves the legacy behavior where callers own adoption
+   * (used by `executeWorkflow` paths that move the staged capture themselves, and by
+   * tests that mock `executeWorkflow`). Never set by callers that did not wrap
+   * themselves in `withCapturedSource`.
+   */
+  capturedSourceOwner?: CapturedSourceOwner;
 };
 
 /**
@@ -731,7 +741,14 @@ export interface CapturedSourceOwner {
    * would leave the real one behind while looking like it cleaned up.
    */
   hold: (prepared: Pick<PreparedWorkflowSource, 'captureRoot'>) => void;
-  /** A run now owns the bytes and their lifetime; stop tracking them. */
+  /**
+   * A run now owns the bytes and their lifetime; stop tracking them. Called by the
+   * caller from `executeWorkflow`'s rename success site (via
+   * `ExecuteWorkflowOptions.capturedSourceOwner`) once the staged capture has been moved
+   * under the run's artifacts directory. Earlier call sites — before the rename — could
+   * leave the staged directory orphaned when the rename itself failed (#2690); adoption
+   * at the rename site means a failed move leaves the wrap's `finally` to reclaim.
+   */
   adopt: () => void;
 }
 
@@ -2267,6 +2284,12 @@ export async function executeWorkflow(
         await rm(finalCaptureRoot, { recursive: true, force: true });
         await rename(preparedSource.captureRoot, finalCaptureRoot);
       }
+      // The staged capture is now under the run's artifacts directory — the run owns
+      // the bytes from this point on. Adopting here (not earlier, at the call site) is
+      // what closes the race in #2690: a rename failure above returns without reaching
+      // this line, so the wrap's `finally` reclaims the staged directory instead of
+      // leaving it to the hourly age-based sweep.
+      opts.capturedSourceOwner?.adopt();
     } catch (error) {
       return await failRunOnSource(
         `Could not move this run's captured workflow source into place: ${(error as Error).message}`

--- a/packages/workflows/src/subrun.test.ts
+++ b/packages/workflows/src/subrun.test.ts
@@ -12,7 +12,7 @@
  * which does (mock.module is process-global and irreversible).
  */
 import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
-import { mkdir, writeFile, rm, cp } from 'fs/promises';
+import { mkdir, writeFile, rm, cp, readdir } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -44,6 +44,65 @@ mock.module('@archon/paths', () => ({
 mock.module('@archon/git', () => ({
   getDefaultBranch: mock(async () => 'main'),
   toRepoPath: mock((p: string) => p),
+}));
+
+// --- Mock fs/promises.rename so a single test can force the rename the recursive
+//     executeWorkflow performs (moving the staged capture under the child's
+//     artifacts directory) to throw. The wrap's `finally` is the only thing that
+//     can reclaim that staged capture when the rename fails — without the fix
+//     in runChildWorkflow, the staged tree leaks until the hourly age-based
+//     sweep reaps it (review R1). Every other fs/promises function delegates
+//     to the real implementation so other tests are unaffected.
+//
+//     The forced failure targets ONLY the move-out-of-staging rename: source
+//     lives under `staged-source/`, destination does NOT. `captureWorkflowSource`
+//     also does a rename (staged-source/<uuid>.partial -> staged-source/<uuid>)
+//     and that one must keep working, otherwise `prepareWorkflowSource` itself
+//     throws before runChildWorkflow reaches the recursive call. ---
+const realFsPromises = await import('fs/promises');
+let forceRenameFailure = false;
+const passthroughRename = realFsPromises.rename;
+mock.module('fs/promises', () => ({
+  access: realFsPromises.access,
+  appendFile: realFsPromises.appendFile,
+  chmod: realFsPromises.chmod,
+  chown: realFsPromises.chown,
+  copyFile: realFsPromises.copyFile,
+  cp: realFsPromises.cp,
+  lchmod: realFsPromises.lchmod,
+  lchown: realFsPromises.lchown,
+  link: realFsPromises.link,
+  lstat: realFsPromises.lstat,
+  lutimes: realFsPromises.lutimes,
+  mkdir: realFsPromises.mkdir,
+  mkdtemp: realFsPromises.mkdtemp,
+  open: realFsPromises.open,
+  opendir: realFsPromises.opendir,
+  readdir: realFsPromises.readdir,
+  readFile: realFsPromises.readFile,
+  readlink: realFsPromises.readlink,
+  realpath: realFsPromises.realpath,
+  rename: async (src: string, dst: string): Promise<void> => {
+    if (
+      forceRenameFailure &&
+      src.includes(`${'staged-source'}/`) &&
+      !dst.includes(`${'staged-source'}/`)
+    ) {
+      throw new Error(`forced rename failure for test: ${src} -> ${dst}`);
+    }
+    return passthroughRename(src, dst);
+  },
+  rm: realFsPromises.rm,
+  rmdir: realFsPromises.rmdir,
+  stat: realFsPromises.stat,
+  statfs: realFsPromises.statfs,
+  symlink: realFsPromises.symlink,
+  truncate: realFsPromises.truncate,
+  unlink: realFsPromises.unlink,
+  utimes: realFsPromises.utimes,
+  watch: realFsPromises.watch,
+  writeFile: realFsPromises.writeFile,
+  constants: realFsPromises.constants,
 }));
 
 // --- Bootstrap provider registry (load-time isRegisteredProvider checks) ---
@@ -5415,5 +5474,105 @@ nodes:
         e.step_name === 'work'
     );
     expect(replayed?.data?.structured_output).toEqual([{ v: 'alpha' }, { v: 'beta' }]);
+  });
+});
+
+/**
+ * Regression for the recursive `workflow:` sub-run path inside runChildWorkflow
+ * (review R1). The wrap the new `capturedSourceOwner` field introduced in
+ * #2690 only fires when the field is wired on the child opts. The top-level
+ * entry points do; the recursive call from runChildWorkflow did not, so a
+ * rename failure inside the child re-leaked the staged capture that the
+ * field's docblock says the wrap's `finally` reclaims.
+ *
+ * The forced rename is what makes this a real regression test: without the
+ * wrap, the staged directory under ARCHON_HOME/staged-source/ survives the
+ * parent run and would only be reaped by the 6-hour age sweep. With the wrap,
+ * it is gone as soon as the recursive executeWorkflow returns.
+ */
+describe('sub-run staged capture is reclaimed when the recursive rename fails (#2690 R1)', () => {
+  let cwd: string;
+  const originalArchonHome = process.env.ARCHON_HOME;
+
+  async function writeWorkflow(name: string, yaml: string): Promise<void> {
+    await writeFile(join(cwd, '.archon', 'workflows', `${name}.yaml`), yaml);
+  }
+
+  async function discover(name: string): Promise<WorkflowDefinition> {
+    const result = await discoverWorkflows(cwd, { loadDefaults: false });
+    const wf = result.workflows.find(w => w.workflow.name === name);
+    if (!wf) throw new Error(`workflow ${name} not found: ${JSON.stringify(result.errors)}`);
+    return wf.workflow;
+  }
+
+  beforeEach(async () => {
+    cwd = join(tmpdir(), `subrun-rename-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(join(cwd, '.archon', 'workflows'), { recursive: true });
+    process.env.ARCHON_HOME = join(cwd, 'home');
+  });
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true }).catch(() => {});
+    if (originalArchonHome === undefined) delete process.env.ARCHON_HOME;
+    else process.env.ARCHON_HOME = originalArchonHome;
+    forceRenameFailure = false;
+  });
+
+  it('reclaims the child staged capture when the recursive rename fails', async () => {
+    await writeWorkflow(
+      'child-rename-fail',
+      `
+name: child-rename-fail
+description: child whose staged capture rename will be forced to fail
+nodes:
+  - id: work
+    prompt: do work for $ARGUMENTS
+`
+    );
+    await writeWorkflow(
+      'parent-rename-fail',
+      `
+name: parent-rename-fail
+description: parent whose sub-run rename will be forced to fail
+nodes:
+  - id: sub
+    workflow: child-rename-fail
+    input: the-goal
+`
+    );
+
+    forceRenameFailure = true;
+    const store = new InMemoryStore();
+    try {
+      const parent = await discover('parent-rename-fail');
+      // The recursive executeWorkflow takes the rename-failure branch and returns
+      // {success: false}; runChildWorkflow reads the child back as failed and the
+      // `sub` node surfaces that. The parent's run is failed for the same reason.
+      const result = await executeWorkflow(
+        makeDeps(store),
+        makePlatform(),
+        'conv-plat',
+        cwd,
+        parent,
+        'goal',
+        'conv-db'
+      );
+      expect(result.success).toBe(false);
+
+      const child = [...store.runs.values()].find(r => r.workflow_name === 'child-rename-fail');
+      expect(child).toBeDefined();
+      expect(child?.status).toBe('failed');
+
+      // The assertion that proves the fix. Without the wrap around the recursive
+      // call, the child's UUID-named directory under ARCHON_HOME/staged-source/
+      // survives the parent run and only the hourly age sweep reclaims it. With
+      // the wrap, the wrap's `finally` reclaims the staged tree the moment
+      // executeWorkflow returns.
+      const stagedDir = join(cwd, 'home', 'staged-source');
+      const stagedEntries = await readdir(stagedDir).catch(() => [] as string[]);
+      expect(stagedEntries).toEqual([]);
+    } finally {
+      forceRenameFailure = false;
+    }
   });
 });

--- a/packages/workflows/src/workflow-source.test.ts
+++ b/packages/workflows/src/workflow-source.test.ts
@@ -669,4 +669,22 @@ describe('a capture is adopted or reclaimed, whichever way the caller leaves', (
       'no capture taken'
     );
   });
+
+  test('reclaims a staged capture when executeWorkflow fails to rename it into place (#2690)', async () => {
+    // The rename-failure branch of `executeWorkflow` returns a failure result WITHOUT
+    // calling `owner.adopt()` — adoption only happens after the durable move succeeds.
+    // Simulating that here is what proves the contract the issue asks for: a rename
+    // failure leaves the wrap's `finally` to reclaim, instead of orphaning the staged
+    // tree for the hourly age-based sweep. The wrap body never adopts, so this is the
+    // pre-#2690 "body returns without adopting" test, replayed through the surface
+    // the failure path actually takes (rename throws / returns / fails before adopt).
+    let staged: { captureRoot: string } | undefined;
+    await withCapturedSource(async owner => {
+      staged = await stage('rename-failed');
+      owner.hold(staged);
+      // Mirror the executor: a rename failure returns without adopting.
+      return { success: false, workflowRunId: 'x', error: 'rename failed' } as const;
+    });
+    expect(await exists(staged!.captureRoot)).toBe(false);
+  });
 });


### PR DESCRIPTION
## Problem and outcome

`withCapturedSource` declared the staged capture adopted *before* `executeWorkflow` moved it under the run's artifacts directory. A failed `rename` inside `executeWorkflow` left the staged directory orphaned — every caller had already told the owner to stop tracking it, so the wrap's `finally` could not reclaim, and the bytes sat under `~/.archon/staged-source/` until the hourly age-based sweep reaped them (up to 6h).

- **Outcome:** A failed rename inside `executeWorkflow` now leaves the staged directory un-adopted, so the wrap's `finally` reclaims it synchronously. The orphan window on the rename-fails arm drops to zero; the sweep remains as a backstop for crash-time orphans unrelated to this path.
- **Invariant:** "This run owns the staged capture iff `executeWorkflow`'s rename succeeded." Adopted ⇔ the run's artifacts directory received the move.
- **Scope boundary:** The `hold()` re-call semantic concern flagged in the issue (unkeyed slot — container `finalizeWorkflowSource` at `packages/cli/src/commands/workflow.ts:1751` does not re-call `owner.hold(...)` after the early move) is unchanged. That gap is independent of the rename race and remains out of scope here.
- **Root cause:** Five caller sites called `owner.adopt()` before `executeWorkflow` ran. Adoption is a fact about the move, not a precondition for it; declaring it early meant a failed move could not undeclare it.

## Review guidance

- **Feedback requested:** Correctness of the rename-site adopt order; whether the new `capturedSourceOwner` opt belongs on `ExecuteWorkflowOptions` (vs a new return-side handshake).
- **Start here:** `packages/workflows/src/executor.ts:2303` — the `opts.capturedSourceOwner?.adopt()` call sits inside the same `try` block as the `await rename(...)` and outside the `catch` that returns `failRunOnSource(...)`. Placement is what closes the race.
- **Review order:**
  1. `packages/workflows/src/executor.ts` — new opt field on `ExecuteWorkflowOptions`, updated `CapturedSourceOwner.adopt` docblock, adopt call inside the rename `try` block at the success site only. The recursive `executeWorkflow` call from `runChildWorkflow` (the `workflow:` sub-run path) is now wrapped in `withCapturedSource` and passes `capturedSourceOwner: owner` on the child opts, so the same rename-failure reclaim fires for child runs.
  2. `packages/core/src/orchestrator/orchestrator.ts:548-571` — fire-and-forget entry point drops its `owner.adopt()` in favor of `capturedSourceOwner: owner` on the opts.
  3. `packages/core/src/orchestrator/orchestrator-agent.ts` — three entry points (resume branch, fresh-in-same-worktree, fresh-foreground) drop their `owner.adopt()` calls and pass `capturedSourceOwner: owner`.
  4. `packages/cli/src/commands/workflow.ts` — `sourceAdopted` flag removed from `runWorkflowWithOwnedSource`; signal handler now unconditionally `disposeWorkflowSource` (no-op once renamed).
  5. Test mocks in `workflow.test.ts`, `orchestrator-agent.test.ts`, `orchestrator-isolation.test.ts` updated so the mock `executeWorkflow` mirrors the real executor's adopt-after-rename behavior.
  6. New regression test `reclaims a staged capture when executeWorkflow fails to rename it into place (#2690)` at `packages/workflows/src/workflow-source.test.ts:673-690`.
  7. New regression test `reclaims the child staged capture when the recursive rename fails` at `packages/workflows/src/subrun.test.ts:5493-5577` — covers the `workflow:` sub-run path inside `runChildWorkflow`; forces the move-into-artifacts rename to throw (via an `fs/promises.rename` mock that targets only the staged-source → artifacts rename, leaving `captureWorkflowSource`'s internal partial → final rename alone) and asserts the `staged-source/` directory is empty after the parent run completes.
- **Lower-attention areas:** The test mock changes are mechanical — each one substitutes a `mockImplementationOnce` for `mockResolvedValueOnce` and adopts the same way the real executor now does. The CLI's `sourceAdopted` flag was a mirror readable from the signal handler that exits the process; with adoption inside `executeWorkflow`, the pre-/post-rename distinction is no longer observable from the handler, so the flag is dead.
- **Known risk or uncertainty:** None. The hour-sweep backstop continues to handle crash-time orphans unrelated to the rename path. A caller that forgets to pass `capturedSourceOwner: owner` compiles and silently re-enables the original bug for that one site — `grep -n "owner.adopt"` across the three caller files now returns zero hits.

## Solution

Move adoption INTO `executeWorkflow`, at the rename success site. A single new optional field — `ExecuteWorkflowOptions.capturedSourceOwner?: CapturedSourceOwner` — is the wrap's owner handle. After `await rename(preparedSource.captureRoot, finalCaptureRoot)` resolves inside the existing try block, `opts.capturedSourceOwner?.adopt()` fires. The rename's `catch` returns `failRunOnSource(...)` and never reaches that line, so the wrap's `finally` reclaims. Exception-throwing paths downstream (validation throw, execution throw) also leave the rename un-adopted, so the same reclaim fires.

This is the smallest coherent fix:

- One new optional opt field (backward-compatible: omitting it preserves legacy caller-owned adoption, which is what test mocks use).
- Five caller-side `owner.adopt()` calls mechanically collapse into `capturedSourceOwner: owner` on the opts.
- The CLI's `sourceAdopted` flag disappears — `rm -rf` on a path that has already been renamed is a no-op, so the signal handler no longer needs the pre-/post-rename distinction.
- `withCapturedSource`'s `finally` reclaim contract (`held && !adopted`) is unchanged; the wrap already does the right thing when the wrap body never adopts.

A regression test at `workflow-source.test.ts` mirrors the rename-failure branch — wrap body returns a failure result without adopting, asserts the staged directory is gone on the way out. The existing `leaves an adopted capture alone — a run owns it now` test continues to cover the success branch.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Captured source is declared adopted before `executeWorkflow` runs the durable rename. | Captured source is declared adopted at the rename success site, by `executeWorkflow`. |
| **Failure behavior** | A failed rename inside `executeWorkflow` orphans the staged directory under `~/.archon/staged-source/` until the hourly sweep reclaims (≤6h). | A failed rename leaves the staged directory un-adopted; `withCapturedSource`'s `finally` reclaims it synchronously. |

## Architecture

```mermaid
flowchart LR
  Caller[Entry-point caller] --> Wrap[withCapturedSource wrap]
  Wrap --> Hold["owner.hold(preparedSource)"]
  Hold --> Exec["executeWorkflow(opts.capturedSourceOwner: owner)"]
  Exec --> Rename["try { await rename(...) }"]
  Rename -- success --> Adopt["opts.capturedSourceOwner?.adopt()"]
  Adopt --> Continue[Run continues; wrap finally is a no-op]
  Rename -- failure --> Fail["failRunOnSource(...) returns"]
  Fail --> Reclaim["Wrap finally: held && !adopted ⇒ reclaim staged dir"]
```

### Changed seams

| Boundary or contract | Change | Evidence |
|---|---|---|
| `ExecuteWorkflowOptions` → `executeWorkflow` | New optional field `capturedSourceOwner?: CapturedSourceOwner` | `packages/workflows/src/executor.ts:632-643`, `executor.test.ts` (101 pass), type-check across `@archon/workflows` |
| `executeWorkflow` → wrap reclaim contract | Adoption happens inside `executeWorkflow` after the rename, never before. | `packages/workflows/src/executor.ts:2298-2303`; new regression test `reclaims a staged capture when executeWorkflow fails to rename it into place (#2690)` at `packages/workflows/src/workflow-source.test.ts:673-690` |
| `CapturedSourceOwner.adopt` docblock | Documents the rename-site call site and the issue it closes. | `packages/workflows/src/executor.ts:741-749` |
| Caller → wrap (orchestrator fire-and-forget) | Drops `owner.adopt()`, passes `capturedSourceOwner: owner` on opts. | `packages/core/src/orchestrator/orchestrator.ts:548-571` |
| Caller → wrap (orchestrator-agent resume, fresh-same-worktree, fresh-foreground) | Three `owner.adopt()` calls removed; `capturedSourceOwner: owner` on each opts block. | `packages/core/src/orchestrator/orchestrator-agent.ts:1091-1237` |
| `runChildWorkflow` recursive sub-run | Recursive `executeWorkflow` call wrapped in `withCapturedSource`; passes `capturedSourceOwner: owner` and `owner.hold(childSource)` so the wrap's `finally` reclaims the child's staged capture on rename failure. | `packages/workflows/src/executor.ts:1365-1388`; new regression test in `packages/workflows/src/subrun.test.ts:5493-5577` |
| CLI signal handler | `sourceAdopted` flag removed; handler unconditionally `disposeWorkflowSource`. | `packages/cli/src/commands/workflow.ts:1007` (declaration gone), `:2062-2070` (handler), `:2216-2222` (opts) |
| Test mocks for `executeWorkflow` | Each mock adopts via `opts.capturedSourceOwner.adopt()` when `preparedSource` is present, matching the real executor. | `packages/cli/src/commands/workflow.test.ts:130-141`, `packages/core/src/orchestrator/orchestrator-agent.test.ts:43-58`, `packages/core/src/orchestrator/orchestrator-isolation.test.ts:156-168` |
| Sub-run rename-failure regression | `fs/promises.rename` mock targets only the staged-source → artifacts rename; child staged capture is reclaimed by the wrap's `finally` on rename failure. | `packages/workflows/src/subrun.test.ts:5493-5577` |

## Validation

- `bun test packages/workflows/src/workflow-source.test.ts` — 33 pass, 0 fail (32 prior + 1 new `#2690` regression test). Proves the rename-failure contract: wrap body returns without adopting, staged directory is gone.
- `bun test packages/workflows/src/executor.test.ts` — 101 pass, 0 fail. Proves the existing success-branch contract (`leaves an adopted capture alone`) still holds.
- `bun test packages/workflows/src/subrun.test.ts` — 78 pass, 0 fail (77 prior + 1 new `#2690 R1` regression test for the recursive `workflow:` sub-run path). Proves the child's staged capture is reclaimed when the move-into-artifacts rename throws inside the recursive call.
- `bun test packages/core/src/orchestrator/orchestrator-agent.test.ts` — 259 pass, 0 fail. Covers the resume, fresh-same-worktree, and fresh-foreground dispatch paths.
- `bun test packages/core/src/orchestrator/orchestrator-isolation.test.ts` — 12 pass, 0 fail. Covers the fire-and-forget isolation path.
- `bun test packages/cli/src/commands/workflow.test.ts` — 263 pass, 0 fail. Covers the CLI handler and the `runWorkflowWithOwnedSource` signal-handler reclaim path.
- `bun run type-check` — exit 0 across `@archon/workflows`, `@archon/core`, `@archon/cli`, `@archon/server`, `@archon/web`, `@archon/adapters`, `@archon/isolation`, `@archon/docs-web`.
- `bun x prettier --check` — clean on every touched file.
- **Pre-existing test isolation failures:** `bun test` across `workflows/core/cli` produces 912/165/18 baseline failures on `b442adfb` (pre-this-PR working tree); the same numbers appear with this PR. These are pre-existing flake / test-ordering issues unrelated to the rename. The targeted suites above all pass individually.
- **Not verified:** Full-repo `bun test` (skipped because of pre-existing isolation failures that are out of scope here; targeted suites that cover the contract land green). The `hold()` re-call semantic gap (the issue's "second related gap") is explicitly out of scope and unchanged.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | Backward-compatible. `capturedSourceOwner` is optional; omitting it preserves the legacy "caller owns adoption" path (used by test mocks). No public package API change beyond the new opt. | `packages/workflows/src/executor.ts:632-643` |
| Security / permissions / data | No change in credential handling. The staged capture's bytes now leave `~/.archon/staged-source/` synchronously on rename failure instead of waiting for the sweep — same data, earlier cleanup. | `packages/workflows/src/executor.ts:2298-2303` |
| Rollout / rollback | Revertible by re-introducing `if (preparedSource) owner.adopt();` at the three caller sites, removing `capturedSourceOwner: owner` from each opts block, removing `opts.capturedSourceOwner?.adopt()` from `executeWorkflow`, and dropping the new regression test. The sweep backstop handles any partial rollback's window. | `git revert 7de07238` reproduces the baseline; sweep params (`STAGED_SOURCE_TTL_MS = 6h`) unchanged |
| Observability | The hourly `sweepStaleStagedSources` log line continues to surface orphans from unrelated paths (process killed mid-capture). The rename-failure arm is now silent — it claims the staged dir through `withCapturedSource`'s `finally`, which already logs reclaim. | `packages/workflows/src/executor.ts:670-697` (sweep), `:770-779` (wrap finally) |
| Documentation / communication | The `CapturedSourceOwner.adopt` docblock records the rename-site call site and the race it closes. No external docs to update. | `packages/workflows/src/executor.ts:741-749` |

## Links

- Closes #2690
