### PR TITLE
fix(workflows): adopt the staged capture at the rename site, now portable to Windows (#2690)

### DIFF
--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -127,7 +127,19 @@ mock.module('@archon/workflows/workflow-discovery', () => ({
 const capturedSourceOwnerCalls: string[] = [];
 
 mock.module('@archon/workflows/executor', () => ({
-  executeWorkflow: mock(() => Promise.resolve({ success: true, workflowRunId: 'test-run-id' })),
+  // Mirrors the real executor's adopt site (#2690): rename happens, then the wrap's
+  // `capturedSourceOwner.adopt()` is called. For a continuation (no `preparedSource`)
+  // the executor takes the legacy branch and does not adopt, so the wrap reclaims.
+  executeWorkflow: mock((...args: unknown[]) => {
+    const opts = args[7] as
+      | {
+          preparedSource?: unknown;
+          capturedSourceOwner?: { adopt: () => void };
+        }
+      | undefined;
+    if (opts?.preparedSource) opts.capturedSourceOwner?.adopt();
+    return Promise.resolve({ success: true, workflowRunId: 'test-run-id' });
+  }),
   hydrateResumableRun: mock(() => Promise.resolve(null)),
   withCapturedSource: mock(
     (
@@ -1323,7 +1335,9 @@ describe('workflowRunCommand — continuation and capture ownership (#2646)', ()
   it('hands the capture to the run that starts, and keeps holding it when none does', async () => {
     // The wrapper only protects anything if the run path actually calls its owner. Assert
     // both edges: a dropped `adopt()` deletes a live run's source, and a missing `hold()`
-    // strands a full frozen tree under staged-source on every refusal.
+    // strands a full frozen tree under staged-source on every refusal. Under #2690 the
+    // run path passes `capturedSourceOwner` through and the (mocked) executor adopts;
+    // the implementation override below mirrors that.
     const { executeWorkflow } = await import('@archon/workflows/executor');
     const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
 
@@ -1331,9 +1345,15 @@ describe('workflowRunCommand — continuation and capture ownership (#2646)', ()
       workflows: [makeTestWorkflowWithSource({ name: 'assist' })],
       errors: [],
     });
-    (executeWorkflow as ReturnType<typeof mock>).mockResolvedValueOnce({
-      success: true,
-      workflowRunId: 'run-ok',
+    (executeWorkflow as ReturnType<typeof mock>).mockImplementationOnce((...args: unknown[]) => {
+      const opts = args[7] as
+        | {
+            preparedSource?: unknown;
+            capturedSourceOwner?: { adopt: () => void };
+          }
+        | undefined;
+      if (opts?.preparedSource) opts.capturedSourceOwner?.adopt();
+      return Promise.resolve({ success: true, workflowRunId: 'run-ok' });
     });
 
     await workflowRunCommand('/repo/root', 'assist', 'go', { noWorktree: true });

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -142,20 +142,35 @@ mock.module('@archon/workflows/executor', () => ({
   }),
   hydrateResumableRun: mock(() => Promise.resolve(null)),
   withCapturedSource: mock(
-    (
+    async (
       body: (owner: {
         hold: (prepared: { captureRoot: string }) => void;
         adopt: () => void;
       }) => Promise<unknown>
-    ) =>
-      body({
-        hold: prepared => {
-          capturedSourceOwnerCalls.push(`hold:${prepared.captureRoot}`);
-        },
-        adopt: () => {
-          capturedSourceOwnerCalls.push('adopt');
-        },
-      })
+    ) => {
+      // Faithful pass-through with an OBSERVABLE owner, INCLUDING the reclaim.
+      // Mirrors the orchestrator/isolation mocks (orchestrator-agent.test.ts:202-231,
+      // orchestrator-isolation.test.ts:204-233): a stub that swallowed the owner would
+      // let a dropped adopt() through, and one that recorded only hold/adopt would
+      // still miss an adopt that arrives after the body returns — by which time the
+      // real wrapper has already deleted the capture a live run is executing from.
+      let held: string | undefined;
+      let adopted = false;
+      try {
+        return await body({
+          hold: prepared => {
+            held = prepared.captureRoot;
+            capturedSourceOwnerCalls.push(`hold:${prepared.captureRoot}`);
+          },
+          adopt: () => {
+            adopted = true;
+            capturedSourceOwnerCalls.push('adopt');
+          },
+        });
+      } finally {
+        if (held && !adopted) capturedSourceOwnerCalls.push(`reclaim:${held}`);
+      }
+    }
   ),
   // Every resume form reaches this now, including `run <name> --resume`. Default: the run
   // predates captures, so the caller keeps live discovery — what the resume tests below
@@ -1368,7 +1383,7 @@ describe('workflowRunCommand — continuation and capture ownership (#2646)', ()
     await expect(
       workflowRunCommand('/repo/root', 'assist', 'go', { noWorktree: true })
     ).rejects.toThrow('No workflows found');
-    expect(capturedSourceOwnerCalls).toEqual(['hold:/test/capture']);
+    expect(capturedSourceOwnerCalls).toEqual(['hold:/test/capture', 'reclaim:/test/capture']);
   });
 });
 

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -10,6 +10,7 @@ import {
   makeTestComposedWorkflow,
   makeTestWorkflow,
   makeTestWorkflowWithSource,
+  withObservableCapturedSource,
 } from '@archon/workflows/test-utils';
 import type { WorkflowEventRow } from '@archon/core/schemas/workflow-event';
 import {
@@ -44,6 +45,20 @@ const mockLogger = {
 };
 
 const mockCreateWorkflowEvent = mock(() => Promise.resolve());
+const mockFolderBackendPrepare = mock(() =>
+  Promise.resolve({
+    cwd: '/test/path',
+    execContext: { kind: 'host' as const },
+    envId: 'container-env-1',
+    overlayMode: 'volume-copy' as const,
+  })
+);
+const mockFolderBackendDestroy = mock(() => Promise.resolve());
+const mockResolveFolderBackend = mock(() => ({
+  prepare: mockFolderBackendPrepare,
+  resumeEnv: mockFolderBackendPrepare,
+  destroy: mockFolderBackendDestroy,
+}));
 
 // Mock @archon/paths (createLogger moved here from @archon/core)
 mock.module('@archon/paths', () => ({
@@ -59,6 +74,7 @@ mock.module('@archon/paths', () => ({
 // Mock @archon/isolation (getIsolationProvider moved here from @archon/core)
 mock.module('@archon/isolation', () => ({
   configureIsolation: mock(() => undefined),
+  classifyIsolationError: (error: Error) => error.message,
   getIsolationProvider: mock(() => ({
     create: mock(() =>
       Promise.resolve({
@@ -73,6 +89,7 @@ mock.module('@archon/isolation', () => ({
     ),
     healthCheck: mock(() => Promise.resolve(true)),
   })),
+  resolveFolderBackend: mockResolveFolderBackend,
 }));
 
 // Mock the @archon/core modules
@@ -141,36 +158,8 @@ mock.module('@archon/workflows/executor', () => ({
     return Promise.resolve({ success: true, workflowRunId: 'test-run-id' });
   }),
   hydrateResumableRun: mock(() => Promise.resolve(null)),
-  withCapturedSource: mock(
-    async (
-      body: (owner: {
-        hold: (prepared: { captureRoot: string }) => void;
-        adopt: () => void;
-      }) => Promise<unknown>
-    ) => {
-      // Faithful pass-through with an OBSERVABLE owner, INCLUDING the reclaim.
-      // Mirrors the orchestrator/isolation mocks (orchestrator-agent.test.ts:202-231,
-      // orchestrator-isolation.test.ts:204-233): a stub that swallowed the owner would
-      // let a dropped adopt() through, and one that recorded only hold/adopt would
-      // still miss an adopt that arrives after the body returns — by which time the
-      // real wrapper has already deleted the capture a live run is executing from.
-      let held: string | undefined;
-      let adopted = false;
-      try {
-        return await body({
-          hold: prepared => {
-            held = prepared.captureRoot;
-            capturedSourceOwnerCalls.push(`hold:${prepared.captureRoot}`);
-          },
-          adopt: () => {
-            adopted = true;
-            capturedSourceOwnerCalls.push('adopt');
-          },
-        });
-      } finally {
-        if (held && !adopted) capturedSourceOwnerCalls.push(`reclaim:${held}`);
-      }
-    }
+  withCapturedSource: mock((body: Parameters<typeof withObservableCapturedSource>[1]) =>
+    withObservableCapturedSource(capturedSourceOwnerCalls, body)
   ),
   // Every resume form reaches this now, including `run <name> --resume`. Default: the run
   // predates captures, so the caller keeps live discovery — what the resume tests below
@@ -291,6 +280,7 @@ mock.module('@archon/core/db/codebases', () => ({
 }));
 
 mock.module('@archon/core/db/isolation-environments', () => ({
+  createIsolationStore: mock(() => ({})),
   findActiveByWorkflow: mock(() => Promise.resolve(null)),
   create: mock(() => Promise.resolve({ id: 'iso-123' })),
   // Reached only by the --resume path. mock.module() MERGES over the real
@@ -1384,6 +1374,57 @@ describe('workflowRunCommand — continuation and capture ownership (#2646)', ()
       workflowRunCommand('/repo/root', 'assist', 'go', { noWorktree: true })
     ).rejects.toThrow('No workflows found');
     expect(capturedSourceOwnerCalls).toEqual(['hold:/test/capture', 'reclaim:/test/capture']);
+  });
+
+  it('reclaims the finalized container capture when backend preparation fails', async () => {
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    const { finalizeWorkflowSource } = await import('@archon/workflows/executor');
+    const codebaseDb = await import('@archon/core/db/codebases');
+
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'assist' })],
+      errors: [],
+    });
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'cb-folder',
+      name: 'platform',
+      default_cwd: '/test/path',
+      default_branch: null,
+      kind: 'folder',
+    });
+    (finalizeWorkflowSource as ReturnType<typeof mock>).mockResolvedValueOnce({
+      runId: 'test-run-id',
+      captureRoot: '/test/finalized/workflow-source',
+      origin: '/test/path',
+      manifest: {
+        version: 1,
+        engine_version: 'test',
+        origin: '/test/path',
+        captured_at: '2026-08-21T00:00:00.000Z',
+        digest: 'test-digest',
+        file_count: 0,
+        byte_count: 0,
+        scopes: [],
+      },
+      roots: {
+        project: '/test/finalized/workflow-source/project',
+        globalWorkflows: '/test/finalized/workflow-source/global/workflows',
+        globalCommands: '/test/finalized/workflow-source/global/commands',
+        globalScripts: '/test/finalized/workflow-source/global/scripts',
+        bundledWorkflows: '/test/finalized/workflow-source/bundled',
+      },
+    });
+    mockFolderBackendPrepare.mockRejectedValueOnce(new Error('container unavailable'));
+
+    await expect(
+      workflowRunCommand('/test/path', 'assist', 'go', { container: true })
+    ).rejects.toThrow('container unavailable');
+
+    expect(capturedSourceOwnerCalls).toEqual([
+      'hold:/test/capture',
+      'hold:/test/finalized/workflow-source',
+      'reclaim:/test/finalized/workflow-source',
+    ]);
   });
 });
 

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -1004,9 +1004,6 @@ async function runWorkflowWithOwnedSource(
   const isContinuation = options.resume === true || continuationRun !== undefined;
 
   let preparedSource: PreparedWorkflowSource | undefined;
-  // Mirrors the owner's own flag, readable from the signal handler — which exits the
-  // process rather than returning, so it cannot consult the owner's closure.
-  let sourceAdopted = false;
   if (!isContinuation && !options.dryRun && !options.stubsInitPath) {
     try {
       preparedSource = await prepareWorkflowSource(createWorkflowDeps(), {
@@ -2065,9 +2062,10 @@ async function runWorkflowWithOwnedSource(
       // the forced exit below never returns up the stack, so the ownership `finally` —
       // whose whole premise is "whichever way we leave" — never runs. Ctrl-C during
       // isolation resolution or worktree creation would otherwise strand a complete
-      // frozen tree.
+      // frozen tree. `rm -rf` on the now-renamed capture root is a no-op once
+      // `executeWorkflow` has adopted it, so no separate guard is needed (#2690).
       .then(async () => {
-        if (preparedSource && !sourceAdopted) {
+        if (preparedSource) {
           await disposeWorkflowSource(preparedSource).catch(() => undefined);
         }
       })
@@ -2218,12 +2216,12 @@ async function runWorkflowWithOwnedSource(
           // The frozen source this run executes, captured before the workflow was even
           // selected. A resume ignores it and loads the source recorded on its own row.
           preparedSource,
+          // The wrap owns the capture until `executeWorkflow`'s rename succeeds; the
+          // executor adopts for us there (see #2690). Until then a rename failure
+          // leaves the staged directory un-adopted so the wrap reclaims it on the
+          // way out.
+          capturedSourceOwner: owner,
         };
-    // Handing the capture to a run: it now owns the bytes and their lifetime.
-    if (preparedSource) {
-      owner.adopt();
-      sourceAdopted = true;
-    }
     result = await executeWorkflow(
       deps,
       adapter,

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -37,6 +37,7 @@ import {
 } from '@archon/paths';
 import { isAbsolute, join } from 'node:path';
 import { mkdirSync, openSync, closeSync, readFileSync, writeSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { spawn, type ChildProcess } from 'node:child_process';
 import { createWorkflowDeps } from '@archon/core/workflows/store-adapter';
 import { createChildWorktreeResolver } from '@archon/core/workflows/child-isolation-resolver';
@@ -44,7 +45,6 @@ import { findCodebaseForCheckoutPath } from '@archon/core/services/codebase-chec
 import { discoverWorkflowsWithConfig } from '@archon/workflows/workflow-discovery';
 import { resolveWorkflowName } from '@archon/workflows/router';
 import {
-  disposeWorkflowSource,
   executeWorkflow,
   finalizeWorkflowSource,
   hydrateResumableRun,
@@ -1004,6 +1004,15 @@ async function runWorkflowWithOwnedSource(
   const isContinuation = options.resume === true || continuationRun !== undefined;
 
   let preparedSource: PreparedWorkflowSource | undefined;
+  // Pinned at the moment of prepare so the SIGINT/SIGTERM cleanup never rm's a
+  // path a live run is reading from. For `--container` folder-codebase runs,
+  // `finalizeWorkflowSource` (workflow.ts:1749) reassigns `preparedSource` to a
+  // new object whose `captureRoot` is the LIVE artifacts directory the run
+  // executes from — rm-ing `preparedSource.captureRoot` on Ctrl-C mid-run would
+  // destroy the run's source. The original staged path is renamed away by
+  // either `finalizeWorkflowSource` (container) or `executeWorkflow`'s rename
+  // (everything else), so an `rm` against it is a no-op once prep has moved it.
+  let originalStagedRoot: string | undefined;
   if (!isContinuation && !options.dryRun && !options.stubsInitPath) {
     try {
       preparedSource = await prepareWorkflowSource(createWorkflowDeps(), {
@@ -1011,6 +1020,7 @@ async function runWorkflowWithOwnedSource(
       });
       // From here the owner reclaims it unless a run adopts it, whichever way we leave.
       owner.hold(preparedSource);
+      originalStagedRoot = preparedSource.captureRoot;
     } catch (error) {
       throw new Error(
         `Failed to capture workflow source from ${effectiveDiscoveryCwd}: ${(error as Error).message}`
@@ -2062,11 +2072,16 @@ async function runWorkflowWithOwnedSource(
       // the forced exit below never returns up the stack, so the ownership `finally` —
       // whose whole premise is "whichever way we leave" — never runs. Ctrl-C during
       // isolation resolution or worktree creation would otherwise strand a complete
-      // frozen tree. `rm -rf` on the now-renamed capture root is a no-op once
-      // `executeWorkflow` has adopted it, so no separate guard is needed (#2690).
+      // frozen tree.
+      //
+      // The rm targets the ORIGINAL staged path pinned at prepare time, not
+      // `preparedSource.captureRoot` (see `originalStagedRoot`'s note above).
+      // For container runs that path was renamed away by `finalizeWorkflowSource`
+      // and `preparedSource.captureRoot` is now the LIVE artifacts directory —
+      // rm-ing it mid-execution would destroy the run's source.
       .then(async () => {
-        if (preparedSource) {
-          await disposeWorkflowSource(preparedSource).catch(() => undefined);
+        if (originalStagedRoot) {
+          await rm(originalStagedRoot, { recursive: true, force: true }).catch(() => undefined);
         }
       })
       .catch(() => undefined)

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -37,7 +37,6 @@ import {
 } from '@archon/paths';
 import { isAbsolute, join } from 'node:path';
 import { mkdirSync, openSync, closeSync, readFileSync, writeSync } from 'node:fs';
-import { rm } from 'node:fs/promises';
 import { spawn, type ChildProcess } from 'node:child_process';
 import { createWorkflowDeps } from '@archon/core/workflows/store-adapter';
 import { createChildWorktreeResolver } from '@archon/core/workflows/child-isolation-resolver';
@@ -46,6 +45,7 @@ import { discoverWorkflowsWithConfig } from '@archon/workflows/workflow-discover
 import { resolveWorkflowName } from '@archon/workflows/router';
 import {
   executeWorkflow,
+  disposeWorkflowSource,
   finalizeWorkflowSource,
   hydrateResumableRun,
   prepareWorkflowSource,
@@ -1762,6 +1762,10 @@ async function runWorkflowWithOwnedSource(
               cwd: folderCodebase.defaultCwd,
               codebaseId: folderCodebase.id,
             });
+            // Finalization moved the capture, so keep ownership on the path that now
+            // exists. If container preparation fails below, the wrap reclaims the
+            // finalized capture instead of the already-renamed staging path.
+            owner.hold(preparedSource);
           }
           prepared = await backend.prepare({
             codebase: folderCodebase,
@@ -2081,7 +2085,7 @@ async function runWorkflowWithOwnedSource(
       // rm-ing it mid-execution would destroy the run's source.
       .then(async () => {
         if (originalStagedRoot) {
-          await rm(originalStagedRoot, { recursive: true, force: true }).catch(() => undefined);
+          await disposeWorkflowSource({ captureRoot: originalStagedRoot });
         }
       })
       .catch(() => undefined)

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -14,7 +14,11 @@
 
 import { mock, describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { createMockLogger } from '../test/mocks/logger';
-import { makeTestWorkflow, makeTestWorkflowWithSource } from '@archon/workflows/test-utils';
+import {
+  makeTestWorkflow,
+  makeTestWorkflowWithSource,
+  withObservableCapturedSource,
+} from '@archon/workflows/test-utils';
 import type { Codebase, Conversation, IPlatformAdapter } from '../types';
 import type { WorkflowDefinition } from '@archon/workflows/schemas/workflow';
 import type { WorkflowRun } from '@archon/workflows/schemas/workflow-run';
@@ -199,35 +203,8 @@ mock.module('@archon/workflows/executor', () => ({
   recordSelectedWorkflow: mock(() => Promise.resolve()),
   disposeWorkflowSource: mock(() => Promise.resolve()),
   resolveContinuationWorkflow: mock(() => Promise.resolve(undefined)),
-  withCapturedSource: mock(
-    async (
-      body: (owner: {
-        hold: (prepared: { captureRoot: string }) => void;
-        adopt: () => void;
-      }) => Promise<unknown>
-    ) => {
-      // Faithful pass-through with an OBSERVABLE owner, INCLUDING the reclaim. A stub
-      // that swallowed the owner would let a dropped adopt() through, and one that
-      // recorded only hold/adopt would still miss an adopt that arrives after the body
-      // returns — by which time the real wrapper has already deleted the capture a live
-      // run is executing from. Recording the reclaim in order is what distinguishes them.
-      let held: string | undefined;
-      let adopted = false;
-      try {
-        return await body({
-          hold: prepared => {
-            held = prepared.captureRoot;
-            capturedSourceOwnerCalls.push(`hold:${prepared.captureRoot}`);
-          },
-          adopt: () => {
-            adopted = true;
-            capturedSourceOwnerCalls.push('adopt');
-          },
-        });
-      } finally {
-        if (held && !adopted) capturedSourceOwnerCalls.push(`reclaim:${held}`);
-      }
-    }
+  withCapturedSource: mock((body: Parameters<typeof withObservableCapturedSource>[1]) =>
+    withObservableCapturedSource(capturedSourceOwnerCalls, body)
   ),
 }));
 

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -40,7 +40,24 @@ const mockGetDefaultRemote = mock(() => Promise.resolve('origin' as string | nul
 const mockLoadRepoConfig = mock(() => Promise.resolve({} as Record<string, unknown>));
 const mockGetOrCreateConversation = mock(() => Promise.resolve(null as unknown));
 const mockGetCodebase = mock(() => Promise.resolve(null as unknown));
-const mockExecuteWorkflow = mock(() => Promise.resolve());
+// Simulates the rename-then-adopt order real `executeWorkflow` runs (#2690): adoption
+// happens INSIDE the executor at the rename success site, not from the caller. The
+// rename (and therefore the adopt) only runs for a non-continuation with a prepared
+// source — a continuation re-uses the capture its own row recorded and never re-adopts
+// here. Tests that observe `capturedSourceOwnerCalls` see the wrap finally behave the
+// same way the real one would.
+const mockExecuteWorkflow = mock((...args: unknown[]) => {
+  const opts = args[7] as
+    | {
+        preparedSource?: unknown;
+        capturedSourceOwner?: { adopt: () => void };
+      }
+    | undefined;
+  if (opts?.preparedSource) {
+    opts.capturedSourceOwner?.adopt();
+  }
+  return Promise.resolve();
+});
 const mockHandleCommand = mock(() =>
   Promise.resolve({ success: true, message: 'ok', workflow: undefined })
 );

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -827,12 +827,9 @@ async function dispatchOrchestratorWorkflowOwned(
   // For a fresh run: freeze, then re-resolve the workflow FROM the frozen copy, so the
   // definition executed and the resources beside it are one consistent set of bytes.
   const runCwd = conversation.cwd ?? codebase.default_cwd;
-  // `preparedSource` is the outer binding the resume branch's defensive guard reads
-  // (always undefined there — step 2 didn't run for a continuation). The two fresh
-  // dispatches read `freshCaptured` directly, so the helper's narrowed return type
-  // survives: a downstream `let` of type `PreparedWorkflowSource | undefined` would
-  // defeat the narrowing and leave the `if (preparedSource) owner.adopt();` guards
-  // structurally always-true at runtime.
+  // `preparedSource` is the outer binding the resume branch reads (always undefined
+  // there — step 2 didn't run for a continuation). The two fresh dispatches read
+  // `freshCaptured` directly, so the helper's narrowed return type survives.
   let preparedSource: PreparedWorkflowSource | undefined;
   let freshCaptured:
     | { preparedSource: PreparedWorkflowSource; workflow: WorkflowDefinition }
@@ -1094,8 +1091,9 @@ async function dispatchOrchestratorWorkflowOwned(
             `(\`/workflow abandon ${resumableRun.id}\`) and re-invoke.`
         );
       }
-      // Handing the capture to a run: it owns the bytes and their lifetime now.
-      if (preparedSource) owner.adopt();
+      // The wrap owns the capture until `executeWorkflow`'s rename succeeds; the
+      // executor adopts for us there (see #2690). Until then a rename failure leaves
+      // the staged directory un-adopted so the wrap reclaims it on the way out.
       await executeWorkflow(
         deps,
         platform,
@@ -1113,6 +1111,7 @@ async function dispatchOrchestratorWorkflowOwned(
           parseWarnings: options?.parseWarnings,
           baseBranch: codebaseBaseBranch,
           resolveChildIsolation,
+          capturedSourceOwner: owner,
           ...prepared,
         }
       );
@@ -1136,11 +1135,10 @@ async function dispatchOrchestratorWorkflowOwned(
         conversationId,
         `⚠️ Prior run for **${workflow.name}** had no completed nodes; starting fresh in the same worktree.`
       );
-      // Handing the capture to a run: it owns the bytes and their lifetime now. `captured`
-      // proves `preparedSource` is non-undefined via the helper's narrowed return type, so
-      // the previous outer-`let`-defeating `if (preparedSource) owner.adopt();` guard
-      // collapses to an unconditional adopt here.
-      owner.adopt();
+      // The wrap owns the capture until `executeWorkflow`'s rename succeeds; the
+      // executor adopts for us there (see #2690). `captured.preparedSource` proves
+      // the helper has already run `owner.hold`, which is the only thing the wrap
+      // needs to know to reclaim if the rename fails.
       await executeWorkflow(
         deps,
         platform,
@@ -1158,6 +1156,7 @@ async function dispatchOrchestratorWorkflowOwned(
           parseWarnings: options?.parseWarnings,
           baseBranch: codebaseBaseBranch,
           resolveChildIsolation,
+          capturedSourceOwner: owner,
           // This branch creates a FRESH run row (the prior run had nothing to resume),
           // so the supplied inputs still need stamping.
           inputs: resolvedInputs,
@@ -1204,9 +1203,7 @@ async function dispatchOrchestratorWorkflowOwned(
     // Fresh foreground execution: web interactive workflows + all chat platforms.
     // Reaching this branch means `resumableRun?.working_path` is falsy, which implies
     // `willContinueExistingRun` was false and step 2 above ran. `freshCaptured` is
-    // invariantly defined here — the previous outer-`let`-defeating
-    // `if (preparedSource) owner.adopt();` guard collapsed to an unconditional adopt
-    // by reading from the hoisted capture instead.
+    // invariantly defined here — the capture-flow helper ran before this branch.
     if (!freshCaptured) {
       // Should never trigger; the reasoning above is the invariant. If it does, the
       // dispatch returned a `preparedSource: undefined` to the executor and we are
@@ -1217,8 +1214,9 @@ async function dispatchOrchestratorWorkflowOwned(
         'orchestrator invariant violated: fresh-foreground dispatch reached without a captured source'
       );
     }
-    // Handing the capture to a run: it owns the bytes and their lifetime now.
-    owner.adopt();
+    // The wrap owns the capture until `executeWorkflow`'s rename succeeds; the
+    // executor adopts for us there (see #2690). `freshCaptured` proves the prior
+    // `captureFreshSource` call already ran `owner.hold`.
     await executeWorkflow(
       createWorkflowDeps(),
       platform,
@@ -1236,6 +1234,7 @@ async function dispatchOrchestratorWorkflowOwned(
         parseWarnings: options?.parseWarnings,
         baseBranch: codebaseBaseBranch,
         resolveChildIsolation,
+        capturedSourceOwner: owner,
         inputs: resolvedInputs,
       }
     );

--- a/packages/core/src/orchestrator/orchestrator-isolation.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-isolation.test.ts
@@ -153,7 +153,19 @@ mock.module('@archon/workflows/workflow-discovery', () => ({
 }));
 // Resolves to a paused result so dispatchBackgroundWorkflow's fire-and-forget
 // tail is a no-op (no result card is surfaced to the parent conversation).
-const mockExecuteWorkflow = mock(() => Promise.resolve({ paused: true }));
+// Mirrors the real executor's adopt site (#2690): rename happens, then the wrap's
+// `capturedSourceOwner.adopt()` is called. For a continuation (no `preparedSource`)
+// the executor takes the legacy branch and does not adopt, so the wrap reclaims.
+const mockExecuteWorkflow = mock((...args: unknown[]) => {
+  const opts = args[7] as
+    | {
+        preparedSource?: unknown;
+        capturedSourceOwner?: { adopt: () => void };
+      }
+    | undefined;
+  if (opts?.preparedSource) opts.capturedSourceOwner?.adopt();
+  return Promise.resolve({ paused: true });
+});
 /** Ownership calls the dispatch path makes on its capture, in order. */
 const capturedSourceOwnerCalls: string[] = [];
 

--- a/packages/core/src/orchestrator/orchestrator-isolation.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-isolation.test.ts
@@ -7,7 +7,11 @@ import type { IsolationEnvironmentRow } from '@archon/isolation';
 // (or the workflow engine) before the mock.module() calls below take effect.
 import type { WorkflowRoutingContext } from './orchestrator';
 import type { WorkflowDefinition } from '@archon/workflows/schemas/workflow';
-import { makeTestComposedWorkflow, makeTestWorkflow } from '@archon/workflows/test-utils';
+import {
+  makeTestComposedWorkflow,
+  makeTestWorkflow,
+  withObservableCapturedSource,
+} from '@archon/workflows/test-utils';
 
 // ─── Mock setup (BEFORE importing module under test) ─────────────────────────
 
@@ -153,18 +157,25 @@ mock.module('@archon/workflows/workflow-discovery', () => ({
 }));
 // Resolves to a paused result so dispatchBackgroundWorkflow's fire-and-forget
 // tail is a no-op (no result card is surfaced to the parent conversation).
-// Mirrors the real executor's adopt site (#2690): rename happens, then the wrap's
-// `capturedSourceOwner.adopt()` is called. For a continuation (no `preparedSource`)
-// the executor takes the legacy branch and does not adopt, so the wrap reclaims.
-const mockExecuteWorkflow = mock((...args: unknown[]) => {
+// Mirrors the real executor's adopt site (#2690): setup awaits happen before rename,
+// then `capturedSourceOwner.adopt()` is called. One regression test holds that await
+// open to prove the background dispatch does not reclaim before adoption.
+let deferExecuteWorkflowAdoption = false;
+let releaseExecuteWorkflowAdoption: (() => void) | undefined;
+const mockExecuteWorkflow = mock(async (...args: unknown[]) => {
   const opts = args[7] as
     | {
         preparedSource?: unknown;
         capturedSourceOwner?: { adopt: () => void };
       }
     | undefined;
+  if (deferExecuteWorkflowAdoption) {
+    await new Promise<void>(resolve => {
+      releaseExecuteWorkflowAdoption = resolve;
+    });
+  }
   if (opts?.preparedSource) opts.capturedSourceOwner?.adopt();
-  return Promise.resolve({ paused: true });
+  return { paused: true };
 });
 /** Ownership calls the dispatch path makes on its capture, in order. */
 const capturedSourceOwnerCalls: string[] = [];
@@ -201,35 +212,8 @@ mock.module('@archon/workflows/executor', () => ({
   recordSelectedWorkflow: mock(() => Promise.resolve()),
   disposeWorkflowSource: mock(() => Promise.resolve()),
   resolveContinuationWorkflow: mock(() => Promise.resolve(undefined)),
-  withCapturedSource: mock(
-    async (
-      body: (owner: {
-        hold: (prepared: { captureRoot: string }) => void;
-        adopt: () => void;
-      }) => Promise<unknown>
-    ) => {
-      // Faithful pass-through with an OBSERVABLE owner, INCLUDING the reclaim. A stub
-      // that swallowed the owner would let a dropped adopt() through, and one that
-      // recorded only hold/adopt would still miss an adopt that arrives after the body
-      // returns — by which time the real wrapper has already deleted the capture a live
-      // run is executing from. Recording the reclaim in order is what distinguishes them.
-      let held: string | undefined;
-      let adopted = false;
-      try {
-        return await body({
-          hold: prepared => {
-            held = prepared.captureRoot;
-            capturedSourceOwnerCalls.push(`hold:${prepared.captureRoot}`);
-          },
-          adopt: () => {
-            adopted = true;
-            capturedSourceOwnerCalls.push('adopt');
-          },
-        });
-      } finally {
-        if (held && !adopted) capturedSourceOwnerCalls.push(`reclaim:${held}`);
-      }
-    }
+  withCapturedSource: mock((body: Parameters<typeof withObservableCapturedSource>[1]) =>
+    withObservableCapturedSource(capturedSourceOwnerCalls, body)
   ),
 }));
 mock.module('@archon/workflows/router', () => ({
@@ -429,6 +413,9 @@ describe('dispatchBackgroundWorkflow', () => {
 
   beforeEach(() => {
     platform = new MockPlatformAdapter();
+    deferExecuteWorkflowAdoption = false;
+    releaseExecuteWorkflowAdoption?.();
+    releaseExecuteWorkflowAdoption = undefined;
     capturedSourceOwnerCalls.length = 0;
     mockResolve.mockClear();
     mockUpdateConversation.mockClear();
@@ -498,19 +485,32 @@ describe('dispatchBackgroundWorkflow', () => {
     await flushBackgroundExecution();
   });
 
-  test('adopts the capture BEFORE returning, not inside the fire-and-forget tail', async () => {
-    // The wrapper reclaims whatever is still held the moment this function returns, and
-    // execution here is fire-and-forget — so `adopt()` has to run synchronously, ahead of
-    // the first await inside that tail. Push an await in front of it and the wrapper
-    // deletes the capture a live run is executing from. Asserting BEFORE the flush is the
-    // whole point: after it, an adopt that came too late looks identical to one on time.
+  test('transfers capture ownership before returning while executor adoption is deferred', async () => {
+    // Production awaits setup before its rename/adopt site. Hold that boundary open: the
+    // dispatch must return without either ownership scope reclaiming the staged source.
     const workflow = makeWorkflow({ worktree: { enabled: false } });
+    deferExecuteWorkflowAdoption = true;
 
-    await dispatchBackgroundWorkflow(makeRoutingCtx(), workflow);
+    try {
+      await dispatchBackgroundWorkflow(makeRoutingCtx(), workflow);
 
-    expect(capturedSourceOwnerCalls).toEqual(['hold:/capture', 'adopt']);
+      // Outer dispatch owner holds, detached owner synchronously takes over, then the
+      // outer owner adopts. The detached owner remains live across the unresolved await.
+      expect(capturedSourceOwnerCalls).toEqual(['hold:/capture', 'hold:/capture', 'adopt']);
 
-    await flushBackgroundExecution();
+      releaseExecuteWorkflowAdoption?.();
+      await flushBackgroundExecution();
+      expect(capturedSourceOwnerCalls).toEqual([
+        'hold:/capture',
+        'hold:/capture',
+        'adopt',
+        'adopt',
+      ]);
+    } finally {
+      deferExecuteWorkflowAdoption = false;
+      releaseExecuteWorkflowAdoption?.();
+      releaseExecuteWorkflowAdoption = undefined;
+    }
   });
 
   test('keeps holding the capture when the dispatch gives up after taking it', async () => {

--- a/packages/core/src/orchestrator/orchestrator.test.ts
+++ b/packages/core/src/orchestrator/orchestrator.test.ts
@@ -5,7 +5,11 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { MockPlatformAdapter } from '../test/mocks/platform';
 import { createMockLogger } from '../test/mocks/logger';
-import { makeTestWorkflow, makeTestWorkflowList } from '@archon/workflows/test-utils';
+import {
+  makeTestWorkflow,
+  makeTestWorkflowList,
+  withObservableCapturedSource,
+} from '@archon/workflows/test-utils';
 import type { Conversation, Codebase, Session } from '../types';
 import { ConversationNotFoundError } from '../types';
 import type { WorkflowDefinition } from '@archon/workflows/schemas/workflow';
@@ -238,35 +242,8 @@ mock.module('@archon/workflows/executor', () => ({
   recordSelectedWorkflow: mock(() => Promise.resolve()),
   disposeWorkflowSource: mock(() => Promise.resolve()),
   resolveContinuationWorkflow: mock(() => Promise.resolve(undefined)),
-  withCapturedSource: mock(
-    async (
-      body: (owner: {
-        hold: (prepared: { captureRoot: string }) => void;
-        adopt: () => void;
-      }) => Promise<unknown>
-    ) => {
-      // Faithful pass-through with an OBSERVABLE owner, INCLUDING the reclaim. A stub
-      // that swallowed the owner would let a dropped adopt() through, and one that
-      // recorded only hold/adopt would still miss an adopt that arrives after the body
-      // returns — by which time the real wrapper has already deleted the capture a live
-      // run is executing from. Recording the reclaim in order is what distinguishes them.
-      let held: string | undefined;
-      let adopted = false;
-      try {
-        return await body({
-          hold: prepared => {
-            held = prepared.captureRoot;
-            capturedSourceOwnerCalls.push(`hold:${prepared.captureRoot}`);
-          },
-          adopt: () => {
-            adopted = true;
-            capturedSourceOwnerCalls.push('adopt');
-          },
-        });
-      } finally {
-        if (held && !adopted) capturedSourceOwnerCalls.push(`reclaim:${held}`);
-      }
-    }
+  withCapturedSource: mock((body: Parameters<typeof withObservableCapturedSource>[1]) =>
+    withObservableCapturedSource(capturedSourceOwnerCalls, body)
   ),
 }));
 mock.module('@archon/workflows/router', () => ({

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -545,8 +545,9 @@ async function dispatchBackgroundWorkflowOwned(
   void (async (): Promise<void> => {
     try {
       try {
-        // Handing the capture to a run: it owns the bytes and their lifetime now.
-        if (preparedSource) owner.adopt();
+        // The wrap owns the capture until `executeWorkflow`'s rename succeeds; the
+        // executor adopts for us there (see #2690). Until then a rename failure leaves
+        // the staged directory un-adopted so the wrap reclaims it on the way out.
         const result = await executeWorkflow(
           workflowDeps,
           ctx.platform,
@@ -567,6 +568,7 @@ async function dispatchBackgroundWorkflowOwned(
             baseBranch: codebaseBaseBranch,
             resolveChildIsolation,
             preparedSource,
+            capturedSourceOwner: owner,
             // Only consumed when `preCreatedRun` is undefined (pre-creation failed and
             // the executor creates the row itself); otherwise the row above already
             // carries them.

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -541,8 +541,13 @@ async function dispatchBackgroundWorkflowOwned(
     // Non-fatal: executeWorkflow will create its own row as fallback
   }
 
-  // 8. Fire-and-forget: run workflow in background
-  void (async (): Promise<void> => {
+  // 8. Fire-and-forget: transfer the capture into a second ownership scope whose
+  // lifetime encloses the detached execution. `withCapturedSource` invokes its body
+  // synchronously, so the new owner holds the capture before the dispatch owner adopts
+  // and returns. The detached scope then reclaims on any pre-rename failure or stops
+  // tracking only when executeWorkflow adopts after the rename succeeds.
+  const backgroundExecution = withCapturedSource(async backgroundOwner => {
+    backgroundOwner.hold(preparedSource);
     try {
       try {
         // The wrap owns the capture until `executeWorkflow`'s rename succeeds; the
@@ -568,7 +573,7 @@ async function dispatchBackgroundWorkflowOwned(
             baseBranch: codebaseBaseBranch,
             resolveChildIsolation,
             preparedSource,
-            capturedSourceOwner: owner,
+            capturedSourceOwner: backgroundOwner,
             // Only consumed when `preCreatedRun` is undefined (pre-creation failed and
             // the executor creates the row itself); otherwise the row above already
             // carries them.
@@ -658,7 +663,9 @@ async function dispatchBackgroundWorkflowOwned(
     } catch (outerError) {
       getLog().error({ err: toError(outerError) }, 'background_workflow_unhandled_error');
     }
-  })();
+  });
+  owner.adopt();
+  void backgroundExecution;
 }
 
 /**

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -1365,17 +1365,28 @@ async function runChildWorkflow(
   // 5. Run the child in-process (reuses the whole lifecycle) in its resolved cwd
   //    (its own worktree when isolated, else the parent's checkout). Its terminal
   //    output + cost + tokens land in the child run metadata on completion.
+  //
+  //    Wrapped in `withCapturedSource` so the staged capture above is reclaimed by
+  //    the wrap's `finally` if `executeWorkflow`'s move-into-artifacts rename fails
+  //    (#2690 recursive path). `failOutcome` already covers early-refusal paths
+  //    before this point; the rename failure inside the recursive call is the one
+  //    path the wrap is the only thing that can see — `executeWorkflow` returns
+  //    `{success: false}` from that branch rather than throwing, so without the
+  //    wrap the staged directory sits for the hourly age sweep.
   try {
-    await executeWorkflow(
-      deps,
-      platform,
-      conversationId,
-      childCwd,
-      childWorkflow,
-      input,
-      conversationDbId,
-      childOpts
-    );
+    await withCapturedSource(async owner => {
+      owner.hold(childSource);
+      await executeWorkflow(
+        deps,
+        platform,
+        conversationId,
+        childCwd,
+        childWorkflow,
+        input,
+        conversationDbId,
+        { ...childOpts, capturedSourceOwner: owner }
+      );
+    });
 
     // 6. Read the child back for the node-facing outcome (status + summary + cost +
     //    tokens). Works for synchronous completion AND a child paused at its gate.

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -632,6 +632,16 @@ export type ExecuteWorkflowOptions = ResumePayload & {
    * Ignored on a resume: the run resolves the source it recorded at start.
    */
   preparedSource?: PreparedWorkflowSource;
+  /**
+   * The owner's adopt/hold handle from the surrounding `withCapturedSource`. When set,
+   * `executeWorkflow` calls `adopt()` itself — at the rename success site — so a rename
+   * failure leaves the staged directory un-adopted and the wrap's `finally` reclaims
+   * it. Optional: omitting it preserves the legacy behavior where callers own adoption
+   * (used by `executeWorkflow` paths that move the staged capture themselves, and by
+   * tests that mock `executeWorkflow`). Never set by callers that did not wrap
+   * themselves in `withCapturedSource`.
+   */
+  capturedSourceOwner?: CapturedSourceOwner;
 };
 
 /**
@@ -731,7 +741,14 @@ export interface CapturedSourceOwner {
    * would leave the real one behind while looking like it cleaned up.
    */
   hold: (prepared: Pick<PreparedWorkflowSource, 'captureRoot'>) => void;
-  /** A run now owns the bytes and their lifetime; stop tracking them. */
+  /**
+   * A run now owns the bytes and their lifetime; stop tracking them. Called by the
+   * caller from `executeWorkflow`'s rename success site (via
+   * `ExecuteWorkflowOptions.capturedSourceOwner`) once the staged capture has been moved
+   * under the run's artifacts directory. Earlier call sites — before the rename — could
+   * leave the staged directory orphaned when the rename itself failed (#2690); adoption
+   * at the rename site means a failed move leaves the wrap's `finally` to reclaim.
+   */
   adopt: () => void;
 }
 
@@ -2267,6 +2284,12 @@ export async function executeWorkflow(
         await rm(finalCaptureRoot, { recursive: true, force: true });
         await rename(preparedSource.captureRoot, finalCaptureRoot);
       }
+      // The staged capture is now under the run's artifacts directory — the run owns
+      // the bytes from this point on. Adopting here (not earlier, at the call site) is
+      // what closes the race in #2690: a rename failure above returns without reaching
+      // this line, so the wrap's `finally` reclaims the staged directory instead of
+      // leaving it to the hourly age-based sweep.
+      opts.capturedSourceOwner?.adopt();
     } catch (error) {
       return await failRunOnSource(
         `Could not move this run's captured workflow source into place: ${(error as Error).message}`

--- a/packages/workflows/src/subrun.test.ts
+++ b/packages/workflows/src/subrun.test.ts
@@ -13,7 +13,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
 import { mkdir, writeFile, rm, cp, readdir } from 'fs/promises';
-import { join } from 'path';
+import { join, sep } from 'path';
 import { tmpdir } from 'os';
 
 // --- Mock logger + telemetry (passthrough real path utilities like loader.test.ts) ---
@@ -58,10 +58,17 @@ mock.module('@archon/git', () => ({
 //     lives under `staged-source/`, destination does NOT. `captureWorkflowSource`
 //     also does a rename (staged-source/<uuid>.partial -> staged-source/<uuid>)
 //     and that one must keep working, otherwise `prepareWorkflowSource` itself
-//     throws before runChildWorkflow reaches the recursive call. ---
+//     throws before runChildWorkflow reaches the recursive call.
+//
+//     The path predicate uses `path.sep`, not a hardcoded forward slash:
+//     `fs/promises.rename` on Windows is called with backslash-separated paths
+//     produced by `path.join`, so a literal `'staged-source/'` substring check
+//     never matches there and the test fails to exercise the reclaim path it is
+//     here to prove. ---
 const realFsPromises = await import('fs/promises');
 let forceRenameFailure = false;
 const passthroughRename = realFsPromises.rename;
+const stagedSourcePathSep = `staged-source${sep}`;
 mock.module('fs/promises', () => ({
   access: realFsPromises.access,
   appendFile: realFsPromises.appendFile,
@@ -85,8 +92,8 @@ mock.module('fs/promises', () => ({
   rename: async (src: string, dst: string): Promise<void> => {
     if (
       forceRenameFailure &&
-      src.includes(`${'staged-source'}/`) &&
-      !dst.includes(`${'staged-source'}/`)
+      src.includes(stagedSourcePathSep) &&
+      !dst.includes(stagedSourcePathSep)
     ) {
       throw new Error(`forced rename failure for test: ${src} -> ${dst}`);
     }
@@ -5574,5 +5581,28 @@ nodes:
     } finally {
       forceRenameFailure = false;
     }
+  });
+
+  // Regression for the path-literal `staged-source/` predicate that made the
+  // test above fail on Windows: `fs/promises.rename` is called there with
+  // backslash paths produced by `path.join`, so the host platform's `sep`
+  // must drive the predicate. The end-to-end test above only proves the host
+  // platform; this one proves the predicate is platform-aware in two ways:
+  // structurally — it is built from `path.sep`, not a hardcoded literal —
+  // and behaviourally — it matches paths that `path.join` produces on the
+  // host platform. The Windows case holds by the same construction on a
+  // Windows runner.
+  it('rename mock predicate is platform-aware (uses path.sep, matches host-platform paths)', () => {
+    // Structural: the predicate is built from `path.sep`. A hardcoded
+    // `'staged-source/'` literal — the original broken form — fails this.
+    expect(stagedSourcePathSep).toBe(`staged-source${sep}`);
+
+    // Behavioural: `path.join` produces host-platform separator paths, and
+    // the predicate matches them. The end-to-end test above exercises the
+    // real rename mock end-to-end; this asserts the predicate logic itself.
+    const hostSrc = join(tmpdir(), 'staged-source', 'uuid-1');
+    const hostDst = join(tmpdir(), 'artifacts', 'workflow-source');
+    expect(hostSrc.includes(stagedSourcePathSep)).toBe(true);
+    expect(hostDst.includes(stagedSourcePathSep)).toBe(false);
   });
 });

--- a/packages/workflows/src/subrun.test.ts
+++ b/packages/workflows/src/subrun.test.ts
@@ -12,7 +12,7 @@
  * which does (mock.module is process-global and irreversible).
  */
 import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
-import { mkdir, writeFile, rm, cp } from 'fs/promises';
+import { mkdir, writeFile, rm, cp, readdir } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -44,6 +44,65 @@ mock.module('@archon/paths', () => ({
 mock.module('@archon/git', () => ({
   getDefaultBranch: mock(async () => 'main'),
   toRepoPath: mock((p: string) => p),
+}));
+
+// --- Mock fs/promises.rename so a single test can force the rename the recursive
+//     executeWorkflow performs (moving the staged capture under the child's
+//     artifacts directory) to throw. The wrap's `finally` is the only thing that
+//     can reclaim that staged capture when the rename fails — without the fix
+//     in runChildWorkflow, the staged tree leaks until the hourly age-based
+//     sweep reaps it (review R1). Every other fs/promises function delegates
+//     to the real implementation so other tests are unaffected.
+//
+//     The forced failure targets ONLY the move-out-of-staging rename: source
+//     lives under `staged-source/`, destination does NOT. `captureWorkflowSource`
+//     also does a rename (staged-source/<uuid>.partial -> staged-source/<uuid>)
+//     and that one must keep working, otherwise `prepareWorkflowSource` itself
+//     throws before runChildWorkflow reaches the recursive call. ---
+const realFsPromises = await import('fs/promises');
+let forceRenameFailure = false;
+const passthroughRename = realFsPromises.rename;
+mock.module('fs/promises', () => ({
+  access: realFsPromises.access,
+  appendFile: realFsPromises.appendFile,
+  chmod: realFsPromises.chmod,
+  chown: realFsPromises.chown,
+  copyFile: realFsPromises.copyFile,
+  cp: realFsPromises.cp,
+  lchmod: realFsPromises.lchmod,
+  lchown: realFsPromises.lchown,
+  link: realFsPromises.link,
+  lstat: realFsPromises.lstat,
+  lutimes: realFsPromises.lutimes,
+  mkdir: realFsPromises.mkdir,
+  mkdtemp: realFsPromises.mkdtemp,
+  open: realFsPromises.open,
+  opendir: realFsPromises.opendir,
+  readdir: realFsPromises.readdir,
+  readFile: realFsPromises.readFile,
+  readlink: realFsPromises.readlink,
+  realpath: realFsPromises.realpath,
+  rename: async (src: string, dst: string): Promise<void> => {
+    if (
+      forceRenameFailure &&
+      src.includes(`${'staged-source'}/`) &&
+      !dst.includes(`${'staged-source'}/`)
+    ) {
+      throw new Error(`forced rename failure for test: ${src} -> ${dst}`);
+    }
+    return passthroughRename(src, dst);
+  },
+  rm: realFsPromises.rm,
+  rmdir: realFsPromises.rmdir,
+  stat: realFsPromises.stat,
+  statfs: realFsPromises.statfs,
+  symlink: realFsPromises.symlink,
+  truncate: realFsPromises.truncate,
+  unlink: realFsPromises.unlink,
+  utimes: realFsPromises.utimes,
+  watch: realFsPromises.watch,
+  writeFile: realFsPromises.writeFile,
+  constants: realFsPromises.constants,
 }));
 
 // --- Bootstrap provider registry (load-time isRegisteredProvider checks) ---
@@ -5415,5 +5474,105 @@ nodes:
         e.step_name === 'work'
     );
     expect(replayed?.data?.structured_output).toEqual([{ v: 'alpha' }, { v: 'beta' }]);
+  });
+});
+
+/**
+ * Regression for the recursive `workflow:` sub-run path inside runChildWorkflow
+ * (review R1). The wrap the new `capturedSourceOwner` field introduced in
+ * #2690 only fires when the field is wired on the child opts. The top-level
+ * entry points do; the recursive call from runChildWorkflow did not, so a
+ * rename failure inside the child re-leaked the staged capture that the
+ * field's docblock says the wrap's `finally` reclaims.
+ *
+ * The forced rename is what makes this a real regression test: without the
+ * wrap, the staged directory under ARCHON_HOME/staged-source/ survives the
+ * parent run and would only be reaped by the 6-hour age sweep. With the wrap,
+ * it is gone as soon as the recursive executeWorkflow returns.
+ */
+describe('sub-run staged capture is reclaimed when the recursive rename fails (#2690 R1)', () => {
+  let cwd: string;
+  const originalArchonHome = process.env.ARCHON_HOME;
+
+  async function writeWorkflow(name: string, yaml: string): Promise<void> {
+    await writeFile(join(cwd, '.archon', 'workflows', `${name}.yaml`), yaml);
+  }
+
+  async function discover(name: string): Promise<WorkflowDefinition> {
+    const result = await discoverWorkflows(cwd, { loadDefaults: false });
+    const wf = result.workflows.find(w => w.workflow.name === name);
+    if (!wf) throw new Error(`workflow ${name} not found: ${JSON.stringify(result.errors)}`);
+    return wf.workflow;
+  }
+
+  beforeEach(async () => {
+    cwd = join(tmpdir(), `subrun-rename-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(join(cwd, '.archon', 'workflows'), { recursive: true });
+    process.env.ARCHON_HOME = join(cwd, 'home');
+  });
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true }).catch(() => {});
+    if (originalArchonHome === undefined) delete process.env.ARCHON_HOME;
+    else process.env.ARCHON_HOME = originalArchonHome;
+    forceRenameFailure = false;
+  });
+
+  it('reclaims the child staged capture when the recursive rename fails', async () => {
+    await writeWorkflow(
+      'child-rename-fail',
+      `
+name: child-rename-fail
+description: child whose staged capture rename will be forced to fail
+nodes:
+  - id: work
+    prompt: do work for $ARGUMENTS
+`
+    );
+    await writeWorkflow(
+      'parent-rename-fail',
+      `
+name: parent-rename-fail
+description: parent whose sub-run rename will be forced to fail
+nodes:
+  - id: sub
+    workflow: child-rename-fail
+    input: the-goal
+`
+    );
+
+    forceRenameFailure = true;
+    const store = new InMemoryStore();
+    try {
+      const parent = await discover('parent-rename-fail');
+      // The recursive executeWorkflow takes the rename-failure branch and returns
+      // {success: false}; runChildWorkflow reads the child back as failed and the
+      // `sub` node surfaces that. The parent's run is failed for the same reason.
+      const result = await executeWorkflow(
+        makeDeps(store),
+        makePlatform(),
+        'conv-plat',
+        cwd,
+        parent,
+        'goal',
+        'conv-db'
+      );
+      expect(result.success).toBe(false);
+
+      const child = [...store.runs.values()].find(r => r.workflow_name === 'child-rename-fail');
+      expect(child).toBeDefined();
+      expect(child?.status).toBe('failed');
+
+      // The assertion that proves the fix. Without the wrap around the recursive
+      // call, the child's UUID-named directory under ARCHON_HOME/staged-source/
+      // survives the parent run and only the hourly age sweep reclaims it. With
+      // the wrap, the wrap's `finally` reclaims the staged tree the moment
+      // executeWorkflow returns.
+      const stagedDir = join(cwd, 'home', 'staged-source');
+      const stagedEntries = await readdir(stagedDir).catch(() => [] as string[]);
+      expect(stagedEntries).toEqual([]);
+    } finally {
+      forceRenameFailure = false;
+    }
   });
 });

--- a/packages/workflows/src/subrun.test.ts
+++ b/packages/workflows/src/subrun.test.ts
@@ -70,25 +70,7 @@ let forceRenameFailure = false;
 const passthroughRename = realFsPromises.rename;
 const stagedSourcePathSep = `staged-source${sep}`;
 mock.module('fs/promises', () => ({
-  access: realFsPromises.access,
-  appendFile: realFsPromises.appendFile,
-  chmod: realFsPromises.chmod,
-  chown: realFsPromises.chown,
-  copyFile: realFsPromises.copyFile,
-  cp: realFsPromises.cp,
-  lchmod: realFsPromises.lchmod,
-  lchown: realFsPromises.lchown,
-  link: realFsPromises.link,
-  lstat: realFsPromises.lstat,
-  lutimes: realFsPromises.lutimes,
-  mkdir: realFsPromises.mkdir,
-  mkdtemp: realFsPromises.mkdtemp,
-  open: realFsPromises.open,
-  opendir: realFsPromises.opendir,
-  readdir: realFsPromises.readdir,
-  readFile: realFsPromises.readFile,
-  readlink: realFsPromises.readlink,
-  realpath: realFsPromises.realpath,
+  ...realFsPromises,
   rename: async (src: string, dst: string): Promise<void> => {
     if (
       forceRenameFailure &&
@@ -99,17 +81,6 @@ mock.module('fs/promises', () => ({
     }
     return passthroughRename(src, dst);
   },
-  rm: realFsPromises.rm,
-  rmdir: realFsPromises.rmdir,
-  stat: realFsPromises.stat,
-  statfs: realFsPromises.statfs,
-  symlink: realFsPromises.symlink,
-  truncate: realFsPromises.truncate,
-  unlink: realFsPromises.unlink,
-  utimes: realFsPromises.utimes,
-  watch: realFsPromises.watch,
-  writeFile: realFsPromises.writeFile,
-  constants: realFsPromises.constants,
 }));
 
 // --- Bootstrap provider registry (load-time isRegisteredProvider checks) ---
@@ -5581,28 +5552,5 @@ nodes:
     } finally {
       forceRenameFailure = false;
     }
-  });
-
-  // Regression for the path-literal `staged-source/` predicate that made the
-  // test above fail on Windows: `fs/promises.rename` is called there with
-  // backslash paths produced by `path.join`, so the host platform's `sep`
-  // must drive the predicate. The end-to-end test above only proves the host
-  // platform; this one proves the predicate is platform-aware in two ways:
-  // structurally — it is built from `path.sep`, not a hardcoded literal —
-  // and behaviourally — it matches paths that `path.join` produces on the
-  // host platform. The Windows case holds by the same construction on a
-  // Windows runner.
-  it('rename mock predicate is platform-aware (uses path.sep, matches host-platform paths)', () => {
-    // Structural: the predicate is built from `path.sep`. A hardcoded
-    // `'staged-source/'` literal — the original broken form — fails this.
-    expect(stagedSourcePathSep).toBe(`staged-source${sep}`);
-
-    // Behavioural: `path.join` produces host-platform separator paths, and
-    // the predicate matches them. The end-to-end test above exercises the
-    // real rename mock end-to-end; this asserts the predicate logic itself.
-    const hostSrc = join(tmpdir(), 'staged-source', 'uuid-1');
-    const hostDst = join(tmpdir(), 'artifacts', 'workflow-source');
-    expect(hostSrc.includes(stagedSourcePathSep)).toBe(true);
-    expect(hostDst.includes(stagedSourcePathSep)).toBe(false);
   });
 });

--- a/packages/workflows/src/test-utils.ts
+++ b/packages/workflows/src/test-utils.ts
@@ -10,6 +10,7 @@ import type {
   WorkflowSource,
 } from './schemas/workflow';
 import { expandWorkflowIncludes } from './include-expander';
+import type { CapturedSourceOwner } from './executor';
 
 const DEFAULT_NODE = { id: 'default', command: 'test-command' };
 
@@ -78,4 +79,31 @@ export function makeTestComposedWorkflow(
   const expanded = workflows.get(name);
   if (!expanded) throw new Error(`makeTestComposedWorkflow: no workflow named '${name}'`);
   return expanded;
+}
+
+/**
+ * Run a capture-owner body with the production hold/adopt/reclaim lifecycle while
+ * recording each transition. Cross-package tests use this as the observable
+ * implementation behind their mocked `withCapturedSource` export.
+ */
+export async function withObservableCapturedSource<T>(
+  calls: string[],
+  body: (owner: CapturedSourceOwner) => Promise<T>
+): Promise<T> {
+  let held: string | undefined;
+  let adopted = false;
+  try {
+    return await body({
+      hold: prepared => {
+        held = prepared.captureRoot;
+        calls.push(`hold:${prepared.captureRoot}`);
+      },
+      adopt: () => {
+        adopted = true;
+        calls.push('adopt');
+      },
+    });
+  } finally {
+    if (held && !adopted) calls.push(`reclaim:${held}`);
+  }
 }

--- a/packages/workflows/src/workflow-source.test.ts
+++ b/packages/workflows/src/workflow-source.test.ts
@@ -669,22 +669,4 @@ describe('a capture is adopted or reclaimed, whichever way the caller leaves', (
       'no capture taken'
     );
   });
-
-  test('reclaims a staged capture when executeWorkflow fails to rename it into place (#2690)', async () => {
-    // The rename-failure branch of `executeWorkflow` returns a failure result WITHOUT
-    // calling `owner.adopt()` — adoption only happens after the durable move succeeds.
-    // Simulating that here is what proves the contract the issue asks for: a rename
-    // failure leaves the wrap's `finally` to reclaim, instead of orphaning the staged
-    // tree for the hourly age-based sweep. The wrap body never adopts, so this is the
-    // pre-#2690 "body returns without adopting" test, replayed through the surface
-    // the failure path actually takes (rename throws / returns / fails before adopt).
-    let staged: { captureRoot: string } | undefined;
-    await withCapturedSource(async owner => {
-      staged = await stage('rename-failed');
-      owner.hold(staged);
-      // Mirror the executor: a rename failure returns without adopting.
-      return { success: false, workflowRunId: 'x', error: 'rename failed' } as const;
-    });
-    expect(await exists(staged!.captureRoot)).toBe(false);
-  });
 });

--- a/packages/workflows/src/workflow-source.test.ts
+++ b/packages/workflows/src/workflow-source.test.ts
@@ -669,4 +669,22 @@ describe('a capture is adopted or reclaimed, whichever way the caller leaves', (
       'no capture taken'
     );
   });
+
+  test('reclaims a staged capture when executeWorkflow fails to rename it into place (#2690)', async () => {
+    // The rename-failure branch of `executeWorkflow` returns a failure result WITHOUT
+    // calling `owner.adopt()` — adoption only happens after the durable move succeeds.
+    // Simulating that here is what proves the contract the issue asks for: a rename
+    // failure leaves the wrap's `finally` to reclaim, instead of orphaning the staged
+    // tree for the hourly age-based sweep. The wrap body never adopts, so this is the
+    // pre-#2690 "body returns without adopting" test, replayed through the surface
+    // the failure path actually takes (rename throws / returns / fails before adopt).
+    let staged: { captureRoot: string } | undefined;
+    await withCapturedSource(async owner => {
+      staged = await stage('rename-failed');
+      owner.hold(staged);
+      // Mirror the executor: a rename failure returns without adopting.
+      return { success: false, workflowRunId: 'x', error: 'rename failed' } as const;
+    });
+    expect(await exists(staged!.captureRoot)).toBe(false);
+  });
 });


### PR DESCRIPTION
## Problem and outcome

`withCapturedSource` declared the staged capture adopted *before* `executeWorkflow` moved it under the run's artifacts directory. A failed `rename` inside `executeWorkflow` left the staged directory orphaned — every caller had already told the owner to stop tracking it, so the wrap's `finally` could not reclaim, and the bytes sat under `~/.archon/staged-source/` until the hourly age-based sweep reaped them (up to 6h).

#2755 wired the rename-site adopt for the top-level entry points and added two regression tests. On `windows-latest` the new sub-run regression test fails its first assertion: `expect(result.success).toBe(false)` receives `true` and Bun stops there. The end-to-end reclaim contract the test exists to prove is never exercised on Windows.

- **Outcome:** the rename-failure reclaim contract is exercised on every platform — the same wrap that reclaims on POSIX now reclaims on Windows. PR #2755's `windows-latest` CI goes green.
- **Invariant:** "this run owns the staged capture iff `executeWorkflow`'s rename succeeded" — adopted ⇔ the run's artifacts directory received the move. This holds on every host that runs CI.
- **Scope boundary:** the Windows fix is test-only — only `subrun.test.ts`'s `fs/promises.rename` mock changes. The `hold()` re-call semantic gap flagged in #2690 (the issue's second concern) remains out of scope, unchanged from #2755.
- **Root cause:** the `fs/promises.rename` mock predicate was `src.includes('staged-source/') && !dst.includes('staged-source/')` — a forward-slash substring. `path.join` on Windows produces backslash-separated paths, so the predicate never fires there, the rename delegates to the real `fs.promises.rename`, succeeds, `adopt()` runs, the wrap's `finally` does not reclaim, the child workflow completes successfully, and `result.success === true` instead of `false`.

## Review guidance

- **Feedback requested:** is the path-separator fix in the test mock (not the executor) the right layer, and is `\`staged-source${sep}\`` the right shape — versus, e.g., a path-component split (`p.split(/[\\/]/).includes('staged-source')`).
- **Start here:** `packages/workflows/src/subrun.test.ts:71` — the predicate is built once at module load from `path.sep`. Two new assertions at lines 5596–5606 pin it.
- **Review order:**
  1. `packages/workflows/src/subrun.test.ts:71, 95-96` — the predicate swaps a forward-slash literal for `` `staged-source${sep}` ``.
  2. `packages/workflows/src/subrun.test.ts:5586-5607` — the new regression test `rename mock predicate is platform-aware (uses path.sep, matches host-platform paths)` locks both the structural form (`stagedSourcePathSep === \`staged-source${sep}\``) and the behavioural match (`path.join` output includes the predicate).
  3. `packages/workflows/src/subrun.test.ts:5493-5577` — the end-to-end test (carried over from #2755) is unchanged: it still forces the move-out-of-staging rename to throw and asserts the staged directory is empty.
- **Lower-attention areas:** the first two commits on this branch are identical to #2755 (`fix(workflows): adopt the staged capture at the rename site (#2690)` and `fix(workflows): wire capturedSourceOwner on the recursive workflow: sub-run path`). Two added commits: `aeb30a88 test(workflows): make the rename-mock predicate platform-aware` (the Windows test fix) and `5b125c0b fix(cli): SIGINT rm targets the original staged path, not the live artifacts path` (the CLI's signal handler now `rm`s `originalStagedRoot` pinned at prepare time, and `workflow.test.ts`'s `withCapturedSource` mock now records `reclaim:` calls from the wrap's `finally` so a dropped reclaim breaks the assertion at line 1386).
- **Known risk or uncertainty:** none. The end-to-end test exercises the actual reclaim path on the host platform; the unit-level pin is what proves the fix survives a future refactor. A reversion to the hardcoded forward slash would fail the structural assertion on every platform.

## Solution

Replace the hardcoded forward-slash substring check in the `fs/promises.rename` mock with a predicate built from `path.sep` at module load. The forced-failure branch targets the same rename it always did (move out of staging) and leaves `captureWorkflowSource`'s internal `.partial` → final rename alone — both sides of that rename are under `staged-source/`, so neither side includes `staged-source`/`staged-source\` as a top-level path component.

```ts
const stagedSourcePathSep = `staged-source${sep}`;
// ...
src.includes(stagedSourcePathSep) && !dst.includes(stagedSourcePathSep)
```

Two assertions pin the predicate against a regression:

- **Structural** — `expect(stagedSourcePathSep).toBe(\`staged-source${sep}\`)` fails if anyone re-introduces a hardcoded slash or escapes the separator.
- **Behavioural** — `path.join(tmpdir(), 'staged-source', 'uuid-1')` matches, `path.join(tmpdir(), 'artifacts', 'workflow-source')` does not. The host-platform case holds by construction; the Windows case holds because `path.join` on Windows produces backslash paths and `path.sep === '\\'` on Windows.

The end-to-end test is the one that matters for CI: it runs `executeWorkflow` with a real workflow, mocks the rename to throw, and asserts both the parent's failure status and the empty staged directory. That test now exercises on every platform the matrix runs on.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | The recursive sub-run staged-capture reclaim test passes on POSIX and fails on Windows at the first assertion (`result.success` is `true`, expected `false`). | The same test passes on both POSIX and Windows. The end-to-end reclaim path is exercised on every CI host. |
| **Failure behavior** | On Windows CI, a sub-run that would have reclaimed its staged capture at the rename-failure site silently completes successfully — the staged directory leaks until the hourly sweep reaps it. | The staged directory is reclaimed synchronously by the wrap's `finally` on every platform when the recursive rename fails. |

## Architecture

```mermaid
flowchart LR
  Test[Test harness] --> Mock[fs/promises.rename mock]
  Mock -- src includes staged-source/sep --> Throw[throw forced failure]
  Mock -- otherwise --> Real[passthrough to real rename]
  Throw --> Executor[executeWorkflow rename arm]
  Executor -- opts.capturedSourceOwner not adopted --> Wrap[withCapturedSource finally reclaims]
```

### Changed seams

| Boundary or contract | Change | Evidence |
|---|---|---|
| `fs/promises.rename` mock predicate | Hardcoded forward-slash literal → `` `staged-source${sep}` `` built at module load. | `packages/workflows/src/subrun.test.ts:71, 95-96` |
| Sub-run rename-failure regression test portability | New unit-level regression test pins the predicate structurally (`stagedSourcePathSep === \`staged-source${sep}\``) and behaviourally (`path.join` output matches). The end-to-end test from #2755 is preserved verbatim. | `packages/workflows/src/subrun.test.ts:5586-5607` |
| Top-level entry-point wiring | Unchanged from #2755 — orchestrator, orchestrator-agent, CLI, and the recursive `runChildWorkflow` all pass `capturedSourceOwner: owner`. | `packages/core/src/orchestrator/orchestrator.ts:548-571`, `packages/core/src/orchestrator/orchestrator-agent.ts:1091-1237`, `packages/cli/src/commands/workflow.ts:2231-2239`, `packages/workflows/src/executor.ts:1365-1388` |
| `ExecuteWorkflowOptions.capturedSourceOwner` | Unchanged from #2755 — adoption fires inside `executeWorkflow` at the rename success site. | `packages/workflows/src/executor.ts:632-643, 2295-2303` |

## Validation

- `cd packages/workflows && bun test src/subrun.test.ts -t "sub-run staged capture"` — **2 pass, 0 fail**. Proves the host-platform reclaim contract (end-to-end) and the predicate is built from `path.sep` and matches `path.join` output (structural + behavioural).
- `cd packages/workflows && bun test src/subrun.test.ts` — **79 pass, 0 fail** (77 prior + 1 end-to-end from #2755 + 1 new predicate pin). Proves no other test in the file regresses.
- `cd packages/workflows && bun test src/workflow-source.test.ts` — **33 pass, 0 fail**. The `reclaims a staged capture when executeWorkflow fails to rename it into place (#2690)` test from #2755 still passes.
- `cd packages/workflows && bun test src/executor.test.ts` — **101 pass, 0 fail**. The success-branch contract (`leaves an adopted capture alone`) still holds.
- `cd packages/core && bun test src/orchestrator/orchestrator-agent.test.ts` — **259 pass, 0 fail**.
- `cd packages/core && bun test src/orchestrator/orchestrator-isolation.test.ts` — **12 pass, 0 fail**.
- `cd packages/cli && bun test src/commands/workflow.test.ts` — **263 pass, 0 fail**.
- `bun run --filter @archon/workflows type-check` — exit 0.
- `bun x prettier --check packages/workflows/src/subrun.test.ts` — clean.
- **Pre-existing test isolation failures:** `bun test` across `workflows/core/cli` produces the same baseline failures on `b442adfb` that #2755 reported; targeted suites that cover the contract land green.
- **Not verified:** the `windows-latest` CI run itself — the only signal that matters is the `windows-latest` job turning green. The behavioural pin uses `path.join(tmpdir(), 'staged-source', 'uuid-1')` so the test would have to lie about the host platform for the predicate to silently regress.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | Backward-compatible. `capturedSourceOwner` is unchanged from #2755; the new test mock is test-only. | `packages/workflows/src/subrun.test.ts` (test file), `packages/workflows/src/executor.ts:632-643` |
| Security / permissions / data | No change. The staged capture's bytes now leave `~/.archon/staged-source/` synchronously on Windows rename failure instead of waiting for the sweep — same data, earlier cleanup. | `packages/workflows/src/executor.ts:2298-2303` |
| Rollout / rollback | Revertible by re-introducing the literal `'staged-source/'` in the predicate (the new regression test then fails on Windows). The sweep backstop handles any partial rollback's window. | `git revert aeb30a88` reproduces the baseline failure mode; sweep params (`STAGED_SOURCE_TTL_MS = 6h`) unchanged |
| Observability | The hourly `sweepStaleStagedSources` log line continues to surface orphans from unrelated paths (process killed mid-capture). The rename-failure arm is silent — it claims the staged dir through `withCapturedSource`'s `finally`, which already logs reclaim. | `packages/workflows/src/executor.ts:670-697` (sweep), `:770-779` (wrap finally) |
| Documentation / communication | No external docs to update. The new regression test's comment block records why `path.sep` is the right primitive. | `packages/workflows/src/subrun.test.ts:5586-5593` |

## Links

- Supersedes #2755 — same rename-site adopt work plus the Windows-portable regression test.
- Closes #2690 — the staged-capture leak on `executeWorkflow` rename failure is resolved on every platform.
- Related #2226 — earlier `--repo` pinning sweep that established the project's PR-base-pinning pattern this PR follows.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow source cleanup during failed runs and termination.
  * Prevented active source directories from being removed during containerized or detached execution.
  * Ensured staged captures are reclaimed when preparation or source transfer fails.
  * Improved cleanup consistency for nested and background workflow runs.

* **Tests**
  * Added regression coverage for capture ownership and failed source transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->