### PR TITLE
fix(core): unhang GitHub Copilot subscription login by defaulting the enterprise-domain prompt

### DIFF
--- a/packages/core/src/credentials/oauth-bridge.test.ts
+++ b/packages/core/src/credentials/oauth-bridge.test.ts
@@ -130,6 +130,25 @@ describe('oauth-bridge', () => {
     expect(pollOAuth(start.sessionId, 'u1').status).toBe('connected');
   });
 
+  // #2763: github-copilot asks its enterprise-domain text prompt BEFORE firing
+  // onDeviceCode. The prompt must be answered with the blank default instead
+  // of awaiting poll(code) — which only resolves in manual/device mode, i.e.
+  // never at this point — or login hangs until the session TTL.
+  test('copilot pre-device-code text prompt is answered with the blank default', async () => {
+    let promptAnswer: string | undefined;
+    loginImpl = async cb => {
+      promptAnswer = await cb.onPrompt({ type: 'text', message: 'GitHub Enterprise URL/domain' });
+      cb.onDeviceCode({ userCode: 'WXYZ', verificationUri: 'https://dev' });
+      return { access: 'a', refresh: 'r', expires: 1 };
+    };
+    const start = await startOAuth('u1', 'copilot');
+    expect(promptAnswer).toBe('');
+    expect(start.mode).toBe('device');
+    expect(start.userCode).toBe('WXYZ');
+    await tick();
+    expect(pollOAuth(start.sessionId, 'u1').status).toBe('connected');
+  });
+
   test('login() rejects AFTER start (during the code wait) → poll surfaces error', async () => {
     loginImpl = async cb => {
       cb.onAuth({ url: 'https://auth.example/login' });

--- a/packages/core/src/credentials/oauth-bridge.ts
+++ b/packages/core/src/credentials/oauth-bridge.ts
@@ -17,7 +17,7 @@
  *
  * Sessions are bound to `userId`, short-TTL, and abortable; credentials are never
  * logged. On a headless host the callback-server flows must complete via the
- * manual-code path (`onManualCodeInput`/`onPrompt`) — nothing can reach their
+ * manual-code path (`onManualCodeInput`) — nothing can reach their
  * localhost callback server (see CANCEL SEMANTICS for the abort side of this).
  *
  * CANCEL SEMANTICS (#1963): pi-ai 0.79.1 ignores `options.signal` in its
@@ -313,11 +313,19 @@ export async function startOAuth(userId: string, providerId: string): Promise<St
           session.mode = 'device';
           session.firstSignal.resolve(true);
         },
-        // Manual providers ask for the pasted code via onManualCodeInput (or onPrompt);
-        // wire both to the same deferred. NOTE: a future provider that used onPrompt for
-        // a DIFFERENT question would get handed the auth code — fine for claude/copilot.
+        // Manual providers ask for the pasted code via onManualCodeInput; route
+        // that to the deferred the client submits through poll(code).
         onManualCodeInput: () => session.codeDeferred.promise,
-        onPrompt: async () => session.codeDeferred.promise,
+        // Free-text/secret prompts have no interactive channel here (#2763):
+        // answering with "" takes the provider's documented blank-input default
+        // (github-copilot's enterprise-domain prompt defaults to github.com).
+        // Routing them to codeDeferred would deadlock — poll(code) only
+        // resolves once the flow reaches manual/device mode, which for
+        // github-copilot happens strictly after this prompt is answered.
+        onPrompt: async () => {
+          getLog().info({ provider }, 'oauth_bridge.prompt_defaulted');
+          return '';
+        },
         // No interactive account picker on the web bridge — take the first option.
         onSelect: async prompt => prompt.options[0]?.id,
         onProgress: (message: string) => {

--- a/packages/providers/src/oauth.ts
+++ b/packages/providers/src/oauth.ts
@@ -135,7 +135,8 @@ function adaptLoginCallbacks(
         return (await callbacks.onSelect({ options: prompt.options })) ?? '';
       }
       // text / secret — Pi uses these for one-off prompts (e.g. github-copilot
-      // enterprise domain). The bridge routes them to the same code-deferred.
+      // enterprise domain). The caller decides how to answer; the Archon
+      // bridge has no interactive channel and returns "" (blank default).
       return callbacks.onPrompt(prompt);
     },
     notify: (event: AuthEvent): void => {


### PR DESCRIPTION
## Problem and outcome

GitHub Copilot subscription login through the web bridge hung until the session TTL. `loginGitHubCopilot()` asks its "GitHub Enterprise URL/domain (blank for github.com)" text prompt **before** firing `device_code`, and the bridge routed every text prompt to the manual-code deferred — which only resolves once the flow reaches manual/device mode, i.e. never at that point.

- **Outcome:** A Copilot login through the bridge proceeds past the enterprise-domain prompt: it is answered with `""`, taking the provider's documented blank default (github.com), and the device-code flow completes normally.
- **Invariant:** Manual-code providers still get their code from `poll(code)` via the same deferred; anthropic (manual_code prompts) and openai (Archon-owned PKCE) flows are behaviorally unchanged.
- **Scope boundary:** No interactive channel is added to the bridge; surfacing arbitrary text prompts to the user remains a possible future enhancement.
- **Root cause:** `oauth-bridge.ts` wired `onPrompt` to `session.codeDeferred.promise`; for copilot, `pollOAuth` can't resolve that deferred until after the prompt is answered → deadlock until TTL.

## Review guidance

- **Feedback requested:** Correctness of answering prompts with the blank default rather than failing fast, and whether any current provider uses `onPrompt` for something a blank answer would break.
- **Start here:** `packages/core/src/credentials/oauth-bridge.ts:316` — the `onPrompt` handler: previously awaited the code deferred, now logs `oauth_bridge.prompt_defaulted` and returns `""`.
- **Review order:** 1) `packages/core/src/credentials/oauth-bridge.ts` (handler + header comment), 2) `packages/providers/src/oauth.ts` (adapter comment only), 3) regression test in `packages/core/src/credentials/oauth-bridge.test.ts`.
- **Lower-attention areas:** The `packages/providers/src/oauth.ts` change is comment-only.
- **Known risk or uncertainty:** None known among shipped providers: anthropic only uses `manual_code` prompts, openai doesn't use Pi's OAuth prompt path.

## Solution

The bridge has no interactive channel on a headless host, so free-text prompts cannot be asked of the user. Instead of deadlocking on the code deferred, `onPrompt` now answers with `""` — each such prompt documents its blank-input semantics, and github-copilot's explicitly defaults to github.com. The manual-code path (`onManualCodeInput`) keeps its existing route to the deferred, so nothing else changes. This matches triage option (a) from the issue discussion: sensible default, no new UI surface.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Copilot login hangs ~10 minutes, then expires | Login answers the enterprise prompt with the blank default and completes the device-code flow |
| **Failure behavior** | Silent hang until session TTL | No failure path introduced; a log line (`oauth_bridge.prompt_defaulted`) records each defaulted prompt |

## Validation

- New regression test `copilot pre-device-code text prompt is answered with the blank default` in `packages/core/src/credentials/oauth-bridge.test.ts` reproduces the exact ordering (prompt before `onDeviceCode`); verified it fails against pre-fix `oauth-bridge.ts` (via git stash) and passes after.
- `bun test src/credentials/oauth-bridge.test.ts` — 23 pass.
- `bun test src/oauth.test.ts` in `packages/providers` — 3 pass.
- `bun run type-check` in `packages/core` and `packages/providers` — pass.
- Full `bun run test` in `packages/core` — 0 failures; root `bun run lint` — clean.
- **Not verified:** A live Copilot subscription login end-to-end (requires an active subscription); covered instead by the regression test pinning the adapter contract.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | Enterprise-domain users going through the web bridge now get github.com semantics; interactive enterprise login would need the future prompt-surfacing enhancement | `packages/core/src/credentials/oauth-bridge.ts` comment |
| Observability | Defaulted prompts emit `oauth_bridge.prompt_defaulted` with the provider id | diff |

## Links

- Closes #2763


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved headless OAuth sign-in flows by automatically handling enterprise-domain prompts with a blank response.
  * Prevented authorization flows from becoming blocked when interactive prompt input is unavailable.
  * Improved GitHub Copilot enterprise authentication reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->