### PR TITLE
fix/flaky-subrun-e2e-per-child-fs

### DIFF
--- a/packages/workflows/src/subrun.test.ts
+++ b/packages/workflows/src/subrun.test.ts
@@ -11,8 +11,9 @@
  * NOT mock ./dag-executor, so it cannot share a process with executor.test.ts,
  * which does (mock.module is process-global and irreversible).
  */
-import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, afterAll, mock } from 'bun:test';
 import { mkdir, writeFile, rm, cp, readdir } from 'fs/promises';
+import { existsSync } from 'fs';
 import { join, sep } from 'path';
 import { tmpdir } from 'os';
 
@@ -31,9 +32,30 @@ const mockLogger = {
   isLevelEnabled: mock(() => true),
   level: 'info',
 };
+// Capture-cost control: captureWorkflowSource copies the BUNDLED defaults scope
+// (the repo's .archon/workflows/defaults + .archon/commands/defaults, ~58 files /
+// ~660KB) into EVERY staged source capture, on every executeWorkflow level of
+// every run in this file — e2e timing evidence (#2121 Phase 2 CI) shows that
+// uncontrolled per-run fs fan-out is what pushed the specimen test past Bun's
+// default 5000ms budget on Windows CI. No test here exercises bundled default
+// CONTENT: every discovery call opts out of loading them (`loadDefaults: false`)
+// and every workflow under test is written to the tmp cwd. Pointing the two
+// bundle path getters at a dedicated EMPTY directory (outside ARCHON_HOME) keeps
+// the capture's bundled-scope semantics (an existing-but-empty tree is scanned,
+// recorded in the manifest with 0 files) while removing ~58 file writes per
+// capture per platform-multiplied runner.
+const bundledDefaultsRoot = join(tmpdir(), `subrun-test-empty-bundled-${process.pid}`);
+await mkdir(join(bundledDefaultsRoot, 'defaults'), { recursive: true });
+afterAll(() => {
+  void rm(bundledDefaultsRoot, { recursive: true, force: true }).catch(() => {});
+});
 const realArchonPaths = await import('@archon/paths');
 mock.module('@archon/paths', () => ({
   ...realArchonPaths,
+  // NB: point these one level DEEP (`<root>/defaults`) — captureWorkflowSource copies
+  // dirname(getDefault*Path()), so the getter's PARENT must be the owned empty tree.
+  getDefaultWorkflowsPath: () => join(bundledDefaultsRoot, 'defaults'),
+  getDefaultCommandsPath: () => join(bundledDefaultsRoot, 'defaults'),
   createLogger: mock(() => mockLogger),
   captureWorkflowInvoked: mock(() => {}),
   captureWorkflowCompleted: mock(() => {}),
@@ -508,7 +530,17 @@ function makeFanResolver(root: string): {
       const idx = req.childIndex ?? 0;
       const dir = join(root, 'wt', `${req.parentRun.id}-child-${String(idx)}`);
       await mkdir(dir, { recursive: true });
-      await cp(join(root, '.archon'), join(dir, '.archon'), { recursive: true });
+      // Copy ONLY the workflows subtree, not all of `.archon`: the child reads no
+      // other fixture state out of its isolated checkout (config comes from the
+      // mocked loadConfig; artifacts land under ARCHON_HOME). A full-tree cp re-copied
+      // every artifact/log directory earlier drives had created into `.archon`,
+      // growing per child per drive — exactly the uncontrolled per-child fs cost this
+      // resolver exists to keep bounded.
+      const workflowsRoot = join(root, '.archon', 'workflows');
+      if (existsSync(workflowsRoot)) {
+        await mkdir(join(dir, '.archon'), { recursive: true });
+        await cp(workflowsRoot, join(dir, '.archon', 'workflows'), { recursive: true });
+      }
       return {
         cwd: dir,
         envId: `env-${req.parentRun.id.slice(0, 8)}-${String(idx)}`,
@@ -3266,7 +3298,10 @@ nodes:
       parent,
       'goal',
       'conv-db',
-      { resolveChildIsolation: resolver }
+      // baseBranch is pinned so the executor's $BASE_BRANCH resolution never falls
+      // through to git auto-detection — nothing in this test asserts that detection,
+      // and every level it reached would otherwise pay for it again.
+      { baseBranch: 'main', resolveChildIsolation: resolver }
     );
     expect(r1.success).toBe(false);
     const parentRun = [...store.runs.values()].find(r => r.workflow_name === 'fan-resume');
@@ -3293,7 +3328,8 @@ nodes:
       parent,
       'goal',
       'conv-db',
-      { ...resumeOpts, resolveChildIsolation: resolver }
+      // Same auto-detection opt-out as drive 1; nothing here asserts branch detection.
+      { baseBranch: 'main', ...resumeOpts, resolveChildIsolation: resolver }
     );
 
     expect(r2.success).toBe(true);
@@ -4449,7 +4485,11 @@ nodes:
       cwd,
       await discover('parent-defaults'),
       'goal',
-      'conv-db'
+      'conv-db',
+      // baseBranch pinned: this suite asserts input contracts, not branch
+      // auto-detection; pinning it keeps every executeWorkflow level off the
+      // git-detection fallback path.
+      { baseBranch: 'main' }
     );
 
     expect(result.success).toBe(true);
@@ -4486,7 +4526,11 @@ nodes:
       cwd,
       await discover('parent-missing'),
       'goal',
-      'conv-db'
+      'conv-db',
+      // baseBranch pinned: this suite asserts input contracts, not branch
+      // auto-detection; pinning it keeps every executeWorkflow level off the
+      // git-detection fallback path.
+      { baseBranch: 'main' }
     );
 
     expect(result.success).toBe(false);
@@ -4519,7 +4563,11 @@ nodes:
       cwd,
       await discover('parent-undeclared'),
       'goal',
-      'conv-db'
+      'conv-db',
+      // baseBranch pinned: this suite asserts input contracts, not branch
+      // auto-detection; pinning it keeps every executeWorkflow level off the
+      // git-detection fallback path.
+      { baseBranch: 'main' }
     );
 
     expect(result.success).toBe(false);
@@ -4560,7 +4608,11 @@ nodes:
       cwd,
       await discover('parent-passthrough'),
       'goal',
-      'conv-db'
+      'conv-db',
+      // baseBranch pinned: this suite asserts input contracts, not branch
+      // auto-detection; pinning it keeps every executeWorkflow level off the
+      // git-detection fallback path.
+      { baseBranch: 'main' }
     );
 
     expect(result.success).toBe(true);
@@ -4594,7 +4646,11 @@ nodes:
       cwd,
       await discover('top-level-defaults'),
       'goal',
-      'conv-db'
+      'conv-db',
+      // baseBranch pinned: this suite asserts input contracts, not branch
+      // auto-detection; pinning it keeps every executeWorkflow level off the
+      // git-detection fallback path.
+      { baseBranch: 'main' }
     );
 
     expect(result.success).toBe(true);


### PR DESCRIPTION


---

Automated fix from an archon-stabilize-batch run.

**Summary:** Confirmed the brief's mechanism by instrumentation before fixing: the specimen runs exactly 4 real bash spawns plus 3 full captureWorkflowSource stagings, and every capture copied the repo's bundled defaults scope (~58 files/660KB); makeFanResolver additionally did mkdir + recursive cp of all of .archon per child per drive. Fixed at the prescribed split-or-recompose-test level, test-file only, with every existing assertion intact and no forbidden shortcuts. Changes to packages/workflows/src/subrun.test.ts: (1) pointed getDefaultWorkflowsPath/getDefaultCommandsPath at an owned empty tree in the '@archon/paths' mock (no test exercises bundled default content; all discovery is loadDefaults:false), so each staged capture scans-and-records the bundled scope with zero file writes instead of copying ~58 files; (2) makeFanResolver now copies only the .archon/workflows subtree each isolated child needs instead of the full .archon tree that grew with artifact directories from earlier drives; (3) pinned baseBranch:'main' on the two target suites' executeWorkflow calls where no assertion covers branch auto-detection, keeping $BASE_BRANCH resolution off the git-detection fallback path. Healthy baselines recorded via bun test --reporter=junit/default reporter: specimen 'parent resume re-drives only the failed instance' 70.20ms (was 402.72ms warm pre-recompose); 'declared input contract at runtime' 44.5/9.3/7.8/13.1/6.9ms per test (was up to 177ms); whole subrun.test.ts 83/83 pass. The Windows-only amplification (process creation + Defender per op) multiplies exactly the structural fs work removed; per-test spawns (plan node, 2 children, 1 re-drive) remain because they are the behavior under test. Verification: cd packages/workflows && bun test src/subrun.test.ts -t 'parent resume re-drives only the failed instance' && bun test src/subrun.test.ts -t 'declared input contract at runtime'; then bun run type-check (exit 0), bun run lint --max-warnings 0 (exit 0), bun run test (exit 0, full parallel package suites). Committed as 28aa32ee and pushed to origin.

**Verification:** targeted test green 5x consecutively + project checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved workflow execution test reliability by isolating temporary bundled defaults and cleaning them up automatically.
  * Added explicit main-branch coverage for workflow execution scenarios.
  * Refined checkout fixtures to validate only the relevant workflow files, reducing unrelated test interference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->