### PR TITLE
test(cli): make detached owner shutdown specs event-driven

### DIFF
--- a/packages/cli/src/utils/detached-run-control.integration.spec.ts
+++ b/packages/cli/src/utils/detached-run-control.integration.spec.ts
@@ -1,10 +1,11 @@
 import { afterEach, describe, expect, it } from 'bun:test';
 import { spawn, type ChildProcess } from 'node:child_process';
-import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { createConnection, createServer, type Server, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
+  DETACHED_RUN_IPC_TIMEOUT_MS,
   detachedRunControlPath,
   requestDetachedRunStop,
   startDetachedRunControlServer,
@@ -42,6 +43,19 @@ function waitForExit(
   });
 }
 
+// Explicit slack for the shutdown steps after the lease socket's idle timeout
+// fires (socket teardown, server close, endpoint unlink) on a loaded host.
+const LEASE_RELEASE_SLACK_MS = 1_000;
+
+function processExists(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 async function listen(server: Server, path: string): Promise<void> {
   await new Promise<void>((resolve: () => void, reject: (reason?: unknown) => void): void => {
     server.once('error', reject);
@@ -74,8 +88,9 @@ describe('detached run control integration', () => {
     cleanupPaths.push(fixtureDir);
     const readyPath = join(fixtureDir, 'ready');
     const leakPath = join(fixtureDir, 'leaked');
+    const goPath = join(fixtureDir, 'go');
     const fixturePath = join(import.meta.dir, 'fixtures', 'detached-run-owner.ts');
-    const owner = spawn(process.execPath, [fixturePath, runId, readyPath, leakPath], {
+    const owner = spawn(process.execPath, [fixturePath, runId, readyPath, leakPath, goPath], {
       detached: true,
       stdio: 'ignore',
     });
@@ -84,10 +99,22 @@ describe('detached run control integration', () => {
 
     try {
       await waitFor(() => existsSync(readyPath));
+      const pids = JSON.parse(readFileSync(readyPath, 'utf8')) as {
+        owner: number;
+        leakWriter: number;
+      };
+      // The descendant is live and armed before the stop: if the coming stop
+      // failed to take the process group, it would remain able to act on the
+      // go signal, so its death is a meaningful (not vacuous) transition.
+      expect(pids.leakWriter).toBeGreaterThan(0);
+      expect(processExists(pids.leakWriter)).toBe(true);
       const target = await requestDetachedRunStop(runId);
       await target.stop();
       await exited;
-      await new Promise<void>(resolve => setTimeout(resolve, 1_300));
+      // Event-driven proof instead of a fixed sleep: wait for the descendant's
+      // observable death. A dead process cannot act on any future signal.
+      await waitFor(() => !processExists(pids.leakWriter));
+      writeFileSync(goPath, 'go');
       expect(existsSync(leakPath)).toBe(false);
     } finally {
       if (owner.exitCode === null && owner.signalCode === null) {
@@ -110,8 +137,9 @@ describe('detached run control integration', () => {
     cleanupPaths.push(fixtureDir);
     const readyPath = join(fixtureDir, 'ready');
     const leakPath = join(fixtureDir, 'leaked');
+    const goPath = join(fixtureDir, 'go');
     const fixturePath = join(import.meta.dir, 'fixtures', 'detached-run-owner.ts');
-    const owner = spawn(process.execPath, [fixturePath, runId, readyPath, leakPath], {
+    const owner = spawn(process.execPath, [fixturePath, runId, readyPath, leakPath, goPath], {
       stdio: ['ignore', 'ignore', 'pipe'],
     });
     if (owner.pid === undefined) throw new Error('Failed to spawn foreground owner fixture');
@@ -134,12 +162,17 @@ describe('detached run control integration', () => {
       client.once('connect', resolve);
       client.once('error', reject);
     });
+    // The client never sends 'terminate', so the owner-side idle timeout is the
+    // only thing that releases close(). The timeout arms when the owner parses
+    // the stop frame (at or after leaseStartedAt) and never fires early, and
+    // close() must not hang materially past it plus explicit shutdown slack.
+    const leaseStartedAt = Date.now();
     client.write('stop\n');
     await waitFor(() => owner.isStopRequested());
-
-    const startedAt = Date.now();
     await owner.close();
-    expect(Date.now() - startedAt).toBeLessThan(3_000);
+    const elapsedMs = Date.now() - leaseStartedAt;
+    expect(elapsedMs).toBeGreaterThanOrEqual(DETACHED_RUN_IPC_TIMEOUT_MS);
+    expect(elapsedMs).toBeLessThan(DETACHED_RUN_IPC_TIMEOUT_MS + LEASE_RELEASE_SLACK_MS);
     client.destroy();
   });
 

--- a/packages/cli/src/utils/detached-run-control.ts
+++ b/packages/cli/src/utils/detached-run-control.ts
@@ -8,10 +8,13 @@ import { promisify } from 'node:util';
 
 export const DETACHED_RUN_OWNER_ENV = 'ARCHON_DETACHED_RUN_OWNER';
 
+/** Idle-lease lifetime for control sockets; owners release a retained lease after this. */
+export const DETACHED_RUN_IPC_TIMEOUT_MS = 2_000;
+
 const STOP_REQUEST = 'stop\n';
 const TERMINATE_REQUEST = 'terminate\n';
 const TERMINATE_READY = 'ready\n';
-const IPC_TIMEOUT_MS = 2_000;
+const IPC_TIMEOUT_MS = DETACHED_RUN_IPC_TIMEOUT_MS;
 const TERMINATION_GRACE_MS = 5_000;
 const TERMINATION_CONFIRM_MS = 1_000;
 const TERMINATION_LEASE_MS = TERMINATION_GRACE_MS + TERMINATION_CONFIRM_MS + IPC_TIMEOUT_MS;

--- a/packages/cli/src/utils/fixtures/detached-run-owner.ts
+++ b/packages/cli/src/utils/fixtures/detached-run-owner.ts
@@ -5,18 +5,28 @@ import {
   startDetachedRunControlServer,
 } from '../detached-run-control';
 
-const [runId, readyPath, leakPath] = process.argv.slice(2);
-if (!runId || !readyPath || !leakPath) {
-  throw new Error('Usage: detached-run-owner.ts <run-id> <ready-path> <leak-path>');
+const [runId, readyPath, leakPath, goPath] = process.argv.slice(2);
+if (!runId || !readyPath || !leakPath || !goPath) {
+  throw new Error('Usage: detached-run-owner.ts <run-id> <ready-path> <leak-path> <go-path>');
 }
 
 assertDetachedRunProcessOwner();
 
+// The descendant leaks work only when an external go signal appears. The spec
+// decides whether that signal can exist, so a correct process-group kill ends
+// the descendant before any signal is ever written; no wall-clock race remains.
 const leakWriter = spawn(
   process.execPath,
   [
     '-e',
-    `setTimeout(() => require('node:fs').writeFileSync(${JSON.stringify(leakPath)}, 'leaked'), 1200)`,
+    [
+      "const fs = require('node:fs');",
+      'const timer = setInterval(() => {',
+      `  if (!fs.existsSync(${JSON.stringify(goPath)})) return;`,
+      '  clearInterval(timer);',
+      `  fs.writeFileSync(${JSON.stringify(leakPath)}, 'leaked');`,
+      '}, 25);',
+    ].join(''),
   ],
   { stdio: 'ignore' }
 );
@@ -25,5 +35,5 @@ leakWriter.on('error', error => {
 });
 
 await startDetachedRunControlServer(runId);
-writeFileSync(readyPath, String(process.pid));
+writeFileSync(readyPath, JSON.stringify({ owner: process.pid, leakWriter: leakWriter.pid }));
 setInterval(() => undefined, 1_000);


### PR DESCRIPTION
## Problem and outcome

Two specs in `detached-run-control.integration.spec.ts` were wall-clock-bound: one slept a fixed 1300ms before asserting, the other asserted shutdown timing against magic `<3000ms` windows. On loaded windows runners these sat inside Bun's 5000ms default timeout envelope — part of the flake family that produced CI failures across three consecutive runs.

- **Outcome:** both specs are event/state-driven. The leak-writer fixture polls an external go-signal file instead of sleeping on a 1200ms internal timer; shutdown bounds derive from the exported `DETACHED_RUN_IPC_TIMEOUT_MS` constant with an explicit slack constant, which also pins the lower bound (close() cannot resolve before the IPC timeout elapses). No fixed sleeps remain; the first spec now runs in ~83ms.
- **Invariant:** all five specs pass repeatedly; no timeout raises, retries, skips, or tolerance widening.
- **Scope boundary:** product code unchanged except exporting the existing constant for test use.

## Validation

Targeted spec green 5/5 consecutive runs locally + full pass just now; branch pushed from the stabilize-batch child run's worktree.

Part of the stabilize-batch dogfood (#2807 evidence thread).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detached process shutdown handling to reduce the risk of lingering descendant processes.
  - Refined shutdown timing and timeout behavior for more reliable termination.
- **Tests**
  - Added stronger verification that detached processes remain active before shutdown and terminate afterward.
  - Improved detection of leaked processes and made shutdown-duration checks more precise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->