### PR TITLE
test: stop the C5 fixture spawning a second Bun process

### DIFF
--- a/packages/cli/src/utils/detached-run-control.integration.spec.ts
+++ b/packages/cli/src/utils/detached-run-control.integration.spec.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { trackTempRoots } from '@archon/paths/test-utils';
 import {
+  DETACHED_RUN_IPC_TIMEOUT_MS,
   detachedRunControlPath,
   requestDetachedRunStop,
   startDetachedRunControlServer,
@@ -45,6 +46,12 @@ function waitForExit(
 /**
  * Ask the endpoint itself whether it is still serving. Connection refusal is the
  * owner's own answer, so this reports shutdown progress without timing it.
+ *
+ * The bound is the same one production `canConnect` puts on its own probe: a
+ * connect that neither succeeds nor errors would otherwise hang until the test
+ * budget expired, which reads as an unrelated timeout instead of an unreachable
+ * endpoint. It is a backstop, not a measurement — on both the reachable and the
+ * refused path the socket settles immediately.
  */
 function endpointIsReachable(path: string): Promise<boolean> {
   return new Promise<boolean>((resolve: (reachable: boolean) => void): void => {
@@ -53,6 +60,9 @@ function endpointIsReachable(path: string): Promise<boolean> {
       probe.destroy();
       resolve(reachable);
     };
+    probe.setTimeout(DETACHED_RUN_IPC_TIMEOUT_MS, (): void => {
+      settle(false);
+    });
     probe.once('connect', (): void => {
       settle(true);
     });

--- a/packages/cli/src/utils/detached-run-control.integration.spec.ts
+++ b/packages/cli/src/utils/detached-run-control.integration.spec.ts
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { trackTempRoots } from '@archon/paths/test-utils';
 import {
-  DETACHED_RUN_IPC_TIMEOUT_MS,
+  canConnect,
   detachedRunControlPath,
   requestDetachedRunStop,
   startDetachedRunControlServer,
@@ -39,35 +39,6 @@ function waitForExit(
     child.once('error', error => {
       clearTimeout(timer);
       reject(error);
-    });
-  });
-}
-
-/**
- * Ask the endpoint itself whether it is still serving. Connection refusal is the
- * owner's own answer, so this reports shutdown progress without timing it.
- *
- * The bound is the same one production `canConnect` puts on its own probe: a
- * connect that neither succeeds nor errors would otherwise hang until the test
- * budget expired, which reads as an unrelated timeout instead of an unreachable
- * endpoint. It is a backstop, not a measurement — on both the reachable and the
- * refused path the socket settles immediately.
- */
-function endpointIsReachable(path: string): Promise<boolean> {
-  return new Promise<boolean>((resolve: (reachable: boolean) => void): void => {
-    const probe = createConnection(path);
-    const settle = (reachable: boolean): void => {
-      probe.destroy();
-      resolve(reachable);
-    };
-    probe.setTimeout(DETACHED_RUN_IPC_TIMEOUT_MS, (): void => {
-      settle(false);
-    });
-    probe.once('connect', (): void => {
-      settle(true);
-    });
-    probe.once('error', (): void => {
-      settle(false);
     });
   });
 }
@@ -197,13 +168,15 @@ describe('detached run control integration', () => {
     const closing = owner.close();
     // close() is parked on the retained lease and has gone no further: it stops
     // the server and unlinks the endpoint only afterwards, so a close() that
-    // ignored the lease would already have made this probe unreachable.
-    expect(await endpointIsReachable(endpointPath)).toBe(true);
+    // ignored the lease would already have made this probe unreachable. Both
+    // polarities are asserted, so a broken probe fails one of them rather than
+    // quietly agreeing with itself.
+    expect(await canConnect(endpointPath)).toBe(true);
     expect(owner.isStopRequested()).toBe(true);
 
     await closing;
     expect(owner.isStopRequested()).toBe(false);
-    expect(await endpointIsReachable(endpointPath)).toBe(false);
+    expect(await canConnect(endpointPath)).toBe(false);
     client.destroy();
   });
 

--- a/packages/cli/src/utils/detached-run-control.ts
+++ b/packages/cli/src/utils/detached-run-control.ts
@@ -107,7 +107,15 @@ function listen(server: Server, path: string): Promise<void> {
   });
 }
 
-function canConnect(path: string): Promise<boolean> {
+/**
+ * True when something is listening on `path`. Connection refusal is the endpoint's
+ * own answer, so this reports liveness without timing it; the timeout is a backstop
+ * for a connect that neither succeeds nor errors.
+ *
+ * Exported for testing: the integration spec asks the same question of a shutting-down
+ * endpoint, and a second copy of this probe would be free to drift from this one.
+ */
+export function canConnect(path: string): Promise<boolean> {
   return new Promise(resolve => {
     const socket = createConnection(path);
     const settle = (connected: boolean): void => {

--- a/scripts/migrate-state-dir.test.ts
+++ b/scripts/migrate-state-dir.test.ts
@@ -105,24 +105,33 @@ async function collect(proc: Bun.Subprocess<'ignore', 'pipe', 'pipe'>): Promise<
 /**
  * Environment for every child, pinned to this sandbox.
  *
- * `DATABASE_URL` is REMOVED, not just overridden. A contributor running the
- * documented Postgres mode (`.env.example`) would otherwise have it inherited
- * here, which flips `getDatabaseType()` inside the child: `registryIsKnownEmpty`
- * goes false and `resolveTarget` reads a Postgres registry, while the C5 fixture
- * writes its row to this sandbox's SQLite file. The two sides would disagree and
- * both C5 tests would fail looking like a climbing regression rather than an
- * environment leak. Stripping it makes the dialect deterministic the same way
- * `ARCHON_HOME` already pins the destination — and it also keeps the fixture from
- * writing test rows into a contributor's real database, which the old subprocess
- * did. The one test that wants the Postgres branch passes it back via `extraEnv`.
+ * `DATABASE_URL` is forced EMPTY rather than deleted. A contributor running the
+ * documented Postgres mode would otherwise have it reach the child, which flips
+ * `getDatabaseType()` there: `registryIsKnownEmpty` goes false and `resolveTarget`
+ * reads a Postgres registry, while the C5 fixture writes its row to this sandbox's
+ * SQLite file. The two sides would disagree and both C5 tests would fail looking
+ * like a climbing regression rather than an environment leak.
+ *
+ * Deleting the key does NOT achieve that: a spawned Bun child re-runs automatic
+ * `.env` loading from its own cwd and fills in every key the passed environment
+ * omits, so a repo-root `.env` — exactly how Postgres mode is configured — puts it
+ * straight back. An empty string is a key that is present, which dotenv leaves
+ * alone, and `getDatabaseType()` reads it as falsy. This is the same suppression
+ * `packages/cli/src/cli.test.ts` uses for its own inherited keys.
+ *
+ * The one test that wants the Postgres branch passes a real DSN via `extraEnv`.
  */
 function childEnv(
   ctx: Sandbox,
   extraEnv: Record<string, string> = {}
 ): Record<string, string | undefined> {
-  const ambient: Record<string, string | undefined> = { ...process.env };
-  delete ambient.DATABASE_URL;
-  return { ...ambient, ARCHON_HOME: ctx.archonHome, LOG_LEVEL: 'silent', ...extraEnv };
+  return {
+    ...process.env,
+    ARCHON_HOME: ctx.archonHome,
+    LOG_LEVEL: 'silent',
+    DATABASE_URL: '',
+    ...extraEnv,
+  };
 }
 
 /** Run with raw argv — no implicit `--cwd`, for argument-parsing cases. */

--- a/scripts/migrate-state-dir.test.ts
+++ b/scripts/migrate-state-dir.test.ts
@@ -32,15 +32,28 @@
  * A larger budget would answer the question by silencing it.
  * If it does recur, find the specific colliding bound the way #2473 did; do not
  * reach for the timeout.
+ *
+ * It did recur, for the two C5 cases only (#2575). Coverage instrumentation was
+ * measured on windows-latest and ruled out. What was left was accidental cost:
+ * their fixture spawned a SECOND cold `bun` process purely to write one registry
+ * row, which is now an in-process write. The budget still has not moved.
  */
 import { describe, test, expect } from 'bun:test';
 import { mkdtemp, mkdir, writeFile, readFile, readdir } from 'fs/promises';
 import { removeTempTree } from '@archon/paths/test-utils';
+import { setLogLevel } from '@archon/paths';
+import { SqliteAdapter } from '@archon/core/db/adapters/sqlite';
 import { tmpdir } from 'os';
 import { join, resolve } from 'path';
 
+// The C5 fixture opens a real adapter in THIS process, which announces its
+// schema init at info. Every subprocess here is already run with LOG_LEVEL=silent;
+// this is the same suppression for the one piece of work that is no longer a
+// subprocess. Children inherit the level at creation, so it has to happen before
+// the first adapter exists.
+setLogLevel('silent');
+
 const SCRIPT = resolve(import.meta.dir, 'migrate-state-dir.ts');
-const REPO_ROOT = resolve(import.meta.dir, '..');
 
 /** Per-test paths. Immutable, and never shared between tests. */
 interface Sandbox {
@@ -418,10 +431,19 @@ describe('migrate-state-dir', () => {
      * silently disable project resolution: here a database exists, so the lookup
      * must still run and still climb.
      *
-     * Registered in a SUBPROCESS: @archon/core's DB connection is a module-level
-     * singleton, so registering in-process would cache a handle to the first
-     * test's temp ARCHON_HOME and fail with SQLITE_IOERR_VNODE once that
-     * directory is torn down.
+     * The row goes in through the SAME adapter the script's lookup opens, so the
+     * fixture cannot drift from the real schema — but through a dedicated instance
+     * rather than `@archon/core/db/codebases`, whose `pool` resolves the
+     * module-level connection singleton from `ARCHON_HOME`. That singleton would
+     * pin the first test's temp home and then fail with SQLITE_IOERR_VNODE once
+     * the directory is torn down; an instance takes an explicit path and is closed
+     * before the sandbox goes away. `name` and `default_cwd` are the only columns
+     * the destination resolution reads (`resolveRepoProjectIdentity`).
+     *
+     * This used to be a cold `bun -e` subprocess importing @archon/core's whole
+     * module graph to write that one row — the accidental half of these tests'
+     * Windows cost (#2575). The subprocess below it runs the migration script
+     * itself and is the contract under test, so it stays a real process.
      */
     async function withProjectSandbox(body: (ctx: ProjectSandbox) => Promise<void>): Promise<void> {
       return withSandbox(async base => {
@@ -432,24 +454,14 @@ describe('migrate-state-dir', () => {
         };
         await mkdir(ctx.subdir, { recursive: true });
 
-        const src = [
-          "const db = await import('@archon/core/db/codebases');",
-          'await db.createCodebase({',
-          `  name: ${JSON.stringify(PROJECT_NAME)},`,
-          `  repository_url: ${JSON.stringify(`https://github.com/${PROJECT_NAME}`)},`,
-          `  default_cwd: ${JSON.stringify(ctx.repo)},`,
-          "  default_branch: 'main',",
-          '});',
-        ].join('\n');
-        const proc = Bun.spawn(['bun', '-e', src], {
-          cwd: REPO_ROOT,
-          env: { ...process.env, ARCHON_HOME: ctx.archonHome, LOG_LEVEL: 'silent' },
-          stdout: 'pipe',
-          stderr: 'pipe',
-        });
-        const { exitCode, stderr } = await collect(proc);
-        if (exitCode !== 0) {
-          throw new Error(`registerProject failed (${String(exitCode)}): ${stderr}`);
+        const registry = new SqliteAdapter(join(ctx.archonHome, 'archon.db'));
+        try {
+          await registry.query(
+            'INSERT INTO remote_agent_codebases (name, default_cwd) VALUES ($1, $2)',
+            [PROJECT_NAME, ctx.repo]
+          );
+        } finally {
+          await registry.close();
         }
 
         await body(ctx);

--- a/scripts/migrate-state-dir.test.ts
+++ b/scripts/migrate-state-dir.test.ts
@@ -41,17 +41,10 @@
 import { describe, test, expect } from 'bun:test';
 import { mkdtemp, mkdir, writeFile, readFile, readdir } from 'fs/promises';
 import { removeTempTree } from '@archon/paths/test-utils';
-import { setLogLevel } from '@archon/paths';
+import { getLogLevel, setLogLevel } from '@archon/paths';
 import { SqliteAdapter } from '@archon/core/db/adapters/sqlite';
 import { tmpdir } from 'os';
 import { join, resolve } from 'path';
-
-// The C5 fixture opens a real adapter in THIS process, which announces its
-// schema init at info. Every subprocess here is already run with LOG_LEVEL=silent;
-// this is the same suppression for the one piece of work that is no longer a
-// subprocess. Children inherit the level at creation, so it has to happen before
-// the first adapter exists.
-setLogLevel('silent');
 
 const SCRIPT = resolve(import.meta.dir, 'migrate-state-dir.ts');
 
@@ -109,11 +102,34 @@ async function collect(proc: Bun.Subprocess<'ignore', 'pipe', 'pipe'>): Promise<
   return { exitCode, stdout, stderr };
 }
 
+/**
+ * Environment for every child, pinned to this sandbox.
+ *
+ * `DATABASE_URL` is REMOVED, not just overridden. A contributor running the
+ * documented Postgres mode (`.env.example`) would otherwise have it inherited
+ * here, which flips `getDatabaseType()` inside the child: `registryIsKnownEmpty`
+ * goes false and `resolveTarget` reads a Postgres registry, while the C5 fixture
+ * writes its row to this sandbox's SQLite file. The two sides would disagree and
+ * both C5 tests would fail looking like a climbing regression rather than an
+ * environment leak. Stripping it makes the dialect deterministic the same way
+ * `ARCHON_HOME` already pins the destination — and it also keeps the fixture from
+ * writing test rows into a contributor's real database, which the old subprocess
+ * did. The one test that wants the Postgres branch passes it back via `extraEnv`.
+ */
+function childEnv(
+  ctx: Sandbox,
+  extraEnv: Record<string, string> = {}
+): Record<string, string | undefined> {
+  const ambient: Record<string, string | undefined> = { ...process.env };
+  delete ambient.DATABASE_URL;
+  return { ...ambient, ARCHON_HOME: ctx.archonHome, LOG_LEVEL: 'silent', ...extraEnv };
+}
+
 /** Run with raw argv — no implicit `--cwd`, for argument-parsing cases. */
 async function runRaw(ctx: Sandbox, ...args: string[]): Promise<RunResult> {
   return collect(
     Bun.spawn(['bun', 'run', SCRIPT, ...args], {
-      env: { ...process.env, ARCHON_HOME: ctx.archonHome, LOG_LEVEL: 'silent' },
+      env: childEnv(ctx),
       cwd: ctx.repo,
       stdout: 'pipe',
       stderr: 'pipe',
@@ -139,7 +155,7 @@ async function runWithEnv(
 ): Promise<RunResult> {
   return collect(
     Bun.spawn(['bun', 'run', SCRIPT, '--cwd', cwd, ...args], {
-      env: { ...process.env, ARCHON_HOME: ctx.archonHome, LOG_LEVEL: 'silent', ...extraEnv },
+      env: childEnv(ctx, extraEnv),
       stdout: 'pipe',
       stderr: 'pipe',
     })
@@ -454,6 +470,13 @@ describe('migrate-state-dir', () => {
         };
         await mkdir(ctx.subdir, { recursive: true });
 
+        // Opening the adapter announces its schema init at info, which every
+        // subprocess here already suppresses with LOG_LEVEL=silent. Scoped rather
+        // than set once at module load: `setLogLevel` mutates the process-wide
+        // root logger, and `bun test ./scripts/` runs all five files in one
+        // process, so an unrestored level would silently follow the others.
+        const priorLogLevel = getLogLevel();
+        setLogLevel('silent');
         const registry = new SqliteAdapter(join(ctx.archonHome, 'archon.db'));
         try {
           await registry.query(
@@ -462,6 +485,7 @@ describe('migrate-state-dir', () => {
           );
         } finally {
           await registry.close();
+          setLogLevel(priorLogLevel);
         }
 
         await body(ctx);


### PR DESCRIPTION
## Problem and outcome

Two Windows CI tests keep failing at hard boundaries they should never be near. The two subdirectory-invocation ("C5") tests in `scripts/migrate-state-dir.test.ts` time out against Bun's 5000 ms default because each starts *two* cold Bun processes, and only one of them is the thing being tested. Separately, the connect probe added by #2877 was the only one of three near-identical probes in the repo with no timeout bound.

- **Outcome:** each C5 test now starts one cold Bun process instead of two, and the spec's probe is production `canConnect` rather than a third copy of it. The C5 pair runs in ~160 ms locally, down from ~250 ms, on a machine where process startup is nearly free.
- **Invariant:** the subprocess that runs `scripts/migrate-state-dir.ts` is the contract under test and stays a real process — this PR only removes the *setup* spawn. Both C5 tests must still fail when the script's guards break, and the sandbox must resolve the same dialect on the write and the read side.
- **Scope boundary:** no timer, timeout, or budget is raised anywhere. The only production change is exporting `canConnect` so the spec can import it; it adds no behavior. The third item in scope, `cli.test.ts`'s detached-config handoff test, is deliberately left unchanged — see below.
- **Root cause:** the C5 fixture spawned `bun -e` to import `@archon/core`'s whole module graph purely to write one registry row. The row itself measures 3-6 ms of work.

## Review guidance

- **Feedback requested:** whether the fixture's raw `INSERT` is the right trade against `createCodebase`, and whether leaving the `cli.test.ts` test unchanged is the right call.
- **Start here:** `scripts/migrate-state-dir.test.ts:480` — the setup spawn replaced by an in-process adapter write.
- **Review order:** the `withProjectSandbox` change first, then `childEnv` at `scripts/migrate-state-dir.test.ts:119` (which keeps that write and the script's read on the same dialect), then the `canConnect` export and the duplicate it replaces.
- **Known risk or uncertainty:** the C5 overrun is a `windows-latest` phenomenon and does not reproduce on macOS. One Windows job on this branch did get past the `@archon/workflows` rotation and measured the pair at 625 ms and 703 ms against the 5000 ms budget, but that is one sample of a load-dependent failure — see Validation.

## Solution

`withProjectSandbox` needs one row in the codebase registry so the script's `findCodebaseByPathPrefix` lookup has something to climb to. It used to get that row by spawning `bun -e` with a snippet importing `@archon/core/db/codebases`, because that module reaches the database through the module-level connection singleton — which, in-process, would pin the first test's temp `ARCHON_HOME` and then fail with `SQLITE_IOERR_VNODE` once the directory was torn down. That hazard is real, but a subprocess is not the only way around it.

The row now goes in through a directly constructed `SqliteAdapter`, closed in a `finally` before the sandbox goes away. It is the same adapter the script's own lookup opens, so the fixture cannot drift from the schema, and it takes an explicit path so no singleton is involved. Only `name` and `default_cwd` are written, because those are the only columns `resolveRepoProjectIdentity` reads; `ai_assistant_type` and `kind` fall to the column defaults, which are the values `createCodebase` supplied anyway.

That makes the sandbox's dialect matter. The fixture writes SQLite, but the migration-script child used to inherit `DATABASE_URL`, so under the documented Postgres mode the child would read a registry the fixture never wrote to and both C5 tests would fail looking like a climbing regression. `childEnv` now forces `DATABASE_URL: ''` for every child, pinning the dialect the way `ARCHON_HOME` already pins the destination. It also stops the fixture writing test rows into a contributor's real database, which the old `bun -e` subprocess did. The one test that wants the Postgres branch passes a real DSN back through `extraEnv`.

Forced empty rather than deleted, and that distinction is load-bearing: a spawned Bun child re-runs automatic `.env` loading from its own cwd and fills in every key the passed environment omits, so a repo-root `.env` — which is how Postgres mode is configured — puts a deleted key straight back. An empty string is a key that is present, which dotenv leaves alone, and `getDatabaseType()` reads it as falsy. `packages/cli/src/cli.test.ts` already suppresses its own inherited keys this way. The first attempt at this fix used `delete` and looked green only because the worktree it was verified in had no `.env`.

Opening the adapter announces its schema init at info, so the fixture silences the logger around that block and restores the prior level in the same `finally`. `setLogLevel` mutates the process-wide root logger and `bun test ./scripts/` runs all five files in one process, so it is scoped rather than set once at module load.

For the probe, the spec no longer carries its own copy: `canConnect` is exported from `detached-run-control.ts` under the same "Exported for testing" convention `calculatePortOffset` uses, and the spec imports it. That removes the third divergent copy rather than making it consistent, and the timeout bound comes along for free. Using the production probe as the test's instrument is safe here because the test asserts both polarities on it, so a broken `canConnect` fails one of them instead of quietly agreeing with itself.

### Why `cli.test.ts:231` is left unchanged

The lane also scoped `keeps a detached config handoff outside repo env overrides`. I measured it before changing anything, and there is no test-side cost to remove:

| Phase of the test body | Cost |
|---|---|
| `spawnSync` of the CLI | 711.2 ms |
| everything else combined | ~21 ms |

Choosing a shallower exit does not help either — `archon --help`, which exits before any command module loads, already costs 670 ms against 751 ms for this test's path. The floor is `packages/cli/src/cli.ts`'s static import graph: every command module plus `@archon/providers`, `@archon/core`, `@archon/workflows` and `@archon/git`, all loaded before argv is parsed.

Converting the test to the probe shape its sibling uses would cut the spawn to ~60 ms but delete the only coverage of `cli.ts`'s real boot ordering — the "must be the very first import" sequence the test exists to protect. That is a bad trade. The real fix is lazy command loading in `cli.ts`, which is a production change and does not belong in a test-stabilisation PR. Full measurement is recorded on the issue: https://github.com/coleam00/Archon/issues/2859#issuecomment-5446581856

## Validation

- `bun test ./scripts/migrate-state-dir.test.ts` ×5 — 19 pass / 0 fail every run — proves the fixture change did not alter any outcome in the file.
- `bun test src/utils/detached-run-control.integration.spec.ts` ×5 — 5 pass / 0 fail, 2.13 s every run — proves the imported probe behaves as the local copy did.
- `bun test src/cli.test.ts` ×5 — 95 pass / 0 fail every run — the unchanged test still passes.
- `bun run validate` — passed, exit 0, zero failing tests, zero type errors.
- **Mutation, C5 refusal guard:** disabling the two-candidate refusal in `migrate-state-dir.ts` turns `refuses when BOTH the subdirectory and the project root hold legacy state` red. The test still discriminates.
- **Mutation, the climb itself:** removing `findCodebaseByPathPrefix` from `resolveTarget` turns both C5 tests red.
- **Mutation, the new fixture:** skipping the `INSERT` turns both C5 tests red, so the in-process registration is load-bearing and not accidentally passing.
- **Dialect leak, red then green:** with `DATABASE_URL` set to a dummy Postgres DSN, both C5 tests failed before `childEnv` (exit 1 where 0 and 2 were expected — the `resolveTarget` catch, which proves the child took the Postgres branch). After it the whole file passes 19/19 in all three environments: ambient variable set, a repo-root `.env` defining it with no ambient variable, and both at once.
- **The `.env` path specifically:** with a repo-root `.env` and no ambient variable, both C5 tests fail under a `delete`-based strip and pass under the forced empty string — which is why the empty string is what shipped.
- **The Postgres opt-in is still live:** dropping `...extraEnv` from `childEnv` fails exactly the "a Postgres registry is never inferred from the local filesystem" test (18 pass / 1 fail).
- **Logger restore:** a temporary probe asserted after the C5 cases reports `getLogLevel()` as `info` with the restore in place and `silent` without it. The `scripts/` leg emits zero log lines either way.
- **Cost removed:** `new SqliteAdapter` + `INSERT` + `close` measures 3-6 ms across three consecutive samples, replacing a whole cold process.
- **Windows, the measurement this PR exists for:** two `windows-latest` jobs on this branch got past the `@archon/workflows` rotation and ran the scripts leg. Four C5 observations: 625 ms / 703 ms ([job 98718687827](https://github.com/coleam00/Archon/actions/runs/33130513243/job/98718687827)) and 1031 ms / 1016 ms ([job 98722467747](https://github.com/coleam00/Archon/actions/runs/33131701283/job/98722467747)), against the 5000 ms budget these two tests were timing out on at ~5015 ms. Mean 844 ms versus the 1160 ms mean the coverage spike measured for the same pair — about a 27% reduction, not the ~50% a naive "two processes became one" model suggests, because the surviving migrate-script spawn is the dominant cost.
- **Not verified:** the tail, which is what actually produces the timeouts. The coverage spike measured a 14.3% rate with max 4219 ms on a mean of 1160 ms; four observations cannot distinguish "the max moved down proportionally" from "we got four ordinary runs." What is established is that the accidental cost is gone and the pair now runs at roughly the same order as the file's other tests. A third re-run for more samples lost the coin flip to the `@archon/workflows` rotation (#2882) again.

## Links

- Related #2575
- Related #2859
- Related #2306
- Blocked from Windows verification by #2882

#2575 is deliberately still `Related` rather than `Closes`: the Windows measurement above is exactly what it asked for, but it is one sample of a stochastic failure. Recommend closing it once #2883 lands and a couple of Windows runs go green in a row. #2859 keeps its remaining instance open: `cli.test.ts`'s detached-config test is unchanged here, and closing it means reducing CLI startup cost, not reshaping the test.
