### PR TITLE
fix(workflows): workflow test no-fixtures error suggests only workflows that carry fixtures

### DIFF
--- a/packages/workflows/src/fixture-runner.test.ts
+++ b/packages/workflows/src/fixture-runner.test.ts
@@ -232,6 +232,27 @@ describe('runFixtures', () => {
     );
   });
 
+  it('suggests only workflows that carry fixtures when a target has none', async () => {
+    const { cwd } = writeTempProject({ body: passingBody });
+    const bareDir = join(cwd, '.archon', 'workflows', 'bare');
+    mkdirSync(bareDir, { recursive: true });
+    writeFileSync(
+      join(bareDir, 'bare-wf.yaml'),
+      'name: bare-wf\ndescription: test\nnodes:\n  - id: node-a\n    prompt: hi\n'
+    );
+    const err = await runFixtures({
+      workflows: [
+        ...workflowsOnDisk(cwd, ['test-wf']),
+        ...workflowsOnDisk(cwd, ['bare-wf'], 'bare'),
+      ],
+      cwd,
+      target: 'bare-wf',
+    }).catch((e: Error) => e);
+    expect(err).toBeInstanceOf(Error);
+    const suggested = /fixtures \(([^)]*)\)/.exec((err as Error).message)?.[1] ?? '';
+    expect(suggested.split(', ')).toEqual(['test-wf']);
+  });
+
   it('restricts to fixtures of the named workflow via target', async () => {
     const { cwd } = writeTempProject({
       workflowName: 'target-wf',

--- a/packages/workflows/src/fixture-runner.test.ts
+++ b/packages/workflows/src/fixture-runner.test.ts
@@ -253,6 +253,57 @@ describe('runFixtures', () => {
     expect(suggested.split(', ')).toEqual(['test-wf']);
   });
 
+  it('excludes fixture-targeted workflows the catalog cannot load from suggestions', async () => {
+    const { cwd } = writeTempProject({ body: passingBody });
+    // A name-only YAML passes workflowNamesBeside but fails parseWorkflow, so the fixture
+    // beside it targets a workflow the command can never resolve (#2850).
+    const brokenDir = join(cwd, '.archon', 'workflows', 'broken');
+    mkdirSync(join(brokenDir, 'fixtures'), { recursive: true });
+    writeFileSync(join(brokenDir, 'broken-wf.yaml'), 'name: broken-wf\n');
+    writeFileSync(join(brokenDir, 'fixtures', 'orphan.stubs.yaml'), passingBody);
+    const err = await runFixtures({
+      workflows: workflowsOnDisk(cwd, ['test-wf']),
+      cwd,
+      target: 'nope',
+    }).catch((e: Error) => e);
+    expect(err).toBeInstanceOf(Error);
+    const suggested = /fixtures \(([^)]*)\)/.exec((err as Error).message)?.[1] ?? '';
+    expect(suggested.split(', ')).toEqual(['test-wf']);
+  });
+
+  it('reports the divergence hint when discovered fixtures target no catalog workflow', async () => {
+    const { cwd } = writeTempProject({ body: passingBody });
+    const err = await runFixtures({
+      workflows: [],
+      cwd,
+      target: 'nope',
+    }).catch((e: Error) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(
+      /Discovered fixtures target no workflow in the discovery catalog/
+    );
+    expect((err as Error).message).not.toMatch(/declares fixtures/);
+  });
+
+  it('says no workflow declares fixtures when discovery found no fixtures at all', async () => {
+    const cwd = makeTempProject();
+    cleanups.push(cwd);
+    const packDir = join(cwd, '.archon', 'workflows', 'pack');
+    mkdirSync(packDir, { recursive: true });
+    writeFileSync(
+      join(packDir, 'test-wf.yaml'),
+      'name: test-wf\ndescription: test\nnodes:\n  - id: node-a\n    prompt: hello\n'
+    );
+    const err = await runFixtures({
+      workflows: workflowsOnDisk(cwd, ['test-wf']),
+      cwd,
+      target: 'test-wf',
+    }).catch((e: Error) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/No workflow in any discovery scope declares fixtures/);
+    expect((err as Error).message).not.toContain('()');
+  });
+
   it('restricts to fixtures of the named workflow via target', async () => {
     const { cwd } = writeTempProject({
       workflowName: 'target-wf',

--- a/packages/workflows/src/fixture-runner.ts
+++ b/packages/workflows/src/fixture-runner.ts
@@ -104,8 +104,10 @@ export function parseFixtureFile(text: string, path: string): ParsedFixtureFile 
 
 const FIXTURES_DIR = 'fixtures';
 const FIXTURE_SUFFIX = '.stubs.yaml';
-// Discovery walks user directories; the bound mirrors discovery's own depth cap so a
-// pathological tree cannot hang the command.
+// Discovery walks user directories. This is a hang-guard margin for a pathological
+// tree, not a mirror of discovery's cap (MAX_DISCOVERY_DEPTH is 1, and the catalog
+// reaches one packaged-scanner level deeper): fixtures below the catalog's reach are
+// discovered here but can never match a loadable workflow.
 const MAX_WALK_DEPTH = 12;
 
 async function exists(path: string): Promise<boolean> {
@@ -257,8 +259,9 @@ export async function runFixtures(options: RunFixturesOptions): Promise<FixtureR
       selected = all.filter(fixture => fixture.pack === options.target);
     }
     if (selected.length === 0) {
-      // Suggest only workflows a discovered fixture actually targets; the full catalog
-      // would point the user at workflows that cannot satisfy the command.
+      // Suggest only workflows a discovered fixture actually targets AND that the catalog
+      // loaded; the full catalog would point the user at workflows that cannot satisfy the
+      // command, and a fixture beside an unloadable workflow would too.
       const names = [...new Set(all.flatMap(f => f.workflowNames))]
         .filter(name => byName.has(name))
         .sort()
@@ -266,7 +269,9 @@ export async function runFixtures(options: RunFixturesOptions): Promise<FixtureR
       const hint =
         names.length > 0
           ? ` Name a workflow with fixtures (${names}) or a pack directory containing them.`
-          : ' No workflow in any discovery scope declares fixtures.';
+          : all.length === 0
+            ? ' No workflow in any discovery scope declares fixtures.'
+            : ' Discovered fixtures target no workflow in the discovery catalog.';
       throw new Error(`No fixtures found for '${targetName}'.${hint}`);
     }
   }

--- a/packages/workflows/src/fixture-runner.ts
+++ b/packages/workflows/src/fixture-runner.ts
@@ -257,10 +257,17 @@ export async function runFixtures(options: RunFixturesOptions): Promise<FixtureR
       selected = all.filter(fixture => fixture.pack === options.target);
     }
     if (selected.length === 0) {
-      const names = [...byName.keys()].sort().join(', ');
-      throw new Error(
-        `No fixtures found for '${targetName}'. Name a workflow with fixtures (${names}) or a pack directory containing them.`
-      );
+      // Suggest only workflows a discovered fixture actually targets; the full catalog
+      // would point the user at workflows that cannot satisfy the command.
+      const names = [...new Set(all.flatMap(f => f.workflowNames))]
+        .filter(name => byName.has(name))
+        .sort()
+        .join(', ');
+      const hint =
+        names.length > 0
+          ? ` Name a workflow with fixtures (${names}) or a pack directory containing them.`
+          : ' No workflow in any discovery scope declares fixtures.';
+      throw new Error(`No fixtures found for '${targetName}'.${hint}`);
     }
   }
 


### PR DESCRIPTION
## Problem and outcome

When `archon workflow test <target>` finds no fixtures for the target, the error's "Name a workflow with fixtures (…)" list included every discovered workflow, not just the ones that actually declare fixtures. Following the suggestion (for example `archon-pr` or `archon-review`) reproduced the same error, so the message dead-ended the user.

- **Outcome:** the suggestion list now contains only workflows that both exist in the discovery catalog and are targeted by at least one discovered fixture. When the filtered list is empty, the message explains why instead of rendering an empty list: either no workflow anywhere declares fixtures, or discovered fixtures target no workflow the catalog can load.
- **Invariant:** target lookup and all successful `workflow test` behavior are unchanged; only the no-fixtures error text changed.
- **Scope boundary:** nothing about fixture discovery, matching, or execution changed; other `workflow test` errors are untouched.
- **Root cause:** the error message reused the keys of `byName`, the full discovered-workflow catalog built for lookup, instead of the fixture-carrying subset. `byName` must stay complete for lookup; only the message needed the narrower source.

## Review guidance

- **Feedback requested:** correctness of the suggestion source and the empty-catalog wording.
- **Start here:** `packages/workflows/src/fixture-runner.ts:260` — the suggestion list now derives from `all.flatMap(f => f.workflowNames)` intersected with `byName`, instead of all `byName` keys.
- **Review order:** `fixture-runner.ts` change, then the four new tests in `fixture-runner.test.ts`.
- **Lower-attention areas:** the test file additions are mechanical setup — temp workflows, a name-only unloadable YAML, and empty discovery scopes — around regex assertions on the error message.
- **Known risk or uncertainty:** None.

## Solution

`runFixtures` already collects every discovered fixture in `all`, and each fixture carries the workflow names it targets. Building the suggestion list from that set, filtered to names still present in the catalog, points the user only at workflows that can actually satisfy the command. The `byName.has(name)` filter goes one step beyond the issue's proposed fix: a fixture can reference a workflow that no longer exists or fell outside discovery, and suggesting it would recreate the same dead-end. When the filtered list is empty, the message distinguishes the two possible causes rather than printing an empty parenthetical: no fixtures discovered at all (a project with zero fixtures hitting `workflow test <anything>`, reachable before this change too) reports that no workflow declares fixtures, while discovered fixtures that target no loadable catalog workflow get an explicit divergence hint.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | `workflow test <target>` with no matching fixtures listed every discovered workflow, including fixture-less ones. | The list contains only discovered workflows that at least one fixture targets. |
| **Failure behavior** | Following a suggestion could return the identical error. | Every suggested workflow name is in the catalog and targeted by a discovered fixture, so following it runs fixtures; an empty list gets an explicit explanation of which of the two causes applies. |

## Validation

- `bun test src/fixture-runner.test.ts` (packages/workflows) — 19 pass, including the new `suggests only workflows that carry fixtures when a target has none`, which failed before the fix (suggestions were `['bare-wf', 'test-wf']`) and passes after (`['test-wf']`), plus tests for the catalog-unloadable exclusion, the divergence hint, and the no-fixtures-at-all message.
- Existing tests `restricts to fixtures of the named workflow via target` and `filters by pack name when the target is not a workflow name` pass unchanged, proving target lookup is preserved.
- `bun run test` (packages/workflows full script) — all pass.
- `bun run type-check` (packages/workflows) — clean.
- `bun test src/commands/workflow.test.ts` (packages/cli) — 298 pass; the CLI mocks `fixture-runner`, so there is no message coupling.
- `bun run lint` (root wrapper) — clean.
- **Not verified:** Nothing material — the error string is fully covered by the package tests above.

## Links

- Closes #2850



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fixture discovery error messages with more accurate workflow suggestions.
  * Excluded unavailable or invalid workflows from suggested targets.
  * Added clearer guidance when fixtures are missing, undiscoverable, or do not match available workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->