### PR TITLE
fix(workflows): reject shared context in parallel layers

### DIFF
--- a/packages/docs-web/src/content/docs/book/quick-reference.md
+++ b/packages/docs-web/src/content/docs/book/quick-reference.md
@@ -135,7 +135,7 @@ All nodes share these base fields:
 | `trigger_rule` | No | string | Join semantics when multiple upstreams exist (see Trigger Rules) |
 | `provider` | No | string | Per-node provider override (any registered provider) |
 | `model` | No | string | Per-node model override |
-| `context` | No | `fresh` \| `shared` | Session context — `fresh` starts a new conversation, `shared` inherits from prior node |
+| `context` | No | `fresh` \| `shared` \| `{ resume: node-id }` | Session context — `fresh` starts a new conversation; scalar `shared` inherits the ambient prior session in a sequential layer; named [`resume`](/guides/authoring-workflows/#addressable-session-ancestry) forks one exact upstream session and is required for parallel ancestry |
 | `output_format` | No | JSON Schema | Enforce structured JSON output from this node |
 | `allowed_tools` | No | string[] | Restrict available tools to this list (Claude only) |
 | `denied_tools` | No | string[] | Remove specific tools from this node's context (Claude only) |

--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -218,7 +218,7 @@ nodes:
 | `depends_on` | string[] | `[]` | Node IDs that must complete before this node runs |
 | `when` | string | — | Condition expression. Node is skipped if false. See [Condition Syntax](#when-condition-syntax) |
 | `trigger_rule` | string | `all_success` | Join semantics when multiple upstreams exist. Distinct from a fan-out node's [`fan_out.join`](#the-four-fields), which reduces one node's N children and defaults to `all_done` |
-| `context` | `'fresh'` \| `'shared'` \| `{ resume: node-id }` | — | `fresh` = new session; `shared` = inherit from the ambient prior node; `resume` = fork the exact completed upstream node's session. Defaults to `fresh` for parallel layers, inherited for sequential |
+| `context` | `'fresh'` \| `'shared'` \| `{ resume: node-id }` | — | `fresh` = new session; `shared` = inherit the ambient prior session in a sequential layer; `resume` = fork the exact completed upstream node's session. Parallel layers require named resume or fresh context |
 | `idle_timeout` | number | — | Kill node if idle for this many milliseconds |
 | `retry` | object | — | Per-node retry configuration. See [Retry Configuration](#retry-configuration) |
 | `always_run` | boolean | `false` | Opt out of resume caching: re-run this node on resume even if a prior run completed it. See [Opting Out of Resume Caching](#opting-out-of-resume-caching) |
@@ -274,6 +274,8 @@ nodes:
 ```
 
 `synthesize` forks the exact provider session produced by `scope`; the parallel lenses do not change that ancestry. The source must be a transitively upstream command, prompt, or plain `loop:` node, and the consumer must be a command or prompt node. Addressable resume is not supported inside `loop_group` bodies.
+
+Scalar `context: shared` is only for ambient session threading through a sequential layer. It is rejected on a node in a structurally parallel layer because there is no single unambiguous ambient lineage there. Use named resume as above, or add dependencies to serialize the nodes. This remains a structural rule when sibling `when:` conditions appear mutually exclusive: Archon constructs the parallel layer before evaluating those conditions.
 
 This is an exact, immutable fork contract:
 

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -5758,6 +5758,120 @@ nodes:
     });
   });
 
+  describe('scalar shared session context', () => {
+    function parseSessionContext(yaml: string): ParseResult {
+      return parseWorkflow(yaml, 'session-context.yaml');
+    }
+
+    it('rejects scalar shared on a node in a structurally parallel layer', () => {
+      const result = parseSessionContext(`
+name: parallel-shared
+description: parallel shared
+nodes:
+  - id: source
+    prompt: source
+  - id: shared
+    prompt: continue
+    depends_on: [source]
+    context: shared
+  - id: sibling
+    prompt: independent
+    depends_on: [source]
+`);
+
+      expect(result.error?.error).toContain(
+        "Node 'shared' uses scalar context: 'shared' in a structurally parallel layer"
+      );
+      expect(result.error?.error).toContain('context: { resume: <upstream-node-id> }');
+      expect(result.error?.error).toContain('depends_on');
+    });
+
+    it('rejects scalar shared when parallel sibling conditions appear mutually exclusive', () => {
+      const result = parseSessionContext(`
+name: conditional-parallel-shared
+description: conditional parallel shared
+nodes:
+  - id: choice
+    bash: echo left
+  - id: left
+    prompt: continue left
+    depends_on: [choice]
+    when: "$choice.output == 'left'"
+    context: shared
+  - id: right
+    prompt: start right
+    depends_on: [choice]
+    when: "$choice.output == 'right'"
+`);
+
+      expect(result.error?.error).toContain(
+        "Node 'left' uses scalar context: 'shared' in a structurally parallel layer"
+      );
+    });
+
+    it('accepts scalar shared in a sequential chain', () => {
+      const result = parseSessionContext(`
+name: sequential-shared
+description: sequential shared
+nodes:
+  - id: source
+    prompt: source
+  - id: continuation
+    prompt: continue
+    depends_on: [source]
+    context: shared
+`);
+
+      expect(result.error).toBeNull();
+    });
+
+    it('accepts named resume in a structurally parallel layer', () => {
+      const result = parseSessionContext(`
+name: parallel-named-resume
+description: parallel named resume
+provider: claude
+nodes:
+  - id: source
+    prompt: source
+  - id: continuation
+    prompt: continue
+    depends_on: [source]
+    context: { resume: source }
+  - id: sibling
+    prompt: independent
+    depends_on: [source]
+`);
+
+      expect(result.error).toBeNull();
+    });
+
+    it('rejects scalar shared in a structurally parallel loop_group body', () => {
+      const result = parseSessionContext(`
+name: loop-group-parallel-shared
+description: loop group parallel shared
+nodes:
+  - id: group
+    loop_group:
+      until: DONE
+      max_iterations: 2
+      nodes:
+        - id: source
+          prompt: source
+        - id: shared
+          prompt: continue
+          depends_on: [source]
+          context: shared
+        - id: sibling
+          prompt: independent
+          depends_on: [source]
+`);
+
+      expect(result.error?.error).toContain("loop_group 'group' body: Node 'shared'");
+      expect(result.error?.error).toContain('context.resume is not supported');
+      expect(result.error?.error).toContain('depends_on');
+    });
+  });
+
   describe('addressable session resume', () => {
     function parseAddressable(yaml: string): ParseResult {
       return parseWorkflow(yaml, 'addressable.yaml');

--- a/packages/workflows/src/loader.ts
+++ b/packages/workflows/src/loader.ts
@@ -791,23 +791,50 @@ export function validateDagStructure(
     }
   }
 
-  const queue = nodes.filter(n => (inDegree.get(n.id) ?? 0) === 0).map(n => n.id);
+  let ready = nodes.filter(n => (inDegree.get(n.id) ?? 0) === 0).map(n => n.id);
+  const layers: string[][] = [];
   let visited = 0;
 
-  while (queue.length > 0) {
-    const nodeId = queue.shift();
-    if (nodeId === undefined) break;
-    visited++;
-    for (const dep of dependents.get(nodeId) ?? []) {
-      const newDegree = (inDegree.get(dep) ?? 0) - 1;
-      inDegree.set(dep, newDegree);
-      if (newDegree === 0) queue.push(dep);
+  while (ready.length > 0) {
+    layers.push(ready);
+    const nextIds: string[] = [];
+    for (const nodeId of ready) {
+      visited++;
+      for (const dep of dependents.get(nodeId) ?? []) {
+        const newDegree = (inDegree.get(dep) ?? 0) - 1;
+        inDegree.set(dep, newDegree);
+        if (newDegree === 0) nextIds.push(dep);
+      }
     }
+    ready = nextIds;
   }
 
   if (visited < nodes.length) {
     const cycleNodes = nodes.filter(n => (inDegree.get(n.id) ?? 0) > 0).map(n => n.id);
     return `Cycle detected among nodes: ${cycleNodes.join(', ')}`;
+  }
+
+  // Scalar `shared` inherits one ambient sequential cursor. A multi-node ready set is
+  // the executor's exact definition of a parallel layer; it clears that cursor before
+  // evaluating `when:` or dispatching either sibling. Reject the otherwise silent no-op
+  // here, while the graph is still being loaded. Explicit named resume owns deliberate
+  // parallel ancestry (#2099/#2643).
+  for (const layer of layers) {
+    if (layer.length < 2) continue;
+    const sharedNode = layer
+      .map(nodeId => nodesById.get(nodeId))
+      .find(
+        (node): node is DagNode =>
+          node !== undefined &&
+          !isIncludeDirective(node) &&
+          isAgentNode(node) &&
+          node.context === 'shared'
+      );
+    if (sharedNode === undefined) continue;
+    if (enclosingNodes !== undefined) {
+      return `Node '${sharedNode.id}' uses scalar context: 'shared' in a structurally parallel loop_group body. Scalar 'shared' only inherits the ambient session in sequential layers. Serialize the body nodes with 'depends_on' or use fresh context; context.resume is not supported inside loop_group bodies`;
+    }
+    return `Node '${sharedNode.id}' uses scalar context: 'shared' in a structurally parallel layer. Scalar 'shared' only inherits the ambient session in sequential layers. Use 'context: { resume: <upstream-node-id> }' to fork an exact upstream session, or serialize the nodes with 'depends_on'`;
   }
 
   const directDeps = new Map<string, string[]>(nodes.map(n => [n.id, n.depends_on ?? []]));


### PR DESCRIPTION
## Problem and outcome

`context: shared` could be authored on agent nodes in the same structurally parallel layer, even though the executor clears the ambient session cursor before dispatching that layer. Those nodes therefore started fresh instead of sharing context, with no author-facing error.

This change makes that invalid shape fail at workflow load time. Scalar `context: shared` remains the sequential ambient-session contract; parallel nodes must name an upstream session with `context: { resume: <upstream-node-id> }` or be serialized with dependencies.

The rule is structural and also applies when sibling `when:` conditions are mutually exclusive, matching how the executor builds a layer before evaluating conditions. This PR does not add provider capability or `sessionFork` machinery; merged #2643 remains the canonical parallel-session path.

## Review guidance

- Start in `packages/workflows/src/loader.ts`, where the existing topological validation now retains ready-set layers and validates scalar shared context after cycle detection.
- Then inspect the focused loader regressions, including conditional siblings and `loop_group` bodies.
- Finally check the authoring guide and quick reference for the sequential/parallel distinction.
- The main compatibility effect is deliberate: workflows that previously received a silent fresh session now fail to load with migration guidance.

## Solution

The loader's existing Kahn traversal now records each ready set as a structural execution layer. After proving the graph is acyclic, it rejects scalar `context: shared` on any agent node in a multi-node layer. Top-level errors direct authors to named resume or serialization; loop-group body errors give only supported remedies because named resume is not available inside loop bodies.

The docs now describe scalar shared context as sequential-only and named resume as the deterministic parallel path.

## Validation

- Before the fix, the five focused regressions produced 3 failures and 2 passes: both invalid parallel forms and the parallel loop body loaded successfully, while sequential shared and named resume already worked.
- `bun test src/loader.test.ts` from `packages/workflows`: 346 pass, 0 fail.
- `bun run validate`: passed.
- `git diff --check`: passed.

## Delivery considerations

Existing workflows with scalar shared context in parallel layers must switch to named resume or add dependencies. No database, configuration, API, or runtime rollout is involved.

## Related documentation

- Updated the workflow authoring guide and quick reference.

## Links

Closes #2538

Supersedes #2539

Plan: https://github.com/coleam00/Archon/issues/2538#issuecomment-5398925483


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that shared session context is supported only through sequential workflow layers.
  * Documented restrictions for parallel layers and loop groups, including alternatives using named resume contexts or explicit dependencies.
  * Added details on exact-session fork behavior and parallel ancestry requirements.

* **Bug Fixes**
  * Improved workflow validation to reject unsupported shared context in structurally parallel workflows.
  * Added clearer guidance for resolving invalid parallel context configurations.

* **Tests**
  * Added coverage for sequential, parallel, conditional, loop-group, and resume-context scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->