### PR TITLE
fix(workflows): restore the delivered-fixture bar after the review-complete join

### DIFF
--- a/.archon/workflows/sdlc/ship/fixtures/direct-delivered.stubs.yaml
+++ b/.archon/workflows/sdlc/ship/fixtures/direct-delivered.stubs.yaml
@@ -47,3 +47,4 @@ deliver__review__mode: '{"continuation":false}'
 deliver__review__scope: "target recorded; head sha stubbed"
 deliver__review__code: "0 findings"
 deliver__review__seams: "0 findings"
+deliver__review__review-complete: "settled"

--- a/.archon/workflows/sdlc/ship/fixtures/planned-delivered.stubs.yaml
+++ b/.archon/workflows/sdlc/ship/fixtures/planned-delivered.stubs.yaml
@@ -50,3 +50,4 @@ deliver__review__mode: '{"continuation":false}'
 deliver__review__scope: "target recorded; head sha stubbed"
 deliver__review__code: "0 findings"
 deliver__review__seams: "0 findings"
+deliver__review__review-complete: "settled"

--- a/.archon/workflows/sdlc/ship/fixtures/rooted-delivered.stubs.yaml
+++ b/.archon/workflows/sdlc/ship/fixtures/rooted-delivered.stubs.yaml
@@ -30,6 +30,7 @@ deliver__review__mode: '{"continuation":false}'
 deliver__review__scope: "target recorded; head sha stubbed"
 deliver__review__code: "0 findings"
 deliver__review__seams: "0 findings"
+deliver__review__review-complete: "settled"
 deliver__review__synthesize:
   ready: true
   action: none

--- a/.archon/workflows/sdlc/stabilize/fixtures/fix-delivered.stubs.yaml
+++ b/.archon/workflows/sdlc/stabilize/fixtures/fix-delivered.stubs.yaml
@@ -47,3 +47,4 @@ deliver__review__mode: '{"continuation":false}'
 deliver__review__scope: "target recorded; head sha stubbed"
 deliver__review__code: "0 findings"
 deliver__review__seams: "0 findings"
+deliver__review__review-complete: "settled"

--- a/.archon/workflows/sdlc/upkeep/fixtures/update-delivered.stubs.yaml
+++ b/.archon/workflows/sdlc/upkeep/fixtures/update-delivered.stubs.yaml
@@ -47,3 +47,4 @@ deliver__review__mode: '{"continuation":false}'
 deliver__review__scope: "target recorded; head sha stubbed"
 deliver__review__code: "0 findings"
 deliver__review__seams: "0 findings"
+deliver__review__review-complete: "settled"


### PR DESCRIPTION
## Problem and outcome

`bun run cli workflow test` has been red on `dev` since #2863 merged: five of the SDLC pack's delivered fixtures fail, so the pack's dry-run bar no longer proves the delivery tail simulates end to end.

- **Outcome:** The fixture bar goes from 23 passed / 5 failed back to 28 passed / 0 failed, and the seven spurious "unused stubs" warnings on those five fixtures disappear.
- **Invariant:** Every exec node a fixture's dry-run actually reaches has an explicit stub, at whatever include depth the fixture's workflow sees it.
- **Scope boundary:** No workflow YAML, engine, or generated-bundle change. The pack fixtures are not embedded in `bundled-defaults.generated.ts` — the generator reads only top-level files per workflow directory, never the `fixtures/` subdirectory — so nothing needed regenerating.
- **Root cause:** #2863 added the `review-complete` barrier node to `archon-review.yaml`. Through two `include:` levels (`archon-review` → `archon-deliver` as `review`, `archon-deliver` → ship/stabilize/upkeep as `deliver`) the parent workflows see it as `deliver__review__review-complete`. It is a real `bash:` node, and `workflow test` passes neither `--default-stubs` nor `--exec-code`, so a reached exec node without a stub is recorded `failed` in the trace, and the dry-run's `anyFailed` check flips the whole run to `failed`. #2863 added the sibling `deliver__review__mode` stub to all five parent fixtures but not `deliver__review__review-complete`, so all five fail on the identical single missing key.

## Review guidance

- **Feedback requested:** Correctness of the stub key and its placement.
- **Start here:** `.archon/workflows/sdlc/ship/fixtures/direct-delivered.stubs.yaml` — the one added line, repeated verbatim in the other four.
- **Review order:** All five files are the same one-line addition; the reference pattern they mirror is `.archon/workflows/sdlc/deliver/fixtures/clean.stubs.yaml:16`.
- **Known risk or uncertainty:** None. The missing key was confirmed from `workflow test --json`, which reported `missingStubs: ["deliver__review__review-complete"]` on each of the five and nothing else.

## Solution

Adds `deliver__review__review-complete: "settled"` to each of the five parent-level delivered fixtures, next to the `deliver__review__*` block #2863 already touched. This mirrors the deliver-level fixtures that exercise the same new topology one include level in (`clean`, `adjacent-discovery`, `selective-review`), which received both new stubs in #2863 and pass. The value is arbitrary — `review-complete` is `bash: "true"` and no node reads its output; `"settled"` is the value the deliver-level fixtures already use.

The topology itself is correct and unchanged. This is fixture maintenance that #2863 missed on the outer workflows, not a defect in the join node.

## Validation

- `bun run cli workflow test` before the change — `23 passed, 5 failed`, each failure reporting `missingStubs: ["deliver__review__review-complete"]` plus seven downstream "unused stubs" warnings for nodes the halted run never reached.
- `bun run cli workflow test` after the change — `28 passed, 0 failed`, warnings gone. Re-run on the committed tree to confirm.
- `bun run lint` — clean.
- `bun run validate` — exit 0, zero test failures across all packages.
- `bun run check:bundled` — up to date, and the pre-commit hook's full regeneration produced no diff, confirming fixtures are not part of the generated bundle.
- All runs were done in an isolated worktree off `origin/dev` at `1cbaf258`, since exec-code fixtures elsewhere in the suite can still write into the caller's tree (#2851, unfixed).
- **Not verified:** Nothing material. The fixture bar is the surface this change exists to restore, and it was observed red before and green after.

## Links

- Related #2807 — the rolling SDLC-pack issue this was diagnosed under. Root-cause comment: https://github.com/coleam00/Archon/issues/2807#issuecomment-5444412470
- Related #2863 — the PR that introduced the `review-complete` join and the fixture gap.

Two adjacent gaps stay open and are deliberately not addressed here.

The first is why nothing caught this before merge. The fixture bar does run in CI, but only in `e2e-smoke.yml`, which triggers on `push` to `main`/`dev` and `workflow_dispatch` — not on `pull_request`. `test.yml` is the workflow that gates PRs and it does not run `workflow test`. So the bar only reports *after* a merge lands on `dev`, which is exactly how #2863 went in green and turned `dev` red. Note the same holds for this PR: its own CI will not exercise the fixture bar, so the local run recorded above is the evidence, and `e2e-smoke` will confirm it on `dev` post-merge. Making the bar gate PRs is the real follow-up, not "add it to CI".

The second is that the dry-run's `anyFailed` computation treats any failed node as a failed run, which does not model the `trigger_rule: all_done` tolerance the real executor applies to a barrier node like this one. A fixture author currently has to know to stub join nodes the engine would happily tolerate skipping.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated workflow dry-run scenarios to include a completed delivery review outcome.
  - Standardized review completion status as “settled” across delivery, stabilization, and upkeep scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->