### PR TITLE
fix(workflows): until_bash fails on unavailable output refs

### DIFF
--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -963,6 +963,59 @@ describe('substituteNodeOutputRefs', () => {
     expect(warnCalls[0]?.[0]).toEqual(expect.objectContaining({ nodeId: 'missing' }));
   });
 
+  it('required mode rejects a missing whole-output ref with consumer context and a hint', () => {
+    const outputs = new Map([['analyze', makeOutput('completed', 'ready')]]);
+
+    expect(() =>
+      substituteNodeOutputRefs('test $analze.output = ready', outputs, true, undefined, {
+        consumerId: 'review-loop',
+        field: 'loop_group.until_bash',
+      })
+    ).toThrow(
+      "Node 'review-loop' field 'loop_group.until_bash' cannot resolve '$analze.output': node 'analze' has not produced output at this point. Did you mean: 'analyze'?"
+    );
+  });
+
+  it.each(['skipped', 'pending'] as const)(
+    'required mode rejects a %s whole-output producer instead of fabricating empty text',
+    state => {
+      const outputs = new Map([['probe', makeOutput(state)]]);
+
+      expect(() =>
+        substituteNodeOutputRefs('test $probe.output != pending', outputs, true, undefined, {
+          consumerId: 'poll',
+          field: 'loop.until_bash',
+        })
+      ).toThrow(
+        "Node 'poll' field 'loop.until_bash' cannot resolve '$probe.output': node 'probe' did not run"
+      );
+    }
+  );
+
+  it('required mode rejects a failed whole-output producer with the owning loop context', () => {
+    const outputs = new Map([['probe', makeOutput('failed', 'stale')]]);
+
+    expect(() =>
+      substituteNodeOutputRefs('test $probe.output = done', outputs, true, undefined, {
+        consumerId: 'poll',
+        field: 'loop.until_bash',
+      })
+    ).toThrow(
+      "Node 'poll' field 'loop.until_bash' cannot resolve '$probe.output': node 'probe' failed (error)"
+    );
+  });
+
+  it('required mode preserves a completed producer whose real output is empty', () => {
+    const outputs = new Map([['probe', makeOutput('completed', '')]]);
+
+    expect(
+      substituteNodeOutputRefs('test -z $probe.output', outputs, true, undefined, {
+        consumerId: 'poll',
+        field: 'loop.until_bash',
+      })
+    ).toBe("test -z ''");
+  });
+
   it('dot notation extracts JSON field', () => {
     const outputs = new Map([['a', makeOutput('completed', JSON.stringify({ type: 'BUG' }))]]);
     expect(substituteNodeOutputRefs('Fix $a.output.type issue', outputs)).toBe('Fix BUG issue');
@@ -1017,6 +1070,17 @@ describe('substituteNodeOutputRefs', () => {
     expect(() => substituteNodeOutputRefs('echo $missing.output.field', outputs, true)).toThrow(
       OutputRefError
     );
+  });
+
+  it('required mode adds the owning until_bash context to a field resolution error', () => {
+    const outputs = new Map<string, NodeOutput>();
+
+    expect(() =>
+      substituteNodeOutputRefs('test $probe.output.state = done', outputs, true, undefined, {
+        consumerId: 'poll',
+        field: 'loop_group.until_bash',
+      })
+    ).toThrow("Node 'poll' field 'loop_group.until_bash' cannot resolve '$probe.output.state'");
   });
 
   it('failed producer (#2713): whole-text $node.output throws instead of splicing stale output', () => {
@@ -8682,6 +8746,61 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
 
       expect(calls).toBe(2);
       expect((await readFile(counterFile, 'utf8')).trim()).toBe('2');
+    });
+
+    it('#2803: loop until_bash fails when an upstream whole-output producer was skipped', async () => {
+      mockSendQueryDag.mockImplementation(async function* () {
+        yield { type: 'assistant', content: 'working' };
+        yield { type: 'result', sessionId: 'loop-required-ref' };
+      });
+      const store = createMockStore();
+      const workflow = workflowDefinitionSchema.parse({
+        name: 'loop-required-output-ref',
+        description: 'A loop must not decide completion from a skipped producer',
+        nodes: [
+          { id: 'gate', bash: "printf 'skip'" },
+          {
+            id: 'probe',
+            bash: "printf 'pending'",
+            depends_on: ['gate'],
+            when: "$gate.output == 'run'",
+          },
+          {
+            id: 'poll',
+            depends_on: ['probe'],
+            trigger_rule: 'all_done',
+            loop: {
+              prompt: 'poll once',
+              until_bash: 'test $probe.output != pending',
+              max_iterations: 1,
+            },
+          },
+        ],
+      });
+
+      await executeDagWorkflow(
+        createMockDeps(store),
+        createMockPlatform(),
+        'conv-dag',
+        testDir,
+        ready(workflow),
+        makeWorkflowRun('loop-required-output-ref'),
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'state'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+
+      const failed = store.createWorkflowEvent.mock.calls
+        .map(([event]) => event)
+        .find(event => event.event_type === 'node_failed' && event.step_name === 'poll');
+      expect(failed?.data?.error).toContain(
+        "Node 'poll' field 'loop.until_bash' cannot resolve '$probe.output'"
+      );
     });
 
     it('reads oversized upstream output in until_bash from the run-owned spill directory', async () => {
@@ -21523,6 +21642,56 @@ describe('executeDagWorkflow -- loop_group node', () => {
     expect(await Bun.file(join(logDir, 'bump.nodeoutput')).exists()).toBe(false);
   });
 
+  it('#2803: loop_group until_bash fails when a direct whole-output producer was skipped', async () => {
+    const store = createMockStore();
+    const workflow = workflowDefinitionSchema.parse({
+      name: 'group-required-output-ref',
+      description: 'A group must not decide completion from a skipped body producer',
+      nodes: [
+        {
+          id: 'poll',
+          loop_group: {
+            until_bash: 'test $probe.output != pending',
+            max_iterations: 1,
+            nodes: [
+              { id: 'gate', bash: "printf 'skip'" },
+              {
+                id: 'probe',
+                bash: "printf 'pending'",
+                depends_on: ['gate'],
+                when: "$gate.output == 'run'",
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    await executeDagWorkflow(
+      createMockDeps(store),
+      createMockPlatform(),
+      'conv-lg',
+      testDir,
+      ready(workflow),
+      makeWorkflowRun('group-required-output-ref'),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    const failed = store.createWorkflowEvent.mock.calls
+      .map(([event]) => event)
+      .find(event => event.event_type === 'node_failed' && event.step_name === 'poll');
+    expect(failed?.data?.error).toContain(
+      "Node 'poll' field 'loop_group.until_bash' cannot resolve '$probe.output'"
+    );
+  });
+
   it('INSTANCE 4: single-node body degenerates like loop: and completes in 1 iteration', async () => {
     // A loop_group with a single prompt node that emits DONE on the very first iteration.
     let calls = 0;
@@ -30068,6 +30237,44 @@ function waitTerminatedLoopGroupWorkflow(): WorkflowDefinition {
   };
 }
 
+function includedProbeWaitTerminatedLoopGroupWorkflow(): WorkflowDefinition {
+  const block = workflowDefinitionSchema.parse({
+    name: 'probe-wait-block',
+    description: 'Included polling loop with a terminal wait',
+    returns: 'await-checks',
+    nodes: [
+      {
+        id: 'await-checks',
+        loop_group: {
+          until_bash: 'test $ci-probe.output != pending',
+          max_iterations: 3,
+          nodes: [
+            { id: 'ci-probe', bash: "printf 'pending'" },
+            { id: 'ci-pause', wait: { duration_ms: 60_000 }, depends_on: ['ci-probe'] },
+          ],
+        },
+      },
+    ],
+  });
+  const parent = workflowDefinitionSchema.parse({
+    name: 'included-probe-wait',
+    description: 'Runs the polling loop through include expansion',
+    nodes: [{ id: 'deliver', include: 'probe-wait-block' }],
+  });
+  const { workflows, errors } = expandWorkflowIncludes(
+    new Map([
+      [block.name, block],
+      [parent.name, parent],
+    ])
+  );
+  if (errors.length > 0) {
+    throw new Error(`included probe fixture failed to expand: ${JSON.stringify(errors)}`);
+  }
+  const expanded = workflows.get(parent.name);
+  if (!expanded) throw new Error('included probe fixture was not expanded');
+  return expanded;
+}
+
 function repeatingWaitTerminatedLoopGroupWorkflow(): WorkflowDefinition {
   return {
     name: 'repeating-wait-terminated-loop-group',
@@ -30273,6 +30480,60 @@ describe('#2707 step 3: gate-terminated loop_group pause escalation', () => {
       bodyWaitId: 'delay',
       iteration: 2,
     });
+  });
+
+  it('#2803: an included wait-resume fails loud when until_bash cannot restore its producer', async () => {
+    const workflow = includedProbeWaitTerminatedLoopGroupWorkflow();
+    const group = workflow.nodes.find(node => node.id === 'deliver__await-checks');
+    expect(group && !('include' in group)).toBe(true);
+    if (!group || 'include' in group || group.kind !== 'loop_group') {
+      throw new Error('expected the included loop_group to be expanded');
+    }
+    expect(group.loop_group.nodes.map(node => node.id)).toEqual(['ci-probe', 'ci-pause']);
+
+    const expiredWait: WorkflowWaitContext = {
+      owner: 'loop_group',
+      nodeId: 'deliver__await-checks',
+      bodyWaitId: 'ci-pause',
+      iteration: 1,
+      sessionId: null,
+      sessionProvider: null,
+      kind: 'time',
+      waitingSince: '2026-08-23T00:00:00.000Z',
+      resumeAt: '2026-08-23T00:01:00.000Z',
+    };
+    const store = createEscalationStore('run-included-missing-probe');
+
+    await executeDagWorkflow(
+      createMockDeps(store),
+      createMockPlatform(),
+      'conv-dag',
+      testDir,
+      ready(workflow),
+      makeWorkflowRun('run-included-missing-probe', { metadata: { wait: expiredWait } }),
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      join(testDir, 'logs'),
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      new Map()
+    );
+
+    expect(store.completeWorkflowRun).not.toHaveBeenCalled();
+    expect(store.failWorkflowRun).toHaveBeenCalledTimes(1);
+    const failed = store.createWorkflowEvent.mock.calls
+      .map(([event]) => event)
+      .find(
+        event => event.event_type === 'node_failed' && event.step_name === 'deliver__await-checks'
+      );
+    expect(failed?.data?.error).toContain(
+      "Node 'deliver__await-checks' field 'loop_group.until_bash' cannot resolve '$ci-probe.output'"
+    );
   });
 
   it('keeps loop ownership when an event signal lands before the pause call returns', async () => {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -1016,6 +1016,22 @@ describe('substituteNodeOutputRefs', () => {
     ).toBe("test -z ''");
   });
 
+  it('required mode preserves an absent field declared optional by the producer', () => {
+    const outputs = new Map([
+      [
+        'probe',
+        makeOutput('completed', '{"state":"pending"}', { state: 'pending' }, ['state', 'note']),
+      ],
+    ]);
+
+    expect(
+      substituteNodeOutputRefs('test -z $probe.output.note', outputs, true, undefined, {
+        consumerId: 'poll',
+        field: 'loop.until_bash',
+      })
+    ).toBe("test -z ''");
+  });
+
   it('dot notation extracts JSON field', () => {
     const outputs = new Map([['a', makeOutput('completed', JSON.stringify({ type: 'BUG' }))]]);
     expect(substituteNodeOutputRefs('Fix $a.output.type issue', outputs)).toBe('Fix BUG issue');
@@ -1072,15 +1088,28 @@ describe('substituteNodeOutputRefs', () => {
     );
   });
 
-  it('required mode adds the owning until_bash context to a field resolution error', () => {
-    const outputs = new Map<string, NodeOutput>();
+  it('required mode preserves the field error cause and nearby-id hint', () => {
+    const outputs = new Map([['analyze', makeOutput('completed', '{"state":"done"}')]]);
+    let caught: unknown;
 
-    expect(() =>
-      substituteNodeOutputRefs('test $probe.output.state = done', outputs, true, undefined, {
+    try {
+      substituteNodeOutputRefs('test $analze.output.state = done', outputs, true, undefined, {
         consumerId: 'poll',
         field: 'loop_group.until_bash',
-      })
-    ).toThrow("Node 'poll' field 'loop_group.until_bash' cannot resolve '$probe.output.state'");
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    const message = (caught as Error).message;
+    expect(message).toContain(
+      "Node 'poll' field 'loop_group.until_bash' cannot resolve '$analze.output.state'"
+    );
+    expect(message).toContain(
+      "references node 'analze', but no node with that id has produced output"
+    );
+    expect(message).toContain("Did you mean: 'analyze'?");
   });
 
   it('failed producer (#2713): whole-text $node.output throws instead of splicing stale output', () => {
@@ -8754,6 +8783,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         yield { type: 'result', sessionId: 'loop-required-ref' };
       });
       const store = createMockStore();
+      const markerPath = join(testDir, 'loop-required-ref-ran.marker');
       const workflow = workflowDefinitionSchema.parse({
         name: 'loop-required-output-ref',
         description: 'A loop must not decide completion from a skipped producer',
@@ -8771,7 +8801,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             trigger_rule: 'all_done',
             loop: {
               prompt: 'poll once',
-              until_bash: 'test $probe.output != pending',
+              until_bash: `printf ran > ${JSON.stringify(markerPath)}; test $probe.output != pending`,
               max_iterations: 1,
             },
           },
@@ -8801,6 +8831,7 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       expect(failed?.data?.error).toContain(
         "Node 'poll' field 'loop.until_bash' cannot resolve '$probe.output'"
       );
+      expect(await Bun.file(markerPath).exists()).toBe(false);
     });
 
     it('reads oversized upstream output in until_bash from the run-owned spill directory', async () => {
@@ -21644,6 +21675,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
 
   it('#2803: loop_group until_bash fails when a direct whole-output producer was skipped', async () => {
     const store = createMockStore();
+    const markerPath = join(testDir, 'group-required-ref-ran.marker');
     const workflow = workflowDefinitionSchema.parse({
       name: 'group-required-output-ref',
       description: 'A group must not decide completion from a skipped body producer',
@@ -21651,7 +21683,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
         {
           id: 'poll',
           loop_group: {
-            until_bash: 'test $probe.output != pending',
+            until_bash: `printf ran > ${JSON.stringify(markerPath)}; test $probe.output != pending`,
             max_iterations: 1,
             nodes: [
               { id: 'gate', bash: "printf 'skip'" },
@@ -21690,6 +21722,7 @@ describe('executeDagWorkflow -- loop_group node', () => {
     expect(failed?.data?.error).toContain(
       "Node 'poll' field 'loop_group.until_bash' cannot resolve '$probe.output'"
     );
+    expect(await Bun.file(markerPath).exists()).toBe(false);
   });
 
   it('INSTANCE 4: single-node body degenerates like loop: and completes in 1 iteration', async () => {
@@ -30237,7 +30270,7 @@ function waitTerminatedLoopGroupWorkflow(): WorkflowDefinition {
   };
 }
 
-function includedProbeWaitTerminatedLoopGroupWorkflow(): WorkflowDefinition {
+function includedProbeWaitTerminatedLoopGroupWorkflow(markerPath: string): WorkflowDefinition {
   const block = workflowDefinitionSchema.parse({
     name: 'probe-wait-block',
     description: 'Included polling loop with a terminal wait',
@@ -30246,7 +30279,7 @@ function includedProbeWaitTerminatedLoopGroupWorkflow(): WorkflowDefinition {
       {
         id: 'await-checks',
         loop_group: {
-          until_bash: 'test $ci-probe.output != pending',
+          until_bash: `printf ran > ${JSON.stringify(markerPath)}; test $ci-probe.output != pending`,
           max_iterations: 3,
           nodes: [
             { id: 'ci-probe', bash: "printf 'pending'" },
@@ -30483,7 +30516,8 @@ describe('#2707 step 3: gate-terminated loop_group pause escalation', () => {
   });
 
   it('#2803: an included wait-resume fails loud when until_bash cannot restore its producer', async () => {
-    const workflow = includedProbeWaitTerminatedLoopGroupWorkflow();
+    const markerPath = join(testDir, 'included-resume-required-ref-ran.marker');
+    const workflow = includedProbeWaitTerminatedLoopGroupWorkflow(markerPath);
     const group = workflow.nodes.find(node => node.id === 'deliver__await-checks');
     expect(group && !('include' in group)).toBe(true);
     if (!group || 'include' in group || group.kind !== 'loop_group') {
@@ -30534,6 +30568,7 @@ describe('#2707 step 3: gate-terminated loop_group pause escalation', () => {
     expect(failed?.data?.error).toContain(
       "Node 'deliver__await-checks' field 'loop_group.until_bash' cannot resolve '$ci-probe.output'"
     );
+    expect(await Bun.file(markerPath).exists()).toBe(false);
   });
 
   it('keeps loop ownership when an event signal lands before the pause call returns', async () => {

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -1361,6 +1361,21 @@ function shellQuoteOrFile(
   return shellQuote(value);
 }
 
+interface RequiredOutputRefContext {
+  consumerId: string;
+  field: 'loop.until_bash' | 'loop_group.until_bash';
+}
+
+function requiredOutputRefError(
+  context: RequiredOutputRefContext,
+  ref: string,
+  detail: string
+): Error {
+  return new Error(
+    `Node '${context.consumerId}' field '${context.field}' cannot resolve '${ref}': ${detail}`
+  );
+}
+
 /**
  * Substitute $node_id.output and $node_id.output.field references in a prompt.
  * Called AFTER the standard substituteWorkflowVariables pass.
@@ -1375,12 +1390,16 @@ function shellQuoteOrFile(
  * @param escapedForBash - When true, wraps substituted values in single quotes so
  *   they are safe to embed in bash scripts passed to `bash -c`. Set true only for
  *   bash node script substitution; AI/command prompt substitution should use false.
+ * @param requiredContext - Makes unavailable whole-output refs fail with the owning
+ *   decision surface named. Used by `until_bash`; other callers keep the legacy empty
+ *   fallback. Field refs remain strict in either mode.
  */
 export function substituteNodeOutputRefs(
   prompt: string,
   nodeOutputs: Map<string, NodeOutput>,
   escapedForBash = false,
-  artifactsDir?: string
+  artifactsDir?: string,
+  requiredContext?: RequiredOutputRefContext
 ): string {
   return prompt.replace(
     /\$([a-zA-Z_][a-zA-Z0-9_-]*)\.output(?:\.([a-zA-Z_][a-zA-Z0-9_]*))?/g,
@@ -1392,20 +1411,50 @@ export function substituteNodeOutputRefs(
         // output is unavailable on this execution path) fails the consuming node loudly,
         // matching the strict
         // no-silent-drop posture for known-producer field access below. The whole-text
-        // `$id.output` form stays lenient ('') as a long-documented surface (changing
-        // it is a bigger compatibility break).
+        // `$id.output` form stays lenient ('') by default as a long-documented surface.
+        // `until_bash` opts into requiredContext because empty text would become an
+        // input to a completion decision rather than merely missing display text.
         if (field) {
-          throw new OutputRefError(
+          const error = new OutputRefError(
             nodeId,
             field,
             'unknown-node',
             similarNodeIds(nodeId, nodeOutputs.keys())
+          );
+          throw requiredContext
+            ? requiredOutputRefError(requiredContext, match, error.message)
+            : error;
+        }
+        if (requiredContext) {
+          const candidates = similarNodeIds(nodeId, nodeOutputs.keys());
+          const hint =
+            candidates.length > 0
+              ? ` Did you mean: ${candidates.map(candidate => `'${candidate}'`).join(', ')}?`
+              : '';
+          throw requiredOutputRefError(
+            requiredContext,
+            match,
+            `node '${nodeId}' has not produced output at this point.${hint} Fix the id, or ensure '${nodeId}' runs before this check.`
           );
         }
         getLog().warn({ nodeId, match }, 'dag_node_output_ref_unknown_node');
         return escapedForBash ? "''" : '';
       }
       if (!field) {
+        if (requiredContext && (nodeOutput.state === 'skipped' || nodeOutput.state === 'pending')) {
+          throw requiredOutputRefError(
+            requiredContext,
+            match,
+            `node '${nodeId}' did not run (skipped or pending), so it has no output to read. Fix the dependency or guard the consuming loop.`
+          );
+        }
+        if (requiredContext && nodeOutput.state === 'failed') {
+          throw requiredOutputRefError(
+            requiredContext,
+            match,
+            `node '${nodeId}' failed (${nodeOutput.error}), so its output cannot be trusted. Fix the failure or guard the consuming loop.`
+          );
+        }
         // A failed producer's stale output is never spliced into a consumer's own
         // prompt/bash/command body (#2713) — matches resolveBindingDirective's #2710
         // guard for the same class of bug (a loop_group's failure paths leave real,
@@ -1431,7 +1480,15 @@ export function substituteNodeOutputRefs(
       // key). The throw propagates to the dag-executor's per-node catch → the
       // consuming node fails visibly instead of receiving a poisoned ''. The only
       // value that resolves to empty is an author-declared-optional field.
-      const resolution = resolveNodeOutputField(nodeOutput, nodeId, field);
+      let resolution: ReturnType<typeof resolveNodeOutputField>;
+      try {
+        resolution = resolveNodeOutputField(nodeOutput, nodeId, field);
+      } catch (error) {
+        if (requiredContext && error instanceof OutputRefError) {
+          throw requiredOutputRefError(requiredContext, match, error.message);
+        }
+        throw error;
+      }
       if (resolution.kind === 'empty') return escapedForBash ? "''" : '';
       const value = resolution.value;
       // numbers and booleans are shell-safe without quoting: JSON disallows
@@ -4692,7 +4749,8 @@ async function executeLoopGroupNode(
           resumedBashPrompt,
           resumedScope,
           true, // escapedForBash
-          artifactsDir
+          artifactsDir,
+          { consumerId: node.id, field: 'loop_group.until_bash' }
         );
         const resumedBashPath = resolveBashPath();
         try {
@@ -5162,7 +5220,8 @@ async function executeLoopGroupNode(
           bashPrompt,
           scopedNodeOutputs,
           true, // escapedForBash
-          artifactsDir
+          artifactsDir,
+          { consumerId: node.id, field: 'loop_group.until_bash' }
         );
         await runSubprocess(execContext, groupBashPath, ['-c', substitutedBash], {
           cwd,
@@ -6860,7 +6919,8 @@ async function executeLoopNode(
           bashPrompt,
           nodeOutputs,
           true, // escapedForBash
-          artifactsDir
+          artifactsDir,
+          { consumerId: node.id, field: 'loop.until_bash' }
         );
         await runSubprocess(execContext, loopBashPath, ['-c', substitutedBash], {
           cwd,

--- a/packages/workflows/src/output-ref.ts
+++ b/packages/workflows/src/output-ref.ts
@@ -42,8 +42,10 @@
  * handled by the callers, not `resolveNodeOutputField` — they own the outputs map.
  * A `.field` ref to such an id throws `OutputRefError('unknown-node')` there, so it
  * fails the consuming node loudly, consistent with the strict field posture above;
- * a whole-text `$typo.output` to an unresolved id stays lenient ('') as a
- * long-documented surface. See `similarNodeIds`.
+ * a whole-text `$typo.output` to an unresolved id stays lenient ('') on the
+ * long-documented prompt/script surfaces. `until_bash` opts into a required-output
+ * policy at its substitution call sites because an empty fallback would decide loop
+ * completion. See `similarNodeIds`.
  */
 import { z } from '@hono/zod-openapi';
 import type { NodeOutput } from './schemas';


### PR DESCRIPTION
## Problem and outcome

An unavailable whole `$node.output` reference in `until_bash` was replaced with empty text, so predicate polarity could accidentally complete or repeat a loop. The completion check must only run against real producer output.

- **Outcome:** `loop.until_bash` and `loop_group.until_bash` now fail before Bash runs when a referenced producer is missing, skipped, pending, or failed.
- **Invariant:** A node-output ref used in `until_bash` either resolves under the existing whole/field contract or fails the owning loop visibly; fabricated empty text never decides completion.
- **Scope boundary:** Other substitution surfaces keep their legacy whole-output fallback. Shell quoting, include expansion, resume ownership, and `$LOOP_PREV` are unchanged.
- **Root cause:** All three `until_bash` paths called the shared substitution helper in its legacy lenient mode, which renders an unknown whole ref as Bash `''`.

## Review guidance

- **Feedback requested:** Check strict producer-state semantics, exact ownership of the opt-in policy, and error propagation across normal and resumed loop-group paths.
- **Start here:** `packages/workflows/src/dag-executor.ts:1364` — defines the required-output context and strict branch on the existing substitution primitive.
- **Review order:** `dag-executor.ts:1364`, then the three call sites around `:4748`, `:5219`, and `:6918`, then the focused regression tests in `dag-executor.test.ts`.
- **Lower-attention areas:** `output-ref.ts` only updates the module contract comment; the full project gate covers it.
- **Known risk or uncertainty:** None for #2803. The distinct authored-quoting gap behind #2794 is tracked in #2806.

## Solution

The shared `$node.output[.field]` substitution primitive now accepts a typed required-output context. Only `until_bash` supplies it. Missing whole refs and unavailable whole producers throw actionable errors naming the consumer, decision field, and full ref; fielded refs continue through the existing strict resolver, with owner context added to its errors. Valid empty completed output and declared-optional fields remain valid values.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Missing whole refs became `''`, and Bash predicate polarity decided completion. | Bash runs only after every node-output ref resolves from an available producer. |
| **Failure behavior** | A loop could complete incorrectly or spin. | The owning loop fails with the consumer, `until_bash` surface, full ref, producer state, and a nearby-ID hint when applicable. |

## Validation

- `cd packages/workflows && bun test src/dag-executor.test.ts -t "substituteNodeOutputRefs"` — 54 passed, 0 failed; proves strict opt-in and unchanged default behavior.
- `cd packages/workflows && bun test src/dag-executor.test.ts -t "until_bash"` — 14 passed, 0 failed; proves normal loop, loop-group, include-expanded, and resumed checks.
- `cd packages/workflows && bun test src/loader.test.ts src/include-expander.test.ts` — 456 passed, 0 failed; proves authored and expanded scope remains valid.
- `cd packages/workflows && bun test src/dag-executor.test.ts` — 653 passed, 0 failed.
- `NODE_OPTIONS=--max-old-space-size=8192 bun run validate` — passed generated-file checks, types, lint, formatting, installer tests, all package tests, and script tests. The larger heap avoided a local ESLint Node heap exhaustion without changing the gate.
- **Not verified:** Nothing material; deterministic execution tests cover every changed runtime boundary and the full repository gate passed.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | Workflows that relied on unavailable predicate input becoming empty now fail; non-decision substitution remains unchanged. No data migration. | Direct legacy-mode and runtime tests. |
| Rollout / rollback | Localized opt-in policy and three callers; no schema or persisted-state change. | Merge-base diff. |
| Observability | Existing `node_failed` events carry the actionable substitution error. | Runtime regression tests assert recorded failure events. |

## Links

- Closes #2803
- Related #2794
- Related #2806
- Plan: https://github.com/coleam00/Archon/issues/2803#issuecomment-5408373742


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Loop completion checks now report clear errors when required upstream outputs are missing, skipped, pending, or failed.
  * Improved error messages identify the affected workflow step and input field, with helpful hints for invalid references.
  * Included polling loops now fail correctly when required outputs cannot be restored after waiting.
* **Documentation**
  * Clarified how unresolved output references behave in prompts, scripts, and loop completion checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->