### PR TITLE
fix(cli): restore the rmSync call site left undefined on dev

### DIFF
--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -115,7 +115,7 @@ describe('removed continue command', () => {
     expect(result.stderr).toContain('--adopt <run-id>');
   });
 
-  it('rejects archon continue outside any git repository', () => {
+  it('rejects archon continue outside any git repository', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'archon-no-repo-'));
     try {
       const result = spawnSync(process.execPath, [CLI_ENTRY, 'continue', 'some/branch'], {
@@ -127,7 +127,7 @@ describe('removed continue command', () => {
       expect(result.stderr).toContain("Removed: 'archon continue'");
       expect(result.stderr).toContain('--adopt <run-id>');
     } finally {
-      rmSync(dir, { recursive: true, force: true });
+      await removeTempTree(dir);
     }
   });
 


### PR DESCRIPTION
## Problem and outcome

`dev` is broken. `bun run test` in `packages/cli` fails at runtime:

```
ReferenceError: rmSync is not defined
  at packages/cli/src/cli.test.ts:130
(fail) removed continue command > rejects archon continue outside any git repository
```

Because the package test script is an `&&` chain and `src/cli.test.ts` sits in the middle of it, everything after that point never runs. Any branch that merges `dev` inherits a red CI that looks like a test failure rather than a broken mainline.

- **Outcome:** `packages/cli`'s suite passes again — all 13 legs, 0 fail — and the legs after `cli.test.ts` run again.
- **Invariant:** every identifier a test file uses is actually imported by that file.
- **Scope boundary:** two lines in one test. No production code, no other test, no timer or budget touched.
- **Root cause:** a semantic conflict between two PRs that were each green on their own.
  - `7a9f15d8` (#2873, remove `archon continue`) **added** the test at `cli.test.ts:118`, whose `finally` calls `rmSync(dir, …)`.
  - `f0646dbd` (#2874, deterministic test cleanup) then swapped this file's teardown to `removeTempTree` and **removed the `rmSync` import**. It converted the four call sites that existed on its branch (lines 227, 294, 366, 527) but not #2873's newer one, because #2874 branched before #2873 merged, so its CI never saw that call site.

  Neither PR conflicted textually, so both merged clean and the break only appears at runtime. Green + green → red is the whole mechanism: no CI run ever executed the composition of the two.

## Review guidance

- **Feedback requested:** none needed beyond confirming the two lines. This is a build fix.
- **Start here:** `packages/cli/src/cli.test.ts:118` and `:130`.
- **Known risk or uncertainty:** None. The replacement is the convention this same file already uses at four other sites.

## Solution

Use `removeTempTree` in the one call site #2874 missed, matching lines 227, 294, 366 and 527. `removeTempTree` is async, so the test callback becomes `async` and the call is awaited — exactly how the other four sites are written.

```diff
-  it('rejects archon continue outside any git repository', () => {
+  it('rejects archon continue outside any git repository', async () => {
...
-      rmSync(dir, { recursive: true, force: true });
+      await removeTempTree(dir);
```

I checked whether this was the only instance rather than assuming it. Across the 11 files #2874 touched, I compared the identifiers it removed from each file's imports against the identifiers still called in that file on current `dev`. `cli.test.ts` / `rmSync` is the only hit, and the check was validated by confirming it finds that known break before trusting its silence elsewhere. The intersection of files touched by both PRs is exactly this one file.

## Why the static gates missed it

Worth recording, because it explains why this class reaches runtime rather than CI-lint. `tsc` would have caught an undefined identifier instantly, but `packages/cli/tsconfig.json` excludes `**/*.test.ts`, and `eslint.config.mjs` ignores `**/*.test.ts` globally. Verified on this branch: `tsc --noEmit --listFiles` does not list `src/cli.test.ts`, and ESLint reports it as ignored. So neither gate covers this file, and only running the tests can catch it. Not changing that here — it is #2407's territory.

## Validation

- **Red before:** on clean `dev` with the fix stashed, `bun test src/cli.test.ts -t 'rejects archon continue outside any git repository'` → `0 pass / 1 fail`, `ReferenceError: rmSync is not defined at cli.test.ts:130`.
- **Green after:** same command → `1 pass / 0 fail`.
- `bun run test` in `packages/cli` → all 13 legs, **0 fail**. The leg containing `cli.test.ts` goes from `106 pass / 1 fail` to `107 pass / 0 fail`, and the four legs after it in the `&&` chain execute again.
- `bun run lint` → exit 0.
- Composition sweep across all 11 files #2874 touched → one finding, the one fixed here.
- **Not verified:** nothing material. The change is two lines in one test, and that test is directly exercised red-then-green.

## Links

- Related #2306


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated CLI test cleanup to use the project’s asynchronous temporary-directory removal pattern.
  * Preserved validation that continuing outside a Git repository is rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->