### PR TITLE
chore(providers): upgrade Codex SDK to 0.150.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -145,7 +145,7 @@
         "@earendil-works/pi-ai": "^0.84.3",
         "@earendil-works/pi-coding-agent": "^0.84.3",
         "@github/copilot-sdk": "~1.0.1",
-        "@openai/codex-sdk": "^0.148.0",
+        "@openai/codex-sdk": "^0.150.1",
         "@opencode-ai/sdk": "^1.17.3",
         "@sinclair/typebox": "^0.34.41",
         "ajv": "^8.20.0",
@@ -779,21 +779,21 @@
 
     "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
 
-    "@openai/codex": ["@openai/codex@0.148.0", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.148.0-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.148.0-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.148.0-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.148.0-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.148.0-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.148.0-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-bh5kH9+BMrFaHGmLeoSansPdfRksvr4UXzjQInns/KRO7r8VJ+6AAW+SqUsE8XcG3+OW/mI4EEy8Gpo9UDXGvQ=="],
+    "@openai/codex": ["@openai/codex@0.150.1", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.150.1-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.150.1-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.150.1-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.150.1-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.150.1-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.150.1-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-knrbhpJH3mEULAVStcZW4F5WEt9MQhBj6KFOonBSIUGTLcHlu9CE7FRmr95E33y94+sWNZSeVBBV/kYvlfgxkQ=="],
 
-    "@openai/codex-darwin-arm64": ["@openai/codex@0.148.0-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-xgBPFiF1fHUlRS7HE6wGB56LjBJh16kGD7b4TTbwdVBZNB4QDkTok+vdkAGrfpVkfKcwGNhPSKDgCw+KMZOVug=="],
+    "@openai/codex-darwin-arm64": ["@openai/codex@0.150.1-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Z614kKSI3/p+YMotBJMxCc4kvRCYEgsVmnaCG6U8HDraqTFxYcQYQ79B4/GBCBS88/KtacHI6qzjA+4Mu5BynA=="],
 
-    "@openai/codex-darwin-x64": ["@openai/codex@0.148.0-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-qepQolhJutfOp+e9i7L3xsi8aoWeCUiiRq274WMWqRj50rKTrXxsuAgkAwDbqEfT3G5VynhYZuQvDsW37JgdNQ=="],
+    "@openai/codex-darwin-x64": ["@openai/codex@0.150.1-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-vcvJ7Q4IP2vA5ZR3v9Pj9VLKtlhD7efujxHqqW/NJ8F2/XqTD4iPjErV07190Om3wONW48yploTgul16QUk9Mg=="],
 
-    "@openai/codex-linux-arm64": ["@openai/codex@0.148.0-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-51DCd+izzk6n4mMh4w2utWj3lTLhSTnCOEJQfRh0LS9nBDkcYZcK3iSKOST6fByRIlLSXuLO33LlYYA1VPot6A=="],
+    "@openai/codex-linux-arm64": ["@openai/codex@0.150.1-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-U0BY5UDsCy1up/O2YzGtVtDbcumNerVyZVVx55PW9gGQsFOL0utOyBJiG/UiocFAXix8JNvNJxYMRt2Jx0FJKg=="],
 
-    "@openai/codex-linux-x64": ["@openai/codex@0.148.0-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-uDT9s7AfMr9xLuJX3ZLVWHgHkUpCnZ33CZjZEdVQhrYCIErkDHsCW5TG290nNjaKngK0WxGt5uCcxeUHv9MWWA=="],
+    "@openai/codex-linux-x64": ["@openai/codex@0.150.1-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-B3Bu5MF/G9qFhbSMrdyZz9ocknXOo45DnOdWrREJaxWTjiuUO1ogoDR0/ttdc29JRFkbbXs3aC+Td8vIx3X0oA=="],
 
-    "@openai/codex-sdk": ["@openai/codex-sdk@0.148.0", "", { "dependencies": { "@openai/codex": "0.148.0" } }, "sha512-NWTd6ZxuwsuNFqFTpONQCnFVCf++g7b8eafScW5Enpv6v2lCXHizpr07iK9U6RFnLEuAP2KFirVUlZnxxY0j6A=="],
+    "@openai/codex-sdk": ["@openai/codex-sdk@0.150.1", "", { "dependencies": { "@openai/codex": "0.150.1" } }, "sha512-/Xp8CM2POoXcZd7MZ+07oXstAgNvflr0Mj7IUPKhyv1HAzaqoedv6PAcgJPUyiNU0vi1lfbkgcJU5QC+lxspSw=="],
 
-    "@openai/codex-win32-arm64": ["@openai/codex@0.148.0-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-a8iOwLzs8UdnlWDHjgK3W/YSBBsUImG8X5XLBjengp3XGJRruhiIsQtUDUOYimCmotKPM4aX7Ub6zjl/KPxMQQ=="],
+    "@openai/codex-win32-arm64": ["@openai/codex@0.150.1-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-8I7N3ppKS1ql9GUr2RHS5Gw+KkRCKfIMIDDK/brxq6HizLgHoDK4CIR0OTvEgdX3Yh/2reBbxr9P4L1e+61e+Q=="],
 
-    "@openai/codex-win32-x64": ["@openai/codex@0.148.0-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-/Jg8eYw0BqTGNUpnrzzWlK2kbu29NWg7t6pnUDEfxqpTUf+mK8r3okXQn60Zjbk9InYZ4d8SwSjrtOa+i5hSPw=="],
+    "@openai/codex-win32-x64": ["@openai/codex@0.150.1-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-1P1tscFnw4A4ip/WN1R5WYPdfuAlxLctPpcE1QAPQnOtbkJR5NX8da4kNTQmiDN/Flx3TLJPDTRHP9Jn435eJg=="],
 
     "@opencode-ai/sdk": ["@opencode-ai/sdk@1.17.3", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-oXrEjOuP3+J9pPNw3cmOnRma/xiVQ4WIIvGd6YkhPQgqqi2PnD/b1qfNY0AMead3QfNhKwKdDM4QFJdN2LpByg=="],
 

--- a/packages/cli/src/commands/ai.test.ts
+++ b/packages/cli/src/commands/ai.test.ts
@@ -345,7 +345,7 @@ describe('aiTierSetCommand', () => {
   });
 
   it('invalid effort for the provider → 1, no write', async () => {
-    expect(await aiTierSetCommand('large', 'claude', 'opus', 'ultra')).toBe(1);
+    expect(await aiTierSetCommand('large', 'claude', 'opus', 'extreme')).toBe(1);
     expect(out()).toContain('Invalid effort');
     expect(mockUpdateGlobalConfig).not.toHaveBeenCalled();
   });

--- a/packages/docs-web/src/content/docs/book/quick-reference.md
+++ b/packages/docs-web/src/content/docs/book/quick-reference.md
@@ -109,8 +109,8 @@ archon workflow run my-workflow "auth refresh-tokens"
 | `nodes` | Yes | array | DAG nodes (see Node Options below) |
 | `provider` | No | string | Registered provider identifier (e.g. `claude`, `codex`). Default: `claude` |
 | `model` | No | string | Model for all nodes (`sonnet`, `opus`, `haiku`, or full model ID) |
-| `effort` | No | string | Reasoning depth on any provider that has one; also a node field: `minimal` \| `low` \| `medium` \| `high` \| `xhigh` \| `max` |
-| `modelReasoningEffort` | No | string | **Deprecated** — translated into `effort` at load (dropped if `effort` is also declared), with a warning: `minimal` \| `low` \| `medium` \| `high` \| `xhigh` |
+| `effort` | No | string | Reasoning depth on any provider that has one; also a node field: `minimal` \| `low` \| `medium` \| `high` \| `xhigh` \| `max` \| `ultra` |
+| `modelReasoningEffort` | No | string | **Deprecated** — translated into `effort` at load (dropped if `effort` is also declared), with a warning: `minimal` \| `low` \| `medium` \| `high` \| `xhigh` \| `max` \| `ultra` |
 | `webSearchMode` | No | string | Codex only, no per-node form. Gates Codex's built-in search tool, not network access: `disabled` \| `cached` \| `live` |
 
 ### Node Options (DAG)

--- a/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
+++ b/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
@@ -233,7 +233,7 @@ You can configure Codex's behavior in `.archon/config.yaml`:
 assistants:
   codex:
     model: gpt-5.6-sol
-    modelReasoningEffort: medium  # 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
+    modelReasoningEffort: medium  # 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra'
                                   # (install default; a workflow's `effort:` overrides it)
     webSearchMode: live           # 'disabled' | 'cached' | 'live'
     additionalDirectories:
@@ -658,7 +658,7 @@ nodes:
 | Extensions (community + local) | ✅ (default on) | `enableExtensions: false` to disable; `interactive: false` to load without UI bridge; `extensionFlags: { <name>: true }` per extension. Scope per node with a `pi:` block (`pi: { interactive, enableExtensions, extensionFlags }`) — see [Scoping extension posture per node](#scoping-extension-posture-per-node) |
 | Session resume | ✅ | automatic (Archon persists `sessionId`) |
 | Tool restrictions | ✅ | `allowed_tools` / `denied_tools` (read, bash, edit, write, grep, find, ls) |
-| Thinking level | ✅ | `effort: minimal\|low\|medium\|high\|xhigh\|max` (every rung is Pi-native; nothing is clamped) |
+| Thinking level | ✅ | `effort: minimal\|low\|medium\|high\|xhigh\|max\|ultra` (`ultra` maps to Pi's native `max`; the other rungs pass through) |
 | Skills | ✅ | `skills: [name]` (searches `.agents/skills`, `.claude/skills`, user-global) |
 | Inline sub-agents | ❌ | `agents:` is Claude-only; ignored with a warning on Pi |
 | System prompt override | ✅ | `systemPrompt:` |
@@ -729,7 +729,7 @@ You can configure Copilot's behavior in `.archon/config.yaml`:
 assistants:
   copilot:
     model: gpt-5-mini             # 'gpt-5', 'gpt-5-mini', 'claude-sonnet-4.5', 'auto', etc.
-    modelReasoningEffort: medium  # 'minimal'..'max' — clamped to the SDK's 'low'..'xhigh'
+    modelReasoningEffort: medium  # 'minimal'..'ultra' — clamped to the SDK's 'low'..'xhigh'
     # configDir: /absolute/path/to/copilot-config
     # enableConfigDiscovery: false  # only enable for trusted repos — bypasses Archon's workflow MCP/skill validation
     # useLoggedInUser: false        # opt into env-token auth (GH_TOKEN / GITHUB_TOKEN); default uses `copilot login`
@@ -743,7 +743,7 @@ Copilot accepts OpenAI models (`gpt-5`, `gpt-5-mini`), Anthropic via BYOK (`clau
 | Feature | Support | Notes |
 |---|---|---|
 | Session resume | ✅ | Returns `sessionId`; reused on resume |
-| Reasoning control | ✅ | `effort:` / string `thinking:` → Copilot `reasoningEffort`; `max` maps to SDK `xhigh` |
+| Reasoning control | ✅ | `effort:` / string `thinking:` → Copilot `reasoningEffort`; `max` and `ultra` map to SDK `xhigh` |
 | System prompt override | ✅ | `systemPrompt:` |
 | Codebase env vars | ✅ | merged into the spawned Copilot CLI environment |
 | Tool restrictions | ✅ | `allowed_tools` → `availableTools`, `denied_tools` → `excludedTools` |

--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -238,7 +238,7 @@ nodes:
 | `mcp` | string | — | Path to MCP server config JSON file. Claude/Codex/Copilot; Codex adds servers to ambient config rather than replacing it. See [MCP Servers](/guides/mcp-servers/) |
 | `skills` | string[] | — | Exact Claude-native skill selection (omission/`[]` selects none); skill declarations for Pi/Copilot. Codex workflow commands/prompts invoke installed skills explicitly with `$skill-name`; OpenCode does not implement this field. See [Skills](/guides/skills/) |
 | `agents` | object | — | Inline sub-agent definitions keyed by kebab-case ID. Claude only. See [Inline sub-agents](#inline-sub-agents) |
-| `effort` | `'minimal'`\|`'low'`\|`'medium'`\|`'high'`\|`'xhigh'`\|`'max'` | — | Reasoning depth. Every provider with a reasoning control — Claude/Codex/Pi/Copilot. Pi accepts all six; the others clamp a rung their model lacks to the nearest one it has. OpenCode configures reasoning in `opencode.json`. Also settable at workflow level |
+| `effort` | `'minimal'`\|`'low'`\|`'medium'`\|`'high'`\|`'xhigh'`\|`'max'`\|`'ultra'` | — | Reasoning depth. Every provider with a reasoning control — Claude/Codex/Pi/Copilot. Codex accepts all seven; the others clamp a rung their SDK lacks to the nearest one it has. OpenCode configures reasoning in `opencode.json`. Also settable at workflow level |
 | `thinking` | string \| object | — | Thinking mode: `'adaptive'`, `'disabled'`, or `{type:'enabled', budgetTokens:N}`. Claude/Pi/Copilot. Also settable at workflow level |
 | `maxBudgetUsd` | number | — | USD cost cap; node fails if exceeded. Claude only. Per-node only |
 | `systemPrompt` | string | — | Override the default `claude_code` system prompt for this node. Claude only. Per-node only |
@@ -297,14 +297,14 @@ Most of these fields map directly to Claude Agent SDK options. `maxBudgetUsd`, `
 ```yaml
 - id: thorough-review
   command: review
-  effort: high   # 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max'
+  effort: high   # 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra'
 ```
 
-The ladder is the union of every provider's vocabulary. Pi accepts all six rungs;
-the others clamp a rung their model does not offer to the nearest one it does —
-`max` becomes `xhigh` on Codex and Copilot, `minimal` becomes `low` on Claude and
-Copilot. So `effort: max` always means "as deep as this model goes", whichever
-provider the node resolves to.
+The ladder is the union of every provider's vocabulary. Codex accepts all seven
+rungs. The others clamp a rung their SDK does not offer to the nearest one it
+does: `ultra` becomes `max` on Claude and Pi or `xhigh` on Copilot, while
+`minimal` becomes `low` on Claude and Copilot. So `effort: ultra` always means
+"as deep as this model goes", whichever provider the node resolves to.
 
 **thinking** — extended thinking mode (string shorthand or object form):
 

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -35,7 +35,7 @@
     "@earendil-works/pi-ai": "^0.84.3",
     "@earendil-works/pi-coding-agent": "^0.84.3",
     "@opencode-ai/sdk": "^1.17.3",
-    "@openai/codex-sdk": "^0.148.0",
+    "@openai/codex-sdk": "^0.150.1",
     "@sinclair/typebox": "^0.34.41",
     "ajv": "^8.20.0",
     "jsonrepair": "^3.14.0",

--- a/packages/providers/src/claude/provider.test.ts
+++ b/packages/providers/src/claude/provider.test.ts
@@ -1879,13 +1879,14 @@ describe('ClaudeProvider', () => {
     });
 
     // #2556: Archon's ladder is the union of every provider's vocabulary, so a
-    // Claude node can now ask for `xhigh` (the SDK has had it since 0.3.209),
-    // and `minimal` — which Claude has no rung for — lands on its shallowest.
-    test('passes xhigh through and clamps minimal to low', async () => {
+    // Claude node can ask for every shared rung; values outside the SDK's slice
+    // land on its nearest endpoint.
+    test('passes native rungs through and clamps the shared endpoints', async () => {
       for (const [declared, applied] of [
         ['xhigh', 'xhigh'],
         ['minimal', 'low'],
         ['max', 'max'],
+        ['ultra', 'max'],
       ] as const) {
         mockQuery.mockClear();
         mockQuery.mockImplementation(async function* () {

--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -655,9 +655,9 @@ async function applyNodeConfig(
     getLog().info({ agentIds: Object.keys(nodeConfig.agents) }, 'claude.inline_agents_registered');
   }
 
-  // effort — clamped into the SDK's own vocabulary. Claude has no `minimal`
-  // rung, so `effort: minimal` becomes `low`, its shallowest. Everything else
-  // on Archon's ladder is a Claude rung already, `xhigh` included.
+  // effort — clamped into the SDK's own vocabulary. Claude has no `minimal` or
+  // `ultra` rung, so they become its shallowest (`low`) and deepest (`max`)
+  // values respectively.
   if (nodeConfig.effort !== undefined) {
     const effort = clampEffort(nodeConfig.effort, CLAUDE_EFFORTS);
     if (effort === undefined) {

--- a/packages/providers/src/codex/config.ts
+++ b/packages/providers/src/codex/config.ts
@@ -31,6 +31,8 @@ export const CODEX_EFFORTS = [
   'medium',
   'high',
   'xhigh',
+  'max',
+  'ultra',
 ] as const satisfies readonly ModelReasoningEffort[];
 
 /** Coverage, which `satisfies` above cannot express — a rung the SDK gains must

--- a/packages/providers/src/codex/provider.test.ts
+++ b/packages/providers/src/codex/provider.test.ts
@@ -1128,7 +1128,7 @@ describe('CodexProvider', () => {
       for await (const _ of client.sendQuery('test prompt', '/workspace', undefined, {
         model: 'gpt-5.6-sol',
         assistantConfig: {
-          modelReasoningEffort: 'medium',
+          modelReasoningEffort: 'ultra',
           webSearchMode: 'live',
           additionalDirectories: ['/other/repo'],
         },
@@ -1139,7 +1139,7 @@ describe('CodexProvider', () => {
       expect(mockStartThread).toHaveBeenCalledWith(
         expect.objectContaining({
           model: 'gpt-5.6-sol',
-          modelReasoningEffort: 'medium',
+          modelReasoningEffort: 'ultra',
           webSearchMode: 'live',
           additionalDirectories: ['/other/repo'],
         })
@@ -1187,23 +1187,27 @@ describe('CodexProvider', () => {
       );
     });
 
-    test('clamps `effort: max` to the SDK top rung, and falls back to config for a non-rung', async () => {
-      mockRunStreamed.mockResolvedValue({
-        events: (async function* () {
-          yield { type: 'turn.completed', usage: defaultUsage };
-        })(),
-      });
+    test.each(['max', 'ultra'] as const)(
+      'passes `effort: %s` to the SDK natively',
+      async effort => {
+        mockRunStreamed.mockResolvedValue({
+          events: (async function* () {
+            yield { type: 'turn.completed', usage: defaultUsage };
+          })(),
+        });
 
-      for await (const _ of client.sendQuery('test prompt', '/workspace', undefined, {
-        nodeConfig: { nodeId: 'n1', effort: 'max' },
-      })) {
-        // consume
+        for await (const _ of client.sendQuery('test prompt', '/workspace', undefined, {
+          nodeConfig: { nodeId: 'n1', effort },
+        })) {
+          // consume
+        }
+        expect(mockStartThread).toHaveBeenCalledWith(
+          expect.objectContaining({ modelReasoningEffort: effort })
+        );
       }
-      expect(mockStartThread).toHaveBeenCalledWith(
-        expect.objectContaining({ modelReasoningEffort: 'xhigh' })
-      );
+    );
 
-      mockStartThread.mockClear();
+    test('falls back to config for a value outside the shared ladder', async () => {
       mockRunStreamed.mockResolvedValue({
         events: (async function* () {
           yield { type: 'turn.completed', usage: defaultUsage };

--- a/packages/providers/src/codex/provider.ts
+++ b/packages/providers/src/codex/provider.ts
@@ -83,10 +83,10 @@ async function getCodex(configCodexBinaryPath?: string): Promise<Codex> {
  * from config.yaml — mirroring Copilot's `resolveCopilotReasoning`, so a workflow's
  * declared depth beats the install default on both providers alike.
  *
- * Codex has no `max` rung, so `effort: max` clamps to `xhigh` (see
- * `clampEffort`). A value that is not on the ladder at all falls back to the
- * config default rather than being invented; the workflow loader rejects such
- * values at parse time, so this only guards programmatic callers.
+ * Codex accepts every rung on Archon's ladder. A value that is not on the
+ * ladder at all falls back to the config default rather than being invented;
+ * the workflow loader rejects such values at parse time, so this only guards
+ * programmatic callers.
  */
 function resolveModelReasoningEffort(
   nodeConfig: NodeConfig | undefined,

--- a/packages/providers/src/community/copilot/config.ts
+++ b/packages/providers/src/community/copilot/config.ts
@@ -41,9 +41,10 @@ export function parseCopilotConfig(raw: Record<string, unknown>): CopilotProvide
   }
 
   // Accept any rung of Archon's shared ladder and clamp it to the SDK's enum
-  // (which has neither `minimal` nor `max`), so `assistants.copilot.*` takes
-  // the same vocabulary a workflow's `effort:` does. Normalizing at parse time
-  // keeps `CopilotProviderDefaults.modelReasoningEffort` SDK-shaped.
+  // (which has neither `minimal` nor `max`/`ultra`), so
+  // `assistants.copilot.*` takes the same vocabulary a workflow's `effort:`
+  // does. Normalizing at parse time keeps
+  // `CopilotProviderDefaults.modelReasoningEffort` SDK-shaped.
   const effort = clampEffort(raw.modelReasoningEffort, COPILOT_EFFORTS);
   if (effort !== undefined) {
     config.modelReasoningEffort = effort;

--- a/packages/providers/src/community/copilot/provider.test.ts
+++ b/packages/providers/src/community/copilot/provider.test.ts
@@ -233,24 +233,27 @@ describe('CopilotProvider.sendQuery', () => {
     expect(opts.reasoningEffort).toBe('high');
   });
 
-  test('workflow `effort: max` maps to SDK `xhigh`', async () => {
-    const session = makeFakeSession();
-    nextCreateSessionResult = session;
+  test.each(['max', 'ultra'] as const)(
+    'workflow `effort: %s` maps to SDK `xhigh`',
+    async effort => {
+      const session = makeFakeSession();
+      nextCreateSessionResult = session;
 
-    const p = new CopilotProvider();
-    const gen = p.sendQuery('hi', '/w', undefined, {
-      model: 'gpt-5',
-      nodeConfig: { effort: 'max' },
-    });
-    const first = gen.next();
-    await new Promise(resolve => setTimeout(resolve, 5));
-    session.resolveSend(undefined);
-    await first;
-    await collect(gen);
+      const p = new CopilotProvider();
+      const gen = p.sendQuery('hi', '/w', undefined, {
+        model: 'gpt-5',
+        nodeConfig: { effort },
+      });
+      const first = gen.next();
+      await new Promise(resolve => setTimeout(resolve, 5));
+      session.resolveSend(undefined);
+      await first;
+      await collect(gen);
 
-    const opts = createSessionSpy.mock.calls[0]![0] as { reasoningEffort?: string };
-    expect(opts.reasoningEffort).toBe('xhigh');
-  });
+      const opts = createSessionSpy.mock.calls[0]![0] as { reasoningEffort?: string };
+      expect(opts.reasoningEffort).toBe('xhigh');
+    }
+  );
 
   // #2556: `minimal` is a rung on Archon's shared ladder that Copilot's SDK
   // lacks, so it clamps to the SDK's shallowest — the same treatment `max`
@@ -282,7 +285,7 @@ describe('CopilotProvider.sendQuery', () => {
     const p = new CopilotProvider();
     const gen = p.sendQuery('hi', '/w', undefined, {
       model: 'gpt-5',
-      nodeConfig: { effort: 'ultra' }, // not a rung on the ladder
+      nodeConfig: { effort: 'extreme' }, // not a rung on the ladder
     });
     const first = gen.next();
     await new Promise(resolve => setTimeout(resolve, 5));

--- a/packages/providers/src/community/copilot/provider.ts
+++ b/packages/providers/src/community/copilot/provider.ts
@@ -127,9 +127,10 @@ function normalizeReasoning(value: unknown): CopilotReasoningEffort | undefined 
  * Precedence:
  *   nodeConfig.thinking > nodeConfig.effort > config.modelReasoningEffort
  *
- * Copilot's SDK has neither end of Archon's ladder, so `max` clamps to `xhigh`
- * and `minimal` to `low` (see `clampEffort`). The `'off'` sentinel disables
- * reasoning. The object form of `thinking` (Claude-specific) returns a warning.
+ * Copilot's SDK covers only `low` through `xhigh`, so `max`/`ultra` clamp to
+ * `xhigh` and `minimal` to `low` (see `clampEffort`). The `'off'` sentinel
+ * disables reasoning. The object form of `thinking` (Claude-specific) returns
+ * a warning.
  */
 function resolveCopilotReasoning(
   nodeConfig: SendQueryOptions['nodeConfig'] | undefined,
@@ -154,7 +155,7 @@ function resolveCopilotReasoning(
     return {
       effort: undefined,
       warning:
-        'Copilot ignored `thinking` (object form is Claude-specific). Use `effort: minimal|low|medium|high|xhigh|max` instead.',
+        'Copilot ignored `thinking` (object form is Claude-specific). Use `effort: minimal|low|medium|high|xhigh|max|ultra` instead.',
     };
   }
 
@@ -162,7 +163,7 @@ function resolveCopilotReasoning(
     const offender = typeof rawThinking === 'string' ? rawThinking : rawEffort;
     return {
       effort: undefined,
-      warning: `Copilot ignored unknown reasoning level '${String(offender)}'. Valid: minimal, low, medium, high, xhigh, max, off.`,
+      warning: `Copilot ignored unknown reasoning level '${String(offender)}'. Valid: minimal, low, medium, high, xhigh, max, ultra, off.`,
     };
   }
 

--- a/packages/providers/src/community/pi/options-translator.test.ts
+++ b/packages/providers/src/community/pi/options-translator.test.ts
@@ -37,8 +37,9 @@ describe('resolvePiThinkingLevel', () => {
     expect(resolvePiThinkingLevel({ effort: 'off' })).toEqual({ level: undefined });
   });
 
-  // Pi's `ThinkingLevel` is Archon's ladder exactly — `max` included
-  // (@earendil-works/pi-ai types.d.ts). This previously asserted a downgrade to
+  // Pi's native `ThinkingLevel` matches Archon's ladder through `max`
+  // (@earendil-works/pi-ai types.d.ts); Codex-only `ultra` clamps separately.
+  // This previously asserted a downgrade to
   // `xhigh`, which was the bug: `effort: max` meant "as deep as this model goes"
   // everywhere except Pi, where a rung was quietly removed before Pi could apply
   // its own per-model handling.

--- a/packages/providers/src/community/pi/options-translator.test.ts
+++ b/packages/providers/src/community/pi/options-translator.test.ts
@@ -47,10 +47,15 @@ describe('resolvePiThinkingLevel', () => {
     expect(resolvePiThinkingLevel({ thinking: 'max' })).toEqual({ level: 'max' });
   });
 
-  test('every rung on the ladder passes through Pi unclamped', () => {
+  test('every Pi-native rung passes through unclamped', () => {
     for (const rung of ['minimal', 'low', 'medium', 'high', 'xhigh', 'max'] as const) {
       expect(resolvePiThinkingLevel({ effort: rung })).toEqual({ level: rung });
     }
+  });
+
+  test("'ultra' clamps to Pi's strongest native rung", () => {
+    expect(resolvePiThinkingLevel({ effort: 'ultra' })).toEqual({ level: 'max' });
+    expect(resolvePiThinkingLevel({ thinking: 'ultra' })).toEqual({ level: 'max' });
   });
 
   test('warns on Claude-shape object thinking config', () => {
@@ -89,14 +94,14 @@ describe('resolvePiThinkingLevel', () => {
     // warning strings that have not earned it.
     expect(result.warning).toBe(
       'Pi ignored `thinking` (object form is Claude-specific). Use ' +
-        '`effort: minimal|low|medium|high|xhigh|max` in YAML — Pi accepts every rung natively.'
+        '`effort: minimal|low|medium|high|xhigh|max|ultra` in YAML — Pi accepts through max natively and maps ultra to max.'
     );
   });
 
   test('warns on unknown string thinking value', () => {
-    const result = resolvePiThinkingLevel({ thinking: 'ultra' });
+    const result = resolvePiThinkingLevel({ thinking: 'extreme' });
     expect(result.level).toBeUndefined();
-    expect(result.warning).toContain("unknown thinking level 'ultra'");
+    expect(result.warning).toContain("unknown thinking level 'extreme'");
   });
 
   test('warns on unknown string effort value', () => {

--- a/packages/providers/src/community/pi/options-translator.ts
+++ b/packages/providers/src/community/pi/options-translator.ts
@@ -27,9 +27,9 @@ import { clampEffort, type AssertNever } from '../../shared/effort';
 // ─── Thinking level ────────────────────────────────────────────────────────
 
 /**
- * Pi's `ThinkingLevel` is Archon's ladder exactly — all six rungs, `max`
- * included — so every rung passes through unclamped. The `off` sentinel is
- * handled by the caller, before this runs.
+ * Pi's `ThinkingLevel` spans the shared ladder through `max`; the Codex-native
+ * `ultra` rung clamps to `max`. The `off` sentinel is handled by the caller,
+ * before this runs.
  *
  * `satisfies` alone would not have caught the omission this list previously
  * carried: it proves every element IS a `ThinkingLevel` (containment), not that
@@ -93,16 +93,16 @@ export function resolvePiThinkingLevel(nodeConfig?: NodeConfig): ResolvedThinkin
     return {
       level: undefined,
       warning:
-        'Pi ignored `thinking` (object form is Claude-specific). Use `effort: minimal|low|medium|high|xhigh|max` in YAML — Pi accepts every rung natively.',
+        'Pi ignored `thinking` (object form is Claude-specific). Use `effort: minimal|low|medium|high|xhigh|max|ultra` in YAML — Pi accepts through max natively and maps ultra to max.',
     };
   }
 
-  // String that isn't a known level (e.g. 'ultra') — warn so users fix it.
+  // String that isn't a known level — warn so users fix it.
   if (typeof thinking === 'string' || typeof effort === 'string') {
     const offender = typeof thinking === 'string' ? thinking : effort;
     return {
       level: undefined,
-      warning: `Pi ignored unknown thinking level '${String(offender)}'. Valid: minimal, low, medium, high, xhigh, max, off.`,
+      warning: `Pi ignored unknown thinking level '${String(offender)}'. Valid: minimal, low, medium, high, xhigh, max, ultra, off.`,
     };
   }
 

--- a/packages/providers/src/shared/effort.test.ts
+++ b/packages/providers/src/shared/effort.test.ts
@@ -1,18 +1,17 @@
 import { describe, test, expect } from 'bun:test';
 import { EFFORT_LADDER, clampEffort, isEffortRung } from './effort';
 
-// The vocabularies the four effort-capable SDKs accept. Pi's is the full ladder;
-// the rest are real slices — Claude has no `minimal`, Codex no `max`, Copilot
-// neither.
+// The vocabularies the four effort-capable SDKs accept. Codex has the full
+// ladder; the rest are contiguous slices.
 const CLAUDE = ['low', 'medium', 'high', 'xhigh', 'max'] as const;
-const CODEX = ['minimal', 'low', 'medium', 'high', 'xhigh'] as const;
-const PI = EFFORT_LADDER; // Pi's ThinkingLevel is the full ladder, `max` included
+const CODEX = EFFORT_LADDER;
+const PI = ['minimal', 'low', 'medium', 'high', 'xhigh', 'max'] as const;
 const COPILOT = ['low', 'medium', 'high', 'xhigh'] as const;
 
 describe('isEffortRung', () => {
   test('accepts every rung on the ladder and nothing else', () => {
     for (const rung of EFFORT_LADDER) expect(isEffortRung(rung)).toBe(true);
-    for (const other of ['off', 'ultra', '', 'HIGH', 3, null, undefined, {}]) {
+    for (const other of ['off', 'extreme', '', 'HIGH', 3, null, undefined, {}]) {
       expect(isEffortRung(other)).toBe(false);
     }
   });
@@ -25,10 +24,11 @@ describe('clampEffort', () => {
   });
 
   test('clamps down to the nearest supported rung', () => {
-    // No `max` on Codex/Copilot — the top of Archon's ladder means "as deep as
-    // this model goes", so it lands on their strongest rung, not nothing. Pi
-    // has `max` natively and must NOT be clamped.
-    expect(clampEffort('max', CODEX)).toBe('xhigh');
+    // The top of Archon's ladder means "as deep as this model goes", so it
+    // lands on each provider's strongest rung rather than disappearing.
+    expect(clampEffort('ultra', CLAUDE)).toBe('max');
+    expect(clampEffort('ultra', PI)).toBe('max');
+    expect(clampEffort('ultra', COPILOT)).toBe('xhigh');
     expect(clampEffort('max', COPILOT)).toBe('xhigh');
     expect(clampEffort('max', PI)).toBe('max');
   });
@@ -50,7 +50,7 @@ describe('clampEffort', () => {
     // `off` is a real sentinel in Pi/Copilot's node config, handled by the
     // caller before the clamp — the clamp itself must not invent a rung for it.
     expect(clampEffort('off', CODEX)).toBeUndefined();
-    expect(clampEffort('ultra', CLAUDE)).toBeUndefined();
+    expect(clampEffort('extreme', CLAUDE)).toBeUndefined();
     expect(clampEffort(undefined, CLAUDE)).toBeUndefined();
     expect(clampEffort(5, CLAUDE)).toBeUndefined();
   });

--- a/packages/providers/src/shared/effort.ts
+++ b/packages/providers/src/shared/effort.ts
@@ -2,22 +2,20 @@
  * The one Archon reasoning-depth vocabulary, and the clamp every provider uses
  * to land a declared rung inside its own SDK's enum.
  *
- * Archon exposes a single `effort:` field in workflow YAML. Pi's vocabulary is the
- * full ladder; the others offer a contiguous slice — Claude has no `minimal`,
- * Codex has no `max`, Copilot has neither — so a rung the resolved provider
- * doesn't offer is clamped into range rather than dropped (weaker first; see
- * `clampEffort` for why the direction matters). That keeps
- * `effort: max` meaning "as deep as this model goes" everywhere, which is the
- * point of having one spelling (#2556). The precedent is `parseCopilotConfig`,
- * which has mapped `max` → `xhigh` at the provider boundary since Copilot
- * landed.
+ * Archon exposes a single `effort:` field in workflow YAML. The ladder is the
+ * union of the effort-capable SDK vocabularies: Codex spans the full ladder,
+ * while Claude, Pi, and Copilot each offer a contiguous slice. A rung the
+ * resolved provider does not offer is clamped into range rather than dropped
+ * (weaker first; see `clampEffort` for why the direction matters). That keeps
+ * the strongest shared rung meaning "as deep as this model goes" everywhere,
+ * which is the point of having one spelling (#2556).
  *
  * Zero SDK deps by design — `@archon/workflows` derives its `effortLevelSchema`
  * from `EFFORT_LADDER`, so the YAML enum and the clamp can never disagree.
  */
 
 /** Reasoning-depth rungs, weakest → strongest. Order is load-bearing: `clampEffort` walks it. */
-export const EFFORT_LADDER = ['minimal', 'low', 'medium', 'high', 'xhigh', 'max'] as const;
+export const EFFORT_LADDER = ['minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'] as const;
 
 /**
  * Compile-time proof that a provider's rung list COVERS its SDK's vocabulary.
@@ -52,9 +50,9 @@ export function isEffortRung(value: unknown): value is EffortRung {
  * buy more reasoning than the author asked for. So `clampEffort('high', ['low',
  * 'xhigh'])` is `'low'` — two rungs down — rather than `'xhigh'`, one rung up.
  * On every real provider vocabulary the two rules coincide, because each is a
- * contiguous slice missing only the ladder's extremes (`max` → `xhigh` on Codex,
- * `minimal` → `low` on Claude); the difference would only appear for a
- * vocabulary with an interior gap.
+ * contiguous slice (`ultra` → `max` on Claude/Pi, `ultra` → `xhigh` on Copilot,
+ * and `minimal` → `low` on Claude/Copilot); the difference would only appear
+ * for a vocabulary with an interior gap.
  *
  * Returns `undefined` for anything that is not on the ladder at all; callers own
  * the warning, since each provider surfaces it through its own channel.

--- a/packages/providers/src/types.ts
+++ b/packages/providers/src/types.ts
@@ -29,7 +29,7 @@ export interface CodexProviderDefaults {
   /** The Codex SDK's `ModelReasoningEffort`, restated by hand because this file
    *  may not import an SDK. `CODEX_EFFORTS` in ./codex/config.ts pins the same
    *  values to the SDK's own type, so upstream drift fails type-check there. */
-  modelReasoningEffort?: 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+  modelReasoningEffort?: 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra';
   /** Structurally matches @archon/workflows WebSearchMode */
   webSearchMode?: 'disabled' | 'cached' | 'live';
   additionalDirectories?: string[];

--- a/packages/server/src/routes/api.providers.test.ts
+++ b/packages/server/src/routes/api.providers.test.ts
@@ -265,7 +265,7 @@ describe('PATCH /api/config/tiers', () => {
   });
 
   test('invalid effort for the provider → 400, no write (not silently dropped)', async () => {
-    const res = await patch({ large: { provider: 'claude', model: 'opus', effort: 'ultra' } });
+    const res = await patch({ large: { provider: 'claude', model: 'opus', effort: 'extreme' } });
     expect(res.status).toBe(400);
     expect(mockUpdateGlobalConfig).not.toHaveBeenCalled();
   });
@@ -340,7 +340,7 @@ describe('PATCH /api/config/aliases', () => {
   });
 
   test('invalid effort for the provider → 400, no write', async () => {
-    const res = await patch({ '@fast': { provider: 'claude', model: 'haiku', effort: 'ultra' } });
+    const res = await patch({ '@fast': { provider: 'claude', model: 'haiku', effort: 'extreme' } });
     expect(res.status).toBe(400);
     expect(mockUpdateGlobalConfig).not.toHaveBeenCalled();
   });

--- a/packages/server/src/routes/api.user-ai-prefs.test.ts
+++ b/packages/server/src/routes/api.user-ai-prefs.test.ts
@@ -306,7 +306,7 @@ describe('PATCH /api/auth/me/ai-prefs/tiers', () => {
       method: 'PATCH',
       headers: JSON_HEADERS,
       body: JSON.stringify({
-        tiers: { large: { provider: 'claude', model: 'opus', effort: 'ultra' } },
+        tiers: { large: { provider: 'claude', model: 'opus', effort: 'extreme' } },
       }),
     });
     expect(res.status).toBe(400);

--- a/packages/web/src/experiments/console/lib/model-options.test.ts
+++ b/packages/web/src/experiments/console/lib/model-options.test.ts
@@ -117,11 +117,12 @@ describe('normalizeEffortForAgent', () => {
     expect(normalizeEffortForAgent('claude', 'high', PROVIDERS)).toBe('high');
     // Both of these used to be cleared, because each agent had its own enum.
     expect(normalizeEffortForAgent('codex', 'max', PROVIDERS)).toBe('max');
+    expect(normalizeEffortForAgent('codex', 'ultra', PROVIDERS)).toBe('ultra');
     expect(normalizeEffortForAgent('claude', 'minimal', PROVIDERS)).toBe('minimal');
   });
 
   test('clears a value that is not a rung', () => {
-    expect(normalizeEffortForAgent('claude', 'ultra', PROVIDERS)).toBe('');
+    expect(normalizeEffortForAgent('claude', 'extreme', PROVIDERS)).toBe('');
   });
 
   test('clears any value for agents without an effort concept', () => {

--- a/packages/web/src/experiments/console/lib/model-options.ts
+++ b/packages/web/src/experiments/console/lib/model-options.ts
@@ -110,14 +110,30 @@ export function curatedOptionsForAgent(agentId: string): readonly ModelOption[] 
 // ---------------------------------------------------------------------------
 
 /** Mirrors `effortLevelSchema` in packages/workflows/src/schemas/dag-node.ts. */
-export const EFFORT_OPTIONS = ['minimal', 'low', 'medium', 'high', 'xhigh', 'max'] as const;
+export const EFFORT_OPTIONS = [
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+  'ultra',
+] as const;
 
 export type EffortOption = (typeof EFFORT_OPTIONS)[number];
 
 /** The rungs `assistants.codex.modelReasoningEffort` accepts — the Codex SDK's
  *  own enum, which is NOT the shared ladder: that config key is unchanged by
  *  #2556 and keeps its vendor vocabulary. */
-export const CODEX_CONFIG_EFFORT_OPTIONS = ['minimal', 'low', 'medium', 'high', 'xhigh'] as const;
+export const CODEX_CONFIG_EFFORT_OPTIONS = [
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+  'ultra',
+] as const;
 
 /**
  * The effort vocabulary an agent's tier/alias `effort` accepts, or null when the

--- a/packages/web/src/lib/api.generated.d.ts
+++ b/packages/web/src/lib/api.generated.d.ts
@@ -3431,12 +3431,12 @@ export interface components {
       provider?: string;
       model?: string;
       /** @enum {string} */
-      modelReasoningEffort?: 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+      modelReasoningEffort?: 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra';
       /** @enum {string} */
       webSearchMode?: 'disabled' | 'cached' | 'live';
       interactive?: boolean;
       /** @enum {string} */
-      effort?: 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+      effort?: 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra';
       thinking?:
         | {
             /** @enum {string} */
@@ -3706,7 +3706,7 @@ export interface components {
         };
       };
       /** @enum {string} */
-      effort?: 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+      effort?: 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra';
       thinking?:
         | {
             /** @enum {string} */

--- a/packages/web/src/routes/SettingsPage.tsx
+++ b/packages/web/src/routes/SettingsPage.tsx
@@ -28,6 +28,7 @@ import type {
   ProviderDefaults,
   ProviderInfo,
 } from '@/lib/api';
+import { CODEX_CONFIG_EFFORT_OPTIONS } from '@/experiments/console/lib/model-options';
 
 const selectClass =
   'h-9 rounded-md border border-border bg-surface-elevated text-text-primary px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring [&>option]:bg-surface-elevated [&>option]:text-text-primary';
@@ -551,11 +552,11 @@ function AssistantConfigSection({ config }: { config: SafeConfigResponse }): Rea
                       }}
                       className={selectClass}
                     >
-                      <option value="minimal">minimal</option>
-                      <option value="low">low</option>
-                      <option value="medium">medium</option>
-                      <option value="high">high</option>
-                      <option value="xhigh">xhigh</option>
+                      {CODEX_CONFIG_EFFORT_OPTIONS.map(effort => (
+                        <option key={effort} value={effort}>
+                          {effort}
+                        </option>
+                      ))}
                     </select>
 
                     <label htmlFor="web-search">Web Search</label>

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -1905,7 +1905,7 @@ async function resolveNodeProviderAndModel(
   // it. `assistants.<provider>.modelReasoningEffort` from config.yaml never
   // enters nodeConfig, so it stays the fallback.
   //
-  // Providers clamp a rung their SDK lacks (`max` → `xhigh` on Codex/Copilot),
+  // Providers clamp a rung their SDK lacks (`ultra` → `max` on Claude/Pi or `xhigh` on Copilot),
   // and this reports the declared rung rather than the clamped one — consistent
   // across providers, and no longer able to name a field the provider ignored,
   // which was the #2395 failure mode.

--- a/packages/workflows/src/model-validation.test.ts
+++ b/packages/workflows/src/model-validation.test.ts
@@ -815,7 +815,7 @@ describe('isLiteralSpec type guard', () => {
 // #2556: one vocabulary, gated by one capability flag. Before this, effort
 // "routed" only on Claude and Codex, each with its own enum, so a tier's
 // `effort` was silently dropped on Pi and Copilot — which do have the control.
-const LADDER = ['minimal', 'low', 'medium', 'high', 'xhigh', 'max'];
+const LADDER = ['minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'];
 
 describe('validEffortsForProvider', () => {
   test('returns the one ladder for every provider with a reasoning control', () => {
@@ -853,7 +853,7 @@ describe('resolvePresetEffort', () => {
   });
 
   test('rejects as unknown, and reports the vocabulary, for a non-rung', () => {
-    const decision = resolvePresetEffort('claude', 'ultra');
+    const decision = resolvePresetEffort('claude', 'extreme');
     expect(decision.ok).toBe(false);
     if (decision.ok) throw new Error('expected a rejection');
     expect(decision.reason).toBe('unknown');
@@ -863,14 +863,14 @@ describe('resolvePresetEffort', () => {
 
 describe('isEffortValidForProvider', () => {
   test('accepts every rung on a provider that has the control', () => {
-    for (const rung of ['minimal', 'low', 'medium', 'high', 'xhigh', 'max']) {
+    for (const rung of ['minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra']) {
       expect(isEffortValidForProvider('codex', rung)).toBe(true);
       expect(isEffortValidForProvider('claude', rung)).toBe(true);
     }
   });
 
   test('rejects a value that is not a rung', () => {
-    expect(isEffortValidForProvider('claude', 'ultra')).toBe(false);
+    expect(isEffortValidForProvider('claude', 'extreme')).toBe(false);
   });
 
   test('accepts anything for a provider with no vocabulary to validate against', () => {

--- a/packages/workflows/src/model-validation.ts
+++ b/packages/workflows/src/model-validation.ts
@@ -588,7 +588,7 @@ export function isLiteralSpec(spec: ResolvedModelSpec): spec is { literal: strin
  * to the nearest one it has. So this answers "does effort reach this provider",
  * and the ladder answers "is this a rung" — which is what the tier-config write
  * paths (`PATCH /api/config/tiers`, `archon ai tier set --effort`) need to
- * reject `--effort ultra` up front instead of accepting a no-op.
+ * reject `--effort extreme` up front instead of accepting a no-op.
  */
 export function validEffortsForProvider(provider: string): readonly string[] | null {
   if (!isRegisteredProvider(provider)) return null;

--- a/packages/workflows/src/schemas.test.ts
+++ b/packages/workflows/src/schemas.test.ts
@@ -577,14 +577,14 @@ describe('dagNodeSchema — empty bash/prompt', () => {
 // ---------------------------------------------------------------------------
 
 describe('dagNodeSchema — new Claude SDK options', () => {
-  test('parses effort enum on prompt node', () => {
-    const result = dagNodeSchema.safeParse({ id: 'n', prompt: 'do it', effort: 'high' });
+  test('parses the strongest effort rung on a prompt node', () => {
+    const result = dagNodeSchema.safeParse({ id: 'n', prompt: 'do it', effort: 'ultra' });
     expect(result.success).toBe(true);
-    if (result.success) expect((result.data as AgentNode).effort).toBe('high');
+    if (result.success) expect((result.data as AgentNode).effort).toBe('ultra');
   });
 
   test('rejects invalid effort value', () => {
-    const result = dagNodeSchema.safeParse({ id: 'n', prompt: 'do it', effort: 'ultra' });
+    const result = dagNodeSchema.safeParse({ id: 'n', prompt: 'do it', effort: 'extreme' });
     expect(result.success).toBe(false);
   });
 

--- a/packages/workflows/src/schemas/dag-node.ts
+++ b/packages/workflows/src/schemas/dag-node.ts
@@ -63,9 +63,10 @@ export const TRIGGER_RULES: readonly TriggerRule[] = triggerRuleSchema.options;
  * Reasoning depth — the one spelling, on every provider that has the control
  * (#2556). The vocabulary is the union of the effort-capable SDKs' enums, and
  * a provider clamps a rung it doesn't offer to the nearest one it does
- * (`clampEffort` in @archon/providers): Pi takes all six, while `max` → `xhigh`
- * on Codex/Copilot and `minimal` → `low` on Claude/Copilot. Derived from `EFFORT_LADDER` rather than
- * restated, so the YAML enum and the clamp cannot disagree.
+ * (`clampEffort` in @archon/providers): Codex takes every rung, while `ultra`
+ * clamps to `max` on Claude/Pi and `xhigh` on Copilot, and `minimal` clamps to
+ * `low` on Claude/Copilot. Derived from `EFFORT_LADDER` rather than restated, so
+ * the YAML enum and the clamp cannot disagree.
  */
 export const effortLevelSchema = z.enum(EFFORT_LADDER);
 

--- a/packages/workflows/src/schemas/workflow.ts
+++ b/packages/workflows/src/schemas/workflow.ts
@@ -31,7 +31,15 @@ import { jsonValueSchema } from '../output-ref';
  * The last provider-specific effort vocabulary left inside @archon/workflows;
  * it goes away with the field. `effortLevelSchema` in ./dag-node is the live one.
  */
-export const modelReasoningEffortSchema = z.enum(['minimal', 'low', 'medium', 'high', 'xhigh']);
+export const modelReasoningEffortSchema = z.enum([
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+  'ultra',
+]);
 
 export type ModelReasoningEffort = z.infer<typeof modelReasoningEffortSchema>;
 


### PR DESCRIPTION
## Problem and outcome

Archon's direct Codex SDK dependency was still on 0.148.0, while the latest stable release is 0.150.1. The newer SDK expands its reasoning-effort contract with native `max` and `ultra` values, so the upgrade also has to keep Archon's exhaustive provider boundary and shared workflow vocabulary truthful.

- **Outcome:** Archon installs Codex SDK and CLI 0.150.1, passes `max` and `ultra` to Codex natively, and exposes `ultra` as the strongest shared reasoning rung.
- **Invariant:** One typed effort vocabulary stays consistent across provider adapters, workflow schemas, generated API types, console controls, tests, and documentation.
- **Scope boundary:** This does not adopt the optional upstream `configOverrides` or `threadSource` APIs, use a prerelease, or change any other dependency.

## Review guidance

- **Feedback requested:** Dependency integrity, SDK compatibility, and the shared effort-clamping contract.
- **Start here:** `packages/providers/src/codex/config.ts:28` — this exhaustive list is checked against the SDK's exported `ModelReasoningEffort` union.
- **Review order:** Codex package and config changes, shared effort ladder and provider clamps, workflow/web schema propagation, then focused tests and docs.
- **Lower-attention areas:** `bun.lock` and `packages/web/src/lib/api.generated.d.ts` are mechanical dependency and generated-schema updates verified by frozen install and repository validation.
- **Known risk or uncertainty:** None.

## Solution

The provider package now declares `@openai/codex-sdk` 0.150.1, with the lockfile resolving its exact SDK, CLI, and platform packages to 0.150.1. Archon's existing compile-time completeness proof detected the two SDK additions. The shared effort ladder now ends in `ultra`; Codex accepts every rung, while the existing clamp primitive maps `ultra` to each other provider's strongest native value. Typed schemas, generated API declarations, console options, tests, and docs were updated together so there is no second vocabulary to drift.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Codex SDK 0.148.0; workflow `max` was clamped to Codex `xhigh`; `ultra` was rejected. | Codex SDK 0.150.1; Codex receives `max` and `ultra` natively; other reasoning providers clamp `ultra` to their strongest supported rung. |
| **Failure behavior** | The exhaustive SDK type assertion failed against 0.150.1 until its new enum values were modeled. | Future SDK effort additions still fail type-check until Archon's typed surfaces are updated deliberately. |

## Validation

- `bun install --frozen-lockfile` — passed with no changes — proves the manifest and lockfile agree.
- Focused provider, workflow, web, CLI, server, and effort-parity tests — passed — prove native Codex forwarding, cross-provider clamping, schema acceptance/rejection, and UI parity.
- `bun --filter @archon/providers type-check` — passed — proves the direct SDK boundary and exhaustive union compile against 0.150.1.
- `NODE_OPTIONS=--max-old-space-size=8192 bun run validate` — passed on the current head — proves bundled artifact checks, all type checks, zero-warning lint, formatting, installer tests, all package tests, and script tests.
- **Not verified:** No live paid Codex request was sent; the SDK boundary is covered through typed mocks and the full repository gate without consuming external credentials or quota.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | Existing effort values retain their meaning; `ultra` is additive and clamps predictably outside Codex. | Shared effort and provider test suites. |
| Security / permissions / data | Codex 0.150.x adds trust-aware project instruction loading; Archon does not override that upstream security behavior. | Official Codex 0.150.0 release notes. |
| Rollout / rollback | A single dependency commit can be reverted without data migration. | One commit; no schema or persisted-data changes. |
| Documentation / communication | Workflow and assistant docs list the new shared/native values and clamp behavior. | Updated quick reference, assistant guide, and workflow authoring guide. |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `max` and `ultra` reasoning-effort levels across workflow configuration, provider settings, and the web console.
  * Codex supports the complete reasoning ladder natively.
  * Unsupported levels map to the nearest provider-supported level.

* **Bug Fixes**
  * Improved background task updates and handling of account-hold errors.
  * Validation accepts `ultra` while continuing to reject unsupported values.

* **Documentation**
  * Updated quick references, AI assistant guides, and workflow authoring guidance with expanded effort levels and provider mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->