### PR TITLE
fix(core): SqliteAdapter finalizes prepared statements so close() releases the db file

### DIFF
--- a/packages/core/src/db/adapters/sqlite.test.ts
+++ b/packages/core/src/db/adapters/sqlite.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, afterEach } from 'bun:test';
 import { SqliteAdapter } from './sqlite';
 import { getSchemaSQL } from '../bundled-schema';
 import { APP_VERSION, readSchemaVersion } from '../schema-version';
-import { Database } from 'bun:sqlite';
+import { Database, type Statement } from 'bun:sqlite';
 import { unlinkSync } from 'fs';
 import { join } from 'path';
 
@@ -1077,3 +1077,72 @@ function raw_query(dbPath: string, sql: string): unknown[] {
     raw.close();
   }
 }
+
+describe('SqliteAdapter native-resource finalization (#2875)', () => {
+  let adapter: SqliteAdapter | undefined;
+
+  afterEach(async () => {
+    if (adapter) {
+      await adapter.close();
+      adapter = undefined;
+    }
+    for (const suffix of ['', '-wal', '-shm']) {
+      try {
+        unlinkSync(currentDbPath + suffix);
+      } catch {
+        /* may not exist */
+      }
+    }
+  });
+
+  test('finalizes every statement it prepares by the time close() resolves', async () => {
+    const originalPrepare = Database.prototype.prepare;
+    let prepared = 0;
+    let finalized = 0;
+    Database.prototype.prepare = function (
+      this: Database,
+      ...args: Parameters<typeof originalPrepare>
+    ) {
+      const stmt = originalPrepare.apply(this, args) as Statement & {
+        finalize: () => unknown;
+      };
+      prepared++;
+      const nativeFinalize = stmt.finalize.bind(stmt);
+      stmt.finalize = () => {
+        finalized++;
+        return nativeFinalize();
+      };
+      return stmt;
+    };
+
+    try {
+      adapter = createTestDb();
+      await insertCodebase(adapter, 'cb-finalize');
+      await adapter.query('SELECT id FROM remote_agent_codebases WHERE id = $1', ['cb-finalize']);
+
+      // A statement that prepares cleanly but fails on execution (primary key
+      // violation) must still be finalized (this is the finally-branch of the fix).
+      await expect(insertCodebase(adapter, 'cb-finalize')).rejects.toThrow();
+
+      await adapter.close();
+      adapter = undefined;
+
+      expect(prepared).toBeGreaterThan(0);
+      expect(finalized).toBe(prepared);
+    } finally {
+      Database.prototype.prepare = originalPrepare;
+    }
+  });
+
+  test('close() leaves the database file immediately deletable', async () => {
+    adapter = createTestDb();
+    await insertCodebase(adapter, 'cb-delete');
+    await adapter.query('SELECT id FROM remote_agent_codebases WHERE id = $1', ['cb-delete']);
+    await adapter.close();
+    adapter = undefined;
+
+    // Passes trivially where POSIX unlink tolerates open handles, but on
+    // windows-latest this fails with EBUSY while any statement is unfinalized.
+    unlinkSync(currentDbPath);
+  });
+});

--- a/packages/core/src/db/adapters/sqlite.ts
+++ b/packages/core/src/db/adapters/sqlite.ts
@@ -8,6 +8,9 @@ import type { IDatabase, QueryResult, SqlDialect } from './types';
 import { createLogger } from '@archon/paths';
 import { APP_VERSION } from '../schema-version';
 
+/** bun:sqlite's get() returns null (not undefined) when the query has no row. */
+type Maybe<T> = T | null;
+
 /** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
 let cachedLog: ReturnType<typeof createLogger> | undefined;
 function getLog(): ReturnType<typeof createLogger> {
@@ -149,10 +152,10 @@ export class SqliteAdapter implements IDatabase {
     }
   }
 
-  private prepareGet(sql: string, params: SQLQueryBindings[] = []): unknown {
+  private prepareGet<T>(sql: string, params: SQLQueryBindings[] = []): Maybe<T> {
     const stmt = this.db.prepare(sql);
     try {
-      return stmt.get(...params);
+      return stmt.get(...params) as Maybe<T>;
     } finally {
       stmt.finalize();
     }
@@ -242,9 +245,9 @@ export class SqliteAdapter implements IDatabase {
       return;
     }
     try {
-      const existing = this.prepareGet(
+      const existing = this.prepareGet<{ app_version: string }>(
         'SELECT app_version FROM remote_agent_schema_version WHERE id = 1'
-      ) as { app_version: string } | undefined;
+      );
 
       if (!existing) {
         this.db.run(
@@ -347,9 +350,9 @@ export class SqliteAdapter implements IDatabase {
       // not on every open: an unconditional DROP + CREATE rebuilds the index
       // each time the adapter is constructed, and leaves a window where the
       // index is gone if the re-create fails.
-      const existingCodebaseIdx = this.prepareGet(
+      const existingCodebaseIdx = this.prepareGet<{ sql: string | null }>(
         "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'idx_conversations_codebase'"
-      ) as { sql: string | null } | undefined;
+      );
       if (existingCodebaseIdx && !(existingCodebaseIdx.sql ?? '').includes('deleted_at IS NULL')) {
         this.db.run('DROP INDEX idx_conversations_codebase');
       }

--- a/packages/core/src/db/adapters/sqlite.ts
+++ b/packages/core/src/db/adapters/sqlite.ts
@@ -67,8 +67,7 @@ export class SqliteAdapter implements IDatabase {
       const sqliteParams = reorderedParams as SQLQueryBindings[];
 
       if (isSelect) {
-        const stmt = this.db.prepare(convertedSql);
-        const rows = stmt.all(...sqliteParams) as T[];
+        const rows = this.prepareAll<T>(convertedSql, sqliteParams);
         return { rows, rowCount: rows.length };
       } else {
         const upperSql = sql.toUpperCase();
@@ -78,8 +77,7 @@ export class SqliteAdapter implements IDatabase {
         // RETURNING results, and its lastInsertRowid is unreliable when
         // ON CONFLICT DO UPDATE fires.
         if (upperSql.includes('RETURNING') && upperSql.includes('INSERT')) {
-          const stmt = this.db.prepare(convertedSql);
-          const rows = stmt.all(...sqliteParams) as T[];
+          const rows = this.prepareAll<T>(convertedSql, sqliteParams);
           return { rows, rowCount: rows.length };
         }
 
@@ -93,9 +91,8 @@ export class SqliteAdapter implements IDatabase {
         }
 
         // Standard INSERT/UPDATE/DELETE without RETURNING
-        const stmt = this.db.prepare(convertedSql);
-        const result = stmt.run(...sqliteParams);
-        return { rows: [], rowCount: result.changes };
+        const rowCount = this.prepareRun(convertedSql, sqliteParams);
+        return { rows: [], rowCount };
       }
     } catch (error) {
       const err = error as Error;
@@ -134,6 +131,40 @@ export class SqliteAdapter implements IDatabase {
 
   async close(): Promise<void> {
     this.db.close();
+  }
+
+  /**
+   * bun:sqlite does not finalize statements automatically when the connection
+   * closes: one unfinalized statement keeps the database file pinned until GC
+   * (delete-after-close fails with EBUSY on Windows). So every prepare() in
+   * this class must funnel through these wrappers, which finalize the
+   * statement within the operation's scope (#2875).
+   */
+  private prepareAll<T>(sql: string, params: SQLQueryBindings[] = []): T[] {
+    const stmt = this.db.prepare(sql);
+    try {
+      return stmt.all(...params) as T[];
+    } finally {
+      stmt.finalize();
+    }
+  }
+
+  private prepareGet(sql: string, params: SQLQueryBindings[] = []): unknown {
+    const stmt = this.db.prepare(sql);
+    try {
+      return stmt.get(...params);
+    } finally {
+      stmt.finalize();
+    }
+  }
+
+  private prepareRun(sql: string, params: SQLQueryBindings[] = []): number {
+    const stmt = this.db.prepare(sql);
+    try {
+      return stmt.run(...params).changes;
+    } finally {
+      stmt.finalize();
+    }
   }
 
   /**
@@ -181,9 +212,10 @@ export class SqliteAdapter implements IDatabase {
 
   /** True when core Archon tables already exist — i.e. this is not a fresh database. */
   private hasAnyArchonTable(): boolean {
-    const row = this.db
-      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
-      .get('remote_agent_codebases');
+    const row = this.prepareGet(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?",
+      ['remote_agent_codebases']
+    );
     return row !== null && row !== undefined;
   }
 
@@ -210,9 +242,9 @@ export class SqliteAdapter implements IDatabase {
       return;
     }
     try {
-      const existing = this.db
-        .prepare('SELECT app_version FROM remote_agent_schema_version WHERE id = 1')
-        .get() as { app_version: string } | null;
+      const existing = this.prepareGet(
+        'SELECT app_version FROM remote_agent_schema_version WHERE id = 1'
+      ) as { app_version: string } | undefined;
 
       if (!existing) {
         this.db.run(
@@ -250,9 +282,7 @@ export class SqliteAdapter implements IDatabase {
     // Better Auth's own tables are PostgreSQL-only — web auth is never enabled
     // on SQLite — so only the role column is backfilled here.
     try {
-      const userCols = this.db.prepare("PRAGMA table_info('remote_agent_users')").all() as {
-        name: string;
-      }[];
+      const userCols = this.prepareAll<{ name: string }>("PRAGMA table_info('remote_agent_users')");
       const userColNames = new Set(userCols.map(c => c.name));
       if (!userColNames.has('role')) {
         this.db.run("ALTER TABLE remote_agent_users ADD COLUMN role TEXT NOT NULL DEFAULT 'admin'");
@@ -264,9 +294,9 @@ export class SqliteAdapter implements IDatabase {
 
     // Codebases columns
     try {
-      const codebaseCols = this.db.prepare("PRAGMA table_info('remote_agent_codebases')").all() as {
-        name: string;
-      }[];
+      const codebaseCols = this.prepareAll<{ name: string }>(
+        "PRAGMA table_info('remote_agent_codebases')"
+      );
       const codebaseColNames = new Set(codebaseCols.map(c => c.name));
 
       if (!codebaseColNames.has('default_branch')) {
@@ -284,9 +314,9 @@ export class SqliteAdapter implements IDatabase {
 
     // Conversations columns
     try {
-      const cols = this.db.prepare("PRAGMA table_info('remote_agent_conversations')").all() as {
-        name: string;
-      }[];
+      const cols = this.prepareAll<{ name: string }>(
+        "PRAGMA table_info('remote_agent_conversations')"
+      );
       const colNames = new Set(cols.map(c => c.name));
 
       if (!colNames.has('title')) {
@@ -317,11 +347,9 @@ export class SqliteAdapter implements IDatabase {
       // not on every open: an unconditional DROP + CREATE rebuilds the index
       // each time the adapter is constructed, and leaves a window where the
       // index is gone if the re-create fails.
-      const existingCodebaseIdx = this.db
-        .prepare(
-          "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'idx_conversations_codebase'"
-        )
-        .get() as { sql: string | null } | null;
+      const existingCodebaseIdx = this.prepareGet(
+        "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'idx_conversations_codebase'"
+      ) as { sql: string | null } | undefined;
       if (existingCodebaseIdx && !(existingCodebaseIdx.sql ?? '').includes('deleted_at IS NULL')) {
         this.db.run('DROP INDEX idx_conversations_codebase');
       }
@@ -335,9 +363,9 @@ export class SqliteAdapter implements IDatabase {
 
     // Workflow runs columns
     try {
-      const wfCols = this.db.prepare("PRAGMA table_info('remote_agent_workflow_runs')").all() as {
-        name: string;
-      }[];
+      const wfCols = this.prepareAll<{ name: string }>(
+        "PRAGMA table_info('remote_agent_workflow_runs')"
+      );
       const wfColNames = new Set(wfCols.map(c => c.name));
 
       if (!wfColNames.has('parent_conversation_id')) {
@@ -401,9 +429,9 @@ export class SqliteAdapter implements IDatabase {
 
     // Sessions columns
     try {
-      const sessCols = this.db.prepare("PRAGMA table_info('remote_agent_sessions')").all() as {
-        name: string;
-      }[];
+      const sessCols = this.prepareAll<{ name: string }>(
+        "PRAGMA table_info('remote_agent_sessions')"
+      );
       const sessColNames = new Set(sessCols.map(c => c.name));
 
       if (!sessColNames.has('ended_reason')) {
@@ -416,9 +444,7 @@ export class SqliteAdapter implements IDatabase {
 
     // Messages columns
     try {
-      const cols = this.db.prepare("PRAGMA table_info('remote_agent_messages')").all() as {
-        name: string;
-      }[];
+      const cols = this.prepareAll<{ name: string }>("PRAGMA table_info('remote_agent_messages')");
       const colNames = new Set(cols.map(c => c.name));
       if (!colNames.has('user_id')) {
         this.db.run(
@@ -432,11 +458,9 @@ export class SqliteAdapter implements IDatabase {
 
     // Isolation environments columns
     try {
-      const cols = this.db
-        .prepare("PRAGMA table_info('remote_agent_isolation_environments')")
-        .all() as {
-        name: string;
-      }[];
+      const cols = this.prepareAll<{ name: string }>(
+        "PRAGMA table_info('remote_agent_isolation_environments')"
+      );
       const colNames = new Set(cols.map(c => c.name));
       if (!colNames.has('created_by_user_id')) {
         this.db.run(
@@ -456,9 +480,9 @@ export class SqliteAdapter implements IDatabase {
     // shipped with Phase 3 (#1948), so pre-existing installs need this ALTER —
     // CREATE TABLE IF NOT EXISTS in createSchema() is a no-op for them.
     try {
-      const cols = this.db.prepare("PRAGMA table_info('remote_agent_user_ai_prefs')").all() as {
-        name: string;
-      }[];
+      const cols = this.prepareAll<{ name: string }>(
+        "PRAGMA table_info('remote_agent_user_ai_prefs')"
+      );
       const colNames = new Set(cols.map(c => c.name));
       if (!colNames.has('default_model')) {
         this.db.run('ALTER TABLE remote_agent_user_ai_prefs ADD COLUMN default_model TEXT');
@@ -471,9 +495,9 @@ export class SqliteAdapter implements IDatabase {
     // Lifecycle ordering: SQLite timestamps have one-second precision. A trigger
     // assigns a durable, monotonically increasing value for each inserted event.
     try {
-      const cols = this.db.prepare("PRAGMA table_info('remote_agent_workflow_events')").all() as {
-        name: string;
-      }[];
+      const cols = this.prepareAll<{ name: string }>(
+        "PRAGMA table_info('remote_agent_workflow_events')"
+      );
       if (!new Set(cols.map(c => c.name)).has('event_order')) {
         this.db.run('ALTER TABLE remote_agent_workflow_events ADD COLUMN event_order INTEGER');
       }


### PR DESCRIPTION
## Problem and outcome

`bun:sqlite`'s `Database.close()` does not release the database file while any prepared statement on the connection is unfinalized — the connection lingers as a zombie until GC. `SqliteAdapter` prepared statements it never finalized (one per `query()` call, plus roughly ten in `initSchema()` helpers), so `await adapter.close()` resolving did not mean the database file was released. On POSIX, native statement handles accumulated until GC; on Windows, any delete/move/replace of the db file right after close could fail with EBUSY, which is how the bug surfaced in CI.

- **Outcome:** After `await adapter.close()` resolves, the database file is immediately deletable — no GC assistance needed on any platform.
- **Invariant:** Closing the adapter releases every native resource it acquired.
- **Scope boundary:** No statement caching, no close-time tracking set, no change to `db.run`/`db.exec` call sites (a probe on bun 1.3.11 showed they leak nothing). The `Bun.gc(true)` workaround in `sqlite-vintages.test.ts` is intentionally not removed here — that file is not on this base; it ships via #2866 and the workaround can be removed there after this lands.
- **Root cause:** `SqliteAdapter` called `db.prepare()` directly and never called `stmt.finalize()`; `sqlite3_close_v2` leaves the connection alive until unfinalized statements are collected.

## Review guidance

- **Feedback requested:** Correctness of the finalize-in-`finally` pattern and its coverage — every `prepare()` in the class should now route through the wrappers.
- **Start here:** `packages/core/src/db/adapters/sqlite.ts:146` — the three private wrappers (`prepareAll`, `prepareGet`, `prepareRun`) that finalize in a `finally` block, so native handles are released whether the operation succeeds or throws.
- **Review order:** `sqlite.ts` wrappers → their call sites in `query()` and the `initSchema()` helpers → the two regression tests in `sqlite.test.ts`.
- **Lower-attention areas:** The `initSchema()` call-site edits are mechanical one-to-one swaps of `db.prepare(...).get()/.all()` for the wrapper equivalents.
- **Known risk or uncertainty:** Finalize-per-use adds one finalize per operation on hot paths. This was accepted over the issue's alternative (track-and-finalize-on-close) because the adapter has no statement cache — it prepares fresh per call — and close-time tracking would mean an unbounded set for no benefit.

## Solution

Every `prepare()` in `SqliteAdapter` now funnels through `prepareAll`, `prepareGet`, or `prepareRun`. Each wrapper calls `stmt.finalize()` in a `finally`, covering the error path as well — a statement that prepares cleanly but fails on execution is still finalized. `query()` (SELECT, INSERT-with-RETURNING, and standard write branches) and the schema-init helpers (`hasAnyArchonTable`, `recordSchemaVersion`, `migrateColumns`) use the wrappers. `db.run`/`db.exec` calls are untouched: they allocate no statement handles, confirmed by probe.

Two regression tests were added to `sqlite.test.ts`:

1. "finalizes every statement it prepares by the time close() resolves" — wraps `Database.prototype.prepare` (scoped to the test, restored in `finally`) to count preparations and finalizations; runs schema init, an insert, a select, a failing statement (primary-key violation, exercising the `finally` branch), then `close()`; asserts `finalized === prepared > 0`. Verified to fail on the pre-fix code (27 pass / 1 fail with the fix stashed) and pass after (28 pass / 0 fail).
2. "close() leaves the database file immediately deletable" — closes the adapter then `unlinkSync`es the db file with no GC call. Passes trivially on POSIX, but fails with EBUSY on windows-latest if any statement is unfinalized, which is where the real proof lands.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | `close()` resolves while the connection stays alive as a zombie until GC; native handles accumulate | `close()` releases all statement handles; the db file is immediately deletable |
| **Failure behavior** | Delete-after-close fails with EBUSY on Windows; test suites need `Bun.gc(true)` before cleanup | Delete-after-close succeeds with no GC call on any platform |

## Validation

- `cd packages/core && bun run test` — 0 failures; `sqlite.test.ts` runs 28 pass / 0 fail with the fix and 27 pass / 1 fail without it, proving the regression test reproduces the bug.
- `bun run type-check` — exit 0.
- `bun run lint --max-warnings 0` — exit 0.
- `bun run format:check` — exit 0.
- `bun run validate` (full chain including generated-file checks and all package tests) — exit 0.
- Probe evidence (bun 1.3.11, macOS): `db.run`/`db.exec` leak nothing; one unfinalized `db.prepare` leaves an open fd on the db file after `close()`; forced GC releases it.
- **Not verified:** The Windows EBUSY failure mode is proven by CI (windows-latest) rather than locally; the second test is written so a zombie connection fails it there.

## Links

- Closes #2875
- Relates to #2306 (probe evidence)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQLite database cleanup so prepared statements are finalized reliably when the database closes.
  * Database files can now be deleted immediately after closing, including on Windows.
  * Preserved existing query, migration, and schema behavior while preventing resource locks from failed operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->