### PR TITLE
docs: add the engineering craft sidecar (.archon/engineering.md)

### DIFF
--- a/.archon/engineering.md
+++ b/.archon/engineering.md
@@ -8,6 +8,7 @@ This document is what work gets checked against, not instructions for doing work
 - Anything here that becomes machine-checkable graduates to a lint rule, a type, or a CI check, and then leaves this file. One owner per rule. This file holds what needs judgment; checkers hold what needs enforcement.
 - Entries are phrased so drift is catchable: prefer claims that can be audited against the codebase over vibes. A periodic pass grades entries confirmed or drifted. Drifted entries are deleted, not annotated; a stale correction is worse than none.
 - Facts that change (counts, paths, inventories) do not belong here at all. Point at the owning source.
+- Rules here earned their place through real failures or operator decisions. The stories stay in run artifacts and git history; this file keeps only the rule.
 
 ## The objective function
 
@@ -34,6 +35,9 @@ These describe where the engineering is going. Do not reject a change for failin
 - Types carry invariants. Invalid states should be hard to represent; a sound type beats a runtime check beats a comment. Escape hatches carry a justification or they are findings.
 - Explicit control flow over meta-programming, shared mutable state, or hidden coupling. Duplicate small local logic until a pattern has repeated and stabilized.
 - Fail early and loudly on unsupported, ambiguous, or unsafe states. A fallback is intentional, documented at the branch, and observable, or it is a bug.
+- Derive shared vocabularies; never re-enumerate them at a use site. A status set or capability list spelled out where it is consumed drifts from its owner. Derived, a new member inherits the right behavior automatically.
+- A guard is evidence only after it has been seen red. Before trusting any check, retry, or validation, watch it fail against the condition it claims to catch. This applies to tests, lint rules, and platform behavior alike: built-in options are claims until probed.
+- When isolating a boundary, prove the isolation against every path in, not only the one you thought of.
 - Comments clarify functionality and how code is used, and they stay current when behavior changes. Never request a comment on self-explanatory code; request removal or editing of comments on self-explanatory code instead. Code that is not self-explanatory is usually too complex and the finding is simplification, not narration. A missing comment is reportable only when the change introduces durable knowledge that code or types cannot express: a surprising external constraint, a non-obvious safety or ordering requirement, a deliberate compatibility compromise a future maintainer could clean up and break, or operational behavior not discoverable from the local code. Never request narration of control flow, parameter names, or implementation steps.
 
 ## Risk taxonomy
@@ -49,20 +53,13 @@ What raises the stakes of a change, and therefore the depth of its review:
 
 A change in these areas gets adversarial review depth: an explicit attempt to refute, input-set variation, and a stated answer to "what would make this merge wrong." A docs or prose change gets the minimum. The review orchestrator's depth signal derives from this list, and so do the pre-triage script's path weights; this section is their single source.
 
-## Case law
-
-Proven rules from real failures. Each entry states the rule, then the mechanism that made it necessary. Origins are dated in prose; this file does not index by tracker numbers.
-
-1. **Status sets near destructive actions are derived, never enumerated, and tests vary them.** A cleanup path defined "live" as "non-terminal" while the codebase's own vocabulary made failed runs resumable; the sweep would have force-deleted recoverable branches. Two review rounds missed it because every test stubbed the deciding primitive and no test varied the status set. Rule: derive such sets from the owning vocabulary so a new status inherits safety automatically; in tests, exercise the real primitive and vary the one input the decision turns on. (Proven live, August 2026, isolation cleanup.)
-2. **The work order outranks the implementation's account of itself.** An implementation narrowed a contract, its PR body described the narrowed version, and review verified the narrowed claims instead of the requested outcome. Rule: review anchors on the original request; the implementor's self-report is a file of claims to verify, never a scope definition. (Proven live, August 2026, fixture isolation.)
-3. **Same function, same invariant: in scope.** A review filed a regression inside the exact function the change rewrote as an out-of-scope discovery. Rule: a defect that violates the same invariant through the same mechanism as the change under review is a correction, not a discovery, no matter how the implementation frames it. (Proven live, August 2026, fixture targeting.)
-4. **A guard is evidence only once seen red.** Cleanup retries via built-in options shipped twice as fixes while the runtime silently ignored those options; the pattern read as safety and did nothing. Rule: before trusting any guard, watch it fail against the condition it claims to catch; a probe beats a documented promise. (Proven live, August 2026, the runtime retry options.)
-5. **Green plus green can be red.** Two individually green changes composed into a runtime failure because no check ever ran on the composition, and the file class involved was invisible to both static gates. Rule: compositions need their own verification, and "the checks passed" is a claim about what the checks cover, not about the code. (Proven live, August 2026, the parallel-merge break.)
-6. **Suppressing inherited state requires an explicit presence, not an absence.** Deleting an environment key from a child process's env did nothing because the child reloaded it from its own configuration files; only an explicitly present empty value suppressed it. Rule: when isolating a boundary, prove the isolation against every path in, not the one you thought of. (Proven live, August 2026, the test sandbox env.)
-
 ## Review posture
 
 - An unengaged risk is a failure. If the orchestrator names a risk and no lens engages it, the review is not clean, it is incomplete, and the verdict must say so.
 - "Could not tell" is a verdict. Ambiguity, lens disagreement, and low confidence produce an inconclusive outcome for a human, never a silent pass and never a manufactured correction.
 - A malformed or failed verdict call defaults conservative: toward not-ready, never toward pass.
 - Findings and discoveries carry their source. Attribution is what makes calibration possible; an unattributed finding cannot teach anything.
+- Review anchors on the original work order. The implementation's account of itself, including the PR body and any self-report, is a set of claims to verify, never a scope definition.
+- A defect that violates the same invariant through the same mechanism as the change under review is in scope: a correction, not a discovery.
+- Tests prove a decision by varying the input it turns on, against the real primitive. A test that stubs the deciding function passes under every mutation of it and proves nothing.
+- Two individually green changes can compose into a failure. A composition is its own change; checks that passed on the parts are claims about the parts.

--- a/.archon/engineering.md
+++ b/.archon/engineering.md
@@ -1,0 +1,68 @@
+# Archon engineering craft
+
+This document is what work gets checked against, not instructions for doing work. Operational rules for agents stay in `AGENTS.md`, which every agent loads and which stays short. This document is loaded selectively by evaluative agents: the review orchestrator, review lenses, and future evaluators such as the questioner and gate-designer patterns. It can afford depth because only evaluators carry it.
+
+## How this document works
+
+- The operator writes it. Agents may propose entries as artifacts from real runs; promotion into this file is always an operator edit. An evaluator that revises its own criteria is not calibrating, it is drifting.
+- Anything here that becomes machine-checkable graduates to a lint rule, a type, or a CI check, and then leaves this file. One owner per rule. This file holds what needs judgment; checkers hold what needs enforcement.
+- Entries are phrased so drift is catchable: prefer claims that can be audited against the codebase over vibes. A periodic pass grades entries confirmed or drifted. Drifted entries are deleted, not annotated; a stale correction is worse than none.
+- Facts that change (counts, paths, inventories) do not belong here at all. Point at the owning source.
+
+## The objective function
+
+Correct first. Cost-efficient second. Speed last.
+
+Speed is a convenience for the operator while working, never a reason to thin verification. A review that is fast and wrong failed. Spend more on changes that can destroy things and less on changes that cannot; a flat cost per change is a sign nobody is judging stakes.
+
+## Aspirations
+
+**The survival shape.** The tools that survive the agentic era, above all tools for engineers and their agents, have a small strong core and extend at the seams. Agents multiply how fast everything around a tool changes: providers, models, harnesses, and integrations churn monthly, and no monolith keeps up by adding surface. It keeps up by owning less, harder. The core must be usable from any surface: our CLI, our server, someone else's product, a script in CI. Users build their own surfaces, providers, adapters, and isolation backends at their own convenience, against contracts we keep stable. That is why the engine becomes an SDK. The SDK is not a packaging decision; it is the survival shape of the product.
+
+The review test this yields: when a change grows the core, ask whether a seam could have carried it. Core growth that a plugin, adapter, or host could express is a finding, not a feature.
+
+These describe where the engineering is going. Do not reject a change for failing to complete an aspiration; reject new coupling that makes one materially harder.
+
+- **The core becomes self-sufficient.** The engine stands alone as an SDK: define, validate, run, resume, govern, and query workflows with no server, no UI, no database, no platform adapter required. Core plus CLI is a complete install. Append-only files are the default persistence; a database is an adapter.
+- **Adapters and providers sit behind clear contracts.** A provider or platform integration attaches through a typed seam the engine owns. If adding an integration requires touching engine control flow, the contract is missing or wrong.
+- **Provider SDKs are for observability and for running the user's configuration.** They translate options, surface events and usage truthfully, and preserve the user's native config, auth, and guidance. They are not a place for engine logic, capability widening, or config replacement.
+- **Every engine capability has a host seam.** Wakes, schedules, triggers, and cleanup are core surfaces a CLI, server loop, or third-party host can drive. The server is a batteries-included host, not the owner.
+
+## Taste
+
+- The smallest truthful system. Every validator, guard, state, and compatibility path protects a named requirement or a concrete failure mode. Before adding machinery, look for machinery to delete.
+- Types carry invariants. Invalid states should be hard to represent; a sound type beats a runtime check beats a comment. Escape hatches carry a justification or they are findings.
+- Explicit control flow over meta-programming, shared mutable state, or hidden coupling. Duplicate small local logic until a pattern has repeated and stabilized.
+- Fail early and loudly on unsupported, ambiguous, or unsafe states. A fallback is intentional, documented at the branch, and observable, or it is a bug.
+- Comments clarify functionality and how code is used, and they stay current when behavior changes. Never request a comment on self-explanatory code; request removal or editing of comments on self-explanatory code instead. Code that is not self-explanatory is usually too complex and the finding is simplification, not narration. A missing comment is reportable only when the change introduces durable knowledge that code or types cannot express: a surprising external constraint, a non-obvious safety or ordering requirement, a deliberate compatibility compromise a future maintainer could clean up and break, or operational behavior not discoverable from the local code. Never request narration of control flow, parameter names, or implementation steps.
+
+## Risk taxonomy
+
+What raises the stakes of a change, and therefore the depth of its review:
+
+- Irreversible or destructive paths: deletion, force operations, terminal state transitions, anything that touches user-owned estate.
+- Lifecycle ownership: code that decides whether work is alive, dead, resumable, or abandoned.
+- Schema and persisted contracts: identifiers, wire values, additive-only evolution.
+- Credentials and auth boundaries.
+- Provider and adapter boundaries: native config preservation, capability scoping.
+- Concurrency and shared estate: worktrees, sessions, leases.
+
+A change in these areas gets adversarial review depth: an explicit attempt to refute, input-set variation, and a stated answer to "what would make this merge wrong." A docs or prose change gets the minimum. The review orchestrator's depth signal derives from this list, and so do the pre-triage script's path weights; this section is their single source.
+
+## Case law
+
+Proven rules from real failures. Each entry states the rule, then the mechanism that made it necessary. Origins are dated in prose; this file does not index by tracker numbers.
+
+1. **Status sets near destructive actions are derived, never enumerated, and tests vary them.** A cleanup path defined "live" as "non-terminal" while the codebase's own vocabulary made failed runs resumable; the sweep would have force-deleted recoverable branches. Two review rounds missed it because every test stubbed the deciding primitive and no test varied the status set. Rule: derive such sets from the owning vocabulary so a new status inherits safety automatically; in tests, exercise the real primitive and vary the one input the decision turns on. (Proven live, August 2026, isolation cleanup.)
+2. **The work order outranks the implementation's account of itself.** An implementation narrowed a contract, its PR body described the narrowed version, and review verified the narrowed claims instead of the requested outcome. Rule: review anchors on the original request; the implementor's self-report is a file of claims to verify, never a scope definition. (Proven live, August 2026, fixture isolation.)
+3. **Same function, same invariant: in scope.** A review filed a regression inside the exact function the change rewrote as an out-of-scope discovery. Rule: a defect that violates the same invariant through the same mechanism as the change under review is a correction, not a discovery, no matter how the implementation frames it. (Proven live, August 2026, fixture targeting.)
+4. **A guard is evidence only once seen red.** Cleanup retries via built-in options shipped twice as fixes while the runtime silently ignored those options; the pattern read as safety and did nothing. Rule: before trusting any guard, watch it fail against the condition it claims to catch; a probe beats a documented promise. (Proven live, August 2026, the runtime retry options.)
+5. **Green plus green can be red.** Two individually green changes composed into a runtime failure because no check ever ran on the composition, and the file class involved was invisible to both static gates. Rule: compositions need their own verification, and "the checks passed" is a claim about what the checks cover, not about the code. (Proven live, August 2026, the parallel-merge break.)
+6. **Suppressing inherited state requires an explicit presence, not an absence.** Deleting an environment key from a child process's env did nothing because the child reloaded it from its own configuration files; only an explicitly present empty value suppressed it. Rule: when isolating a boundary, prove the isolation against every path in, not the one you thought of. (Proven live, August 2026, the test sandbox env.)
+
+## Review posture
+
+- An unengaged risk is a failure. If the orchestrator names a risk and no lens engages it, the review is not clean, it is incomplete, and the verdict must say so.
+- "Could not tell" is a verdict. Ambiguity, lens disagreement, and low confidence produce an inconclusive outcome for a human, never a silent pass and never a manufactured correction.
+- A malformed or failed verdict call defaults conservative: toward not-ready, never toward pass.
+- Findings and discoveries carry their source. Attribution is what makes calibration possible; an unattributed finding cannot teach anything.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Archon is a self-hostable, governed agentic automation engine. It runs workflows that mix deterministic steps, AI agents, human gates, and audit trails. Coding automation is its most mature surface, but the engine is intended for general business operations too.
 
-This file is the canonical project guidance for coding agents. Keep it short, durable, and about judgment. Put changing product direction in [`.archon/direction.md`](.archon/direction.md), workflow-language design in [`.archon/workflow-language-constitution.md`](.archon/workflow-language-constitution.md), user documentation in the docs site, and machine-checkable rules in code, types, tests, lint, or CI.
+This file is the canonical project guidance for coding agents. Keep it short, durable, and about judgment. Put changing product direction in [`.archon/direction.md`](.archon/direction.md), workflow-language design in [`.archon/workflow-language-constitution.md`](.archon/workflow-language-constitution.md), aspirational engineering craft and review values in [`.archon/engineering.md`](.archon/engineering.md), user documentation in the docs site, and machine-checkable rules in code, types, tests, lint, or CI.
 
 ## Read before changing code
 
@@ -159,6 +159,7 @@ Do not expand this file with copied reference material. Use the owning source:
 
 - Product direction: [`.archon/direction.md`](.archon/direction.md)
 - Workflow-language design: [`.archon/workflow-language-constitution.md`](.archon/workflow-language-constitution.md)
+- Engineering craft and review values: [`.archon/engineering.md`](.archon/engineering.md)
 - Contributor setup and checks: [`packages/docs-web/src/content/docs/contributing/index.md`](packages/docs-web/src/content/docs/contributing/index.md)
 - Architecture: [`packages/docs-web/src/content/docs/reference/architecture.md`](packages/docs-web/src/content/docs/reference/architecture.md) and package manifests
 - Configuration: [`packages/docs-web/src/content/docs/reference/configuration.md`](packages/docs-web/src/content/docs/reference/configuration.md) and the config schema

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,9 +160,6 @@ Do not expand this file with copied reference material. Use the owning source:
 - Product direction: [`.archon/direction.md`](.archon/direction.md)
 - Workflow-language design: [`.archon/workflow-language-constitution.md`](.archon/workflow-language-constitution.md)
 - Engineering craft and review values: [`.archon/engineering.md`](.archon/engineering.md)
-- Contributor setup and checks: [`packages/docs-web/src/content/docs/contributing/index.md`](packages/docs-web/src/content/docs/contributing/index.md)
-- Architecture: [`packages/docs-web/src/content/docs/reference/architecture.md`](packages/docs-web/src/content/docs/reference/architecture.md) and package manifests
-- Configuration: [`packages/docs-web/src/content/docs/reference/configuration.md`](packages/docs-web/src/content/docs/reference/configuration.md) and the config schema
 - CLI: [`packages/docs-web/src/content/docs/reference/cli.md`](packages/docs-web/src/content/docs/reference/cli.md) and `archon --help`
 - Workflow authoring: [`packages/docs-web/src/content/docs/guides/authoring-workflows.md`](packages/docs-web/src/content/docs/guides/authoring-workflows.md) and workflow schemas
 - Database behavior: [`packages/docs-web/src/content/docs/reference/database.md`](packages/docs-web/src/content/docs/reference/database.md), migrations, and adapter tests


### PR DESCRIPTION
## Problem

The project has a product sidecar (`.archon/direction.md`) and a language sidecar (`.archon/workflow-language-constitution.md`), but nothing carried the engineering side: the objective function (correct first, cost-efficient second, speed last), the survival-shape thesis behind the small core and the SDK direction, provider/adapter contract expectations, the review risk taxonomy, and the case law this month's dogfooding proved. Those lived in session context, canvases, and review comments — checked against nothing.

## Solution

`.archon/engineering.md`: the craft sidecar. Evaluative context, loaded selectively by review-class agents (the review orchestrator and lenses, and future evaluators), not ambient context for every node. Its own charter enforces the boundaries that keep it from becoming a fourth overlapping guidance file: the operator authors it and agents may only propose entries; anything machine-checkable graduates to a lint rule, type, or CI check and then leaves the file; entries are phrased so drift is catchable and drifted entries are deleted, not annotated; changing facts stay in their owning sources.

Content: the objective function, the survival-shape aspiration (small strong core, extensible at the seams, engine as SDK), provider/adapter contract expectations, engineering taste including the comment doctrine, the risk taxonomy that drives review depth (the single source for both the review orchestrator's depth signal and the planned pre-triage script's path weights), six case-law entries proven by real failures this month, and the review posture rules (unengaged risk is a failure, inconclusive is a verdict, conservative fallback, mandatory attribution).

`AGENTS.md` gains two pointer lines (the sidecar sentence and the Find-current-facts list), mirroring how the other two sidecars are referenced.

## Validation

Prose-only change; two files. The doc deliberately contains no counts, paths, or inventories that rot — its own charter forbids them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added engineering standards covering quality priorities, design principles, risk assessment, and review practices.
  - Updated project guidance to direct contributors to the new engineering standards document.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->