### PR TITLE
docs(pi): recipes for web search and MCP via your own extensions

### DIFF
--- a/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
+++ b/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
@@ -504,6 +504,104 @@ assistants:
         extensionFlags: { plan: false }
 ```
 
+#### Recipe: web search and fetch through your own extension
+
+Archon does not build web search into the Pi engine — and deliberately so: Pi's extension API already lets you register custom tools, and Archon picks them up automatically because extensions load inside the same Pi session Archon drives. The result is a workflow node that can search the web with **zero Archon-side configuration** beyond the extension posture you already know.
+
+Write the extension once, into your global Pi extensions directory:
+
+```ts
+// ~/.pi/agent/extensions/web-search.ts
+export default function (pi) {
+  pi.registerTool({
+    name: "web_search",
+    description:
+      "Search the web. Returns titles, URLs and snippets for each result.",
+    parameters: {
+      type: "object",
+      properties: { query: { type: "string" } },
+      required: ["query"],
+    },
+    async execute(_callId, { query }) {
+      const res = await fetch(
+        `https://api.duckduckgo.com/?q=${encodeURIComponent(query)}&format=json`,
+      );
+      return JSON.stringify(await res.json());
+    },
+  });
+
+  pi.registerTool({
+    name: "web_fetch",
+    description: "Fetch a URL and return its body as plain text.",
+    parameters: {
+      type: "object",
+      properties: { url: { type: "string" } },
+      required: ["url"],
+    },
+    async execute(_callId, { url }) {
+      const res = await fetch(url);
+      return res.text();
+    },
+  });
+}
+```
+
+That's the whole setup. Extensions are on by default (`enableExtensions` defaults to true), Pi discovers `~/.pi/agent/extensions/*.ts` on every session, and Archon restarts Pi sessions fresh per run — so the tools appear on the next workflow run without touching `.archon/config.yaml` at all. For a production extension you'd use a real search API key via the `env:` surface instead of a keyless endpoint, and install it as an npm package with `pi install npm:<package>`.
+
+Then use it from any workflow node — no Archon config changes:
+
+```yaml
+# .archon/workflows/research.yaml
+name: research
+provider: pi
+nodes:
+  - id: research
+    prompt: "Research $ARGUMENTS using web_search/web_fetch and summarize the findings with citations."
+```
+
+To restrict where the tools appear, scope the posture per node exactly as described in [Scoping extension posture per node](#scoping-extension-posture-per-node): leave `assistants.pi` clean and put `pi: { enableExtensions: true }` only on nodes that should search, or flip it to `false` on nodes that shouldn't.
+
+#### Recipe: MCP servers through an extension bridge
+
+Pi rejects MCP by design — there is no `mcpServers` field to set, and Archon does not add one. The supported route is the same as above: an extension that acts as the MCP **client** itself and re-exposes each MCP server's tools as ordinary Pi tools. The model never knows MCP is involved; Archon sees nothing but regular extension tools.
+
+Sketch of such a bridge:
+
+```ts
+// ~/.pi/agent/extensions/mcp-bridge.ts
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+export default function (pi) {
+  const client = new Client({ name: "archon-mcp-bridge", version: "1.0.0" });
+
+  pi.on("session_start", async () => {
+    await client.connect(
+      new StdioClientTransport({
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-everything"],
+      }),
+    );
+    const { tools } = await client.listTools();
+    for (const tool of tools) {
+      pi.registerTool({
+        name: `mcp_${tool.name}`,
+        description: tool.description ?? `MCP tool ${tool.name}`,
+        parameters: tool.inputSchema,
+        execute: async (_callId, args) =>
+          JSON.stringify(await client.callTool({ name: tool.name, arguments: args })),
+      });
+    }
+  });
+}
+```
+
+The bridge runs inside the Pi session process, subject to everything above: it loads only when `enableExtensions` is true for that node, its tools are just tools (so you can keep them off nodes with a scoped `pi:` block), and if it needs a UI-bound approval gate you give it `interactive: true`. Community bridges exist too — search the [package ecosystem](https://shittycodingagent.ai/packages) for `mcp` before writing your own.
+
+:::warning Repo-controlled `.pi/` directories
+Extension discovery also includes `<cwd>/.pi/extensions/*.ts` and `<cwd>/.pi/settings.json` in the **working directory of the run**. When Archon executes a workflow against a repository you didn't write, anything shipped in that repo's `.pi/` loads automatically — arbitrary JS with the Archon server's OS permissions — unless you disable extensions. Before running workflows on third-party repos either audit their `.pi/` directory first or set `enableExtensions: false` (globally, or per node via the `pi:` block). This trust decision lives with the operator; Archon will not make it for you.
+:::
+
 ### Model reference format
 
 Pi models use a `<pi-provider-id>/<model-id>` format:
@@ -552,7 +650,7 @@ nodes:
 | Inline sub-agents | ❌ | `agents:` is Claude-only; ignored with a warning on Pi |
 | System prompt override | ✅ | `systemPrompt:` |
 | Codebase env vars (`envInjection`) | ✅ | `.archon/config.yaml` `env:` section |
-| MCP servers | ❌ | Pi rejects MCP by design |
+| MCP servers | ❌ (bridged via your own extension) | No `mcpServers` field exists. An extension can act as MCP client and expose the tools in-process — see [Recipe: MCP servers through an extension bridge](#recipe-mcp-servers-through-an-extension-bridge). |
 | In-process native tools | ✅ | none — Archon's `manage_run` tool is auto-injected in project-scoped chat via Pi `customTools` (distinct from MCP, which Pi rejects). Gated on the `nativeTools` provider capability. |
 | Claude-SDK hooks | ❌ | Claude-specific format |
 | Structured output | ✅ (best-effort) | `output_format:` — schema is appended to the prompt and JSON is parsed out of the assistant text. Handles bare JSON, ```json```-fenced, reasoning-model prose preambles like `Let me evaluate... {...}` (Minimax M2.x pattern), and structurally-corrupt JSON (trailing commas, single quotes, truncated tails) via repair. The parsed output is then **validated against the schema**; on a miss the executor re-asks (prompt + the schema errors) up to **3×**, and only then **fails** the node (it no longer degrades silently to a warning). Not SDK-enforced like Claude/Codex. |

--- a/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
+++ b/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
@@ -526,7 +526,8 @@ export default function (pi) {
       const res = await fetch(
         `https://api.duckduckgo.com/?q=${encodeURIComponent(query)}&format=json`,
       );
-      return JSON.stringify(await res.json());
+      const body = JSON.stringify(await res.json());
+      return { content: [{ type: "text", text: body }], details: {} };
     },
   });
 
@@ -540,7 +541,8 @@ export default function (pi) {
     },
     async execute(_callId, { url }) {
       const res = await fetch(url);
-      return res.text();
+      const text = await res.text();
+      return { content: [{ type: "text", text }], details: {} };
     },
   });
 }
@@ -573,28 +575,39 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 
 export default function (pi) {
+  // Module scope persists for the whole process while session_start fires per
+  // session — the loader is reloaded once per run, so connect must be idempotent
+  // or the second session throws.
+  let connected = false;
   const client = new Client({ name: "archon-mcp-bridge", version: "1.0.0" });
 
   pi.on("session_start", async () => {
-    await client.connect(
-      new StdioClientTransport({
-        command: "npx",
-        args: ["-y", "@modelcontextprotocol/server-everything"],
-      }),
-    );
+    if (!connected) {
+      await client.connect(
+        new StdioClientTransport({
+          command: "npx",
+          args: ["-y", "@modelcontextprotocol/server-everything"],
+        }),
+      );
+      connected = true;
+    }
     const { tools } = await client.listTools();
     for (const tool of tools) {
       pi.registerTool({
         name: `mcp_${tool.name}`,
         description: tool.description ?? `MCP tool ${tool.name}`,
         parameters: tool.inputSchema,
-        execute: async (_callId, args) =>
-          JSON.stringify(await client.callTool({ name: tool.name, arguments: args })),
+        execute: async (_callId, args) => {
+          const body = JSON.stringify(await client.callTool({ name: tool.name, arguments: args }));
+          return { content: [{ type: "text", text: body }], details: {} };
+        },
       });
     }
   });
 }
 ```
+
+Note that `execute` must return an `AgentToolResult` (`{ content, details }`); a bare string is normalized to an empty tool result and the model never sees any output.
 
 The bridge runs inside the Pi session process, subject to everything above: it loads only when `enableExtensions` is true for that node, its tools are just tools (so you can keep them off nodes with a scoped `pi:` block), and if it needs a UI-bound approval gate you give it `interactive: true`. Community bridges exist too — search the [package ecosystem](https://shittycodingagent.ai/packages) for `mcp` before writing your own.
 
@@ -651,7 +664,7 @@ nodes:
 | System prompt override | ✅ | `systemPrompt:` |
 | Codebase env vars (`envInjection`) | ✅ | `.archon/config.yaml` `env:` section |
 | MCP servers | ❌ (bridged via your own extension) | No `mcpServers` field exists. An extension can act as MCP client and expose the tools in-process — see [Recipe: MCP servers through an extension bridge](#recipe-mcp-servers-through-an-extension-bridge). |
-| In-process native tools | ✅ | none — Archon's `manage_run` tool is auto-injected in project-scoped chat via Pi `customTools` (distinct from MCP, which Pi rejects). Gated on the `nativeTools` provider capability. |
+| In-process native tools | ✅ | none — Archon's `manage_run` tool is auto-injected in project-scoped chat via Pi `customTools` (distinct from MCP, which Pi has no native surface for — see the [bridge recipe](#recipe-mcp-servers-through-an-extension-bridge)). Gated on the `nativeTools` provider capability. |
 | Claude-SDK hooks | ❌ | Claude-specific format |
 | Structured output | ✅ (best-effort) | `output_format:` — schema is appended to the prompt and JSON is parsed out of the assistant text. Handles bare JSON, ```json```-fenced, reasoning-model prose preambles like `Let me evaluate... {...}` (Minimax M2.x pattern), and structurally-corrupt JSON (trailing commas, single quotes, truncated tails) via repair. The parsed output is then **validated against the schema**; on a miss the executor re-asks (prompt + the schema errors) up to **3×**, and only then **fails** the node (it no longer degrades silently to a warning). Not SDK-enforced like Claude/Codex. |
 | Cost limits (`maxBudgetUsd`) | ❌ | tracked in result chunk, not enforced |


### PR DESCRIPTION
## Problem and outcome

Pi ships without built-in web search/fetch and without an MCP client, so Archon's per-node `mcp:` config has no effect on Pi nodes — and users had no documented route to either capability. The maintainer decision on #2764 was that Archon builds neither into the engine; the supported route is the user's own Pi extensions, which Archon already loads automatically.

- **Outcome:** The ai-assistants docs now carry two worked recipes — a web search/fetch extension usable from any Pi workflow node with zero Archon-side configuration, and an MCP-bridge extension that re-exposes MCP server tools as ordinary in-process Pi tools — plus the per-node scoping cross-reference and a trust warning for repo-controlled `.pi/` directories.
- **Invariant:** Pi's no-MCP posture is unchanged: no `mcpServers` surface is introduced anywhere. Extension gating remains three-layer (`assistants.pi.*` → `assistants.pi.nodes.<nodeId>` → node `pi:` block), already documented and here only cross-referenced, not duplicated.
- **Scope boundary:** Engine code untouched. This is documentation only.

## Review guidance

- **Feedback requested:** Technical accuracy of the two extension samples against the Pi extension API (`pi.registerTool`, `pi.on("session_start", ...)`), and whether the security warning is strong enough for third-party-repo runs.
- **Start here:** `packages/docs-web/src/content/docs/getting-started/ai-assistants.md:507` — the web-search recipe; everything else hangs off it.
- **Review order:** web-search recipe → MCP-bridge recipe → `.pi/` warning admonition → capability-matrix "MCP servers" row update.
- **Lower-attention areas:** The capability-matrix row edit (one line, link swap).
- **Known risk or uncertainty:** Exact SDK signatures in the samples should be verified against upstream Pi docs if API drift is reported; the samples follow the API cited in the provider's `resource-loader.ts`.

## Solution

The recipes reuse the extension-loading behavior Archon already has (`config.enableExtensions !== false` in the Pi provider): an operator drops a `.ts` file in `~/.pi/agent/extensions/`, Pi registers its tools at session start inside the same session Archon drives, and the workflow node uses them like any other tool — subject to existing `allowed_tools`/`denied_tools`. The MCP bridge applies the same primitive with the extension acting as the MCP client itself, so Archon sees only regular extension tools. A warning admonition documents that `<cwd>/.pi/extensions/*.ts` and `.pi/settings.json` load automatically on third-party repos unless extensions are disabled, keeping the trust decision explicit for operators running isolated workflows.

## Validation

- `bun install --frozen-lockfile` — pass.
- `cd packages/docs-web && bun run type-check` — pass.
- `cd packages/docs-web && bun run build` — pass (astro build + llms.txt normalization).
- lint-staged prettier ran on commit — pass.
- **Not verified:** Running the sample extensions end-to-end against a live Pi session; they are documented sketches anchored on the API cited in `resource-loader.ts`.

## Links

- Closes #2764
