### PR TITLE
ci: allow manual runs of core checks

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -10,6 +10,7 @@ name: Docs Build
 # reason to pay it on the ~95% of PRs that never touch packages/docs-web.
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - 'packages/docs-web/**'

--- a/.github/workflows/marketplace-lint.yml
+++ b/.github/workflows/marketplace-lint.yml
@@ -1,6 +1,7 @@
 name: Marketplace Lint
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - 'packages/docs-web/src/data/marketplace.ts'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Test Suite
 
 on:
+  workflow_dispatch:
   push:
     branches: [main, dev]
   pull_request:


### PR DESCRIPTION
## Problem and outcome

GitHub can occasionally fail to enqueue a workflow after a pull-request event, and three core checks had no direct recovery path.

- **Outcome:** Maintainers can manually run Test Suite, Docs Build, and Marketplace Lint against a selected ref from Actions or the GitHub CLI.
- **Invariant:** Existing push, pull-request, path-filter, job, and permission behavior remains unchanged.
- **Scope boundary:** Marketplace Auto-Review remains event-only because it depends on pull_request_target payload data and write permissions.

## Review guidance

- **Feedback requested:** Confirm each trigger is additive and the event-bound auto-review workflow remains outside this change.
- **Start here:** .github/workflows/test.yml:3 — representative input-free manual trigger.
- **Review order:** Test Suite, Docs Build, then Marketplace Lint.
- **Lower-attention areas:** All three changes are the same one-line workflow event declaration.
- **Known risk or uncertainty:** GitHub only exposes workflow_dispatch after this change reaches the default branch, so the UI path cannot be exercised from the feature branch itself.

## Solution

Each safe, event-independent workflow now declares workflow_dispatch alongside its existing automatic events. No inputs or job conditionals are needed because GitHub supplies the selected ref and the jobs already operate entirely on the checked-out repository state.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | The three checks could only start from automatic events. | Maintainers can also start them manually for a selected ref. |
| **Failure behavior** | A missed pull-request event had no direct rerun path. | A maintainer can dispatch the missing check after this workflow definition reaches dev. |

## Validation

- git diff --check — passed — proves the patch has no whitespace errors.
- bunx prettier --check .github/workflows/test.yml .github/workflows/docs-build.yml .github/workflows/marketplace-lint.yml — passed — proves the workflow files match repository formatting.
- NODE_OPTIONS=--max-old-space-size=8192 bun run validate — passed — proves the repository's full local validation remains green.
- **Not verified:** The GitHub Actions manual-run UI cannot expose a new workflow trigger until the workflow definition exists on the default branch.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Rollout / rollback | Merge to dev to expose the manual controls; rollback is removal of the three additive trigger entries. | Three-line diff in the scoped workflow files. |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added the ability to manually run documentation builds, Marketplace linting, and test suite checks.
  * Existing automatic triggers and pull-request filtering remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->