### PR TITLE
test: retry temp-directory cleanup that races handle release

### DIFF
--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -9,8 +9,9 @@ import { Database } from 'bun:sqlite';
 import { parseArgs } from 'util';
 import { cliArgOptions } from './args';
 import * as git from '@archon/git';
+import { removeTempTree } from '@archon/paths/test-utils';
 import { spawnSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join, relative } from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -149,7 +150,7 @@ describe('workflow run config argument', () => {
     expect(message).toContain('--config can only be used with workflow run');
   });
 
-  it('resolves a relative config path from the requested subdirectory cwd', () => {
+  it('resolves a relative config path from the requested subdirectory cwd', async () => {
     const repo = mkdtempSync(join(tmpdir(), 'archon-cli-config-cwd-'));
     const subdir = join(repo, 'bench');
     mkdirSync(subdir, { recursive: true });
@@ -166,11 +167,11 @@ describe('workflow run config argument', () => {
       expect(result.stderr).toContain("Run config key 'paths' cannot apply");
       expect(result.stderr).not.toContain('Unable to read run config');
     } finally {
-      rmSync(repo, { recursive: true, force: true });
+      await removeTempTree(repo);
     }
   });
 
-  it('keeps a detached config handoff outside repo env overrides', () => {
+  it('keeps a detached config handoff outside repo env overrides', async () => {
     const repo = mkdtempSync(join(tmpdir(), 'archon-cli-detached-config-'));
     const archonHome = join(repo, 'archon-home');
     mkdirSync(join(repo, '.archon'), { recursive: true });
@@ -233,11 +234,11 @@ describe('workflow run config argument', () => {
       expect(result.stderr).not.toContain('could not be decrypted');
       expect(result.stderr).toContain('--resume and --config are mutually exclusive');
     } finally {
-      rmSync(repo, { recursive: true, force: true });
+      await removeTempTree(repo);
     }
   });
 
-  it('keeps a detached Docker install classified through target env loading', () => {
+  it('keeps a detached Docker install classified through target env loading', async () => {
     const repo = mkdtempSync(join(tmpdir(), 'archon-cli-detached-docker-'));
     mkdirSync(join(repo, '.archon'), { recursive: true });
     writeFileSync(
@@ -305,7 +306,7 @@ describe('workflow run config argument', () => {
         },
       });
     } finally {
-      rmSync(repo, { recursive: true, force: true });
+      await removeTempTree(repo);
     }
   });
 
@@ -383,7 +384,7 @@ describe('workflow get arguments', () => {
 });
 
 describe('CLI workflow event dispatch', () => {
-  it('resolves a run prefix using the registered effective cwd', () => {
+  it('resolves a run prefix using the registered effective cwd', async () => {
     const scratch = mkdtempSync(join(tmpdir(), 'archon-cli-event-'));
     const archonHome = join(scratch, 'home');
     const repoDir = join(scratch, 'repo');
@@ -466,7 +467,7 @@ describe('CLI workflow event dispatch', () => {
         verify.close();
       }
     } finally {
-      rmSync(scratch, { recursive: true, force: true });
+      await removeTempTree(scratch);
     }
   }, 30_000);
 });

--- a/packages/cli/src/commands/workflow-terminal-event.integration.spec.ts
+++ b/packages/cli/src/commands/workflow-terminal-event.integration.spec.ts
@@ -1,10 +1,10 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
-import { rm } from 'node:fs/promises';
 import { createConnection } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
+import { removeTempTree } from '@archon/paths/test-utils';
 import { detachedRunControlPath, requestDetachedRunStop } from '../utils/detached-run-control';
 
 const cleanupPaths: string[] = [];
@@ -21,10 +21,7 @@ afterEach(async () => {
   }
   activeRunIds.clear();
   for (const path of cleanupPaths.splice(0)) {
-    // The control endpoint closes after the workflow settles but just before the
-    // detached process finishes its remaining CLI cleanup. Windows can retain an
-    // inherited log or SQLite handle during that short gap.
-    await rm(path, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+    await removeTempTree(path);
   }
 });
 
@@ -170,7 +167,16 @@ describe('detached workflow terminal database events', () => {
         return run?.status === fixture.status ? run : undefined;
       });
       expect(terminal.id).toBe(created.id);
-      const events = readTerminalEvents(databasePath, terminal.id, fixture.event);
+      // The status row and the terminal-event row are two separate writes, so a terminal
+      // status does not mean the event is visible to a second connection yet — on Windows
+      // that contention surfaced as `SQLiteError: disk I/O error` from a single-shot read
+      // (#2306). Waiting for the row is safe rather than lenient about the count: the
+      // owner's endpoint is already unreachable above, so no further event can be written
+      // after the first one appears.
+      const events = await waitFor(() => {
+        const rows = readTerminalEvents(databasePath, terminal.id, fixture.event);
+        return rows.length > 0 ? rows : undefined;
+      });
       expect(events).toHaveLength(1);
       const data = JSON.parse(events[0]?.data ?? '{}') as Record<string, unknown>;
       if (fixture.status === 'completed') expect(data.duration_ms).toBeNumber();

--- a/packages/cli/src/commands/workflow-terminal-event.integration.spec.ts
+++ b/packages/cli/src/commands/workflow-terminal-event.integration.spec.ts
@@ -10,6 +10,10 @@ import { detachedRunControlPath, requestDetachedRunStop } from '../utils/detache
 const cleanupPaths: string[] = [];
 const activeRunIds = new Set<string>();
 
+// Deliberately one explicit hook rather than `trackTempRoots()` from the same module:
+// a still-running owner has to be stopped before its tree can be removed, and splitting
+// that into two `afterEach` hooks would leave the order they were registered in as the
+// only thing keeping it correct.
 afterEach(async () => {
   for (const runId of activeRunIds) {
     try {
@@ -167,12 +171,15 @@ describe('detached workflow terminal database events', () => {
         return run?.status === fixture.status ? run : undefined;
       });
       expect(terminal.id).toBe(created.id);
-      // The status row and the terminal-event row are two separate writes, so a terminal
-      // status does not mean the event is visible to a second connection yet — on Windows
-      // that contention surfaced as `SQLiteError: disk I/O error` from a single-shot read
-      // (#2306). Waiting for the row is safe rather than lenient about the count: the
-      // owner's endpoint is already unreachable above, so no further event can be written
-      // after the first one appears.
+      // Not a write-ordering gap: `completeWorkflowRun` and `failWorkflowRun` write the
+      // status UPDATE and the event INSERT inside one `withTransaction`, so a reader can
+      // never see the terminal status without the event. What retries here is the READ.
+      // Opening a second readonly connection against a database that is still settling
+      // that commit fails outright on Windows — `SQLiteError: disk I/O error` from
+      // `prepare()`, not an empty result (#2306). So this waits out reader-side
+      // contention, and the count stays exact: the event was committed atomically with
+      // the status already observed above, and the owner's endpoint is unreachable, so
+      // nothing can append a second row after the first read succeeds.
       const events = await waitFor(() => {
         const rows = readTerminalEvents(databasePath, terminal.id, fixture.event);
         return rows.length > 0 ? rows : undefined;

--- a/packages/cli/src/utils/detached-run-control.integration.spec.ts
+++ b/packages/cli/src/utils/detached-run-control.integration.spec.ts
@@ -1,9 +1,10 @@
-import { afterEach, describe, expect, it } from 'bun:test';
+import { describe, expect, it } from 'bun:test';
 import { spawn, type ChildProcess } from 'node:child_process';
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { createConnection, createServer, type Server, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { trackTempRoots } from '@archon/paths/test-utils';
 import {
   DETACHED_RUN_IPC_TIMEOUT_MS,
   detachedRunControlPath,
@@ -11,11 +12,10 @@ import {
   startDetachedRunControlServer,
 } from './detached-run-control';
 
-const cleanupPaths: string[] = [];
-
-afterEach(() => {
-  for (const path of cleanupPaths.splice(0)) rmSync(path, { recursive: true, force: true });
-});
+// These fixtures are torn down after tests that spawn, and then kill, a real detached
+// child. A killed process can still hold a handle inside its temp tree at the instant of
+// cleanup, and an unretried removal fails a test whose assertions already passed (#2306).
+const trackTempRoot = trackTempRoots();
 
 async function waitFor(check: () => boolean, timeoutMs = 5_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
@@ -84,8 +84,7 @@ async function rejectedError(action: () => Promise<unknown>): Promise<Error> {
 describe('detached run control integration', () => {
   it('stops the detached owner process group before its descendant can leak work', async () => {
     const runId = `tree-${crypto.randomUUID()}`;
-    const fixtureDir = mkdtempSync(join(tmpdir(), 'archon-detached-control-'));
-    cleanupPaths.push(fixtureDir);
+    const fixtureDir = trackTempRoot(mkdtempSync(join(tmpdir(), 'archon-detached-control-')));
     const readyPath = join(fixtureDir, 'ready');
     const leakPath = join(fixtureDir, 'leaked');
     const goPath = join(fixtureDir, 'go');
@@ -133,8 +132,7 @@ describe('detached run control integration', () => {
     if (process.platform === 'win32') return;
 
     const runId = `foreground-${crypto.randomUUID()}`;
-    const fixtureDir = mkdtempSync(join(tmpdir(), 'archon-foreground-control-'));
-    cleanupPaths.push(fixtureDir);
+    const fixtureDir = trackTempRoot(mkdtempSync(join(tmpdir(), 'archon-foreground-control-')));
     const readyPath = join(fixtureDir, 'ready');
     const leakPath = join(fixtureDir, 'leaked');
     const goPath = join(fixtureDir, 'go');

--- a/packages/core/src/orchestrator/orchestrator.test.ts
+++ b/packages/core/src/orchestrator/orchestrator.test.ts
@@ -1,5 +1,6 @@
 import { mock, describe, test, expect, beforeEach } from 'bun:test';
-import { mkdtemp, rm } from 'fs/promises';
+import { mkdtemp } from 'fs/promises';
+import { removeTempTree } from '@archon/paths/test-utils';
 import { realpathSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -1624,7 +1625,7 @@ describe('orchestrator-agent handleMessage', () => {
           expect.stringContaining('registered successfully')
         );
       } finally {
-        await rm(projectPath, { recursive: true, force: true });
+        await removeTempTree(projectPath);
       }
     });
 
@@ -1665,7 +1666,7 @@ describe('orchestrator-agent handleMessage', () => {
           kind: 'repo',
         });
       } finally {
-        await rm(projectPath, { recursive: true, force: true });
+        await removeTempTree(projectPath);
       }
     });
 

--- a/packages/isolation/src/container/overlay-scripts.test.ts
+++ b/packages/isolation/src/container/overlay-scripts.test.ts
@@ -9,9 +9,10 @@
  * dest-symlink traversal. Char-device (0,0) whiteout detection needs `mknod` (root)
  * and is exercised by the live in-container malicious-overlay smoke instead.
  */
-import { describe, test, expect } from 'bun:test';
+import { afterEach, describe, test, expect } from 'bun:test';
 import { execFileSync } from 'child_process';
 import { resolveBashPath } from '@archon/git';
+import { removeTempTree } from '@archon/paths/test-utils';
 import {
   mkdtempSync,
   mkdirSync,
@@ -21,7 +22,6 @@ import {
   existsSync,
   lstatSync,
   readlinkSync,
-  rmSync,
   chmodSync,
 } from 'fs';
 import { tmpdir } from 'os';
@@ -84,9 +84,25 @@ function runScript(
   return { records, stdout, stderr, code };
 }
 
+/**
+ * Temp roots awaiting teardown.
+ *
+ * Cleanup used to be a trailing `rmSync` in each test body, which ran only when every
+ * assertion above it passed — so the tests most worth diagnosing were the ones that left
+ * their fixture behind. Draining here also gets the removal off each test's own budget,
+ * and lets it retry against a bash/tar child that has exited but not yet released its
+ * handles (#2306).
+ */
+const cleanupRoots: string[] = [];
+
+afterEach(async () => {
+  for (const root of cleanupRoots.splice(0)) await removeTempTree(root);
+});
+
 /** Fresh {upper, dest} pair under a temp root; `data` is the overlay upperdir. */
 function makeDirs(): { root: string; upper: string; dest: string; ws: string } {
   const root = mkdtempSync(join(tmpdir(), 'overlay-sec-'));
+  cleanupRoots.push(root);
   const upper = join(root, 'upper', 'data');
   const dest = join(root, 'dest');
   mkdirSync(upper, { recursive: true });
@@ -96,7 +112,7 @@ function makeDirs(): { root: string; upper: string; dest: string; ws: string } {
 
 describe('apply script — C1 whiteout-name traversal', () => {
   test('`.wh.` (empty decoded name) does NOT wipe the parent dir', () => {
-    const { root, upper, dest, ws } = makeDirs();
+    const { upper, dest, ws } = makeDirs();
     mkdirSync(join(upper, 'subdir'), { recursive: true });
     writeFileSync(join(upper, 'subdir', '.wh.'), ''); // malicious: decodes to empty name
     mkdirSync(join(dest, 'subdir'), { recursive: true });
@@ -105,11 +121,10 @@ describe('apply script — C1 whiteout-name traversal', () => {
     const { records } = runScript(buildApplyScript(), upper, dest, ws);
     expect(existsSync(join(dest, 'subdir', 'keepme.txt'))).toBe(true); // NOT wiped
     expect(records.some(r => r.tag === 'S' && r.fields[1] === 'unsafe-whiteout-name')).toBe(true);
-    rmSync(root, { recursive: true, force: true });
   });
 
   test('`.wh...` (decoded name `..`) does NOT rm the parent-of-parent', () => {
-    const { root, upper, dest, ws } = makeDirs();
+    const { upper, dest, ws } = makeDirs();
     writeFileSync(join(upper, '.wh...'), ''); // decodes to '..'
     const canary = join(dest, 'canary.txt');
     writeFileSync(canary, 'alive');
@@ -118,11 +133,10 @@ describe('apply script — C1 whiteout-name traversal', () => {
     expect(existsSync(canary)).toBe(true);
     expect(existsSync(dest)).toBe(true);
     expect(records.some(r => r.tag === 'S' && r.fields[1] === 'unsafe-whiteout-name')).toBe(true);
-    rmSync(root, { recursive: true, force: true });
   });
 
   test('a legit `.wh.<name>` whiteout deletes exactly that file', () => {
-    const { root, upper, dest, ws } = makeDirs();
+    const { upper, dest, ws } = makeDirs();
     writeFileSync(join(upper, '.wh.gone.txt'), '');
     writeFileSync(join(dest, 'gone.txt'), 'bye');
     writeFileSync(join(dest, 'stay.txt'), 'keep');
@@ -131,7 +145,6 @@ describe('apply script — C1 whiteout-name traversal', () => {
     expect(existsSync(join(dest, 'gone.txt'))).toBe(false);
     expect(existsSync(join(dest, 'stay.txt'))).toBe(true);
     expect(records.some(r => r.tag === 'D' && r.fields[0] === 'gone.txt')).toBe(true);
-    rmSync(root, { recursive: true, force: true });
   });
 });
 
@@ -147,7 +160,7 @@ describe('apply script — C1 whiteout-name traversal', () => {
 // whose filenames cannot portably exist on win32 carry a skipIf, individually.
 describe('apply script — rel/base/dir splitting', () => {
   test('a legit whiteout inside a subdirectory deletes exactly that nested file', () => {
-    const { root, upper, dest, ws } = makeDirs();
+    const { upper, dest, ws } = makeDirs();
     mkdirSync(join(upper, 'sub'), { recursive: true });
     writeFileSync(join(upper, 'sub', '.wh.gone.txt'), '');
     mkdirSync(join(dest, 'sub'), { recursive: true });
@@ -163,7 +176,6 @@ describe('apply script — rel/base/dir splitting', () => {
     // target to top-level 'gone.txt' and delete the wrong file entirely.
     expect(existsSync(join(dest, 'gone.txt'))).toBe(true);
     expect(records.some(r => r.tag === 'D' && r.fields[0] === 'sub/gone.txt')).toBe(true);
-    rmSync(root, { recursive: true, force: true });
   });
 
   // The expansions are not merely cheaper than the forks they replaced — they are
@@ -174,7 +186,7 @@ describe('apply script — rel/base/dir splitting', () => {
     // `evil` and delete a different, innocent file — while `safe_parent` also
     // confined the wrong path. Skipped on win32 only because a trailing-newline
     // filename is not portably creatable there.
-    const { root, upper, dest, ws } = makeDirs();
+    const { upper, dest, ws } = makeDirs();
     writeFileSync(join(upper, '.wh.evil\n'), '');
     writeFileSync(join(dest, 'evil\n'), 'the real target');
     writeFileSync(join(dest, 'evil'), 'innocent bystander');
@@ -184,7 +196,6 @@ describe('apply script — rel/base/dir splitting', () => {
     expect(existsSync(join(dest, 'evil\n'))).toBe(false);
     expect(existsSync(join(dest, 'evil'))).toBe(true);
     expect(records.some(r => r.tag === 'D' && r.fields[0] === 'evil\n')).toBe(true);
-    rmSync(root, { recursive: true, force: true });
   });
 
   test('a whiteout under a `-`-prefixed directory still decodes instead of being copied', () => {
@@ -193,7 +204,7 @@ describe('apply script — rel/base/dir splitting', () => {
     // empty, the `.wh.*` arm never matched, and the marker was applied as an
     // ordinary FILE — planting a `.wh.foo` file in the live root instead of
     // deleting `foo`.
-    const { root, upper, dest, ws } = makeDirs();
+    const { upper, dest, ws } = makeDirs();
     mkdirSync(join(upper, '-d'), { recursive: true });
     writeFileSync(join(upper, '-d', '.wh.foo'), '');
     mkdirSync(join(dest, '-d'), { recursive: true });
@@ -205,7 +216,6 @@ describe('apply script — rel/base/dir splitting', () => {
     // The marker itself must never land in the destination.
     expect(existsSync(join(dest, '-d', '.wh.foo'))).toBe(false);
     expect(records.some(r => r.tag === 'D' && r.fields[0] === '-d/foo')).toBe(true);
-    rmSync(root, { recursive: true, force: true });
   });
 
   test('`.wh..wh.x` decodes to `.wh.x` — one prefix stripped, not four characters', () => {
@@ -214,7 +224,7 @@ describe('apply script — rel/base/dir splitting', () => {
     // the wrong entry. Note plain `##` is NOT the hazard: with a literal pattern
     // `${base##.wh.}` is byte-identical to `${base#.wh.}` — only adding the `*`
     // makes it greedy.
-    const { root, upper, dest, ws } = makeDirs();
+    const { upper, dest, ws } = makeDirs();
     writeFileSync(join(upper, '.wh..wh.x'), '');
     writeFileSync(join(dest, '.wh.x'), 'the real target');
     writeFileSync(join(dest, 'x'), 'must survive');
@@ -224,7 +234,6 @@ describe('apply script — rel/base/dir splitting', () => {
     expect(existsSync(join(dest, '.wh.x'))).toBe(false);
     expect(existsSync(join(dest, 'x'))).toBe(true);
     expect(records.some(r => r.tag === 'D' && r.fields[0] === '.wh.x')).toBe(true);
-    rmSync(root, { recursive: true, force: true });
   });
 });
 
@@ -236,7 +245,7 @@ describe('apply script — guards pinned on the apply copy', () => {
   // R9: commit 3 tested the TAB guard only through the SUMMARY script, so deleting the
   // apply-side guard outright passed everything. Apply is the copy that writes.
   test.skipIf(isWin)('a TAB-bearing entry is refused by the APPLY script, not applied', () => {
-    const { root, upper, dest, ws } = makeDirs();
+    const { upper, dest, ws } = makeDirs();
     writeFileSync(join(upper, 'a\tb'), 'payload');
 
     const { records } = runScript(buildApplyScript(), upper, dest, ws);
@@ -245,7 +254,6 @@ describe('apply script — guards pinned on the apply copy', () => {
     // Nothing was written under either the real or the mangled name.
     expect(existsSync(join(dest, 'a\tb'))).toBe(false);
     expect(existsSync(join(dest, 'a?b'))).toBe(false);
-    rmSync(root, { recursive: true, force: true });
   });
 
   // The apply-side mirror of the summary's TAB-target guard. Deleting that guard left
@@ -258,7 +266,7 @@ describe('apply script — guards pinned on the apply copy', () => {
   //   apply   → K x, symlink lands in the live root
   // i.e. the summary lies to the approver about what apply will do.
   test.skipIf(isWin)('a TAB in a symlink target is refused by the APPLY script too', () => {
-    const { root, upper, dest, ws } = makeDirs();
+    const { upper, dest, ws } = makeDirs();
     symlinkSync('foo\tbar', join(upper, 'x'));
 
     const { records } = runScript(buildApplyScript(), upper, dest, ws);
@@ -273,7 +281,6 @@ describe('apply script — guards pinned on the apply copy', () => {
       landed = false;
     }
     expect(landed).toBe(false);
-    rmSync(root, { recursive: true, force: true });
   });
 
   // R4: the newline fix had two halves and only the whiteout half was pinned. The
@@ -296,7 +303,6 @@ describe('apply script — guards pinned on the apply copy', () => {
       expect(existsSync(join(outside, 'f.txt'))).toBe(false);
       // And it was refused rather than reported applied.
       expect(records.some(r => r.tag === 'W' && r.fields[0] === 'd\n/f.txt')).toBe(false);
-      rmSync(root, { recursive: true, force: true });
     }
   );
 
@@ -317,14 +323,13 @@ describe('apply script — guards pinned on the apply copy', () => {
       // Replaced as a real file, and the symlink's old target left untouched.
       expect(lstatSync(join(dest, 'f.txt')).isSymbolicLink()).toBe(false);
       expect(readFileSync(join(root, 'elsewhere.txt'), 'utf8')).toBe('old');
-      rmSync(root, { recursive: true, force: true });
     }
   );
 });
 
 describe('apply script — C2 special files + setuid', () => {
   test('setuid/setgid/sticky bits are stripped from applied files', () => {
-    const { root, upper, dest, ws } = makeDirs();
+    const { upper, dest, ws } = makeDirs();
     const src = join(upper, 'tool');
     writeFileSync(src, '#!/bin/sh\n');
     chmodSync(src, 0o6755); // setuid + setgid + rwxr-xr-x
@@ -336,56 +341,50 @@ describe('apply script — C2 special files + setuid', () => {
     expect(mode & 0o4000).toBe(0); // no setuid
     expect(mode & 0o2000).toBe(0); // no setgid
     expect(mode & 0o1000).toBe(0); // no sticky
-    rmSync(root, { recursive: true, force: true });
   });
 
   test.skipIf(!hasMkfifo)('a fifo (special file) is skipped, never reproduced on the host', () => {
-    const { root, upper, dest, ws } = makeDirs();
+    const { upper, dest, ws } = makeDirs();
     execFileSync('mkfifo', [join(upper, 'pipe')]);
     const { records } = runScript(buildApplyScript(), upper, dest, ws);
     expect(existsSync(join(dest, 'pipe'))).toBe(false);
     expect(records.some(r => r.tag === 'S' && r.fields[0] === 'pipe')).toBe(true);
-    rmSync(root, { recursive: true, force: true });
   });
 });
 
 describe('apply script — M1/M4 symlinks', () => {
   test.skipIf(isWin)('a symlink whose target escapes the project root is REFUSED', () => {
-    const { root, upper, dest, ws } = makeDirs();
+    const { upper, dest, ws } = makeDirs();
     symlinkSync('/etc/passwd', join(upper, 'leak')); // absolute, outside ws
     const { records } = runScript(buildApplyScript(), upper, dest, ws);
     expect(existsSync(join(dest, 'leak'))).toBe(false);
     expect(records.some(r => r.tag === 'S' && r.fields[1] === 'escaping-symlink')).toBe(true);
-    rmSync(root, { recursive: true, force: true });
   });
 
   test.skipIf(isWin)('a relative `..` symlink target is refused', () => {
-    const { root, upper, dest, ws } = makeDirs();
+    const { upper, dest, ws } = makeDirs();
     symlinkSync('../../../../etc/hosts', join(upper, 'up'));
     const { records } = runScript(buildApplyScript(), upper, dest, ws);
     expect(existsSync(join(dest, 'up'))).toBe(false);
     expect(records.some(r => r.tag === 'S' && r.fields[1] === 'escaping-symlink')).toBe(true);
-    rmSync(root, { recursive: true, force: true });
   });
 
   test.skipIf(isWin)('an in-project relative symlink is reproduced as a symlink', () => {
-    const { root, upper, dest, ws } = makeDirs();
+    const { upper, dest, ws } = makeDirs();
     writeFileSync(join(upper, 'real.txt'), 'x');
     symlinkSync('real.txt', join(upper, 'link'));
     const { records } = runScript(buildApplyScript(), upper, dest, ws);
     expect(lstatSync(join(dest, 'link')).isSymbolicLink()).toBe(true);
     expect(readlinkSync(join(dest, 'link'))).toBe('real.txt');
     expect(records.some(r => r.tag === 'K' && r.fields[0] === 'link')).toBe(true);
-    rmSync(root, { recursive: true, force: true });
   });
 
   test.skipIf(isWin)('M4: a symlink-to-dir is applied as a SYMLINK, not a real directory', () => {
-    const { root, upper, dest, ws } = makeDirs();
+    const { upper, dest, ws } = makeDirs();
     mkdirSync(join(upper, 'realdir'), { recursive: true });
     symlinkSync('realdir', join(upper, 'dirlink'));
     runScript(buildApplyScript(), upper, dest, ws);
     expect(lstatSync(join(dest, 'dirlink')).isSymbolicLink()).toBe(true);
-    rmSync(root, { recursive: true, force: true });
   });
 });
 
@@ -401,13 +400,12 @@ describe('apply script — dest-symlink traversal confinement', () => {
     const { records } = runScript(buildApplyScript(), upper, dest, ws);
     expect(existsSync(join(outside, 'pwned.txt'))).toBe(false); // did NOT traverse
     expect(records.some(r => r.tag === 'S' && r.fields[1] === 'escaping-file')).toBe(true);
-    rmSync(root, { recursive: true, force: true });
   });
 });
 
 describe('summary script — faithful representation (M1)', () => {
   test.skipIf(isWin)('symlinks are shown with target + escape flag; specials flagged', () => {
-    const { root, upper, dest, ws } = makeDirs();
+    const { upper, dest, ws } = makeDirs();
     writeFileSync(join(upper, 'added.txt'), 'x');
     symlinkSync('/etc/shadow', join(upper, 'exfil')); // escaping
     symlinkSync('added.txt', join(upper, 'ok-link')); // in-project
@@ -423,7 +421,6 @@ describe('summary script — faithful representation (M1)', () => {
     expect(okLink?.fields[2]).toBe('0'); // in-project
     expect(records.some(r => r.tag === 'A' && r.fields[0] === 'added.txt')).toBe(true);
     expect(records.some(r => r.tag === 'M' && r.fields[0] === 'mod.txt')).toBe(true);
-    rmSync(root, { recursive: true, force: true });
   });
 
   // The summary script carries its OWN copy of the rel/base/dir splitting, and
@@ -438,7 +435,7 @@ describe('summary script — faithful representation (M1)', () => {
   // reaching the gate looking safe. Apply still refused it, so the exposure was
   // misinformed consent rather than over-apply, which is why it survived unnoticed.
   test.skipIf(isWin)('a TAB in a filename cannot forge the fields of a later record', () => {
-    const { root, upper, dest, ws } = makeDirs();
+    const { upper, dest, ws } = makeDirs();
     symlinkSync('/etc/shadow', join(upper, 'a\tb'));
 
     const { records } = runScript(buildSummaryScript(), upper, dest, ws);
@@ -448,7 +445,6 @@ describe('summary script — faithful representation (M1)', () => {
     // (Asserting merely that no `L … '0'` record exists passed before the guard too,
     // because the forged flag was a path rather than '0'.)
     expect(records).toEqual([{ tag: 'S', fields: ['a?b', 'unsafe-record-name'] }]);
-    rmSync(root, { recursive: true, force: true });
   });
 
   // C1's mirror on the consent surface. The apply script's valid_name refusal is
@@ -458,7 +454,7 @@ describe('summary script — faithful representation (M1)', () => {
   // about to be deleted. A human asked to approve a deletion that will not happen is
   // being misinformed just as surely as one shown a deletion that will.
   test('the summary refuses an unsafe whiteout name rather than reporting a deletion', () => {
-    const { root, upper, dest, ws } = makeDirs();
+    const { upper, dest, ws } = makeDirs();
     mkdirSync(join(upper, 'subdir'), { recursive: true });
     writeFileSync(join(upper, 'subdir', '.wh.'), ''); // decodes to the empty name
     mkdirSync(join(dest, 'subdir'), { recursive: true });
@@ -469,7 +465,6 @@ describe('summary script — faithful representation (M1)', () => {
     expect(records.some(r => r.tag === 'S' && r.fields[1] === 'unsafe-whiteout-name')).toBe(true);
     // Nothing may be presented as a pending deletion — least of all the parent dir.
     expect(records.some(r => r.tag === 'D')).toBe(false);
-    rmSync(root, { recursive: true, force: true });
   });
 
   // R6, second half: a TAB in the symlink TARGET forges the fields after it, so the
@@ -478,20 +473,19 @@ describe('summary script — faithful representation (M1)', () => {
   // — the gate renders "-> src/utils.ts", no warning, while the real target escapes.
   // The name-only guard did not catch this; both variable-width fields need checking.
   test.skipIf(isWin)('a TAB in a symlink TARGET cannot forge the escape flag', () => {
-    const { root, upper, dest, ws } = makeDirs();
+    const { upper, dest, ws } = makeDirs();
     symlinkSync('src/utils.ts\t../../../../etc/shadow', join(upper, 'utils-link.ts'));
 
     const { records } = runScript(buildSummaryScript(), upper, dest, ws);
 
     expect(records).toEqual([{ tag: 'S', fields: ['utils-link.ts', 'unsafe-record-target'] }]);
-    rmSync(root, { recursive: true, force: true });
   });
 
   // R8: the previous summary fixture pinned only `dir`. These pin the `base`/`whname`
   // decodes on the consent surface too — reverting the summary copy's split to forks,
   // or making its whiteout decode greedy, passed the whole suite before this.
   test('the summary decodes a nested whiteout name, not just its directory', () => {
-    const { root, upper, dest, ws } = makeDirs();
+    const { upper, dest, ws } = makeDirs();
     mkdirSync(join(upper, 'sub'), { recursive: true });
     writeFileSync(join(upper, 'sub', '.wh..wh.x'), '');
     mkdirSync(join(dest, 'sub'), { recursive: true });
@@ -503,7 +497,6 @@ describe('summary script — faithful representation (M1)', () => {
     // component would report nothing at all.
     expect(records.some(r => r.tag === 'D' && r.fields[0] === 'sub/.wh.x')).toBe(true);
     expect(records.some(r => r.tag === 'D' && r.fields[0] === 'sub/x')).toBe(false);
-    rmSync(root, { recursive: true, force: true });
   });
 
   // Reverting the summary copy's rel/base to forks passed even the test above,
@@ -512,7 +505,7 @@ describe('summary script — faithful representation (M1)', () => {
   // option and fails, so `base` comes back empty, the whiteout arm never matches, and
   // the summary shows the approver an ADDED marker file instead of a deletion.
   test('the summary decodes a whiteout under a `-`-prefixed directory', () => {
-    const { root, upper, dest, ws } = makeDirs();
+    const { upper, dest, ws } = makeDirs();
     mkdirSync(join(upper, '-d'), { recursive: true });
     writeFileSync(join(upper, '-d', '.wh.foo'), '');
     mkdirSync(join(dest, '-d'), { recursive: true });
@@ -523,11 +516,10 @@ describe('summary script — faithful representation (M1)', () => {
     expect(records.some(r => r.tag === 'D' && r.fields[0] === '-d/foo')).toBe(true);
     // A failed decode surfaces the marker itself as an addition — the wrong story.
     expect(records.some(r => r.tag === 'A' && r.fields[0] === '-d/.wh.foo')).toBe(false);
-    rmSync(root, { recursive: true, force: true });
   });
 
   test('a nested whiteout is reported at its full path, not its stem', () => {
-    const { root, upper, dest, ws } = makeDirs();
+    const { upper, dest, ws } = makeDirs();
     mkdirSync(join(upper, 'sub'), { recursive: true });
     writeFileSync(join(upper, 'sub', '.wh.gone.txt'), '');
     mkdirSync(join(dest, 'sub'), { recursive: true });
@@ -539,6 +531,5 @@ describe('summary script — faithful representation (M1)', () => {
     // An empty `dir` would report the top-level name and invite the approver to
     // sign off on deleting a different file.
     expect(records.some(r => r.tag === 'D' && r.fields[0] === 'gone.txt')).toBe(false);
-    rmSync(root, { recursive: true, force: true });
   });
 });

--- a/packages/isolation/src/container/overlay-scripts.test.ts
+++ b/packages/isolation/src/container/overlay-scripts.test.ts
@@ -9,10 +9,10 @@
  * dest-symlink traversal. Char-device (0,0) whiteout detection needs `mknod` (root)
  * and is exercised by the live in-container malicious-overlay smoke instead.
  */
-import { afterEach, describe, test, expect } from 'bun:test';
+import { describe, test, expect } from 'bun:test';
 import { execFileSync } from 'child_process';
 import { resolveBashPath } from '@archon/git';
-import { removeTempTree } from '@archon/paths/test-utils';
+import { trackTempRoots } from '@archon/paths/test-utils';
 import {
   mkdtempSync,
   mkdirSync,
@@ -84,25 +84,14 @@ function runScript(
   return { records, stdout, stderr, code };
 }
 
-/**
- * Temp roots awaiting teardown.
- *
- * Cleanup used to be a trailing `rmSync` in each test body, which ran only when every
- * assertion above it passed — so the tests most worth diagnosing were the ones that left
- * their fixture behind. Draining here also gets the removal off each test's own budget,
- * and lets it retry against a bash/tar child that has exited but not yet released its
- * handles (#2306).
- */
-const cleanupRoots: string[] = [];
-
-afterEach(async () => {
-  for (const root of cleanupRoots.splice(0)) await removeTempTree(root);
-});
+// Cleanup used to be a trailing `rmSync` in each test body; the tracker reaps every root
+// even when a test fails first, and retries against a bash/tar child that has exited but
+// not yet released its handles (#2306).
+const trackTempRoot = trackTempRoots();
 
 /** Fresh {upper, dest} pair under a temp root; `data` is the overlay upperdir. */
 function makeDirs(): { root: string; upper: string; dest: string; ws: string } {
-  const root = mkdtempSync(join(tmpdir(), 'overlay-sec-'));
-  cleanupRoots.push(root);
+  const root = trackTempRoot(mkdtempSync(join(tmpdir(), 'overlay-sec-')));
   const upper = join(root, 'upper', 'data');
   const dest = join(root, 'dest');
   mkdirSync(upper, { recursive: true });

--- a/packages/paths/package.json
+++ b/packages/paths/package.json
@@ -9,7 +9,8 @@
     "./bundled-build": "./src/bundled-build.ts",
     "./strip-cwd-env": "./src/strip-cwd-env.ts",
     "./strip-cwd-env-boot": "./src/strip-cwd-env-boot.ts",
-    "./env-loader": "./src/env-loader.ts"
+    "./env-loader": "./src/env-loader.ts",
+    "./test-utils": "./src/test-utils.ts"
   },
   "scripts": {
     "test": "bun test src/",

--- a/packages/paths/src/install-manifest.test.ts
+++ b/packages/paths/src/install-manifest.test.ts
@@ -6,7 +6,6 @@ import {
   readFileSync,
   readdirSync,
   realpathSync,
-  rmSync,
   statSync,
   utimesSync,
   writeFileSync,
@@ -15,6 +14,7 @@ import { tmpdir } from 'os';
 import { isAbsolute, join, resolve } from 'path';
 import { spawnSync } from 'node:child_process';
 import { refreshCompiledInstallManifest, type InstallManifest } from './install-manifest';
+import { removeTempTree } from './test-utils';
 
 describe('compiled install manifest', () => {
   const envKeys = ['ARCHON_HOME', 'WORKSPACE_PATH', 'ARCHON_DOCKER'] as const;
@@ -29,13 +29,15 @@ describe('compiled install manifest', () => {
     process.env.ARCHON_HOME = testDir;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     for (const key of envKeys) {
       const value = originalEnv[key];
       if (value === undefined) delete process.env[key];
       else process.env[key] = value;
     }
-    rmSync(testDir, { recursive: true, force: true });
+    // Async so the removal can retry: this suite runs the compiled-startup path through
+    // a real `spawnSync`, and `rmSync` has no retry of its own on any runtime (#2306).
+    await removeTempTree(testDir);
   });
 
   function manifestPath(): string {

--- a/packages/paths/src/test-utils.ts
+++ b/packages/paths/src/test-utils.ts
@@ -11,6 +11,26 @@ const MAX_ATTEMPTS = 10;
 const RETRY_DELAY_MS = 50;
 
 /**
+ * Codes meaning "something still holds this tree", not "this can never be removed".
+ *
+ * The first five are the set Node documents for `rm`'s own `maxRetries`. `EFAULT` is the
+ * odd one, and it is not defensive padding — under Bun it is the only entry that does any
+ * work. Bun's `rm` maps any underlying OS error it cannot classify onto `EFAULT`, so an
+ * ordinary lock arrives wearing a code that reads as a bad pointer. Measured against the
+ * probe described below, which induces a genuine `EPERM` with the macOS `uchg` flag and
+ * releases it after 300 ms: with `EFAULT` listed the tree is removed after ~310 ms of
+ * retrying; with it dropped the same call gives up in 0 ms and leaves the tree on disk,
+ * because the `EPERM` never arrives under that name. This is the signature these cleanups
+ * fail with on Windows CI (#2306).
+ *
+ * Because Bun collapses unmapped errors onto `EFAULT`, this set cannot be exhaustive in
+ * either direction; a permanently unremovable tree may also arrive as `EFAULT` and simply
+ * costs the full retry budget before it is reported. That is acceptable because both
+ * paths end the same way — see `removeTempTree`.
+ */
+const TRANSIENT_CODES = new Set(['EBUSY', 'EMFILE', 'ENFILE', 'ENOTEMPTY', 'EPERM', 'EFAULT']);
+
+/**
  * Remove a test temp tree, retrying while the OS still holds a handle inside it.
  *
  * A just-exited child process, or the test's own preceding async writes, can leave a
@@ -29,10 +49,10 @@ const RETRY_DELAY_MS = 50;
  * CI carry a code that looks nothing like a lock. Switching back to the built-in options
  * is safe only once Bun actually honors them.
  *
- * Failing to delete a scratch directory is not a test failure, so exhausting the attempts
- * warns instead of throwing — but it does warn, so a genuine leak stays visible. Because
- * every outcome ends that same way, there is nothing to gain from classifying the error
- * code, and `force: true` already absorbs the one code that means "already gone".
+ * Failing to delete a scratch directory is not a test failure, so a tree that never comes
+ * free warns instead of throwing — but it does warn, so a genuine leak stays visible. An
+ * error outside `TRANSIENT_CODES` takes that same exit immediately rather than retrying
+ * against a condition that will not clear. (`force: true` already absorbs "already gone".)
  */
 export async function removeTempTree(path: string): Promise<void> {
   for (let attempt = 1; ; attempt++) {
@@ -40,7 +60,8 @@ export async function removeTempTree(path: string): Promise<void> {
       await rm(path, { recursive: true, force: true });
       return;
     } catch (error) {
-      if (attempt >= MAX_ATTEMPTS) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (attempt >= MAX_ATTEMPTS || code === undefined || !TRANSIENT_CODES.has(code)) {
         console.warn(`temp cleanup failed for ${path}: ${String(error)}`);
         return;
       }

--- a/packages/paths/src/test-utils.ts
+++ b/packages/paths/src/test-utils.ts
@@ -4,6 +4,7 @@
  * This module is test-only. Nothing in `src/` imports it; it lives here because
  * `@archon/paths` is the one package every consumer of these helpers already depends on.
  */
+import { afterEach } from 'bun:test';
 import { rm } from 'node:fs/promises';
 
 /** Attempts before a stuck tree is reported as a leak rather than retried again. */
@@ -68,4 +69,42 @@ export async function removeTempTree(path: string): Promise<void> {
       await Bun.sleep(RETRY_DELAY_MS);
     }
   }
+}
+
+/**
+ * Track temp roots for teardown, and register the `afterEach` that removes them.
+ *
+ * Call once at module scope and pass every root through the returned function as it is
+ * created:
+ *
+ * ```ts
+ * const trackTempRoot = trackTempRoots();
+ * const root = trackTempRoot(mkdtempSync(join(tmpdir(), 'fixture-')));
+ * ```
+ *
+ * Registering at creation rather than removing at the end of the test body is the point:
+ * a trailing removal runs only when every assertion above it passed, so the tests most
+ * worth diagnosing are exactly the ones that leak their fixture. It also keeps the
+ * removal off the test's own time budget.
+ *
+ * The invariant is "every root this file created gets torn down", and it holds only while
+ * roots are created through one helper that tracks them. A test that calls `mkdtemp`
+ * inline instead leaks silently, so give each file a single creation helper and route
+ * every fixture through it.
+ *
+ * Not for a teardown that has to do something else first — stopping a child process,
+ * closing a database — before the tree can be removed. Splitting that into two hooks
+ * makes correctness depend on their registration order, which nothing states and a later
+ * edit can invert. Keep those files on one explicit `afterEach` that calls
+ * `removeTempTree` in the right sequence.
+ */
+export function trackTempRoots(): (root: string) => string {
+  const roots: string[] = [];
+  afterEach(async () => {
+    for (const root of roots.splice(0)) await removeTempTree(root);
+  });
+  return root => {
+    roots.push(root);
+    return root;
+  };
 }

--- a/packages/paths/src/test-utils.ts
+++ b/packages/paths/src/test-utils.ts
@@ -1,0 +1,50 @@
+/**
+ * Filesystem helpers shared by tests across packages.
+ *
+ * This module is test-only. Nothing in `src/` imports it; it lives here because
+ * `@archon/paths` is the one package every consumer of these helpers already depends on.
+ */
+import { rm } from 'node:fs/promises';
+
+/** Attempts before a stuck tree is reported as a leak rather than retried again. */
+const MAX_ATTEMPTS = 10;
+const RETRY_DELAY_MS = 50;
+
+/**
+ * Remove a test temp tree, retrying while the OS still holds a handle inside it.
+ *
+ * A just-exited child process, or the test's own preceding async writes, can leave a
+ * handle open for a short window after the work that created it finished. Windows is
+ * where this actually bites: an unretried cleanup there fails the test that just passed
+ * (#2306).
+ *
+ * The retry is written out rather than delegated to `rm`'s own `maxRetries`/`retryDelay`
+ * because **Bun accepts those options and ignores them**. Measured on Bun 1.3.11: against
+ * a tree holding one file locked with the macOS `uchg` flag (unlink returns EPERM, which
+ * is in the retry set Node documents), `rm(..., { maxRetries: 10, retryDelay: 50 })`
+ * rejects in 0 ms, while the same call on node v25.6.1 retries for ~300 ms and succeeds
+ * once the flag clears. `rmSync` behaves the same way. Bun also reports errors it cannot
+ * map as `EFAULT` — that same locked-file probe surfaces EPERM as
+ * `EFAULT: bad address in system call argument`, which is why cleanup failures on Windows
+ * CI carry a code that looks nothing like a lock. Switching back to the built-in options
+ * is safe only once Bun actually honors them.
+ *
+ * Failing to delete a scratch directory is not a test failure, so exhausting the attempts
+ * warns instead of throwing — but it does warn, so a genuine leak stays visible. Because
+ * every outcome ends that same way, there is nothing to gain from classifying the error
+ * code, and `force: true` already absorbs the one code that means "already gone".
+ */
+export async function removeTempTree(path: string): Promise<void> {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      await rm(path, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if (attempt >= MAX_ATTEMPTS) {
+        console.warn(`temp cleanup failed for ${path}: ${String(error)}`);
+        return;
+      }
+      await Bun.sleep(RETRY_DELAY_MS);
+    }
+  }
+}

--- a/packages/workflows/src/bundled-script-materialization.test.ts
+++ b/packages/workflows/src/bundled-script-materialization.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
-import { mkdtemp, readFile, rm } from 'fs/promises';
+import { mkdtemp, readFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import * as realPaths from '@archon/paths';
+import { removeTempTree } from '@archon/paths/test-utils';
 
 const bundledName = '__archon_pack__bundled:video-pack:render::hello';
 
@@ -41,7 +42,7 @@ describe('bundled packaged script materialization (#2527)', () => {
   afterEach(async () => {
     if (originalArchonHome === undefined) delete process.env.ARCHON_HOME;
     else process.env.ARCHON_HOME = originalArchonHome;
-    await rm(root, { recursive: true, force: true });
+    await removeTempTree(root);
   });
 
   it('writes embedded content to a stable file and executes it', async () => {

--- a/packages/workflows/src/workflow-source.test.ts
+++ b/packages/workflows/src/workflow-source.test.ts
@@ -2,7 +2,7 @@
  * Source capture: what a run freezes, and what it must keep resolving after the
  * authoring checkout moves on.
  */
-import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, test, expect, afterEach } from 'bun:test';
 import { mkdtemp, mkdir, writeFile, rm, readFile, readdir, symlink, stat } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -22,11 +22,50 @@ import { discoverScriptsForCwd } from './script-discovery';
 import { loadCommandPrompt } from './executor-shared';
 import { withCapturedSource } from './executor';
 import type { WorkflowDeps } from './deps';
+import { removeTempTree } from '@archon/paths/test-utils';
 
-let root: string;
-let source: string;
-let target: string;
-let runArtifacts: string;
+/** One test's paths. Created by the test, never shared with another. */
+interface Sandbox {
+  readonly root: string;
+  readonly source: string;
+  readonly target: string;
+  readonly runArtifacts: string;
+}
+
+/**
+ * Temp roots awaiting teardown.
+ *
+ * Only `afterEach` reads this. Each test holds its own paths as locals, so an assertion
+ * left running by a timed-out test can only ever describe its own sandbox (#2306). These
+ * used to be module-level `let` bindings reassigned in `beforeEach`, which let such an
+ * orphaned assertion read the NEXT test's paths and report a mutation that never happened.
+ */
+const cleanupRoots: string[] = [];
+
+async function createTempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'archon-source-'));
+  cleanupRoots.push(root);
+  return root;
+}
+
+async function createSandbox(): Promise<Sandbox> {
+  const root = await createTempRoot();
+  const sandbox: Sandbox = {
+    root,
+    source: join(root, 'authoring'),
+    target: join(root, 'target'),
+    runArtifacts: join(root, 'artifacts'),
+  };
+  await mkdir(join(sandbox.source, '.archon', 'workflows', 'pack', 'flow', 'commands'), {
+    recursive: true,
+  });
+  await mkdir(join(sandbox.source, '.archon', 'commands'), { recursive: true });
+  await mkdir(join(sandbox.source, '.archon', 'scripts'), { recursive: true });
+  // A clean target: it is a real checkout, it just never held the authoring source.
+  await mkdir(join(sandbox.target, '.archon', 'workflows'), { recursive: true });
+  await mkdir(sandbox.runArtifacts, { recursive: true });
+  return sandbox;
+}
 
 /**
  * Files captured under one scope.
@@ -57,27 +96,13 @@ const deps = {
     Promise.resolve({} as unknown as Awaited<ReturnType<WorkflowDeps['loadConfig']>>),
 } satisfies Pick<WorkflowDeps, 'loadConfig'>;
 
-beforeEach(async () => {
-  root = await mkdtemp(join(tmpdir(), 'archon-source-'));
-  source = join(root, 'authoring');
-  target = join(root, 'target');
-  runArtifacts = join(root, 'artifacts');
-  await mkdir(join(source, '.archon', 'workflows', 'pack', 'flow', 'commands'), {
-    recursive: true,
-  });
-  await mkdir(join(source, '.archon', 'commands'), { recursive: true });
-  await mkdir(join(source, '.archon', 'scripts'), { recursive: true });
-  // A clean target: it is a real checkout, it just never held the authoring source.
-  await mkdir(join(target, '.archon', 'workflows'), { recursive: true });
-  await mkdir(runArtifacts, { recursive: true });
-});
-
 afterEach(async () => {
-  await rm(root, { recursive: true, force: true });
+  for (const root of cleanupRoots.splice(0)) await removeTempTree(root);
 });
 
 describe('captureWorkflowSource', () => {
   test('freezes commands and scripts so the target never needs them', async () => {
+    const { source, runArtifacts } = await createSandbox();
     await writeFile(join(source, '.archon', 'commands', 'review.md'), 'review the diff');
     await writeFile(join(source, '.archon', 'scripts', 'check.ts'), 'console.log("ok")');
 
@@ -97,6 +122,7 @@ describe('captureWorkflowSource', () => {
   });
 
   test('keeps a script tree whole so sibling imports and data still resolve', async () => {
+    const { source, runArtifacts } = await createSandbox();
     // The reason a capture copies whole directories rather than the files a DAG names:
     // a script's imports and data reads are invisible to the workflow graph.
     await writeFile(join(source, '.archon', 'scripts', 'main.ts'), "import './helper';");
@@ -119,6 +145,7 @@ describe('captureWorkflowSource', () => {
   });
 
   test('a later edit or deletion of the authoring source does not change the capture', async () => {
+    const { source, runArtifacts } = await createSandbox();
     await writeFile(join(source, '.archon', 'commands', 'review.md'), 'original');
     const capture = await captureWorkflowSource({
       sourceRoot: source,
@@ -144,6 +171,7 @@ describe('captureWorkflowSource', () => {
   });
 
   test('a fresh capture after an edit sees the new bytes', async () => {
+    const { source, runArtifacts } = await createSandbox();
     await writeFile(join(source, '.archon', 'commands', 'review.md'), 'v1');
     const first = await captureWorkflowSource({
       sourceRoot: source,
@@ -164,6 +192,7 @@ describe('captureWorkflowSource', () => {
   });
 
   test('dereferences symlinks so nothing in the capture points back out', async () => {
+    const { root, source, runArtifacts } = await createSandbox();
     const outside = join(root, 'outside.md');
     await writeFile(outside, 'external');
     await symlink(outside, join(source, '.archon', 'commands', 'linked.md'));
@@ -181,6 +210,7 @@ describe('captureWorkflowSource', () => {
   });
 
   test('keeps script dependencies but drops derived bytecode', async () => {
+    const { source, runArtifacts } = await createSandbox();
     await writeFile(join(source, '.archon', 'scripts', 'main.py'), 'print(1)');
     await mkdir(join(source, '.archon', 'scripts', '__pycache__'), { recursive: true });
     await writeFile(join(source, '.archon', 'scripts', '__pycache__', 'main.pyc'), 'junk');
@@ -208,6 +238,7 @@ describe('captureWorkflowSource', () => {
   });
 
   test('cuts a directory symlink that points back into its own tree', async () => {
+    const { source, runArtifacts } = await createSandbox();
     // Directory symlinks are FOLLOWED (that is what dereferencing means), so a link to an
     // ancestor re-enters the tree. Without a cycle guard the walk only stops when the
     // kernel refuses the path with ELOOP, having copied the same files at every level.
@@ -228,6 +259,7 @@ describe('captureWorkflowSource', () => {
   });
 
   test('captures nothing under project scope when the source holds none', async () => {
+    const { root, runArtifacts } = await createSandbox();
     const empty = join(root, 'empty');
     await mkdir(empty, { recursive: true });
     const capture = await captureWorkflowSource({
@@ -244,6 +276,7 @@ describe('captureWorkflowSource', () => {
   });
 
   test('leaves no usable capture behind when it cannot finish', async () => {
+    const { source, runArtifacts } = await createSandbox();
     await writeFile(join(source, '.archon', 'commands', 'review.md'), 'x');
     const captureRoot = getRunSourceCapturePath(runArtifacts);
     // A file where the staging directory must go: the copy fails part-way through.
@@ -260,6 +293,7 @@ describe('captureWorkflowSource', () => {
   });
 
   test('replaces a stale capture rather than merging two vintages', async () => {
+    const { source, runArtifacts } = await createSandbox();
     const captureRoot = getRunSourceCapturePath(runArtifacts);
     await writeFile(join(source, '.archon', 'commands', 'gone.md'), 'old');
     await captureWorkflowSource({ sourceRoot: source, captureRoot });
@@ -280,6 +314,7 @@ describe('captureWorkflowSource', () => {
 
 describe('resolving against a capture instead of the target', () => {
   test('a command resolves from the source even though the target lacks it', async () => {
+    const { source, target, runArtifacts } = await createSandbox();
     await writeFile(join(source, '.archon', 'commands', 'review.md'), 'from authoring');
     const capture = await captureWorkflowSource({
       sourceRoot: source,
@@ -301,6 +336,7 @@ describe('resolving against a capture instead of the target', () => {
   });
 
   test('a packaged command resolves from the source under its owner identity', async () => {
+    const { source, target, runArtifacts } = await createSandbox();
     await writeFile(
       join(source, '.archon', 'workflows', 'pack', 'flow', 'commands', 'step.md'),
       'packaged body'
@@ -321,6 +357,7 @@ describe('resolving against a capture instead of the target', () => {
   });
 
   test('a named script resolves from the source, at a path outside the target', async () => {
+    const { source, target, runArtifacts } = await createSandbox();
     await writeFile(join(source, '.archon', 'scripts', 'check.ts'), 'console.log(1)');
     const capture = await captureWorkflowSource({
       sourceRoot: source,
@@ -345,6 +382,7 @@ describe('resolving against a capture instead of the target', () => {
   });
 
   test('the target cannot shadow a command the run captured', async () => {
+    const { source, target, runArtifacts } = await createSandbox();
     await writeFile(join(source, '.archon', 'commands', 'review.md'), 'authoring version');
     await mkdir(join(target, '.archon', 'commands'), { recursive: true });
     await writeFile(join(target, '.archon', 'commands', 'review.md'), 'TARGET VERSION');
@@ -379,6 +417,7 @@ describe("a run's own source versus a child's discovery root", () => {
   });
 
   test('a run reloads its OWN graph from the frozen copy, not from authoring', async () => {
+    const { source, runArtifacts } = await createSandbox();
     await writeFile(join(source, '.archon', 'commands', 'c.md'), 'x');
     const capture = await captureWorkflowSource({
       sourceRoot: source,
@@ -390,6 +429,7 @@ describe("a run's own source versus a child's discovery root", () => {
   });
 
   test('a not-yet-started child resolves from LIVE authoring, so a fix can land', async () => {
+    const { source, runArtifacts } = await createSandbox();
     // The load-bearing difference. A `workflow:` child is not a run until it starts, so
     // freezing it into the parent would make an authoring fix — removing a gate from a
     // child workflow and resuming the parent — permanently ineffective.
@@ -407,6 +447,7 @@ describe("a run's own source versus a child's discovery root", () => {
   });
 
   test('a recorded run FAILS when its capture is gone; a child falls back to live', async () => {
+    const root = await createTempRoot();
     // The asymmetry is the contract. A run that recorded a source must execute that
     // source or stop — falling back would resume it against different bytes. A child's
     // origin is only a hint about where to capture FROM, so its absence is recoverable.
@@ -439,6 +480,7 @@ describe("a run's own source versus a child's discovery root", () => {
   });
 
   test('a record from a newer Archon fails closed rather than resuming live', async () => {
+    const { source } = await createSandbox();
     // The tempting mistake is to treat "I cannot parse this" as "there is nothing here".
     // Only a genuinely absent record — a run predating capture — may resume live.
     const future = { [WORKFLOW_SOURCE_METADATA_KEY]: { version: 99, root: source } };
@@ -449,6 +491,7 @@ describe("a run's own source versus a child's discovery root", () => {
 
 describe('the capture is authoritative, not advisory', () => {
   test('a tampered capture fails to load instead of executing quietly', async () => {
+    const { source, runArtifacts } = await createSandbox();
     await writeFile(join(source, '.archon', 'commands', 'review.md'), 'original');
     const capture = await captureWorkflowSource({
       sourceRoot: source,
@@ -468,6 +511,7 @@ describe('the capture is authoritative, not advisory', () => {
   });
 
   test('a run whose capture no longer verifies refuses to resolve a source root', async () => {
+    const { source, runArtifacts } = await createSandbox();
     const capture = await captureWorkflowSource({
       sourceRoot: source,
       captureRoot: getRunSourceCapturePath(runArtifacts),
@@ -491,6 +535,7 @@ describe('the capture is authoritative, not advisory', () => {
   });
 
   test('freezes every statically reachable scope, not just the project', async () => {
+    const { source, runArtifacts } = await createSandbox();
     await writeFile(join(source, '.archon', 'commands', 'review.md'), 'x');
     const capture = await captureWorkflowSource({
       sourceRoot: source,
@@ -505,6 +550,7 @@ describe('the capture is authoritative, not advisory', () => {
   });
 
   test('records the selected workflow without disturbing what was frozen', async () => {
+    const { source, runArtifacts } = await createSandbox();
     await writeFile(join(source, '.archon', 'commands', 'review.md'), 'x');
     const capture = await captureWorkflowSource({
       sourceRoot: source,
@@ -522,6 +568,7 @@ describe('the capture is authoritative, not advisory', () => {
 
 describe("the source's own settings travel with its bytes", () => {
   test('a custom commands.folder is captured and resolves from the capture', async () => {
+    const { source, target, runArtifacts } = await createSandbox();
     // Discovery honors `commands.folder`, so a capture taken without it finds the command
     // at selection time and loses it at execution time.
     await mkdir(join(source, 'team-commands'), { recursive: true });
@@ -553,6 +600,7 @@ describe("the source's own settings travel with its bytes", () => {
   });
 
   test('without the recorded folder the same command is not found', async () => {
+    const { source, target, runArtifacts } = await createSandbox();
     await mkdir(join(source, 'team-commands'), { recursive: true });
     await writeFile(join(source, 'team-commands', 'shipit.md'), 'ship it');
     const capture = await captureWorkflowSource({
@@ -575,6 +623,7 @@ describe("the source's own settings travel with its bytes", () => {
 
 describe('continuing a run resolves with the settings it froze', () => {
   test('the manifest supplies the config, so a custom command folder survives resume', async () => {
+    const { source, target, runArtifacts } = await createSandbox();
     // The regression: continuation built roots with DEFAULT_WORKFLOW_SOURCE_CONFIG, which
     // is worse than degraded — a defined-but-default config also suppresses discovery's
     // live-config fallback, so the result is confidently wrong.
@@ -604,7 +653,7 @@ describe('continuing a run resolves with the settings it froze', () => {
 
 describe('a capture is adopted or reclaimed, whichever way the caller leaves', () => {
   /** Stand in for a staged capture: what the owner is handed and may have to reclaim. */
-  async function stage(name: string): Promise<{ captureRoot: string }> {
+  async function stage(root: string, name: string): Promise<{ captureRoot: string }> {
     const captureRoot = join(root, name);
     await mkdir(captureRoot, { recursive: true });
     await writeFile(join(captureRoot, 'manifest.json'), '{}');
@@ -618,21 +667,23 @@ describe('a capture is adopted or reclaimed, whichever way the caller leaves', (
     );
 
   test('reclaims when the body returns without adopting', async () => {
+    const root = await createTempRoot();
     // The shape of every early exit that used to leak: an unknown workflow, a refused
     // input contract, the "resume or force?" menu. None of them adopt.
     let staged: { captureRoot: string } | undefined;
     await withCapturedSource(async owner => {
-      staged = await stage('returned');
+      staged = await stage(root, 'returned');
       owner.hold(staged);
     });
     expect(await exists(staged!.captureRoot)).toBe(false);
   });
 
   test('reclaims when the body throws', async () => {
+    const root = await createTempRoot();
     let staged: { captureRoot: string } | undefined;
     await expect(
       withCapturedSource(async owner => {
-        staged = await stage('threw');
+        staged = await stage(root, 'threw');
         owner.hold(staged);
         throw new Error('a gate refused this run');
       })
@@ -641,9 +692,10 @@ describe('a capture is adopted or reclaimed, whichever way the caller leaves', (
   });
 
   test('leaves an adopted capture alone — a run owns it now', async () => {
+    const root = await createTempRoot();
     let staged: { captureRoot: string } | undefined;
     await withCapturedSource(async owner => {
-      staged = await stage('adopted');
+      staged = await stage(root, 'adopted');
       owner.hold(staged);
       owner.adopt();
     });
@@ -651,14 +703,15 @@ describe('a capture is adopted or reclaimed, whichever way the caller leaves', (
   });
 
   test('reclaims the CURRENT path after a container run moves the capture', async () => {
+    const root = await createTempRoot();
     // `finalizeWorkflowSource` moves a container run's capture out of staging early. If
     // the owner kept tracking the pre-move path it would reclaim a directory that is
     // already gone and leave the real one behind, looking like it had cleaned up.
     let moved: { captureRoot: string } | undefined;
     await withCapturedSource(async owner => {
-      const staged = await stage('pre-move');
+      const staged = await stage(root, 'pre-move');
       owner.hold(staged);
-      moved = await stage('post-move');
+      moved = await stage(root, 'post-move');
       owner.hold(moved);
     });
     expect(await exists(moved!.captureRoot)).toBe(false);

--- a/packages/workflows/src/workflow-source.test.ts
+++ b/packages/workflows/src/workflow-source.test.ts
@@ -2,7 +2,7 @@
  * Source capture: what a run freezes, and what it must keep resolving after the
  * authoring checkout moves on.
  */
-import { describe, test, expect, afterEach } from 'bun:test';
+import { describe, test, expect } from 'bun:test';
 import { mkdtemp, mkdir, writeFile, rm, readFile, readdir, symlink, stat } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -22,7 +22,7 @@ import { discoverScriptsForCwd } from './script-discovery';
 import { loadCommandPrompt } from './executor-shared';
 import { withCapturedSource } from './executor';
 import type { WorkflowDeps } from './deps';
-import { removeTempTree } from '@archon/paths/test-utils';
+import { trackTempRoots } from '@archon/paths/test-utils';
 
 /** One test's paths. Created by the test, never shared with another. */
 interface Sandbox {
@@ -32,20 +32,18 @@ interface Sandbox {
   readonly runArtifacts: string;
 }
 
-/**
- * Temp roots awaiting teardown.
- *
- * Only `afterEach` reads this. Each test holds its own paths as locals, so an assertion
- * left running by a timed-out test can only ever describe its own sandbox (#2306). These
- * used to be module-level `let` bindings reassigned in `beforeEach`, which let such an
- * orphaned assertion read the NEXT test's paths and report a mutation that never happened.
- */
-const cleanupRoots: string[] = [];
+const trackTempRoot = trackTempRoots();
 
+/**
+ * A temp root owned by one test.
+ *
+ * Each test holds its own paths as locals, so an assertion left running by a timed-out
+ * test can only ever describe its own sandbox (#2306). These used to be module-level
+ * `let` bindings reassigned in `beforeEach`, which let such an orphaned assertion read
+ * the NEXT test's paths and report a mutation that never happened.
+ */
 async function createTempRoot(): Promise<string> {
-  const root = await mkdtemp(join(tmpdir(), 'archon-source-'));
-  cleanupRoots.push(root);
-  return root;
+  return trackTempRoot(await mkdtemp(join(tmpdir(), 'archon-source-')));
 }
 
 async function createSandbox(): Promise<Sandbox> {
@@ -95,10 +93,6 @@ const deps = {
   loadConfig: () =>
     Promise.resolve({} as unknown as Awaited<ReturnType<WorkflowDeps['loadConfig']>>),
 } satisfies Pick<WorkflowDeps, 'loadConfig'>;
-
-afterEach(async () => {
-  for (const root of cleanupRoots.splice(0)) await removeTempTree(root);
-});
 
 describe('captureWorkflowSource', () => {
   test('freezes commands and scripts so the target never needs them', async () => {

--- a/scripts/migrate-state-dir.test.ts
+++ b/scripts/migrate-state-dir.test.ts
@@ -34,7 +34,8 @@
  * reach for the timeout.
  */
 import { describe, test, expect } from 'bun:test';
-import { mkdtemp, mkdir, rm, writeFile, readFile, readdir } from 'fs/promises';
+import { mkdtemp, mkdir, writeFile, readFile, readdir } from 'fs/promises';
+import { removeTempTree } from '@archon/paths/test-utils';
 import { tmpdir } from 'os';
 import { join, resolve } from 'path';
 
@@ -53,12 +54,11 @@ interface Sandbox {
 /**
  * Create a sandbox, run `body`, and always tear down.
  *
- * `maxRetries` covers the Windows case where a just-exited child still holds a
- * handle inside the sandbox: node's `rm` retries on EBUSY, EMFILE, ENFILE,
- * ENOTEMPTY and EPERM, which covers what this hits. On PR #2513 an unretried `rm`
- * threw `EBUSY … archon-migrate-dhOLl3` from teardown and failed the check. A leaked
- * temp directory is not a test failure, so a final failure warns instead of
- * throwing — but it does warn, so a genuine leak stays visible.
+ * Teardown has to survive the Windows case where a just-exited child still holds a
+ * handle inside the sandbox: on PR #2513 an unretried `rm` threw
+ * `EBUSY … archon-migrate-dhOLl3` and failed the check. `removeTempTree` owns that
+ * retry — and owns it explicitly, because passing `maxRetries` to `rm` does nothing
+ * under Bun (#2306). This docblock used to claim that option was the fix.
  */
 async function withSandbox(body: (ctx: Sandbox) => Promise<void>): Promise<void> {
   const root = await mkdtemp(join(tmpdir(), 'archon-migrate-'));
@@ -77,11 +77,7 @@ async function withSandbox(body: (ctx: Sandbox) => Promise<void>): Promise<void>
   try {
     await body(ctx);
   } finally {
-    try {
-      await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
-    } catch (error) {
-      console.warn(`sandbox cleanup failed for ${root}: ${(error as Error).message}`);
-    }
+    await removeTempTree(root);
   }
 }
 


### PR DESCRIPTION
## Problem and outcome

Test teardown that removed a temp tree could fail outright when the OS still held a handle inside it — a just-exited child process, or the test's own preceding async writes. On Windows CI that turned tests red from the cleanup line, after every assertion had already passed (`workflow-source.test.ts`, PR #2861 run 33109426740: four failures, three `EBUSY`, one `EFAULT`). A second race in the same family made a single-shot SQLite read fail as `SQLiteError: disk I/O error` on `dev` at `17ab6093`.

- **Outcome:** every test teardown that removes a temp tree downstream of a real subprocess or heavy async fs write now retries while the handle clears, and a tree that stays stuck warns instead of failing a test that passed. The detached terminal-event read waits for its row instead of reading once.
- **The inventory's sweep was 6+1.** Its "unretried cleanup" mechanism table lists six files; `packages/cli/src/utils/detached-run-control.integration.spec.ts` has the identical shape after spawning and killing a real detached child, and appears in the inventory only under an unrelated wall-clock note. Found in review, fixed here — see **Sites**, and flagged on #2306 so lanes 3-5 don't inherit the same gap.
- **Invariant:** no timeout or timer budget is raised anywhere. Every fix retries on the real failure or awaits the real condition. `grep` over the diff for changed numeric budgets returns only comments.
- **Scope boundary:** groups 1 and 2 of the [class inventory](https://github.com/coleam00/Archon/issues/2306#issuecomment-5444668633) only. `conversation-lock.test.ts`, the `detached-run-control` fake-clock work, the `migrate-state-dir` C5 coverage experiment, and inventory groups 3–5 are untouched.
- **Root cause:** **Bun accepts `rm`'s `maxRetries`/`retryDelay` and ignores them.** The inventory prescribed adding those options, matching `aad8aa7a`. Measured on Bun 1.3.11 against a tree holding one file locked with the macOS `uchg` flag (unlink returns `EPERM`, which is in the set Node documents):

  | runtime | `rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 })` |
  |---|---|
  | node v25.6.1 | **RESOLVED** after 306 ms — waited past the unlock, then succeeded |
  | bun 1.3.11 | **REJECTED in 0 ms** (`rmSync` identical) |

  The same probe also showed Bun reporting that genuine `EPERM` as `EFAULT: bad address in system call argument` — reproducing the Windows CI signature on macOS. `EFAULT` is Bun's fallback for an OS error it cannot map, not a real bad-address condition, which makes it the entry that actually carries the retry here: dropping it from the set makes the shipped helper give up in 0 ms and leave the tree on disk. Both defects are written up under **Upstream Bun defect** below.

## Review guidance

- **Feedback requested:** correctness of the root cause above, and whether `@archon/paths/test-utils` is the right home for a cross-package test helper.
- **Start here:** `packages/paths/src/test-utils.ts` — the whole PR is call sites of this one helper. Its docblock carries the measurement, so the workaround can be reverted when Bun honors the built-in options.
- **Review order:** `packages/paths/src/test-utils.ts` → `packages/cli/src/commands/workflow-terminal-event.integration.spec.ts` (the read-race fix) → `packages/workflows/src/workflow-source.test.ts` (the module-state change) → the rest, which are mechanical.
- **Lower-attention areas:** `orchestrator.test.ts`, `bundled-script-materialization.test.ts`, `install-manifest.test.ts`, `cli.test.ts` are one-line call-site swaps. `overlay-scripts.test.ts` is 25 deletions plus one hook.
- **Known risk or uncertainty:** the Windows failures cannot be reproduced on this host, so the CI evidence stays circumstantial — but the *mechanism* (unretried cleanup, built-in retry inert, `EPERM` surfacing as `EFAULT`) was reproduced locally under Bun.

## Solution

One shared helper, `removeTempTree`, exported from `@archon/paths/test-utils` — the one package every consumer here already depends on, following the existing `@archon/workflows/test-utils` convention. It retries `rm` on a bounded schedule and warns rather than throwing when the attempts run out, because failing to delete a scratch directory is not a test failure and the existing precedent in `migrate-state-dir.test.ts` already said so. Since every outcome ends in that same warning, the helper does not classify the error code — which matters, because Bun's `EFAULT` mapping means the code cannot be relied on anyway.

Two sites that already passed `maxRetries` (`workflow-terminal-event.integration.spec.ts:27` from `aad8aa7a`, and `migrate-state-dir.test.ts:81`) were inert and now use the helper. The `migrate-state-dir.test.ts` docblock that taught the inert pattern as the fix is corrected; leaving it would keep propagating the bug.

Three sites needed more than a call-site swap:

- **`workflow-source.test.ts`** held `root`/`source`/`target`/`runArtifacts` as module-level `let` bindings reassigned in `beforeEach`. An assertion left running by a timed-out test read the *next* test's paths and reported a mutation that never happened (on PR #2513 that surfaced as a dry run appearing to move a file). Each test now creates its sandbox as locals; only `afterEach` touches the shared registry, and it only reads paths to delete them.
- **`workflow-terminal-event.integration.spec.ts`** called `readTerminalEvents` once, directly, while `readRun` was already wrapped in the file's own `waitFor`. This is **not** a write-ordering gap — `completeWorkflowRun` and `failWorkflowRun` in `packages/core/src/db/workflows.ts` each write the status `UPDATE` and the event `INSERT` inside one `withTransaction`, so a reader can never see the status without the event. What retries is the **read**: a second readonly connection opened while that commit is still settling throws `SQLiteError: disk I/O error` out of `prepare()` rather than returning an empty result. The count stays exact, since the event was committed atomically with the status already observed and the owner's endpoint is asserted unreachable earlier in the test.
- **`overlay-scripts.test.ts`** cleaned up from a trailing statement in each test body, which ran only when every assertion above it passed — so the tests most worth diagnosing were the ones that leaked their fixture. Cleanup moved to `afterEach` via a registry, which also covers the one `makeDirs()` call site that never had a cleanup line and takes the removal off each test's own budget. Net 25 deletions.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Teardown removed the tree in one attempt | Teardown retries while the handle clears; unchanged on the happy path (1 attempt, 0 ms) |
| **Failure behavior** | A held handle threw from `afterEach` and failed a test whose assertions had all passed | The tree is retried; a tree still stuck after the attempts logs `temp cleanup failed for <path>` and the test keeps its own verdict |

## Sites, and one candidate left out

Nine cleanup sites across seven files now route through `removeTempTree`. Three files that had hand-written the same "module-level array drained by an `afterEach`" registry share a second small export, `trackTempRoots()`, from the same module.

`workflow-terminal-event.integration.spec.ts` deliberately keeps its own explicit hook rather than using that registry: a live owner has to be stopped before its tree can be removed, and splitting that across two `afterEach` hooks would leave their registration order as the only thing keeping it correct. That reason is a comment in the file and a documented constraint on `trackTempRoots`.

**Left out, with evidence, for a later lane:** `packages/cli/src/commands/workflow.test.ts` has five bare `rmSync` teardowns (lines 903, 1546, 5695, 5750, 6127). I found them because four stale `archon-detached-control-failure-*` fixtures from line 6095 are sitting in `$TMPDIR` on this machine, dated 24-25 August. They are a weaker candidate than the sites fixed here — that file's `Bun.spawn` is **mocked**, so no real child holds a handle — and the leak's cause is not established (an interrupted run explains it just as well as a failed removal, since the `rmSync` is in a `finally`). No CI failure has been attributed to them. Widening this PR on that evidence would be guessing; they are noted on #2306 instead.

## Upstream Bun defect

Flagged separately from this PR so it can be filed upstream on its own merits. Both behaviours were measured on **Bun 1.3.11** (macOS arm64), with **node v25.6.1** as the control on identical fixtures.

**1. `fs.rm` / `fs.rmSync` accept `maxRetries` and `retryDelay`, then never retry.** Neither option is honoured; the call makes exactly one attempt and rejects. Repro — lock one file inside a temp tree with the macOS `uchg` flag so `unlink` returns `EPERM` (a code Node documents as retryable), clear the flag from a 300 ms timer, then call `rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 })`:

| runtime | outcome | elapsed |
|---|---|---|
| node v25.6.1 | RESOLVED — waited past the unlock, then succeeded | 306 ms |
| bun 1.3.11 | REJECTED | **0 ms** |

`rmSync` behaves identically. The options are silently inert rather than rejected, so calling code looks correct and is not.

**2. `rm` reports errors it cannot classify as `EFAULT`.** The same probe surfaces a genuine `EPERM` as `EFAULT: bad address in system call argument`. `EFAULT` conventionally means a bad pointer was passed to a syscall, so an ordinary file lock is reported as what reads like a memory-safety bug. This is why the cleanup failures on Windows CI carry a code that looks nothing like a lock, and it is the reason `EFAULT` has to appear in this PR's retry set — dropping it makes the retry give up in 0 ms and leave the tree on disk.

Defect 2 also makes defect 1 harder to notice: the inert options produce a plausible-looking failure with a misleading code rather than an obvious no-op.

## Validation

- `bun run validate` — exit 0 — full gate (bundled/skill/schema/vendor-map/capability checks, type-check, lint `--max-warnings 0`, format:check, test:install, tests).
- `bun run test` per affected package — all exit 0 — workflows 2509 pass, core 1833, cli 696, paths 293, isolation 83; `bun test ./scripts/` 101 pass. 0 fail throughout.
- **Root cause proven, not inferred:** the locked-tree probe above, run under both runtimes. A real retry loop cleared the same fixture in 7 attempts / 310 ms and cost 1 attempt / 0 ms on an unlocked tree.
- **The read-race fix was seen red and green.** Injecting three `SQLiteError: disk I/O error` throws into `readTerminalEvents`: on the pre-fix single-shot read the test **fails** (`0 pass, 1 fail`); with the `waitFor` wrap the same injection **passes** (`1 pass, 0 fail`). Injection reverted; the file is byte-identical to the committed version.
- **The shipped helper was verified directly**, not a copy of its logic — importing `removeTempTree` and running it against real fixtures: a tree whose lock clears is removed (310 ms, gone from disk, no warning); a tree whose lock never clears **does not throw**, warns once, and is **still on disk** afterwards, so a leak stays visible rather than silently swallowed (470 ms); an ordinary tree costs one attempt (1 ms). Dropping `EFAULT` from the retry set breaks the first case (0 ms, tree left on disk), which is what makes that entry load-bearing rather than defensive.
- **No timer regression:** `git diff -U0 | grep '^+' | grep -E 'timeout|maxRetries|retryDelay|[0-9]_000|setTimeout|sleep|budget'` returns two comment lines and no code.
- `orchestrator.test.ts` and `cli.test.ts` are excluded from `tsc` by their packages, so both were type-checked explicitly through a temporary config: `cli.test.ts` clean; `orchestrator.test.ts` reports 89 errors **both with this change and on the `origin/dev` baseline** — identical count, all pre-existing, none at the changed lines.
- **One Windows CI run went red on this branch; it was not this PR.** Run 33116052433 attempt 1 failed `migrate-state-dir > subdirectory invocation (C5) > refuses when BOTH the subdirectory and the project root hold legacy state [5016.00ms]` — the pre-existing C5 timeout #2306 already tracks as live and out of scope here (identical test and duration to PR #2863 run 33103058896). Attempt 2 of the same commit passed. Ruled out as a regression four ways: the whole job log contains **zero** `temp cleanup failed` warnings, so no cleanup in this PR ever retried; the failing stack is inside `withSandbox`'s **body** (`migrate-state-dir.test.ts:78`), not the cleanup in its `finally` (line 80); the subprocess died with exit **143** (SIGTERM), i.e. the harness timeout killed the second cold `bun -e` spawn at line 444, which is the documented C5 mechanism; and the earlier commit `e250a58b`, which already contained the same `migrate-state-dir.test.ts` change, passed Windows. Locally the C5 block is if anything faster on this branch than on `origin/dev` (5 runs each: ~269 ms vs ~287 ms mean).
- **Not verified:** the Windows failures this PR targets. No Windows host was available, and CI on this branch is the first Windows exercise. The mechanism was reproduced locally instead.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | Test-only. `packages/paths/src/test-utils.ts` is imported by no production code; it follows the existing `@archon/workflows/test-utils` subpath-export pattern. | `packages/paths/package.json` exports diff |
| Observability | A tree that cannot be removed now logs `temp cleanup failed for <path>` instead of failing the test, so a genuine leak stays visible rather than silent. | `packages/paths/src/test-utils.ts` |
| Documentation / communication | The `migrate-state-dir.test.ts` docblock claiming `maxRetries` was the fix is corrected, and the inventory comment on #2306 needs the same correction for the remaining lanes. | `scripts/migrate-state-dir.test.ts:54-62` |

## Links

- Related #2306 — class-level record. Deliberately no closing keyword: groups 3–5 remain open.
- Related #2859 — CLI-specific sibling. Its PR #2860 was **closed unmerged**, and `resolveRunConfigPath` does not exist on `dev`, so nothing there landed and no site was skipped for collision. This PR touches `cli.test.ts` cleanup only and does not overlap #2860's spawn-consolidation approach.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of temporary-file cleanup, including after failed tests or interrupted processes.
  * Reduced intermittent integration-test failures by waiting for terminal events to be fully written before reading them.

* **Tests**
  * Standardized sandbox and temporary-directory cleanup across CLI, workflow, isolation, and state migration test suites.
  * Added shared test utilities for tracking and retrying cleanup of temporary resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->