### PR TITLE
fix(core): reject malformed stored OpenAI OAuth expiry

### DIFF
--- a/packages/core/src/db/user-provider-key-store.test.ts
+++ b/packages/core/src/db/user-provider-key-store.test.ts
@@ -320,6 +320,7 @@ describe('user-provider-key-store', () => {
 
     test('openai oauth row → null on malformed expires, no mint attempt', async (): Promise<void> => {
       const malformedExpires = [
+        { label: 'null payload', raw: 'null', type: 'undefined' },
         { label: 'missing', raw: '{"access":"oa"}', type: 'undefined' },
         { label: 'non-numeric', raw: '{"access":"oa","expires":"soon"}', type: 'string' },
         { label: 'non-finite', raw: '{"access":"oa","expires":1e400}', type: 'number' },

--- a/packages/core/src/db/user-provider-key-store.test.ts
+++ b/packages/core/src/db/user-provider-key-store.test.ts
@@ -318,6 +318,34 @@ describe('user-provider-key-store', () => {
       expect(mockGetOAuthApiKey).not.toHaveBeenCalled();
     });
 
+    test('openai oauth row → null on malformed expires, no mint attempt', async (): Promise<void> => {
+      const malformedExpires = [
+        { label: 'missing', raw: '{"access":"oa"}', type: 'undefined' },
+        { label: 'non-numeric', raw: '{"access":"oa","expires":"soon"}', type: 'string' },
+        { label: 'non-finite', raw: '{"access":"oa","expires":1e400}', type: 'number' },
+      ];
+
+      for (const { label, raw, type } of malformedExpires) {
+        mockMintOpenAi.mockClear();
+        mockLogger.error.mockClear();
+        mockQuery.mockResolvedValueOnce(
+          createQueryResult([
+            oauthRow({
+              provider: 'openai',
+              oauth_creds_encrypted: encryptToken(raw, getEncryptionKey()),
+            }),
+          ])
+        );
+
+        expect(await getDecryptedProviderCredential('user-1', 'openai'), label).toBeNull();
+        expect(mockMintOpenAi, label).not.toHaveBeenCalled();
+        expect(mockLogger.error, label).toHaveBeenCalledWith(
+          { userId: 'user-1', provider: 'openai', expiresType: type },
+          'user_provider_key.oauth_malformed_expires'
+        );
+      }
+    });
+
     test("legacy 'codex' rows normalize onto the openai path", async () => {
       mockGetOAuthApiKey.mockClear();
       mockMintOpenAi.mockClear();

--- a/packages/core/src/db/user-provider-key-store.ts
+++ b/packages/core/src/db/user-provider-key-store.ts
@@ -213,14 +213,11 @@ async function resolveOAuthCredential(
     );
     return null;
   }
-  // The Pi mint path decides refresh purely by `Date.now() >= creds.expires`
-  // (`@archon/providers/oauth`, Archon-owned since pi-ai 0.84 — the SDK's
-  // toAuth never checks expiry). A missing or non-numeric `expires` from a
-  // legacy/corrupt row would make that comparison silently false and serve a
-  // stale token as success, so enforce the shape here where the raw blob
-  // enters, and treat a mismatch like the decrypt failure above. (The openai
-  // branch validates its own shape inside mintOpenAiOAuthApiKey.)
-  if (piProvider && !Number.isFinite(creds.expires)) {
+  // Both mint paths decide refresh from `creds.expires`. A missing or
+  // non-numeric value from a legacy/corrupt row would make that comparison
+  // silently false and serve a stale token as success, so enforce the shape
+  // here where the raw blob enters and treat a mismatch like decrypt failure.
+  if (!Number.isFinite(creds.expires)) {
     getLog().error(
       { userId, provider, expiresType: typeof creds.expires },
       'user_provider_key.oauth_malformed_expires'

--- a/packages/core/src/db/user-provider-key-store.ts
+++ b/packages/core/src/db/user-provider-key-store.ts
@@ -203,9 +203,9 @@ async function resolveOAuthCredential(
     getLog().warn({ userId, provider }, 'user_provider_key.oauth_no_pi_provider');
     return null;
   }
-  let creds: OAuthCredentials;
+  let parsed: unknown;
   try {
-    creds = JSON.parse(decryptToken(ciphertext, key)) as OAuthCredentials;
+    parsed = JSON.parse(decryptToken(ciphertext, key));
   } catch (err) {
     getLog().error(
       { err: err as Error, userId, provider },
@@ -213,13 +213,14 @@ async function resolveOAuthCredential(
     );
     return null;
   }
+  const creds = typeof parsed === 'object' && parsed !== null ? (parsed as OAuthCredentials) : null;
   // Both mint paths decide refresh from `creds.expires`. A missing or
   // non-numeric value from a legacy/corrupt row would make that comparison
   // silently false and serve a stale token as success, so enforce the shape
   // here where the raw blob enters and treat a mismatch like decrypt failure.
-  if (!Number.isFinite(creds.expires)) {
+  if (!creds || !Number.isFinite(creds.expires)) {
     getLog().error(
-      { userId, provider, expiresType: typeof creds.expires },
+      { userId, provider, expiresType: typeof creds?.expires },
       'user_provider_key.oauth_malformed_expires'
     );
     return null;


### PR DESCRIPTION
## Problem and outcome

A stored OpenAI OAuth credential with a missing or malformed `expires` value bypassed the Pi-only deserialization guard. The expiry comparison then evaluated false and could serve the stored access token without refresh.

- **Outcome:** Malformed OpenAI expiry data is logged and treated as an absent credential before minting.
- **Invariant:** No stored OAuth credential reaches a vendor mint path unless `expires` is a finite number.
- **Scope boundary:** Token exchange, refresh response validation, and valid credential behavior are unchanged.
- **Root cause:** The shared boundary guard was conditional on selecting a Pi provider, while OpenAI's mint path also relies on `expires` to decide whether to refresh.

## Review guidance

- **Feedback requested:** Correctness of the shared boundary condition and focused malformed-input coverage.
- **Start here:** `packages/core/src/db/user-provider-key-store.ts:216` — the guard now applies before either mint path.
- **Review order:** Boundary guard, then `user-provider-key-store.test.ts` malformed OpenAI cases.
- **Lower-attention areas:** None; the PR changes only the guard and its regression test.
- **Known risk or uncertainty:** None.

## Solution

Apply the existing `Number.isFinite(creds.expires)` check to every decrypted OAuth blob at the one shared deserialization boundary. The existing error event and `null` result are reused, so malformed OpenAI rows follow the established Pi behavior without adding another schema or vendor-specific validation path.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Missing, string, or non-finite OpenAI expiry could reach minting and return the stored token. | The credential resolves to `null` and the OpenAI mint path is not called. |
| **Failure behavior** | The malformed row was silently treated as unexpired. | Archon logs `user_provider_key.oauth_malformed_expires`, forcing refresh or re-login behavior. |

## Validation

- `cd packages/core && bun test src/db/user-provider-key-store.test.ts` — 28 passed, 0 failed; proves missing, string, and non-finite OpenAI expiry are logged, rejected, and never minted while valid Pi/OpenAI paths remain green.
- `bun run validate` — passed; generated checks, type-check, lint with zero warnings, format, installer tests, all package tests, and script tests are green.
- **Not verified:** Nothing material; the outcome is fully covered at the stored credential decrypt/parse boundary.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | Existing malformed rows become unavailable until refresh or re-login; valid stored credentials are unchanged. | Focused store regression and existing happy-path tests. |
| Observability | Malformed expiry is emitted through the existing credential error event with provider and expiry type. | `user_provider_key.oauth_malformed_expires` assertion. |
| Rollout / rollback | No data migration; reverting restores the previous behavior. | Two-file boundary-only diff. |

## Links

- Closes #2768
- Plan: https://github.com/coleam00/Archon/issues/2768#issuecomment-5394967237


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved OAuth credential validation for Pi and OpenAI integrations.
  - Credentials with null, primitive, missing, malformed, or non-finite expiration values are now rejected safely.
  - Prevented token minting attempts when credential expiration data is invalid.
  - Added error logging for malformed OAuth credential data.
  - Expanded validation coverage to ensure malformed credential payloads return safely without disrupting authentication flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->