### PR TITLE
docs: direction.md becomes the project's direction doc at a canonical path

### DIFF
--- a/.archon/direction.md
+++ b/.archon/direction.md
@@ -1,6 +1,6 @@
 # Archon Direction
 
-The maintainer-standup workflow consults this document when triaging PRs and issues to suggest which contributions align with the project and which are likely polite-decline candidates.
+The project's product-direction document, for maintainers and agents alike: PR/issue triage (the maintainer-standup workflow consults it to flag polite-decline candidates), grounding for agent runs, and a direction sidecar any workflow can read.
 
 This file is **committed and shared by all maintainers**. Edit deliberately — direction calls live here so that PR triage stays consistent across runs and across maintainers. When declining a PR, cite the specific clause (e.g., `direction.md §single-tenant-per-install`).
 
@@ -8,14 +8,14 @@ This file is **committed and shared by all maintainers**. Edit deliberately — 
 
 ## What Archon IS
 
-- **A governed agentic automation engine.** Runs multi-step workflows that mix deterministic steps (bash/scripts) with AI agents (Claude Code SDK, Codex SDK, Pi community provider), with human approval gates and audit trails — driven remotely from Slack, Telegram, GitHub, Discord, CLI, and Web UI. Its most mature surface today is agentic **coding**; the same engine is being extended to drive general **business-operations** automation.
+- **A governed agentic automation engine.** Runs multi-step workflows that mix deterministic steps (bash/scripts) with AI agents (Claude Code SDK, Codex SDK, and community providers), with human approval gates and audit trails — driven remotely from Slack, Telegram, GitHub, Discord, CLI, and Web UI. Its most mature surface today is agentic **coding**; the same engine is being extended to drive general **business-operations** automation.
 - **Single-tenant per install.** One isolated instance per operator or client (the deployment model is one install/VPS per client, not one install serving many tenants). Data model and runtime stay single-tenant — client isolation is at the deployment layer, not in code. Multi-**user** within an install (several humans sharing one instance, each with their own identity/credentials) is supported and is distinct from multi-**tenant**.
 - **Heading toward always-on automation.** Native scheduling and event/webhook triggers are a planned primitive (tracked in the workflow-triggers PRD), enabling scheduled, event-driven, and unattended runs — including operational, non-coding work. PRs toward this direction align.
 - **Platform-agnostic at the conversation layer.** Unified interface across adapters via `IPlatformAdapter`. Stream/batch AI responses in real time.
 - **Workflow-driven.** Reproducible AI execution chains defined as YAML DAGs in `.archon/workflows/`. Workflows run in isolated git worktrees by default.
 - **Type-safe.** Strict TypeScript everywhere. No `any` without justification.
 - **Composable.** Scripts in `.archon/scripts/`, commands in `.archon/commands/`, workflows compose them.
-- **Bundled defaults are reference implementations — composition is how we author them, not a stability contract we offer.** "Reference patterns" is the user-facing posture; "composable" is the authoring technique. The set demonstrates capabilities and authoring best practice, stack-agnostic so it runs on any project (rewrite: #2123). `include:` blocks stay internally consistent within a bundle release, never guaranteed across releases (declare `returns:` once #2470 lands). User copies are expected to diverge; building on a bundled block is allowed but neither mandatory nor the recommendation — the best workflows are project-specific. Repo-override by name is the pinning mechanism. Cite as `direction.md §defaults-reference-implementations`.
+- **Bundled defaults are reference implementations — composition is how we author them, not a stability contract we offer.** "Reference patterns" is the user-facing posture; "composable" is the authoring technique. The set demonstrates capabilities and authoring best practice, stack-agnostic so it runs on any project (rewrite: #2123). `include:` blocks stay internally consistent within a bundle release, never guaranteed across releases (declare `returns:` — #2470). User copies are expected to diverge; building on a bundled block is allowed but neither mandatory nor the recommendation — the best workflows are project-specific. Repo-override by name is the pinning mechanism. Cite as `direction.md §defaults-reference-implementations`.
 - **Has a community workflow marketplace.** A place for the community to share their workflows — the registry at `packages/docs-web/src/data/marketplace.ts` (each entry pinned to a commit SHA), surfaced on the docs site.
 - **Self-hostable.** Bun + TypeScript runtime. SQLite by default; PostgreSQL optional. Zero external service dependencies for core operation.
 - **Forge-agnostic.** GitHub is the primary forge, but Gitea and GitLab are community supported targets via community adapters at `packages/adapters/src/community/forge/`. Long-term home for outbound forge operations (PR/issue/review CRUD) is the same per-forge adapter that handles inbound webhooks. New forges land as new community adapters that implement the shared interface.
@@ -33,7 +33,7 @@ This file is **committed and shared by all maintainers**. Edit deliberately — 
 
 ## Community providers
 
-Archon ships built-in providers for Claude (`@anthropic-ai/claude-agent-sdk`) and Codex (`@openai/codex-sdk`). Pi (`@mariozechner/pi-coding-agent`) is the reference community provider and sets the pattern others should follow.
+Archon ships built-in providers for Claude (`@anthropic-ai/claude-agent-sdk`) and Codex (`@openai/codex-sdk`). Pi (`@earendil-works/pi-coding-agent`) is the reference community provider and sets the pattern others should follow.
 
 **Acceptance criteria** for new community providers:
 

--- a/.archon/scripts/maintainer-standup-read-context.ts
+++ b/.archon/scripts/maintainer-standup-read-context.ts
@@ -13,7 +13,7 @@ const RECENT_BRIEFS_LIMIT = 3;
 
 const baseDir = resolve(process.cwd(), '.archon/maintainer-standup');
 
-const directionPath = resolve(baseDir, 'direction.md');
+const directionPath = resolve(process.cwd(), '.archon/direction.md');
 const direction = existsSync(directionPath) ? readFileSync(directionPath, 'utf8') : '';
 
 const profilePath = resolve(baseDir, 'profile.md');

--- a/.archon/workflows/rasmus-tests/t3-probe-issue.yaml
+++ b/.archon/workflows/rasmus-tests/t3-probe-issue.yaml
@@ -26,7 +26,7 @@ nodes:
       $issue.output
 
       Check the issue's claims against the actual code, then check it against the
-      project direction in `.archon/maintainer-standup/direction.md`.
+      project direction in `.archon/direction.md`.
 
       Pick one label:
         should-fix    — real, in scope, worth doing


### PR DESCRIPTION
## Problem and outcome

`direction.md` is becoming the project's product-direction document — consulted by maintainers during triage, by agents grounding their runs, and by workflows as a direction sidecar — but it lived at `.archon/maintainer-standup/direction.md`, hidden inside one workflow's folder, and carried three stale claims.

- **Outcome:** The doc lives at `.archon/direction.md` with its header stating the promoted role; the Pi package identity in the community-provider acceptance criteria is corrected (`@mariozechner/…` → `@earendil-works/pi-coding-agent`); the `returns:` clause reflects that #2470 landed; and the provider inventory line is de-listed to "community providers" so it stops rotting each time a provider is added.
- **Scope boundary:** No direction calls changed — every clause keeps its meaning and its citation anchors (`direction.md §…` citations in existing PR comments remain valid since they cite the filename, not the path).

## Review guidance

- **Start here:** the `direction.md` diff (93% rename — the content changes are four small hunks).
- **Lower-attention areas:** the two reference updates (`maintainer-standup-read-context.ts` reads the canonical path; `t3-probe-issue.yaml` cites it).

## Solution

`git mv` to `.archon/direction.md`, a rewritten opening paragraph stating the doc's role, and the three factual corrections. The standup workflow keeps working: its context script now resolves the canonical path, and `profile.md`/`state.json`/briefs stay in the workflow's own folder.

## Validation

- `grep -rn 'maintainer-standup/direction'` over the tree: zero remaining references.
- The Pi package name verified against `packages/providers/package.json` (`@earendil-works/pi-coding-agent`, the dependency the provider actually imports).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project guidance to reflect broader workflow and business-operations use.
  * Clarified supported provider references.
  * Consolidated direction guidance at the repository level.
  * Updated related workflow instructions to use the consolidated guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->