### PR TITLE
Script node failure diagnostics include stdout

### DIFF
--- a/packages/docs-web/src/content/docs/guides/script-nodes.md
+++ b/packages/docs-web/src/content/docs/guides/script-nodes.md
@@ -75,9 +75,12 @@ The file `.archon/scripts/fetch-github-pages.ts` is loaded and executed with
 4. **Capture.** `stdout` (with the trailing newline stripped) becomes
    `$nodeId.output`. On a successful run, `stderr` is logged as a warning and
    posted to the conversation but does **not** fail the node. A non-zero exit
-   code fails the node; on failure, `stderr` is the diagnostic surfaced in the
-   error message (`Script node 'X' failed [exit N]: <stderr>`) — the script
-   body is never echoed back to users.
+   code fails the node; on failure, tails of both streams are surfaced in the
+   error message (`Script node 'X' failed [exit N]: [stderr] ... [stdout] ...`),
+   sharing a ~2 KB diagnostic budget — stderr keeps priority, stdout gets the
+   remainder, and a label prefixes each stream only when both are populated.
+   With stderr empty, the stdout tail becomes the diagnostic. The script body
+   is never echoed back to users.
 
 ## YAML Schema
 

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -2586,14 +2586,16 @@ describe('executeDagWorkflow -- bash nodes', () => {
       user_message: 'test',
     });
 
-    // Marker is echoed to stdout only (so it lands in the command line embedded
-    // in err.message but never in stderr). If it shows up in errorMsg the
-    // prefix line was not stripped.
+    // The marker appears only in the script body (never echoed to stdout or
+    // stderr). If it shows up in errorMsg the "Command failed: bash -c <body>"
+    // prefix line was not stripped. The stdout echo is separately asserted so a
+    // regression that drops stdout from the diagnostics is caught.
     const bashNode: ExecNode = {
       id: 'fail-bash-1389',
       kind: 'exec',
       runtime: 'sh',
-      script: 'echo UNIQUE_CMDLINE_MARKER_1389; echo "diagnostic from stderr" >&2; exit 1',
+      script:
+        'UNIQUE_CMDLINE_MARKER_1389=; echo "stdout context before failure"; echo "diagnostic from stderr" >&2; exit 1',
     };
 
     await executeDagWorkflow(
@@ -2626,6 +2628,9 @@ describe('executeDagWorkflow -- bash nodes', () => {
     expect(errorMsg).not.toContain('Command failed:');
     expect(errorMsg).not.toContain('UNIQUE_CMDLINE_MARKER_1389');
     expect(errorMsg).toContain('diagnostic from stderr');
+    expect(errorMsg).toContain('stdout context before failure');
+    expect(errorMsg).toContain('[stderr]');
+    expect(errorMsg).toContain('[stdout]');
   });
 
   it('variable substitution works in bash scripts', async () => {

--- a/packages/workflows/src/executor-shared.test.ts
+++ b/packages/workflows/src/executor-shared.test.ts
@@ -767,16 +767,15 @@ describe('formatSubprocessFailure', () => {
     expect(userMessage).toContain('[exit 2]');
   });
 
-  it('truncates diagnostics larger than 2 KB from the tail', () => {
+  it('keeps the tail of diagnostics larger than 2 KB and bounds the output', () => {
     const big = 'x'.repeat(5000) + '\nactual error at end';
     const { userMessage } = formatSubprocessFailure(
       { message: 'Command failed: cmd\n', stderr: big, code: 1 },
       "Script node 'n1'"
     );
     expect(userMessage).toContain('actual error at end');
-    expect(userMessage).toContain('[truncated]');
-    // Tight bound: ~2 KB diagnostic + label prefix + truncation suffix should fit
-    // well under 2.1 KB. Bumping SUBPROCESS_ERROR_MAX_CHARS would trip this.
+    // Tight bound: ~2 KB diagnostic + label prefix should fit well under 2.1 KB.
+    // Bumping SUBPROCESS_ERROR_MAX_CHARS would trip this.
     expect(userMessage.length).toBeLessThan(2100);
   });
 
@@ -810,6 +809,56 @@ describe('formatSubprocessFailure', () => {
     expect(logFields.exitCode).toBeUndefined();
     expect(logFields.killed).toBe(false);
     expect(logFields.stderrTail).toBeUndefined();
+  });
+
+  it('uses a stdout tail as the diagnostic when stderr is empty', () => {
+    const err = {
+      message: 'Command failed: bash -c script body\n',
+      stdout: 'targeted test failed on repetition 3/5: bun test foo.test.ts',
+      code: 1,
+    };
+    const { userMessage, logFields } = formatSubprocessFailure(err, "Script node 'n1'");
+    expect(userMessage).not.toContain('no diagnostic output');
+    expect(userMessage).toContain('targeted test failed on repetition 3/5');
+    expect(userMessage).toContain('[exit 1]');
+    expect(logFields.stdoutTail).toBe(err.stdout);
+    expect(logFields.stderrTail).toBeUndefined();
+  });
+
+  it('includes labelled stderr and stdout tails when both streams are populated', () => {
+    const err = {
+      message: 'Command failed: bash -c script body\n',
+      stderr: 'error: assertion failed',
+      stdout: 'progress line before failure',
+      code: 1,
+    };
+    const { userMessage, logFields } = formatSubprocessFailure(err, "Script node 'n1'");
+    expect(userMessage).toContain('[stderr]');
+    expect(userMessage).toContain('error: assertion failed');
+    expect(userMessage).toContain('[stdout]');
+    expect(userMessage).toContain('progress line before failure');
+    expect(logFields.stderrTail).toBe('error: assertion failed');
+    expect(logFields.stdoutTail).toBe('progress line before failure');
+  });
+
+  it('caps stderr and stdout tails jointly under the existing 2 KB budget', () => {
+    const err = {
+      message: 'Command failed: cmd\n',
+      stderr: 'e'.repeat(1200),
+      stdout: 'o'.repeat(5000),
+      code: 1,
+    };
+    const { userMessage, logFields } = formatSubprocessFailure(err, "Script node 'n1'");
+    expect(userMessage.length).toBeLessThan(2100);
+    expect(userMessage).toContain('[stderr]');
+    expect(userMessage).toContain('[stdout]');
+    const { stderrTail, stdoutTail } = logFields;
+    expect(typeof stderrTail).toBe('string');
+    expect(typeof stdoutTail).toBe('string');
+    if (typeof stderrTail !== 'string' || typeof stdoutTail !== 'string')
+      throw new Error('tails missing');
+    expect(stderrTail.length).toBeLessThanOrEqual(1000);
+    expect(stdoutTail.length).toBeLessThanOrEqual(2000 - stderrTail.length);
   });
 
   it('omits the [exit N] suffix when no code is present', () => {

--- a/packages/workflows/src/executor-shared.ts
+++ b/packages/workflows/src/executor-shared.ts
@@ -191,8 +191,13 @@ export function toTelemetryErrorClass(errorType: ErrorType): archonPaths.Workflo
 
 // ─── Subprocess Failure Formatting ───────────────────────────────────────────
 
-/** Max characters of stderr/message we keep in user-facing and logged fields. */
+/** Max characters of combined stdout+stderr we keep in user-facing and logged fields. */
 const SUBPROCESS_ERROR_MAX_CHARS = 2000;
+
+function streamTail(text: string, max: number): string | undefined {
+  if (text.length === 0) return undefined;
+  return text.length > max ? text.slice(-max) : text;
+}
 
 /**
  * Raw ExecFileException shape from Node's `child_process.execFile`. For inline
@@ -215,7 +220,9 @@ interface RawSubprocessError {
  * Produce a concise, diagnostic-first summary of a failed subprocess.
  *
  * User-visible output strips Node's `"Command failed: <cmd>"` prefix (which for
- * inline scripts contains the full script body) and prefers stderr when present.
+ * inline scripts contains the full script body) and includes a jointly capped
+ * tail of stderr and stdout — stderr keeps budget priority, stdout gets the
+ * remainder, so scripts that report failure context on stdout stay visible.
  * Log fields expose a controlled, tail-truncated subset — never the full `err`
  * object, to prevent Pino's default error serializer from emitting three copies
  * of the script body (`err.message`, `err.stack`, `err.cmd`).
@@ -225,6 +232,7 @@ export function formatSubprocessFailure(
   label: string
 ): { userMessage: string; logFields: Record<string, unknown> } {
   const stderr = (err.stderr ?? '').trim();
+  const stdout = (err.stdout ?? '').trim();
   const rawMessage = (err.message ?? '').trim();
 
   // The first line of Node's ExecFileException.message is `Command failed: <cmd>`,
@@ -235,9 +243,26 @@ export function formatSubprocessFailure(
     ? rawMessage.split('\n').slice(1).join('\n').trim()
     : rawMessage;
 
+  // Well-behaved scripts print failure context to stdout, so both streams share
+  // the cap. stderr keeps budget priority; the leftover goes to stdout, and each
+  // stream is labelled only when both are present. The budget accounts for the
+  // label overhead so the joined diagnostic never truncates away a label.
+  const STDERR_LABEL = '[stderr]\n';
+  const STDOUT_LABEL = '\n[stdout]\n';
+  const bothPresent = stderr.length > 0 && stdout.length > 0;
+  const labelsOverhead = bothPresent ? STDERR_LABEL.length + STDOUT_LABEL.length : 0;
+  const halfCap = Math.floor(SUBPROCESS_ERROR_MAX_CHARS / 2);
+  const stderrTail = streamTail(stderr, bothPresent ? halfCap : SUBPROCESS_ERROR_MAX_CHARS);
+  const stdoutTail = streamTail(
+    stdout,
+    SUBPROCESS_ERROR_MAX_CHARS - labelsOverhead - (stderrTail?.length ?? 0)
+  );
+
   let diagnostic: string;
-  if (stderr) {
-    diagnostic = stderr;
+  if (stderrTail && stdoutTail) {
+    diagnostic = `${STDERR_LABEL}${stderrTail}${STDOUT_LABEL}${stdoutTail}`;
+  } else if (stderrTail || stdoutTail) {
+    diagnostic = (stderrTail ?? '') + (stdoutTail ?? '');
   } else if (bodyAfterPrefix) {
     diagnostic = bodyAfterPrefix;
   } else if (hasCommandFailedPrefix) {
@@ -254,15 +279,13 @@ export function formatSubprocessFailure(
 
   const exitSuffix = err.code != null ? ` [exit ${String(err.code)}]` : '';
 
-  const stderrTail =
-    stderr.length > SUBPROCESS_ERROR_MAX_CHARS ? stderr.slice(-SUBPROCESS_ERROR_MAX_CHARS) : stderr;
-
   return {
     userMessage: `${label} failed${exitSuffix}: ${truncated}`,
     logFields: {
       exitCode: err.code ?? undefined,
       killed: err.killed === true,
-      stderrTail: stderrTail.length > 0 ? stderrTail : undefined,
+      stderrTail,
+      stdoutTail,
     },
   };
 }


### PR DESCRIPTION
## Problem and outcome

When a `script:` or bash node fails, the node error and log carried only the subprocess **stderr** (or "no diagnostic output" when stderr was empty). Well-behaved scripts print progress and failure context to stdout, so the decisive evidence — a repetition count, the failing command, a test output tail — was silently dropped and an operator had to re-run the script manually to learn why it failed.

- **Outcome:** Failed script/bash node diagnostics now include tails of both streams under the existing 2 KB budget. With stderr empty, the stdout tail becomes the diagnostic; when both streams are populated each is labelled and stderr keeps budget priority.
- **Invariant:** The diagnostic never exceeds the `SUBPROCESS_ERROR_MAX_CHARS` (2000) budget, stream labels only appear when both streams are populated, and the script body (embedded in Node's `Command failed:` prefix) is never echoed back to users.
- **Scope boundary:** The dry-run simulator (`dry-run.ts`) has its own stderr-only reporting path and was intentionally left untouched; see Review guidance.
- **Root cause:** `formatSubprocessFailure` built its diagnostic from `err.stderr` alone and never read `err.stdout`, even though the subprocess rejection already carries a redacted stdout.

## Review guidance

- **Feedback requested:** Correctness of the joint budget arithmetic and whether the label shapes (`[stderr]` / `[stdout]`) read well in batch reports and conversation messages.
- **Start here:** `packages/workflows/src/executor-shared.ts:246` — the diagnostic construction is the load-bearing change; both `dag-executor.ts` call sites (bash nodes, script nodes) consume this one formatter, so node_error events, batch reports, and the `dag_node_failed` log line all pick up the behavior here.
- **Review order:** `executor-shared.ts` (formatter), `executor-shared.test.ts` (stream-tail behavior and budget), `dag-executor.test.ts` (end-to-end bash-node assertion), `script-nodes.md` (capture-section docs).
- **Lower-attention areas:** The docs capture section and the bash-node test rework. The test's stdout marker had been a proxy for the leaked `Command failed:` prefix; since stdout is now legitimately surfaced, the marker moved into the script body only and the stdout inclusion got its own assertion.
- **Known risk or uncertainty:** `dry-run.ts:677` reports a failing script node as `err.stderr?.trim() || err.message`, which still drops stdout and can leak the script body into the dry-run report when stderr is empty. It sits outside the pinned sanitized formatter path and is not fixed here.

## Solution

`formatSubprocessFailure` now caps both streams jointly: stderr keeps budget priority (up to 1000 chars when stdout is also populated, up to the full 2000 otherwise) and stdout gets the remainder. The budget accounts for the label overhead so the joined diagnostic never truncates away a stream label. With stderr empty, the stdout tail becomes the diagnostic. Log fields now carry `stdoutTail` alongside `stderrTail`, still a controlled, tail-truncated subset — never the full error object — so Pino's serializer cannot emit copies of the script body. The fallback chain after the streams and the prefix stripping that keeps the script body out of user-facing output are unchanged. The subprocess rejection already carries credential-scrubbed stdout (`redactSubprocessError`), so no new redaction is needed before the text reaches the formatter.

One test rework was required: an existing executor-shared test asserted a `…[truncated]` suffix. Tails are now pre-capped, so a single-stream diagnostic never exceeds the budget and the suffix is unreachable for stream content; the guard remains for the uncapped `bodyAfterPrefix` fallback path.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Failed script/bash node error carried stderr only, or "no diagnostic output" when stderr was empty. | Error carries labelled tails of both streams (`[stderr]` / `[stdout]`) sharing the 2 KB budget; with stderr empty, the stdout tail is the diagnostic. |
| **Failure behavior** | Live failure showed `[exit 1]: no diagnostic output` while stdout held the repetition count and failing command — unrecoverable without a manual re-run. | The same failure surfaces the stdout context (`targeted test failed on repetition N/5: <cmd>`) in the node error, batch report, and log fields. |

## Validation

- `packages/workflows`: `bun run test` — 0 failures across all suite chunks; proves the both-streams diagnostic, the stderr-empty fallback, and the joint cap bounds.
- `packages/workflows`: `bun run type-check` — clean.
- Root `bun run lint` and `bun run format:check` — clean.
- Root `bun run type-check` — clean.
- **Not verified:** Root `bun run validate` was not run end to end; the changed paths are covered by the package test script, both type-checks, lint, and format:check, and no other packages are touched by this diff.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | Additive: new `stdoutTail` log field and longer diagnostics. Existing stderr-only diagnostics keep their shape when stdout is empty. | `executor-shared.ts` fallback chain unchanged |
| Security / permissions / data | Stdout text entering diagnostics is already redacted by `redactSubprocessError`; log fields remain a tail-truncated subset, never the full error object. | `dag-executor.ts` redaction at subprocess rejection |
| Documentation / communication | Script-nodes guide capture section updated to describe the both-streams diagnostic. | `packages/docs-web/src/content/docs/guides/script-nodes.md` |

## Links

- Closes #2825


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Script execution errors now include relevant output from both standard error and standard output.
  * Diagnostics are limited to approximately 2,000 characters, prioritizing standard error for clearer failure messages.
  * Output sections are labeled when both streams contain information.

* **Documentation**
  * Updated script-node guidance to describe the improved failure diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->