### PR TITLE
test(workflows): take the Windows suite off the 5000ms budget edge

### DIFF
--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -33084,12 +33084,17 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
 describe('executeDagWorkflow -- node-level mutates_checkout: false (#2771)', () => {
   let testDir: string;
 
+  // Three git processes, not five: the identity travels as `-c` overrides on the commit
+  // rather than as two separate `git config` writes. Six tests here pay this cost, and
+  // process creation is the expensive part on Windows CI (#2882).
   const initRepo = async (dir: string): Promise<void> => {
     await git.execFileAsync('git', ['init', '-q'], { cwd: dir });
-    await git.execFileAsync('git', ['config', 'user.email', 't@t'], { cwd: dir });
-    await git.execFileAsync('git', ['config', 'user.name', 't'], { cwd: dir });
     await git.execFileAsync('git', ['add', '-A'], { cwd: dir });
-    await git.execFileAsync('git', ['commit', '-qm', 'init', '--allow-empty'], { cwd: dir });
+    await git.execFileAsync(
+      'git',
+      ['-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-qm', 'init', '--allow-empty'],
+      { cwd: dir }
+    );
   };
 
   const runBashNode = async (

--- a/packages/workflows/src/defaults/review-mode-script.test.ts
+++ b/packages/workflows/src/defaults/review-mode-script.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, describe, expect, it } from 'bun:test';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { afterAll, describe, expect, it } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import { rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -14,8 +15,18 @@ const SCRIPT_PATH = join(
   'resolve-review-mode.py'
 );
 const PYTHON_COMMAND = globalThis.process.platform === 'win32' ? 'python' : 'python3';
-const tempDirs: string[] = [];
+const tempFiles: string[] = [];
 
+/**
+ * Start the interpreter once, for one input.
+ *
+ * The script's PROCESS contract is the subject — stdout JSON, exit status, and the
+ * stderr message a failing node reports — so a real interpreter start is what proves
+ * it. Each case therefore gets its own test and its own start: three of them charged
+ * to a single test's budget is what timed out on Windows CI (#2882). Hoisting the
+ * starts into a shared `beforeAll` would put them back under one deadline (#2860), so
+ * the split is the fix, not a shared setup hook.
+ */
 async function runResolver(priorReport: string): Promise<{
   exitCode: number;
   stdout: string;
@@ -35,25 +46,37 @@ async function runResolver(priorReport: string): Promise<{
   return { exitCode, stdout, stderr };
 }
 
-afterEach(async () => {
-  await Promise.all(tempDirs.splice(0).map(path => rm(path, { recursive: true, force: true })));
+/** A path under the system temp dir that nothing creates. */
+function unusedPath(): string {
+  return join(tmpdir(), `archon-review-mode-${randomUUID()}.md`);
+}
+
+afterAll(async () => {
+  await Promise.all(tempFiles.splice(0).map(path => rm(path, { force: true })));
 });
 
 describe('resolve-review-mode', () => {
-  it('distinguishes full, continuation, and broken continuation inputs', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'archon-review-mode-'));
-    tempDirs.push(dir);
-    const existingReport = join(dir, 'report.md');
-    const missingReport = join(dir, 'missing.md');
-    await writeFile(existingReport, '# Prior review\n');
-
+  it('reports a full review when no prior report is named', async () => {
     const full = await runResolver('');
     expect(full.exitCode).toBe(0);
     expect(JSON.parse(full.stdout)).toEqual({ continuation: false });
+  });
+
+  it('reports a continuation when the named prior report exists', async () => {
+    // A single file, not a directory: the script only stats the path it is given, and a
+    // recursive temp-tree removal is the part of this fixture that is slow and flaky on
+    // Windows (#2306).
+    const existingReport = unusedPath();
+    tempFiles.push(existingReport);
+    await writeFile(existingReport, '# Prior review\n');
 
     const continuation = await runResolver(existingReport);
     expect(continuation.exitCode).toBe(0);
     expect(JSON.parse(continuation.stdout)).toEqual({ continuation: true });
+  });
+
+  it('fails when the named prior report does not exist', async () => {
+    const missingReport = unusedPath();
 
     const broken = await runResolver(missingReport);
     expect(broken.exitCode).toBe(1);

--- a/packages/workflows/src/fixture-runner.test.ts
+++ b/packages/workflows/src/fixture-runner.test.ts
@@ -1,5 +1,5 @@
 /** Tests for the declared-data dry-run fixture runner (#2772). */
-import { describe, it, expect, afterEach } from 'bun:test';
+import { describe, it, expect, afterEach, afterAll, mock } from 'bun:test';
 import {
   existsSync,
   mkdirSync,
@@ -10,8 +10,35 @@ import {
   symlinkSync,
   writeFileSync,
 } from 'node:fs';
+import { mkdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+
+// Capture-cost control, same lever and same reason as `subrun.test.ts` (#2882): every
+// `runFixtures` call takes one source capture, and a capture copies and digests the
+// repo's OWN bundled scope — `.archon/workflows` plus `.archon/commands`, ~178 files —
+// alongside the handful of fixture files the test wrote. Thirty captures in this file
+// is ~5,300 incidental file copies, and that bulk IO is what puts this suite at Bun's
+// 5000ms budget on a contended Windows runner. No test here reads bundled CONTENT: the
+// bundled SCOPE tests drive `sourceRoots.bundledWorkflows`, which is a discovery root
+// this file already points at a temp directory. Pointing the two bundle getters at an
+// owned EMPTY tree keeps the bundled scope's semantics intact — an existing directory
+// is still scanned, still copied, still recorded in the manifest — while removing the
+// file fan-out.
+// NB: point these one level DEEP (`<root>/defaults`) — captureWorkflowSource copies
+// dirname(getDefault*Path()), so the getter's PARENT must be the owned empty tree.
+const bundledDefaultsRoot = join(tmpdir(), `fixture-runner-test-empty-bundled-${process.pid}`);
+await mkdir(join(bundledDefaultsRoot, 'defaults'), { recursive: true });
+afterAll(async () => {
+  await rm(bundledDefaultsRoot, { recursive: true, force: true }).catch(() => {});
+});
+const realArchonPaths = await import('@archon/paths');
+mock.module('@archon/paths', () => ({
+  ...realArchonPaths,
+  getDefaultWorkflowsPath: () => join(bundledDefaultsRoot, 'defaults'),
+  getDefaultCommandsPath: () => join(bundledDefaultsRoot, 'defaults'),
+}));
+
 import { execFileAsync } from '@archon/git';
 import { parseWorkflow } from './loader';
 import { expandWorkflowIncludes } from './include-expander';
@@ -601,14 +628,18 @@ describe('runFixtures exec-code isolation (#2851)', () => {
   const git = (cwd: string, ...args: string[]): Promise<unknown> =>
     execFileAsync('git', args, { cwd });
 
-  /** Turn a plain temp project into a git repo with one committed file besides the project's own. */
+  /**
+   * Turn a plain temp project into a git repo with one committed file besides the project's own.
+   *
+   * Three git processes, not five: the identity travels as `-c` overrides on the commit
+   * itself rather than as two separate `git config` writes. Every test in this block pays
+   * this cost, and process creation is the expensive part on Windows CI (#2882).
+   */
   async function initGitWithCommittedFile(cwd: string): Promise<void> {
     await git(cwd, 'init', '-q');
-    await git(cwd, 'config', 'user.email', 't@t');
-    await git(cwd, 'config', 'user.name', 't');
     writeFileSync(join(cwd, 'tracked.txt'), COMMITTED_YAML);
     await git(cwd, 'add', '-A');
-    await git(cwd, 'commit', '-qm', 'init');
+    await git(cwd, '-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-qm', 'init');
   }
 
   it('gives clean and pre-dirtied callers the same verdict (#2851)', async () => {

--- a/packages/workflows/src/workflow-source.test.ts
+++ b/packages/workflows/src/workflow-source.test.ts
@@ -2,10 +2,35 @@
  * Source capture: what a run freezes, and what it must keep resolving after the
  * authoring checkout moves on.
  */
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect, afterAll, mock } from 'bun:test';
 import { mkdtemp, mkdir, writeFile, rm, readFile, readdir, symlink, stat } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
+
+// Capture-cost control, same lever and same reason as `subrun.test.ts` (#2882):
+// every `captureWorkflowSource` call here copies and digests the repo's OWN bundled
+// scope — `.archon/workflows` plus `.archon/commands`, ~178 files — on top of the
+// handful of fixture files the test wrote. Twenty-five captures in this file is ~4,400
+// incidental file copies, and that bulk IO is what puts this suite at Bun's 5000ms
+// budget on a contended Windows runner. No test here reads bundled CONTENT: the
+// assertions count the PROJECT scope (`countScopeFiles`) and resolve fixture-written
+// commands. Pointing the two bundle getters at an owned EMPTY tree keeps the bundled
+// scope's semantics intact — an existing directory is still scanned, still copied,
+// still recorded in the manifest — while removing the file fan-out.
+// NB: point these one level DEEP (`<root>/defaults`) — captureWorkflowSource copies
+// dirname(getDefault*Path()), so the getter's PARENT must be the owned empty tree.
+const bundledDefaultsRoot = join(tmpdir(), `workflow-source-test-empty-bundled-${process.pid}`);
+await mkdir(join(bundledDefaultsRoot, 'defaults'), { recursive: true });
+afterAll(async () => {
+  await rm(bundledDefaultsRoot, { recursive: true, force: true }).catch(() => {});
+});
+const realArchonPaths = await import('@archon/paths');
+mock.module('@archon/paths', () => ({
+  ...realArchonPaths,
+  getDefaultWorkflowsPath: () => join(bundledDefaultsRoot, 'defaults'),
+  getDefaultCommandsPath: () => join(bundledDefaultsRoot, 'defaults'),
+}));
+
 import {
   captureWorkflowSource,
   capturedSourceRoots,
@@ -538,6 +563,11 @@ describe('the capture is authoritative, not advisory', () => {
     // A project workflow can `include:` a global or bundled one, so leaving those live
     // would let an included workflow change shape across a resume.
     expect(capture.manifest.scopes).toContain('project');
+    // Named explicitly because this file redirects the bundle getters at an EMPTY tree to
+    // keep capture cost off the Windows budget (#2882). That lever is only safe while an
+    // empty bundled tree is still SCANNED and recorded; if it ever silently stopped being
+    // captured, every other assertion here would keep passing.
+    expect(capture.manifest.scopes).toContain('bundled');
     const roots = capturedSourceRoots(capture.captureRoot, capture.manifest.source_config);
     expect(roots.globalWorkflows.startsWith(capture.captureRoot)).toBe(true);
     expect(roots.globalCommands.startsWith(capture.captureRoot)).toBe(true);


### PR DESCRIPTION
## Problem and outcome

`@archon/workflows` has been failing on `windows-latest` with a **different test each run**, all at Bun's 5000 ms default budget, while ubuntu stays green ([rotation evidence](https://github.com/coleam00/Archon/issues/2859#issuecomment-5446724756)). That is not three per-test defects: the package's filesystem- and process-heavy tests run close enough to the budget that scheduling decides which one dies. Because the root script is `bun --filter '*' --parallel test && bun test ./scripts/`, each of those failures also short-circuits the scripts leg, so no `scripts/` test has executed on Windows in any of those runs.

- **Outcome:** the three named rotation members, and the suite around them, do materially less work per test. Measured on macOS, worst-of-5 per-test cost drops 91.8 ms → 24.2 ms (`resolve-review-mode`), 112.2 ms → 11.7 ms (`workflow-source`), 279.9 ms → 160.4 ms (`fixture-runner`); package wall time 14.1 s → 11.2 s.
- **Invariant:** a test spawns a subprocess only where the subprocess is the behavior under test, and at most the minimum number that proves it. Every behavior proven before is still proven.
- **Scope boundary:** no timer, timeout, or budget was raised anywhere — cost was only removed. No production code changed; the diff is four test files.

## Review guidance

- **Feedback requested:** correctness of the two cost levers, specifically whether the empty-bundled-tree redirect weakens anything the capture tests claim to prove.
- **Start here:** `packages/workflows/src/workflow-source.test.ts:563` — the new `scopes).toContain('bundled')` assertion is what makes the biggest lever safe.
- **Review order:** `workflow-source.test.ts` and `fixture-runner.test.ts` (the capture lever), then `review-mode-script.test.ts` (the interpreter split), then `dag-executor.test.ts` (mechanical).
- **Lower-attention areas:** the `git config` → `-c` change in `dag-executor.test.ts` and `fixture-runner.test.ts` is mechanical and behavior-identical; it is the pattern `generate-bundled-defaults.test.ts:62` already uses.
- **Known risk or uncertainty:** `mock.module` is process-global, and `fixture-runner.test.ts` shares a `bun test` invocation with `state-migration.test.ts`, which installs its own `@archon/paths` mock. Verified they coexist: `bun test src/state-migration.test.ts src/dry-run.test.ts src/fixture-runner.test.ts` is 111/111, and that file's non-vacuous `expect(warnCalls).toHaveLength(1)` still passes in-group, so its logger mock is not being clobbered.

## Solution

Three sources of accidental cost, each removed at its own boundary.

**Three interpreter starts inside one budget.** `resolve-review-mode` drove `python`/`python3` three times inside a single test. The script's *process* contract — stdout JSON, exit status, stderr message — genuinely is the subject, so the starts stay; each case now gets its own test and therefore its own budget. Moving them into a shared `beforeAll` was rejected on purpose: that puts them back under one deadline, which is #2860's lesson. The fixture also drops a `mkdtemp` plus recursive removal for a single file write, since the script only stats the path it is handed.

**~9,700 incidental file copies.** Every `captureWorkflowSource` call copies *and digests* the repo's own bundled scope — `.archon/workflows` plus `.archon/commands`, ~178 files, 1.1 MB — on top of the handful of files the fixture wrote. `workflow-source.test.ts` takes 25 captures and `fixture-runner.test.ts` takes 30, and no test in either reads bundled content: the capture assertions count the *project* scope, and the bundled-*scope* fixture tests drive `sourceRoots.bundledWorkflows`, a discovery root already pointed at a temp directory. Both files now point the two bundle getters at an owned empty tree — the lever `subrun.test.ts:35-63` already documents for this exact Windows budget problem. The bundled scope keeps its semantics: an existing directory is still scanned, still copied, still recorded in the manifest (`scopes` remains `project,global,bundled`).

Because nothing previously asserted that, the lever could have silently degraded into "the bundled scope is no longer captured" with every other assertion still green. `workflow-source.test.ts:563` now pins it.

**Five git processes to make a throwaway repo.** Two helpers ran `git init`, two `git config` writes, `git add`, `git commit`. The identity now travels as `-c` overrides on the commit, which is what `generate-bundled-defaults.test.ts` already does — 3 processes instead of 5, across 6 tests in `dag-executor.test.ts` and 6 repos in `fixture-runner.test.ts`.

## Validation

- `bun run validate` — exit 0, zero failing test groups — proves the repository gates hold.
- `bun run lint` — clean.
- `cd packages/workflows && bun run test` — every group green (682, 111, 32, … 0 fail) — proves the package suite as CI invokes it.
- Each touched file run 5×, worst-of-5 per test recorded before and after (see Outcome). Package wall time measured 3× each way: 14.65 / 14.09 / 13.82 s → 11.30 / 11.20 / 11.26 s.
- Mutation evidence, each seen red: forcing `continuation` to `False`, to `True`, and removing the missing-file guard in `resolve-review-mode.py` each failed exactly one of the three new tests, and the right one. Removing the empty bundled tree failed the new `scopes).toContain('bundled')` assertion and only that one.
- Capture-volume evidence: an instrumented `captureWorkflowSource` counted 180 files per capture before and 0–6 after, across 55 captures in the two files.
- **Not verified:** Windows CI. macOS cannot prove the Windows outcome — this PR's `windows-latest` leg is the real evidence, and the issue only closes if it is green there and the scripts leg demonstrably runs.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Observability | If the bundled scope ever stops being captured, the capture tests now fail loudly instead of passing cheaply | `packages/workflows/src/workflow-source.test.ts:563`, seen red |

## Deliberately left unchanged

- `executor.test.ts` "records even when the platform cannot be written to" (~1000 ms, the largest single test in the package) — the cost is production retry backoff behind a rejecting platform, not test scaffolding. Removing it would mean changing a timer.
- `dag-executor.test.ts` "timeout kills subprocess" (~506 ms) and the `idle-timeout` tests — the delay is the subject in each.
- `generate-bundled-defaults.test.ts` — already amortized by an earlier pass to one `bun` spawn plus at most one `git` per test.
- `fixture-runner.test.ts` "gives clean and pre-dirtied callers the same verdict" still builds two repos; comparing a clean caller against a pre-dirtied one is the point of the test, so merging them would destroy what it proves.
- `script-node-deps.test.ts` and `runtime-check.test.ts` already mock `execFileAsync` and spawn nothing.

## Links

- Related #2882 (close after a few consecutive clean windows-latest runs on dev — its acceptance is consistency, which one green run cannot prove)
- Related #2859, #2575, #2860


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved workflow and repository test reliability by isolating temporary files and bundled resources.
  * Added coverage for empty bundled workflow sources.
  * Simplified test setup and cleanup for faster, more consistent execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
