### PR TITLE
Stabilize the flaky subrun GAP fan-out test on Windows CI

### DIFF
--- a/packages/workflows/src/subrun.test.ts
+++ b/packages/workflows/src/subrun.test.ts
@@ -101,6 +101,11 @@ import type {
   ChildIsolationResult,
 } from './child-isolation';
 
+// A run in one of these statuses still holds the ancestor-aware path lock; this
+// must stay in lockstep with the production collision check in dag-executor.ts.
+const holdsPathLock = (status: WorkflowRun['status']): boolean =>
+  status === 'pending' || status === 'running' || status === 'paused';
+
 // ---------------------------------------------------------------------------
 // Stateful in-memory store — implements just enough of IWorkflowStore to drive
 // the real run lifecycle (create / pause / resume / complete / fail / cancel),
@@ -179,12 +184,7 @@ class InMemoryStore implements IWorkflowStore {
   ): Promise<WorkflowRun | null> {
     const exclude = new Set([self?.id, ...(self?.excludeRunIds ?? [])].filter(Boolean));
     const active = [...this.runs.values()]
-      .filter(
-        r =>
-          r.working_path === workingPath &&
-          (r.status === 'running' || r.status === 'paused' || r.status === 'pending') &&
-          !exclude.has(r.id)
-      )
+      .filter(r => r.working_path === workingPath && holdsPathLock(r.status) && !exclude.has(r.id))
       .sort((a, b) => a.started_at.getTime() - b.started_at.getTime());
     return Promise.resolve(active[0] ? this.clone(active[0]) : null);
   }
@@ -3807,6 +3807,10 @@ nodes:
     expect(result.workflows.map(w => w.workflow.name)).toContain('leaky-slot');
   });
 
+  // The rendezvous wait runs inside executeWorkflow's lock guard, so it counts
+  // fully against this test's clock: the timeout must exceed the rendezvous
+  // deadline (5s) or a loaded CI run dies as a bun-test timeout instead of the
+  // diagnostic rendezvous error.
   it('GAP: concurrent fan-out cancels a sibling unless the child sets mutates_checkout:false', async () => {
     // The path lock (executor.ts, "Siblings are intentionally NOT excluded") means two
     // `workflow:` nodes in one layer collide on the shared checkout: the loser
@@ -3873,7 +3877,7 @@ nodes:
         const deadline = Date.now() + 5000;
         for (;;) {
           const children = await this.findChildRuns(parent.id);
-          const live = children.filter(c => c.status === 'pending' || c.status === 'running');
+          const live = children.filter(c => holdsPathLock(c.status));
           if (live.length >= 2) {
             this.overlapSeen = true;
           }
@@ -3914,7 +3918,7 @@ nodes:
     );
     expect(safeResult.success).toBe(true);
     expect(kids(safeStore, 'parent-fanout-safe-child')).toEqual(['completed', 'completed']);
-  });
+  }, 20000);
 
   it('GAP (#2180 Defect A): a GATING child loses the path lock before it ever reaches its gate', async () => {
     // Fan-out where both children would gate. What actually happens is the PATH LOCK

--- a/packages/workflows/src/subrun.test.ts
+++ b/packages/workflows/src/subrun.test.ts
@@ -172,10 +172,11 @@ class InMemoryStore implements IWorkflowStore {
     return Promise.resolve(out);
   };
 
-  getActiveWorkflowRunByPath = (
+  // Prototype method (not an arrow-field) so store doubles can call it via `super`.
+  getActiveWorkflowRunByPath(
     workingPath: string,
     self?: { id: string; startedAt: Date; excludeRunIds?: string[] }
-  ): Promise<WorkflowRun | null> => {
+  ): Promise<WorkflowRun | null> {
     const exclude = new Set([self?.id, ...(self?.excludeRunIds ?? [])].filter(Boolean));
     const active = [...this.runs.values()]
       .filter(
@@ -186,7 +187,7 @@ class InMemoryStore implements IWorkflowStore {
       )
       .sort((a, b) => a.started_at.getTime() - b.started_at.getTime());
     return Promise.resolve(active[0] ? this.clone(active[0]) : null);
-  };
+  }
 
   resumeWorkflowRun = (id: string): Promise<WorkflowRun> => {
     const r = this.runs.get(id);
@@ -3852,7 +3853,42 @@ nodes:
     };
 
     // Default posture: the sibling is cancelled and the parent run fails.
-    const racyStore = new InMemoryStore();
+    // Whether the collision fires depends on both child rows coexisting in
+    // non-terminal state when either lock query runs; under CI load the children
+    // can serialize end-to-end and both succeed. This store holds each child's
+    // lock query until BOTH child rows exist and are live, so the overlap the test
+    // characterizes is a precondition instead of a chance interleaving.
+    class RendezvousStore extends InMemoryStore {
+      private overlapSeen = false;
+      getActiveWorkflowRunByPath: IWorkflowStore['getActiveWorkflowRunByPath'] = async (
+        path,
+        self
+      ) => {
+        const selfRow = self ? this.runs.get(self.id) : undefined;
+        if (!selfRow?.parent_run_id || this.overlapSeen) {
+          return super.getActiveWorkflowRunByPath(path, self);
+        }
+        const parent = this.runs.get(selfRow.parent_run_id);
+        if (!parent) return super.getActiveWorkflowRunByPath(path, self);
+        const deadline = Date.now() + 5000;
+        for (;;) {
+          const children = await this.findChildRuns(parent.id);
+          const live = children.filter(c => c.status === 'pending' || c.status === 'running');
+          if (live.length >= 2) {
+            this.overlapSeen = true;
+          }
+          if (this.overlapSeen) break;
+          if (Date.now() > deadline) {
+            throw new Error(
+              `rendezvous failed: ${children.length} child rows, ${live.length} live`
+            );
+          }
+          await new Promise(resolve => setTimeout(resolve, 1));
+        }
+        return super.getActiveWorkflowRunByPath(path, self);
+      };
+    }
+    const racyStore = new RendezvousStore();
     const racyResult = await executeWorkflow(
       makeDeps(racyStore),
       makePlatform(),


### PR DESCRIPTION
## Problem and outcome

The `windows-latest` CI leg fails intermittently on the subrun GAP test (`workflow: late resolution is a deliberate affordance > GAP: concurrent fan-out cancels a sibling unless the child sets mutates_checkout:false`): under load the two concurrent child runs serialize end-to-end, so neither lock query ever sees a live sibling, both children succeed, and `expect(racyResult.success).toBe(false)` receives `true`. The windows 5766 ms per-test timeout hits were the same failure mode — the children spent the budget waiting for an overlap that never formed.

- **Outcome:** The sibling-overlap the test characterizes is now a precondition rather than a chance interleaving. 30 consecutive full-file runs and 10 consecutive root-level `bun run test` runs (the CI command) are green.
- **Invariant:** The assertions are untouched: racy child must fail with status in `['cancelled','completed']`; safe-child case must still produce `['completed','completed']`.
- **Scope boundary:** No production code changed. No retries, no skips. The only timeout change is the test's own per-test budget, raised to 20 s so the rendezvous deadline surfaces as its diagnostic error instead of a bun-test timeout under load.
- **Root cause:** Test flake, not a product bug — the executor's path-lock guard is correct; the test just never reliably arranged the concurrency it exercises.

## Review guidance

- **Feedback requested:** Correctness of the rendezvous mechanism (bounded wait, latch) and whether holding child lock queries can deadlock in some interleaving we haven't considered.
- **Start here:** `packages/workflows/src/subrun.test.ts:3865` — the new `RendezvousStore`, which is the entire behavioral change.
- **Review order:** 1) `RendezvousStore` (line ~3865), 2) the arrow-field → prototype-method conversion of `InMemoryStore.getActiveWorkflowRunByPath` (~line 181), 3) confirm the assertion blocks below are byte-identical to before.
- **Lower-attention areas:** The mechanical method conversion — behavior-identical, required because `super.method` is undefined when the base defines methods as instance fields.
- **Known risk or uncertainty:** The windows-latest leg itself could not be observed locally; see Validation.

## Solution

For the racy parent only, a `RendezvousStore extends InMemoryStore` overrides `getActiveWorkflowRunByPath`. Non-child callers pass through immediately. For child runs it polls `findChildRuns(parentId)` until BOTH child rows exist in a lock-holding state (`pending`/`running`/`paused`) — with a 5 s bounded wait that throws an explicit `rendezvous failed` error if overlap is never reached, so the test can never hang or silently pass on a wrong interleaving. Once overlap is observed, an instance latch (`overlapSeen`) releases all subsequent queries so the losing child proceeds to self-cancel without deadlocking.

This is the smallest coherent fix: it changes only the test harness store, keeps the executor/dag-executor contract exactly as exercised before, and makes the flake impossible by construction instead of masking it.

Enabling detail: `InMemoryStore.getActiveWorkflowRunByPath` moved from an arrow-function instance field to a prototype method (behavior identical), because a subclass cannot reach an instance field via `super`.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | GAP test flakes under CI load when children serialize; windows leg red | Overlap is forced by the harness store; test deterministic |
| **Failure behavior** | `success === true` on the racy path, or 5766 ms timeout | If rendezvous is never reached within 5 s, explicit `rendezvous failed` error |

## Validation

- `bun test src/subrun.test.ts` (packages/workflows, bun 1.3.11, macOS) ×30 consecutive runs — green every time; proves the flake is dead locally.
- `bun run test` from repo root (= CI test step, all packages, parallel) ×10 — green; proves stability under CI-grade co-load.
- Fault-catching preserved: temporarily disabling the path-lock guard in `executor.ts` made the test fail with `success === true`; reverted. Proves the test still catches the regression it exists for.
- `bun run type-check` — pass; `bun run lint --max-warnings 0` — pass.
- Note: bare `bun test` inside `packages/workflows` fails ~919 tests identically on baseline and with this change — pre-existing environment issue (tests expect the root-level filter invocation), unrelated.
- **Not verified:** A green `windows-latest` leg on this PR — CI must supply that evidence; watch the window leg here.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | None — test-only file | Diff touches `subrun.test.ts` only |
| Rollout / rollback | Revert single commit | Single commit `4762b637` |

## Links

- Related: other flaky suspects observed but intentionally left out of scope: systemic >5000 ms bun per-test timeouts on windows-latest across several tests, and providers mode-bit tests asserting POSIX modes on NTFS. Worth separate passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path-lock detection during concurrent workflow runs.
  * Prevented collisions when multiple child runs access the same path simultaneously.
  * Improved compatibility for customized workflow stores.

* **Tests**
  * Strengthened concurrency coverage to make collision checks more reliable and deterministic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->