### PR TITLE
fix(cli): approve after a dashboard approval resumes instead of dead-ending

### DIFF
--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -5870,6 +5870,43 @@ describe('workflowApproveCommand / workflowRejectCommand / workflowResumeCommand
     });
   };
 
+  // The regression this pairs with the inline fix. `dev` grew a read-only
+  // precheck in the detaching parent AFTER the inline fix was first written, so
+  // rebasing forward left the two paths disagreeing: the child approves with
+  // allowAlreadyApproved set, while a strict precheck refused the run before the
+  // child ever started. `--detach` would then dead-end on precisely the case
+  // this command exists to unblock, and the parent's own comment says the gate
+  // must be "the SAME gate approveWorkflow enforces — not a copy of one branch".
+  it('approve --detach still spawns when the gate was already approved from the dashboard', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      ...pausedRun,
+      metadata: {
+        approval: { nodeId: 'gate', message: 'Approve?', type: 'approval', resolved: 'approved' },
+      },
+    });
+    await silenceLogFile();
+
+    const child = createDetachedChildFixture();
+    const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(child.child);
+    const savedArgv = process.argv;
+    process.argv = ['bun', '/abs/cli.ts', 'workflow', 'approve', 'run-123', '--detach'];
+    try {
+      const commandPromise = workflowApproveCommand(
+        'run-123',
+        undefined,
+        undefined,
+        undefined,
+        true
+      );
+      await finishStartupWindow(commandPromise, spawnSpy);
+      expect(spawnSpy).toHaveBeenCalled();
+    } finally {
+      process.argv = savedArgv;
+      spawnSpy.mockRestore();
+    }
+  });
+
   it('approve --detach spawns a detached child (minus --detach) and performs ZERO writes in the parent', async () => {
     const workflowDb = await import('@archon/core/db/workflows');
     const { executeWorkflow } = await import('@archon/workflows/executor');

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -3892,7 +3892,14 @@ export async function workflowApproveCommand(
       }
       // The SAME gate approveWorkflow enforces — not a copy of one branch of it.
       // A partial copy acks { ok: true } and lets the child die unseen.
-      assertApprovable(run);
+      //
+      // allowAlreadyApproved must match what the child will do, for the same
+      // reason: the child approves with it set, so a strict precheck here would
+      // refuse a dashboard-approved run BEFORE the child ever starts, and
+      // `--detach` would dead-end on exactly the case this command exists to
+      // unblock. The remaining gates inside assertApprovable (unrecognized
+      // suspend reason, child_workflow redirect) still apply — see its doc.
+      assertApprovable(run, { allowAlreadyApproved: true });
       // The child always auto-resumes after approving, and the inline path below
       // refuses a run with no recorded working path. Same check here (message
       // copied verbatim) so the refusal is synchronous instead of buried in a log.
@@ -3914,13 +3921,17 @@ export async function workflowApproveCommand(
   if (json) {
     try {
       const resolvedId = await resolveRunIdArg(runId, cwd);
-      const result = await approveWorkflow(resolvedId, comment);
+      // allowAlreadyApproved: a gate approved from the dashboard is recorded but
+      // not resumed on a CLI-created run, so `approve` is the natural next command
+      // and must not dead-end on "already approved". See ApproveWorkflowOptions.
+      const result = await approveWorkflow(resolvedId, comment, { allowAlreadyApproved: true });
       await writeJsonLine({
         ok: true,
         runId: resolvedId,
         action: 'approve',
         type: result.type,
         workflowName: result.workflowName,
+        alreadyApproved: result.alreadyApproved === true,
         resumable: true,
       });
     } catch (error) {
@@ -3930,7 +3941,9 @@ export async function workflowApproveCommand(
   }
 
   const resolvedId = await resolveRunIdArg(runId, cwd);
-  const result = await approveWorkflow(resolvedId, comment);
+  // See the JSON branch above: approving a gate the dashboard already resolved
+  // must resume rather than dead-end.
+  const result = await approveWorkflow(resolvedId, comment, { allowAlreadyApproved: true });
 
   // CLI auto-resumes after approval, as chat does since #2565. `--json` (handled
   // above) is the one surface that records the decision without continuing.
@@ -3940,7 +3953,11 @@ export async function workflowApproveCommand(
         'Cannot determine where to resume.'
     );
   }
-  console.log(`Approved workflow: ${result.workflowName}`);
+  console.log(
+    result.alreadyApproved
+      ? `Already approved (resolved elsewhere, e.g. the dashboard): ${result.workflowName}`
+      : `Approved workflow: ${result.workflowName}`
+  );
   console.log(`Path: ${result.workingPath}`);
   console.log('');
   console.log('Resuming workflow...');

--- a/packages/core/src/operations/workflow-operations.test.ts
+++ b/packages/core/src/operations/workflow-operations.test.ts
@@ -396,6 +396,106 @@ describe('approveWorkflow', () => {
     expect(mockUpdateWorkflowRun).not.toHaveBeenCalled();
   });
 
+  test('allowAlreadyApproved returns the resume context instead of throwing', async () => {
+    // The dashboard resolved this gate; the run has no parent conversation (every
+    // CLI-created run), so tryAutoResumeAfterGate returned early and nothing
+    // resumed it. `archon workflow approve` is the natural next command and must
+    // hand back the resume context rather than dead-ending on "already approved".
+    const run = makePausedRun({
+      metadata: {
+        approval: {
+          nodeId: 'review',
+          message: 'Please review',
+          type: 'approval',
+          resolved: 'approved',
+        },
+      },
+    });
+    mockGetWorkflowRun.mockResolvedValueOnce(run);
+
+    const result = await approveWorkflow('run-1', undefined, { allowAlreadyApproved: true });
+
+    expect(result.alreadyApproved).toBe(true);
+    expect(result.workingPath).toBe(run.working_path);
+    expect(result.workflowName).toBe(run.workflow_name);
+    expect(result.type).toBe('approval_gate');
+    // Nothing is being RESOLVED here, only read: no second CAS, no duplicate
+    // audit event, no double-counted telemetry.
+    expect(mockResolveApprovalGate).not.toHaveBeenCalled();
+    expect(mockCreateWorkflowEvent).not.toHaveBeenCalled();
+    expect(mockCaptureApprovalResolved).not.toHaveBeenCalled();
+    expect(mockUpdateWorkflowRun).not.toHaveBeenCalled();
+  });
+
+  test('allowAlreadyApproved does not bypass the child_workflow redirect', async () => {
+    // The opt-in is checked INSIDE assertApprovable, after every other gate, so
+    // that a resolved sub-run pause still redirects to the child. Checking it
+    // before the call would have been the obvious rebase and would silently
+    // stamp a node_completed on the parent with empty output, discard the
+    // child's real output on resume, and orphan the still-paused child.
+    const run = makePausedRun({
+      metadata: {
+        approval: {
+          nodeId: 'sub',
+          message: 'waiting on child',
+          type: 'child_workflow',
+          childRunId: 'child-9',
+          resolved: 'approved',
+        },
+      },
+    });
+    mockGetWorkflowRun.mockResolvedValueOnce(run);
+
+    await expect(
+      approveWorkflow('run-1', undefined, { allowAlreadyApproved: true })
+    ).rejects.toThrow('child-9');
+    expect(mockResolveApprovalGate).not.toHaveBeenCalled();
+  });
+
+  test('allowAlreadyApproved does not bypass the unrecognized-gate refusal', async () => {
+    // Same reasoning: a gate this build cannot resolve must refuse whether or
+    // not it has been marked approved elsewhere. Opting into idempotency says
+    // "do not dead-end on a decision already made", never "resolve something
+    // you do not understand".
+    const run = makePausedRun({
+      metadata: {
+        approval: {
+          nodeId: 'gate',
+          message: 'm',
+          type: 'some_future_gate_type',
+          resolved: 'approved',
+        },
+      },
+    });
+    mockGetWorkflowRun.mockResolvedValueOnce(run);
+
+    await expect(
+      approveWorkflow('run-1', undefined, { allowAlreadyApproved: true })
+    ).rejects.toThrow('unrecognized gate type');
+    expect(mockResolveApprovalGate).not.toHaveBeenCalled();
+  });
+
+  test('allowAlreadyApproved still throws on an already-REJECTED gate', async () => {
+    // Opt-in idempotency covers approval only. Treating a rejected gate as
+    // approvable would silently overturn the decision.
+    const run = makePausedRun({
+      metadata: {
+        approval: {
+          nodeId: 'review',
+          message: 'Please review',
+          type: 'approval',
+          resolved: 'rejected',
+        },
+      },
+    });
+    mockGetWorkflowRun.mockResolvedValueOnce(run);
+
+    await expect(
+      approveWorkflow('run-1', undefined, { allowAlreadyApproved: true })
+    ).rejects.toThrow('already rejected and is awaiting resume');
+    expect(mockResolveApprovalGate).not.toHaveBeenCalled();
+  });
+
   test('concurrent loser (CAS miss) writes NO events or telemetry (#2113)', async () => {
     // Both callers read an UNRESOLVED gate (fast-path passes), but only one wins
     // the atomic CAS. The loser must not duplicate events/telemetry.

--- a/packages/core/src/operations/workflow-operations.ts
+++ b/packages/core/src/operations/workflow-operations.ts
@@ -36,6 +36,12 @@ export interface WorkflowStatusData {
 }
 
 export interface ApprovalOperationResult {
+  /**
+   * True when the gate was ALREADY resolved as approved and this call returned
+   * the resume context instead of recording a fresh approval. Only ever set
+   * when the caller opts in via `allowAlreadyApproved`.
+   */
+  alreadyApproved?: boolean;
   workflowName: string;
   workingPath: string | null;
   userMessage: string | null;
@@ -237,7 +243,10 @@ function resolvedNodeCompletedStepName(approval: ApprovalContext): string {
     : approval.nodeId;
 }
 
-export function assertApprovable(run: WorkflowRun): ApprovalContext {
+export function assertApprovable(
+  run: WorkflowRun,
+  options?: { allowAlreadyApproved?: boolean }
+): ApprovalContext {
   if (run.status !== 'paused') {
     throw new Error(
       `Cannot approve run with status '${run.status}'. Only paused runs can be approved.`
@@ -273,6 +282,14 @@ export function assertApprovable(run: WorkflowRun): ApprovalContext {
     );
   }
   if (isGateResolved(approval)) {
+    // Opt-in idempotency, checked HERE rather than before the call so that every
+    // gate above still runs: a resolved `child_workflow` pause must still
+    // redirect to the child, and an unrecognized suspend reason must still
+    // refuse, regardless of who is asking. The caller distinguishes this return
+    // from a fresh one with its own isGateResolved check.
+    if (options?.allowAlreadyApproved && approval.resolved === 'approved') {
+      return approval;
+    }
     // Fast-path friendly error for the common (sequential) case. The run stays
     // 'paused' after a resolution, so the status check alone no longer blocks a
     // second approve. This in-memory read can still race a concurrent approve —
@@ -488,6 +505,28 @@ export async function abandonResumableRunsForConversation(
   };
 }
 
+export interface ApproveWorkflowOptions {
+  /**
+   * Return the resume context instead of throwing when the gate is already
+   * resolved as APPROVED.
+   *
+   * A gate approved from the dashboard is recorded but not auto-resumed when the
+   * run has no parent conversation — which is every CLI-created run
+   * (`tryAutoResumeAfterGate` returns early). The run is then paused-and-approved,
+   * and the natural next command, `archon workflow approve`, throws
+   * "already approved and is awaiting resume" — so approving again cannot work and
+   * the only way forward is `archon workflow resume`, which the error does not name.
+   *
+   * Callers whose very next step is to resume (the CLI) can opt in: the user's
+   * intent is unambiguous and the gate already carries the decision. Rejection is
+   * deliberately NOT covered — re-running a reject would re-run its on_reject
+   * prompt, which is a side effect, not an idempotent no-op.
+   *
+   * Off by default, so HTTP and chat callers keep the strict double-resolution error.
+   */
+  allowAlreadyApproved?: boolean;
+}
+
 /**
  * Approve a paused workflow run.
  *
@@ -499,10 +538,28 @@ export async function abandonResumableRunsForConversation(
  */
 export async function approveWorkflow(
   runId: string,
-  comment?: string
+  comment?: string,
+  options?: ApproveWorkflowOptions
 ): Promise<ApprovalOperationResult> {
   const run = await getRunOrThrow(runId, 'operations.workflow_approve_lookup_failed');
-  const approval = assertApprovable(run);
+  const approval = assertApprovable(run, {
+    allowAlreadyApproved: options?.allowAlreadyApproved === true,
+  });
+  if (isGateResolved(approval)) {
+    // Opt-in idempotency: the gate already says approved, so hand back the same
+    // resume context a fresh approval would have produced. No CAS, no second
+    // audit event, no telemetry — nothing is being resolved here, only read.
+    // Only reachable when the caller opted in; assertApprovable throws otherwise.
+    return {
+      alreadyApproved: true,
+      workflowName: run.workflow_name,
+      workingPath: run.working_path,
+      userMessage: run.user_message,
+      codebaseId: run.codebase_id,
+      conversationId: run.conversation_id,
+      type: approval.type === 'interactive_loop' ? 'interactive_loop' : 'approval_gate',
+    };
+  }
 
   // Whitespace-only comments count as absent (mirrors feedbackProvided below):
   // HTTP/CLI/chat pass the raw comment through since #2074, so '   ' would


### PR DESCRIPTION
## The problem

Approving a **CLI-created** run from the dashboard leaves it unrecoverable by any obvious next command.

`tryAutoResumeAfterGate` returns early when a run has no `parent_conversation_id` — which is every run created by `archon workflow run`. That behaviour is correct and documented as non-fatal (*"the gate decision is recorded regardless"*), so the run is left **paused-and-approved**.

The natural next command is then `archon workflow approve <id>`, which throws:

```
Workflow run <id> was already approved and is awaiting resume.
```

Approving again cannot work — the gate is already resolved. The error names the *state* but not the *way out*, so the run looks dead. The real recovery is `archon workflow resume <id> --cwd <worktree>`, which nothing points you to.

## The change

Make the CLI's approve idempotent for exactly that case. When the gate is already resolved as APPROVED, `approveWorkflow` can return the same resume context a fresh approval would have produced, and the CLI proceeds to its existing auto-resume. The user's intent is unambiguous and the decision is already recorded.

Deliberately narrow:

- **Opt-in** via `ApproveWorkflowOptions.allowAlreadyApproved`. HTTP and chat callers keep the strict double-resolution error, unchanged.
- **APPROVED only.** An already-REJECTED gate still throws — treating it as approvable would silently overturn the decision. Rejection is also not idempotent in general: re-running a reject re-runs its `on_reject` prompt, which is a side effect.
- **Purely a read.** No second CAS, no duplicate audit event, no double-counted telemetry — asserted in the new tests.
- `alreadyApproved` is surfaced on the result, so the CLI prints *"Already approved (resolved elsewhere, e.g. the dashboard)"* rather than claiming it approved something, and `--json` reports it as a field.

## Tests

```
bun test packages/core/src/operations/workflow-operations.test.ts
36 pass, 0 fail
```

Two new cases: the resume context is returned with no CAS/events/telemetry, and an already-rejected gate still throws.

## Pre-existing failures, unrelated to this change

Flagging so they aren't attributed here — all verified identical on an unmodified checkout:

- `bun run type-check` fails in `packages/providers/src/claude/provider.ts` (TS2367) and `packages/providers/src/community/pi/provider.ts` (TS2307, missing optional `@earendil-works/pi-ai/compat`).
- `bun run lint` fails on the same `pi/provider.ts`.
- 17 tests in `packages/cli/src/commands` fail on a clean checkout — confirmed with and without a `.env` present.

Pre-commit hooks (eslint --fix, prettier) ran clean on the three files touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Workflow approvals now support gates already approved elsewhere, including through the dashboard.
  - CLI and detached approval flows resume correctly when a gate was previously resolved.
  - JSON output identifies previously approved gates with an `alreadyApproved` indicator.

- **Bug Fixes**
  - Prevented duplicate approval actions and related side effects for already-approved gates.
  - Preserved validation and error handling for rejected, unsupported, and redirected approval scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->