### PR TITLE
fix/flaky-generate-bundled-defaults-forks

### DIFF
--- a/packages/workflows/src/defaults/generate-bundled-defaults.test.ts
+++ b/packages/workflows/src/defaults/generate-bundled-defaults.test.ts
@@ -5,9 +5,30 @@
  * Drives the real script via spawnSync inside an isolated mkdtempSync git
  * repo (same pattern as .archon/scripts/__tests__/marketplace-fetch-source.test.ts),
  * pointed at the throwaway repo via the BUNDLED_DEFAULTS_REPO_ROOT test seam.
+ *
+ * Fork-cost amortization: the expensive git init/add/commit template repo is
+ * built ONCE per file; every scenario gets its own working copy via an
+ * in-process recursive fs copy instead of a fresh git init/add/commit chain.
+ * The positive scenarios (all-tracked, staged-but-uncommitted, packaged
+ * embed) assert against one shared generator run because their expectations
+ * are mutually compatible and none depends on a per-run process boundary.
+ * The three negative scenarios stay in separate runs: they trip different
+ * guards (workflows-defaults guard vs commands-defaults guard vs packaged
+ * tracked-set check) whose failure messages land on stderr
+ * nondeterministically if raced in parallel, so merging them would force
+ * weaker assertions. All original assertions from the six-case suite are
+ * preserved verbatim (30 expect() calls).
  */
-import { describe, it, expect } from 'bun:test';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { describe, it, expect, afterAll } from 'bun:test';
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
@@ -24,8 +45,8 @@ function runGit(repoRoot: string, args: string[]): void {
 }
 
 /** Create a temp git repo with one tracked command + workflow default, committed. */
-function createRepo(): string {
-  const repoRoot = mkdtempSync(join(tmpdir(), 'bundled-defaults-test-'));
+function createTemplateRepo(): string {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'bundled-defaults-template-'));
   mkdirSync(join(repoRoot, '.archon/commands/defaults'), { recursive: true });
   mkdirSync(join(repoRoot, '.archon/workflows/defaults'), { recursive: true });
   mkdirSync(join(repoRoot, 'packages/workflows/src/defaults'), { recursive: true });
@@ -50,6 +71,30 @@ function createRepo(): string {
   return repoRoot;
 }
 
+let templateRepo: string | null = null;
+
+/** Build the committed template repo lazily, exactly once for the whole file. */
+function getTemplateRepo(): string {
+  if (templateRepo === null) {
+    templateRepo = createTemplateRepo();
+  }
+  return templateRepo;
+}
+
+afterAll(() => {
+  if (templateRepo !== null) {
+    rmSync(templateRepo, { recursive: true, force: true });
+    templateRepo = null;
+  }
+});
+
+/** Cheap in-process clone of the committed template repo (no git spawns). */
+function createRepo(): string {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'bundled-defaults-test-'));
+  cpSync(getTemplateRepo(), repoRoot, { recursive: true });
+  return repoRoot;
+}
+
 function runScript(repoRoot: string): { exitCode: number; stderr: string } {
   const result = spawnSync('bun', [SCRIPT], {
     env: { ...process.env, BUNDLED_DEFAULTS_REPO_ROOT: repoRoot },
@@ -62,15 +107,64 @@ function runScript(repoRoot: string): { exitCode: number; stderr: string } {
 }
 
 describe('generate-bundled-defaults: untracked-file guard (#1578)', () => {
-  it('exits 0 and writes the bundle when all defaults are tracked', () => {
+  it('exits 0 for tracked defaults, staged-but-uncommitted defaults, and embedded packaged workflows (single amortized run)', () => {
+    // One scenario covers what used to be three separate generator runs:
+    //   - all tracked legacy defaults (positive path)
+    //   - staged-but-uncommitted default (staged is not untracked)
+    //   - packaged workflow with commands + scripts + owner metadata
+    // Each set of assertions below is preserved verbatim from its origin case.
     const repoRoot = createRepo();
     try {
+      // Staged-but-uncommitted default (previously its own case).
+      writeFileSync(
+        join(repoRoot, '.archon/workflows/defaults/staged-draft.yaml'),
+        'name: staged-draft\n'
+      );
+      // Packaged workflow tree (previously its own case).
+      const packageDir = join(repoRoot, '.archon/workflows/author-pack/release-flow');
+      mkdirSync(join(packageDir, 'commands'), { recursive: true });
+      mkdirSync(join(packageDir, 'scripts/helpers'), { recursive: true });
+      writeFileSync(
+        join(packageDir, 'release.yaml'),
+        'name: release\ndescription: release\nnodes:\n  - id: run\n    command: prepare\n'
+      );
+      writeFileSync(join(packageDir, 'commands/prepare.md'), '# Prepare the release\n');
+      writeFileSync(join(packageDir, 'scripts/publish.ts'), "console.log('published');\n");
+      writeFileSync(join(packageDir, 'scripts/helpers/announce.py'), "print('announced')\n");
+      // One git spawn stages both trees; nothing is committed after init.
+      runGit(repoRoot, [
+        'add',
+        '.archon/workflows/defaults/staged-draft.yaml',
+        '.archon/workflows/author-pack',
+      ]);
+
       const { exitCode, stderr } = runScript(repoRoot);
+
+      // Assertions from the former "all tracked" case.
       expect(stderr).not.toContain('untracked');
       expect(exitCode).toBe(0);
       const output = readFileSync(join(repoRoot, OUTPUT_REL), 'utf-8');
       expect(output).toContain('tracked-command');
       expect(output).toContain('tracked-workflow');
+
+      // Assertions from the former "staged-but-uncommitted" case.
+      expect(stderr).not.toContain('untracked');
+      expect(exitCode).toBe(0);
+      expect(existsSync(join(repoRoot, OUTPUT_REL))).toBe(true);
+      expect(readFileSync(join(repoRoot, OUTPUT_REL), 'utf-8')).toContain('staged-draft');
+
+      // Assertions from the former "packaged embed" case.
+      expect(stderr).toBe('');
+      expect(exitCode).toBe(0);
+      const packagedOutput = readFileSync(join(repoRoot, OUTPUT_REL), 'utf-8');
+      expect(packagedOutput).toContain('BUNDLED_WORKFLOW_OWNERS');
+      expect(packagedOutput).toContain(
+        '"release": {"pack":"author-pack","workflow":"release-flow"}'
+      );
+      expect(packagedOutput).toContain('__archon_pack__bundled:author-pack:release-flow::prepare');
+      expect(packagedOutput).toContain('__archon_pack__bundled:author-pack:release-flow::publish');
+      expect(packagedOutput).toContain('__archon_pack__bundled:author-pack:release-flow::announce');
+      expect(packagedOutput).toContain('BUNDLED_SCRIPTS');
     } finally {
       rmSync(repoRoot, { recursive: true, force: true });
     }
@@ -106,54 +200,6 @@ describe('generate-bundled-defaults: untracked-file guard (#1578)', () => {
       // Remediation names the command-scoped destinations, not workflows.
       expect(stderr).toContain('.archon/commands/ (project-scope)');
       expect(readFileSync(join(repoRoot, OUTPUT_REL), 'utf-8')).toBe(SENTINEL);
-    } finally {
-      rmSync(repoRoot, { recursive: true, force: true });
-    }
-  });
-
-  it('exits 0 for a staged-but-uncommitted default (staged is not untracked)', () => {
-    const repoRoot = createRepo();
-    try {
-      writeFileSync(
-        join(repoRoot, '.archon/workflows/defaults/staged-draft.yaml'),
-        'name: staged-draft\n'
-      );
-      runGit(repoRoot, ['add', '.archon/workflows/defaults/staged-draft.yaml']);
-      const { exitCode, stderr } = runScript(repoRoot);
-      expect(stderr).not.toContain('untracked');
-      expect(exitCode).toBe(0);
-      expect(existsSync(join(repoRoot, OUTPUT_REL))).toBe(true);
-      expect(readFileSync(join(repoRoot, OUTPUT_REL), 'utf-8')).toContain('staged-draft');
-    } finally {
-      rmSync(repoRoot, { recursive: true, force: true });
-    }
-  }, 15_000);
-
-  it('embeds packaged workflows, commands, scripts, and owner metadata', () => {
-    const repoRoot = createRepo();
-    try {
-      const packageDir = join(repoRoot, '.archon/workflows/author-pack/release-flow');
-      mkdirSync(join(packageDir, 'commands'), { recursive: true });
-      mkdirSync(join(packageDir, 'scripts/helpers'), { recursive: true });
-      writeFileSync(
-        join(packageDir, 'release.yaml'),
-        'name: release\ndescription: release\nnodes:\n  - id: run\n    command: prepare\n'
-      );
-      writeFileSync(join(packageDir, 'commands/prepare.md'), '# Prepare the release\n');
-      writeFileSync(join(packageDir, 'scripts/publish.ts'), "console.log('published');\n");
-      writeFileSync(join(packageDir, 'scripts/helpers/announce.py'), "print('announced')\n");
-      runGit(repoRoot, ['add', '.archon/workflows/author-pack']);
-
-      const { exitCode, stderr } = runScript(repoRoot);
-      expect(stderr).toBe('');
-      expect(exitCode).toBe(0);
-      const output = readFileSync(join(repoRoot, OUTPUT_REL), 'utf-8');
-      expect(output).toContain('BUNDLED_WORKFLOW_OWNERS');
-      expect(output).toContain('"release": {"pack":"author-pack","workflow":"release-flow"}');
-      expect(output).toContain('__archon_pack__bundled:author-pack:release-flow::prepare');
-      expect(output).toContain('__archon_pack__bundled:author-pack:release-flow::publish');
-      expect(output).toContain('__archon_pack__bundled:author-pack:release-flow::announce');
-      expect(output).toContain('BUNDLED_SCRIPTS');
     } finally {
       rmSync(repoRoot, { recursive: true, force: true });
     }


### PR DESCRIPTION


---

Automated fix from an archon-stabilize-batch run.

**Summary:** Amortized the generate-bundled-defaults test fork chain per the split-or-recompose order in packages/workflows/src/defaults/generate-bundled-defaults.test.ts. Changes: (1) the committed template repo (mkdtemp + git init/add/commit = 3 spawns) is now built once per file and each scenario gets a cheap recursive fs copy instead of its own git init/add/commit chain; (2) the three mutually compatible positive scenarios — all-tracked, staged-but-uncommitted, and packaged embed — were merged into ONE generator run with one combined `git add` spawn, since their assertions don't depend on per-run process boundaries; (3) the three negative scenarios remain separate runs because they trip different guards (.archon/workflows/defaults untracked guard vs .archon/commands/defaults untracked guard vs packaged tracked-set check) whose stderr messages race under Promise.all, so batching them would force weaker assertions; their remediation-message assertions are preserved byte-for-byte. All 30 original expect() calls are kept verbatim (16 in the merged positive run counting the duplicated idempotent asserts, 14 across the negatives). Results: fork chain drops from ~41 child processes over 6 cases to ~18 over 4 runs; local wall time 1268ms -> ~521-548ms total (per-case 183-233ms -> 97-225ms), and on CI-class Windows where the old file consumed ~19% of the 5000ms/case budget green, per-case exposure is now ~1 bun cold-start + <=3 inner git ls-files, below the single-case cost of any old case. The suite's pre-existing bespoke 15_000 timeout override (on the staged-but-uncommitted case) vanished with that case's merge and was NOT propagated to any test. No timeouts added, no retries/sleeps/skips/platform guards, no tolerance widening, no assertion changes anywhere. Verification: targeted test 6-pass baseline -> 4-pass post-change with all 30 expects, bun run check:bundled / check:bundled-skill / check:bundled-schema all up-to-date, bun run type-check exit 0, bun run test at repo root exit 0 (0 fail across @archon/* filters and scripts). Note: `bun x eslint .` aborts with node SIGABRT on this machine but reproduces identically on pristine HEAD (pre-existing environment failure of the local node binary), so lint gate evidence is limited to lint-staged's eslint --fix --max-warnings 0 pass during commit plus tsc.

**Verification:** targeted test green 5x consecutively + project checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored regression test setup to run more efficiently while preserving existing coverage and assertions.
  * Consolidated multiple positive scenarios into a single test case.
  * Retained validation for tracked, staged, packaged, and untracked-file scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->