### PR TITLE
test(core): wait on the conversation lock instead of the clock

### DIFF
--- a/packages/core/src/utils/conversation-lock.test.ts
+++ b/packages/core/src/utils/conversation-lock.test.ts
@@ -1,5 +1,70 @@
 import { ConversationLockManager } from './conversation-lock';
 
+/**
+ * Nothing in this file sleeps. `acquireLock` resolves with the acquisition
+ * status, not with handler completion, so the handlers report their own starts
+ * into a log and the test decides when each one finishes. Waiting is always
+ * "drain microtasks until the manager reached this state", and ordering is
+ * asserted against the log rather than assumed from a wall-clock margin.
+ */
+
+interface GatedHandler {
+  /** Lets the handler finish. */
+  release: () => void;
+  handler: () => Promise<void>;
+}
+
+/**
+ * A handler the test drives explicitly: it appends its label to `log` when it
+ * starts and stays in flight until released. `fail` makes it reject on release,
+ * which exercises the manager's error path without a timing assumption.
+ */
+function gate(log: string[], label: string, { fail = false } = {}): GatedHandler {
+  let release!: () => void;
+  const released = new Promise<void>(resolve => {
+    release = resolve;
+  });
+  return {
+    release,
+    handler: async () => {
+      log.push(label);
+      await released;
+      if (fail) throw new Error(`handler ${label} failed`);
+    },
+  };
+}
+
+/**
+ * The manager releases a lock and hands off to the next queued message entirely
+ * on the microtask queue, so draining microtasks converges without touching the
+ * clock. The bound turns a broken handoff into an immediate failure rather than
+ * a hang.
+ */
+async function drainUntil(predicate: () => boolean, expectation: string): Promise<void> {
+  for (let tick = 0; tick < 100; tick++) {
+    if (predicate()) return;
+    await Promise.resolve();
+  }
+  throw new Error(`manager never reached expected state: ${expectation}`);
+}
+
+/**
+ * Waits for one more handler to start, whichever one the manager picked. The
+ * caller then asserts the log, so picking the wrong one fails on the ordering
+ * assertion instead of blocking on a handler that never runs.
+ */
+function drainUntilStarted(log: string[], count: number): Promise<void> {
+  return drainUntil(() => log.length >= count, `${count} handler(s) started, saw [${log}]`);
+}
+
+/** Waits for the manager to have no active conversations and nothing queued. */
+function drainUntilIdle(manager: ConversationLockManager): Promise<void> {
+  return drainUntil(() => {
+    const stats = manager.getStats();
+    return stats.active === 0 && stats.queuedTotal === 0;
+  }, 'idle (no active conversations, empty queues)');
+}
+
 describe('ConversationLockManager', () => {
   test('initializes with correct maxConcurrent', () => {
     const manager = new ConversationLockManager(5);
@@ -23,183 +88,166 @@ describe('ConversationLockManager', () => {
 
   test('processes handler immediately when under capacity', async () => {
     const manager = new ConversationLockManager(10);
-    let executed = false;
+    const log: string[] = [];
+    const only = gate(log, 'only');
 
-    await manager.acquireLock('test-1', async () => {
-      executed = true;
-    });
+    const result = await manager.acquireLock('test-1', only.handler);
+    await drainUntilStarted(log, 1);
 
-    // Small delay to allow async completion
-    await new Promise(resolve => setTimeout(resolve, 10));
+    expect(result.status).toBe('started');
+    expect(log).toEqual(['only']);
+    expect(manager.getStats().active).toBe(1);
 
-    expect(executed).toBe(true);
-    expect(manager.getStats().active).toBe(0); // Should be completed
+    only.release();
+    await drainUntilIdle(manager);
   });
 
   test('queues message when same conversation already active', async () => {
     const manager = new ConversationLockManager(10);
-    const executionOrder: number[] = [];
+    const log: string[] = [];
+    const first = gate(log, 'first');
+    const second = gate(log, 'second');
 
-    // Start first message (will block for 50ms)
-    manager.acquireLock('same-conv', async () => {
-      executionOrder.push(1);
-      await new Promise(resolve => setTimeout(resolve, 50));
-    });
+    await manager.acquireLock('same-conv', first.handler);
+    await drainUntilStarted(log, 1);
 
-    // Small delay to ensure first handler is started
-    await new Promise(resolve => setTimeout(resolve, 10));
+    const queued = await manager.acquireLock('same-conv', second.handler);
+    expect(queued.status).toBe('queued-conversation');
 
-    // Start second message (should queue)
-    manager.acquireLock('same-conv', async () => {
-      executionOrder.push(2);
-    });
-
-    // Check stats immediately
     const stats = manager.getStats();
     expect(stats.active).toBe(1);
     expect(stats.queuedTotal).toBe(1);
     expect(stats.queuedByConversation).toEqual([
       { conversationId: 'same-conv', queuedMessages: 1 },
     ]);
+    expect(log).toEqual(['first']);
 
-    // Wait for both to complete
-    await new Promise(resolve => setTimeout(resolve, 100));
+    first.release();
+    await drainUntilStarted(log, 2);
+    expect(log).toEqual(['first', 'second']);
 
-    expect(executionOrder).toEqual([1, 2]); // Should execute in order
-    expect(manager.getStats().active).toBe(0);
-    expect(manager.getStats().queuedTotal).toBe(0);
+    second.release();
+    await drainUntilIdle(manager);
   });
 
   test('queues message when at max capacity', async () => {
     const manager = new ConversationLockManager(2);
+    const log: string[] = [];
+    const one = gate(log, 'conv-1');
+    const two = gate(log, 'conv-2');
+    const three = gate(log, 'conv-3');
 
-    // Start 2 conversations (fills capacity)
-    manager.acquireLock('conv-1', async () => {
-      await new Promise(resolve => setTimeout(resolve, 50));
-    });
-    manager.acquireLock('conv-2', async () => {
-      await new Promise(resolve => setTimeout(resolve, 50));
-    });
+    await manager.acquireLock('conv-1', one.handler);
+    await manager.acquireLock('conv-2', two.handler);
+    await drainUntilStarted(log, 2);
 
-    // Small delay to ensure both started
-    await new Promise(resolve => setTimeout(resolve, 10));
+    // A third distinct conversation has nowhere to run until capacity frees up.
+    const queued = await manager.acquireLock('conv-3', three.handler);
+    expect(queued.status).toBe('queued-capacity');
+    expect(manager.getStats().active).toBe(2);
+    expect(manager.getStats().queuedTotal).toBe(1);
+    expect(log).toEqual(['conv-1', 'conv-2']);
 
-    // Try to start third (should queue)
-    manager.acquireLock('conv-3', async () => {
-      // This should execute eventually
-    });
+    // Finishing one occupant is what admits the queued conversation.
+    one.release();
+    await drainUntilStarted(log, 3);
+    expect(log).toEqual(['conv-1', 'conv-2', 'conv-3']);
 
-    const stats = manager.getStats();
-    expect(stats.active).toBe(2); // At capacity
-    expect(stats.queuedTotal).toBe(1); // One queued
-
-    // Wait for completion (need longer to process queued item)
-    await new Promise(resolve => setTimeout(resolve, 150));
-
-    expect(manager.getStats().active).toBe(0);
-    expect(manager.getStats().queuedTotal).toBe(0);
+    two.release();
+    three.release();
+    await drainUntilIdle(manager);
   });
 
   test('multiple conversations process concurrently', async () => {
     const manager = new ConversationLockManager(10);
-    const startTimes: Record<string, number> = {};
+    const log: string[] = [];
+    const conversations = ['conv-1', 'conv-2', 'conv-3'].map(id => ({ id, gated: gate(log, id) }));
 
-    // Start 3 conversations simultaneously
-    const promises = [1, 2, 3].map(i =>
-      manager.acquireLock(`conv-${i}`, async () => {
-        startTimes[`conv-${i}`] = Date.now();
-        await new Promise(resolve => setTimeout(resolve, 30));
-      })
-    );
+    for (const { id, gated } of conversations) {
+      const result = await manager.acquireLock(id, gated.handler);
+      expect(result.status).toBe('started');
+    }
+    await drainUntilStarted(log, 3);
 
-    await Promise.all(promises);
+    // None has been released, so all three are genuinely in flight at once.
+    const stats = manager.getStats();
+    expect(stats.active).toBe(3);
+    expect(stats.queuedTotal).toBe(0);
+    expect(stats.activeConversationIds.sort()).toEqual(['conv-1', 'conv-2', 'conv-3']);
 
-    // Small delay to allow all to start
-    await new Promise(resolve => setTimeout(resolve, 20));
-
-    // All should have started around the same time (concurrent)
-    const times = Object.values(startTimes);
-    expect(times.length).toBe(3);
-    const maxDiff = Math.max(...times) - Math.min(...times);
-    expect(maxDiff).toBeLessThan(20); // Started within 20ms of each other
-
-    // Wait for completion
-    await new Promise(resolve => setTimeout(resolve, 100));
+    for (const { gated } of conversations) gated.release();
+    await drainUntilIdle(manager);
   });
 
   test('queued messages process in order after completion', async () => {
     const manager = new ConversationLockManager(10);
-    const executionOrder: number[] = [];
+    const log: string[] = [];
+    const first = gate(log, 'first');
+    const second = gate(log, 'second');
+    const third = gate(log, 'third');
 
-    // Start first message
-    manager.acquireLock('test-conv', async () => {
-      executionOrder.push(1);
-      await new Promise(resolve => setTimeout(resolve, 30));
-    });
+    await manager.acquireLock('test-conv', first.handler);
+    await drainUntilStarted(log, 1);
 
-    // Small delay
-    await new Promise(resolve => setTimeout(resolve, 10));
+    await manager.acquireLock('test-conv', second.handler);
+    await manager.acquireLock('test-conv', third.handler);
+    expect(manager.getStats().queuedTotal).toBe(2);
+    expect(log).toEqual(['first']);
 
-    // Queue second and third messages
-    manager.acquireLock('test-conv', async () => {
-      executionOrder.push(2);
-      await new Promise(resolve => setTimeout(resolve, 10));
-    });
-    manager.acquireLock('test-conv', async () => {
-      executionOrder.push(3);
-    });
+    // Each release admits exactly the next message in arrival order.
+    first.release();
+    await drainUntilStarted(log, 2);
+    expect(log).toEqual(['first', 'second']);
 
-    // Wait for all to complete
-    await new Promise(resolve => setTimeout(resolve, 100));
+    second.release();
+    await drainUntilStarted(log, 3);
+    expect(log).toEqual(['first', 'second', 'third']);
 
-    expect(executionOrder).toEqual([1, 2, 3]); // FIFO order
+    third.release();
+    await drainUntilIdle(manager);
   });
 
   test('error in handler does not prevent queue processing', async () => {
     const manager = new ConversationLockManager(10);
-    const executionOrder: number[] = [];
+    const log: string[] = [];
+    const failing = gate(log, 'failing', { fail: true });
+    const next = gate(log, 'next');
 
-    // First message throws error
-    manager.acquireLock('test-conv', async () => {
-      executionOrder.push(1);
-      throw new Error('Test error');
-    });
+    await manager.acquireLock('test-conv', failing.handler);
+    await drainUntilStarted(log, 1);
 
-    // Small delay
-    await new Promise(resolve => setTimeout(resolve, 10));
+    await manager.acquireLock('test-conv', next.handler);
+    expect(manager.getStats().queuedTotal).toBe(1);
 
-    // Second message should still execute
-    manager.acquireLock('test-conv', async () => {
-      executionOrder.push(2);
-    });
+    failing.release();
+    await drainUntilStarted(log, 2);
+    expect(log).toEqual(['failing', 'next']);
 
-    // Wait for completion
-    await new Promise(resolve => setTimeout(resolve, 50));
-
-    expect(executionOrder).toEqual([1, 2]); // Second still executes
-    expect(manager.getStats().active).toBe(0); // Cleaned up properly
+    next.release();
+    await drainUntilIdle(manager);
   });
 
-  test('stats show correct active conversation IDs', async () => {
+  test('stats stop reporting a conversation once it finishes', async () => {
     const manager = new ConversationLockManager(10);
+    const log: string[] = [];
+    const a = gate(log, 'conv-a');
+    const b = gate(log, 'conv-b');
 
-    // Start 2 conversations
-    manager.acquireLock('conv-a', async () => {
-      await new Promise(resolve => setTimeout(resolve, 50));
-    });
-    manager.acquireLock('conv-b', async () => {
-      await new Promise(resolve => setTimeout(resolve, 50));
-    });
+    await manager.acquireLock('conv-a', a.handler);
+    await manager.acquireLock('conv-b', b.handler);
+    await drainUntilStarted(log, 2);
 
-    // Small delay
-    await new Promise(resolve => setTimeout(resolve, 10));
+    expect(manager.getStats().activeConversationIds.sort()).toEqual(['conv-a', 'conv-b']);
 
-    const stats = manager.getStats();
-    expect(stats.activeConversationIds).toContain('conv-a');
-    expect(stats.activeConversationIds).toContain('conv-b');
-    expect(stats.activeConversationIds.length).toBe(2);
+    a.release();
+    await drainUntil(
+      () => manager.getStats().active === 1,
+      'only conv-b active after conv-a finished'
+    );
+    expect(manager.getStats().activeConversationIds).toEqual(['conv-b']);
 
-    // Wait for completion
-    await new Promise(resolve => setTimeout(resolve, 100));
+    b.release();
+    await drainUntilIdle(manager);
+    expect(manager.getStats().activeConversationIds).toEqual([]);
   });
 });


### PR DESCRIPTION
## Problem and outcome

`ConversationLockManager > queued messages process in order after completion` fails intermittently on `windows-latest` and blocks unrelated PRs. It asserts FIFO ordering after an unconditional 100ms sleep that has to cover ~40ms of handler work, so a loaded runner exhausts the budget before the queue drains. The reported failure took 125ms and the ordering was never wrong — only the wall-clock margin ran out.

- **Outcome:** the file contains no `setTimeout` and no `Date.now` call. Every wait is a wait on a state the manager reports, so no amount of scheduler pressure can change the result. It runs in ~35ms instead of ~800ms.
- **Invariant:** the tests still fail on a real regression. FIFO drain order, per-conversation serialisation, the concurrency cap, lock release, error containment, and the freed-capacity wakeup are each proven by a mutation that turns the suite red.
- **Scope boundary:** `packages/core/src/utils/conversation-lock.ts` is unchanged. No test budget or timer value was raised anywhere.
- **Root cause:** `acquireLock` resolves with the acquisition status, not with handler completion, so the original tests dropped the handler promises entirely and used sleeps as a stand-in for completion. The clock was substituting for a signal that the handlers themselves can produce.

## Review guidance

- **Feedback requested:** whether the microtask-drain helper is the right waiting primitive here, and whether the reworked assertions still cover what the originals intended.
- **Start here:** `packages/core/src/utils/conversation-lock.test.ts:39-66` — `drainUntil` and its two wrappers are the load-bearing change; every other edit follows from them.
- **Review order:** the three helpers at the top, then `queued messages process in order after completion` (the test named in #2689), then `multiple conversations process concurrently` (the one that asserted scheduler jitter).
- **Lower-attention areas:** `initializes with correct maxConcurrent` and `getStats returns empty state initially` are untouched; they had no timing dependency.
- **Known risk or uncertainty:** `drainUntil` bounds itself at 100 microtask ticks. That is a bound on failure, not on success — the manager's queue handoff and cleanup are entirely microtask-driven, so a correct implementation converges in a handful of ticks and a broken one fails immediately with a message naming the state it never reached.

## Solution

Handlers are now gated: each one appends its label to a shared log when it starts and stays in flight until the test releases it. That gives the test both halves of what the sleeps were faking — a start signal it can wait for, and control over when work finishes.

Waiting became "drain microtasks until the manager reports this state" rather than "sleep long enough". Ordering is asserted against the recorded start log instead of being assumed from a wall-clock margin, so a wrong pick fails on an ordering diff rather than blocking on a handler that never runs. Concurrency is asserted from the manager's own `active` count and `activeConversationIds` with all three handlers deliberately still in flight, which is a stronger claim than the `maxDiff < 20ms` jitter check it replaces. Queueing decisions are asserted against the `LockAcquisitionResult` status the manager already returns and nothing previously tested.

One test changed its claim rather than only its mechanism: `stats show correct active conversation IDs` only ever checked the set at one moment, which the concurrency test now covers. It became `stats stop reporting a conversation once it finishes`, which checks that the id set tracks completion and not just starts.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | 10 hardcoded sleeps pace 9 tests; assertions run after a fixed budget | No timers; each assertion runs when the manager reports the awaited state |
| **Failure behavior** | A slow runner fails the FIFO test at 125ms with correct ordering; a real FIFO break also fails, indistinguishably | A slow runner cannot fail it; a real FIFO break fails in 0.26ms with an ordering diff |

## Validation

- `bun test src/utils/conversation-lock.test.ts` — 9 pass, 0 fail, 20 consecutive runs, 32–40ms each — proves stability.
- Same file, 5 runs under 8 saturating CPU processes — 9 pass, 61–71ms — proves the result does not depend on scheduler slack.
- Reproduced the original failure mechanism: with `setTimeout` patched so one 30ms timer is delivered at 130ms, the old FIFO test fails at 115ms with `expected [1,2,3], received [1]` — ordering intact, budget expired, matching the 125ms CI signature. The rewritten file passes unchanged under the same patched clock.
- Mutation testing against `conversation-lock.ts`, each mutation reverted afterwards:

  | Mutation | Result |
  |---|---|
  | `queue.shift()` → `queue.pop()` (LIFO drain) | `queued messages process in order after completion` fails in 0.26ms on the ordering diff |
  | drop the "already active" check | 3 tests fail; first is `expected "queued-conversation", received "started"` |
  | drop the capacity check | `queues message when at max capacity` fails: `expected "queued-capacity", received "started"` |
  | drop `activeConversations.delete` | 7 tests fail with `manager never reached expected state: …` |
  | drop the handler `.catch` | `error in handler does not prevent queue processing` fails on the escaped rejection |
  | drop the `processGlobalQueue` wakeup | `queues message when at max capacity` fails: `3 handler(s) started, saw [conv-1,conv-2]` |

- `bun run lint` — clean. `bun run validate` — exit 0 (bundled/schema/pi-vendor/capability checks, type-check, lint at `--max-warnings 0`, format check, installer tests, full test suite).
- **Not verified:** the fix is not observed green on `windows-latest` itself; that only happens once CI runs this branch. The mechanism is host-independent — a file with no timers cannot lose a timing race — and the reproduction above shows the old test failing under exactly the delivery delay the issue diagnoses.

## Links

- Closes #2689
- Related #2306


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated coverage for conversation locking and handler execution ordering.
  * Added deterministic validation that conversations are released correctly after all processing completes.
  * Reduced timing-related test variability, supporting more reliable verification of conversation activity behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->