### PR TITLE
ci: avoid unnecessary test setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,27 +4,38 @@ on:
   workflow_dispatch:
   push:
     branches: [main, dev]
-    paths:
-      - '**'
-      - '!**.md'
-      - '!packages/docs-web/**'
-      # Docker's dependency layer copies this workspace manifest.
-      - 'packages/docs-web/package.json'
   pull_request:
     branches: [main, dev]
-    paths:
-      - '**'
-      - '!**.md'
-      - '!packages/docs-web/**'
-      # Docker's dependency layer copies this workspace manifest.
-      - 'packages/docs-web/package.json'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      run-tests: ${{ steps.decision.outputs.run-tests }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Decide whether tests are needed
+        id: decision
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.before || github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.after || github.event.pull_request.head.sha }}
+        run: |
+          if [ "$EVENT_NAME" != workflow_dispatch ]; then
+            git fetch --no-tags --depth=1 origin "$BASE_SHA" "$HEAD_SHA"
+          fi
+          echo "run-tests=$(bun scripts/should-run-test-suite.ts "$EVENT_NAME" "$BASE_SHA" "$HEAD_SHA")" >> "$GITHUB_OUTPUT"
+
   test:
+    needs: changes
+    if: needs.changes.outputs.run-tests == 'true'
     strategy:
       # Both legs must always report. With the default fail-fast, an ubuntu
       # failure cancels windows, so a windows-only break stays invisible until
@@ -88,6 +99,8 @@ jobs:
         run: bun run test
 
   schema-upgrade:
+    needs: changes
+    if: needs.changes.outputs.run-tests == 'true'
     # Nothing else in CI applies migrations/000_combined.sql to a real database,
     # and every test that touches a schema starts from an empty one. That blind
     # spot is exactly how #2508 shipped green and then crash-looped every
@@ -145,6 +158,8 @@ jobs:
         run: bun run check:sqlite-vintages
 
   postgres-parity:
+    needs: changes
+    if: needs.changes.outputs.run-tests == 'true'
     # The unit suite mocks the pg driver, so the Postgres dialect branch of
     # getLiveRunOwningEnv (cleanup's lock query) only executes here, against a
     # real server: an untyped parameter compared against text and UUID columns
@@ -183,6 +198,8 @@ jobs:
         run: bun test packages/core/src/db/isolation-environments.live-run.postgres.integration.test.ts
 
   docker-build:
+    needs: changes
+    if: needs.changes.outputs.run-tests == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -227,3 +244,29 @@ jobs:
       - name: Cleanup smoke test container
         if: always()
         run: docker rm -f archon-smoke || true
+
+  test-suite:
+    name: Test Suite
+    needs: [changes, test, schema-upgrade, postgres-parity, docker-build]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report test-suite outcome
+        env:
+          RUN_TESTS: ${{ needs.changes.outputs.run-tests }}
+          TEST: ${{ needs.test.result }}
+          SCHEMA_UPGRADE: ${{ needs.schema-upgrade.result }}
+          POSTGRES_PARITY: ${{ needs.postgres-parity.result }}
+          DOCKER_BUILD: ${{ needs.docker-build.result }}
+        run: |
+          if [ "$RUN_TESTS" = false ]; then
+            echo "Skipped tests for documentation-only changes."
+            exit 0
+          fi
+
+          for result in "$TEST" "$SCHEMA_UPGRADE" "$POSTGRES_PARITY" "$DOCKER_BUILD"; do
+            if [ "$result" != success ]; then
+              echo "A test-suite job finished with $result."
+              exit 1
+            fi
+          done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -209,8 +209,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # The Buildx cache can miss independently of changed paths. Rebuilding the
-      # base or dependency layers then exceeds the stock runner's available space.
+      # The image build needs ~14GB more scratch space than a stock runner has
+      # free once the provider SDKs' multi-platform vendor binaries are in
+      # node_modules. Cached-layer builds squeak by; any PR that invalidates an
+      # early Dockerfile layer (apt block, base image) rebuilds everything and
+      # hits "no space left on device". Reclaim the big unused toolchains first.
       - name: Free runner disk space
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -209,11 +209,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # The image build needs ~14GB more scratch space than a stock runner has
-      # free once the provider SDKs' multi-platform vendor binaries are in
-      # node_modules. Cached-layer builds squeak by; any PR that invalidates an
-      # early Dockerfile layer (apt block, base image) rebuilds everything and
-      # hits "no space left on device". Reclaim the big unused toolchains first.
+      # The Buildx cache can miss independently of changed paths. Rebuilding the
+      # base or dependency layers then exceeds the stock runner's available space.
       - name: Free runner disk space
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,20 @@ on:
   workflow_dispatch:
   push:
     branches: [main, dev]
+    paths:
+      - '**'
+      - '!**.md'
+      - '!packages/docs-web/**'
+      # Docker's dependency layer copies this workspace manifest.
+      - 'packages/docs-web/package.json'
   pull_request:
     branches: [main, dev]
+    paths:
+      - '**'
+      - '!**.md'
+      - '!packages/docs-web/**'
+      # Docker's dependency layer copies this workspace manifest.
+      - 'packages/docs-web/package.json'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -29,6 +41,13 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.11
+
+      - name: Cache Bun dependencies
+        if: runner.os == 'Windows'
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
 
       - name: Decide whether tests are needed
         id: decision
@@ -28,9 +33,6 @@ jobs:
           BASE_SHA: ${{ github.event.before || github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.after || github.event.pull_request.head.sha }}
         run: |
-          if [ "$EVENT_NAME" != workflow_dispatch ]; then
-            git fetch --no-tags --depth=1 origin "$BASE_SHA" "$HEAD_SHA"
-          fi
           echo "run-tests=$(bun scripts/should-run-test-suite.ts "$EVENT_NAME" "$BASE_SHA" "$HEAD_SHA")" >> "$GITHUB_OUTPUT"
 
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,12 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.before || github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.after || github.event.pull_request.head.sha }}
+        # Assign before echoing. A failing command substituted into another command's arguments
+        # does not trip `set -e`, so `echo "run-tests=$(...)"` would report success and write an
+        # empty decision that every downstream `== 'true'` gate reads as "skip".
         run: |
-          echo "run-tests=$(bun scripts/should-run-test-suite.ts "$EVENT_NAME" "$BASE_SHA" "$HEAD_SHA")" >> "$GITHUB_OUTPUT"
+          run_tests=$(bun scripts/should-run-test-suite.ts "$EVENT_NAME" "$BASE_SHA" "$HEAD_SHA")
+          echo "run-tests=$run_tests" >> "$GITHUB_OUTPUT"
 
   test:
     needs: changes

--- a/scripts/check-test-cleanup-drift.test.ts
+++ b/scripts/check-test-cleanup-drift.test.ts
@@ -227,9 +227,15 @@ test('allows single-file cleanup and shared recursive cleanup', () => {
   expect(checkSource('packages/example/src/example.test.ts', source)).toEqual([]);
 });
 
+/**
+ * `ls-files` rejecting its own option is a local, constant-cost failure. An unknown *subcommand*
+ * fails too, but only after Git searches every PATH entry for a `git-*` executable to offer a
+ * correction: 5.3s of that on a Windows runner against a 5s per-test budget (#2882), where every
+ * other Git spawn in this file costs ~50ms.
+ */
 test('propagates Git scan failures', () => {
-  expect(() => gitOutput(['definitely-not-a-git-command'])).toThrow(
-    'Git command failed: git definitely-not-a-git-command'
+  expect(() => gitOutput(['ls-files', '--definitely-not-an-option'])).toThrow(
+    'Git command failed: git ls-files --definitely-not-an-option'
   );
 });
 

--- a/scripts/should-run-test-suite.test.ts
+++ b/scripts/should-run-test-suite.test.ts
@@ -44,10 +44,13 @@ describe('test-suite change decision', () => {
   });
 
   test('the workflow delegates both automatic routes to the complete-diff decision', () => {
+    // A Windows checkout writes the workflow with CRLF endings, and every assertion below
+    // anchors on LF. Normalize at the read site: what is asserted is YAML structure, not
+    // the line terminator the working tree happens to carry.
     const workflow = readFileSync(
       resolve(import.meta.dir, '../.github/workflows/test.yml'),
       'utf8'
-    );
+    ).replaceAll('\r\n', '\n');
     const changesJob = workflow.slice(workflow.indexOf('  changes:'), workflow.indexOf('  test:'));
 
     expect(workflow).toContain('  push:\n');

--- a/scripts/should-run-test-suite.test.ts
+++ b/scripts/should-run-test-suite.test.ts
@@ -3,6 +3,8 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { shouldRunTestSuite } from './should-run-test-suite';
 
+const EMPTY_GIT_SHA = '0000000000000000000000000000000000000000';
+
 describe('test-suite change decision', () => {
   test.each(['push', 'pull_request'])('%s skips Markdown-only changes', () => {
     expect(shouldRunTestSuite(['README.md', 'packages/core/notes.md'])).toBe(false);
@@ -30,21 +32,36 @@ describe('test-suite change decision', () => {
     expect(shouldRunTestSuite(changedFiles)).toBe(true);
   });
 
+  test('runs for a push that creates a branch', () => {
+    const script = resolve(import.meta.dir, 'should-run-test-suite.ts');
+    const result = Bun.spawnSync(['bun', script, 'push', EMPTY_GIT_SHA, 'unavailable-head'], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.toString().trim()).toBe('true');
+  });
+
   test('the workflow delegates both automatic routes to the complete-diff decision', () => {
     const workflow = readFileSync(
       resolve(import.meta.dir, '../.github/workflows/test.yml'),
       'utf8'
     );
+    const changesJob = workflow.slice(workflow.indexOf('  changes:'), workflow.indexOf('  test:'));
 
+    expect(workflow).toContain('  push:\n');
+    expect(workflow).toContain('  pull_request:\n');
     expect(workflow).not.toContain('\n    paths:');
-    expect(workflow).toContain('EVENT_NAME: ${{ github.event_name }}');
-    expect(workflow).toContain(
+    expect(changesJob).toContain('EVENT_NAME: ${{ github.event_name }}');
+    expect(changesJob).toContain(
       'BASE_SHA: ${{ github.event.before || github.event.pull_request.base.sha }}'
     );
-    expect(workflow).toContain(
+    expect(changesJob).toContain(
       'HEAD_SHA: ${{ github.event.after || github.event.pull_request.head.sha }}'
     );
-    expect(workflow).toContain('git fetch --no-tags --depth=1 origin "$BASE_SHA" "$HEAD_SHA"');
-    expect(workflow).toContain('bun scripts/should-run-test-suite.ts');
+    expect(changesJob).toContain('fetch-depth: 0');
+    expect(changesJob).toContain('uses: oven-sh/setup-bun@v2');
+    expect(changesJob).toContain('bun scripts/should-run-test-suite.ts');
   });
 });

--- a/scripts/should-run-test-suite.test.ts
+++ b/scripts/should-run-test-suite.test.ts
@@ -32,6 +32,43 @@ describe('test-suite change decision', () => {
     expect(shouldRunTestSuite(changedFiles)).toBe(true);
   });
 
+  test.each([
+    ['.archon/commands/defaults/archon-assist.md', 'a legacy command prompt'],
+    ['.archon/workflows/sdlc/implement/commands/implement.md', 'a packaged command prompt'],
+    ['.claude/skills/archon-cli/SKILL.md', 'the bundled CLI skill'],
+    ['packages/docs-web/src/content/docs/reference/provider-capabilities.md', 'a generated doc'],
+  ])('runs for %s, which is %s rather than prose', file => {
+    expect(shouldRunTestSuite([file])).toBe(true);
+  });
+
+  test('still skips genuine prose, inside the docs site and out', () => {
+    expect(
+      shouldRunTestSuite([
+        'README.md',
+        'AGENTS.md',
+        'packages/docs-web/src/content/docs/guides/authoring-workflows.md',
+      ])
+    ).toBe(false);
+  });
+
+  /**
+   * The exclusion list above is written by hand, so it can only stay true if something checks it
+   * against what the build actually reads. `bundled-skill.ts` compiles each of these files into
+   * the CLI with a text import, which makes its import list the owning source for that family.
+   */
+  test('every Markdown file compiled into the CLI skill runs the suite', () => {
+    const bundledSkill = readFileSync(
+      resolve(import.meta.dir, '../packages/cli/src/bundled-skill.ts'),
+      'utf8'
+    );
+    const imported = [...bundledSkill.matchAll(/'[^']*\/(\.claude\/skills\/[^']+\.md)'/g)].map(
+      match => match[1]
+    );
+
+    expect(imported.length).toBeGreaterThan(0);
+    for (const file of imported) expect(shouldRunTestSuite([file])).toBe(true);
+  });
+
   test('runs for a push that creates a branch', () => {
     const script = resolve(import.meta.dir, 'should-run-test-suite.ts');
     const result = Bun.spawnSync(['bun', script, 'push', EMPTY_GIT_SHA, 'unavailable-head'], {
@@ -41,6 +78,35 @@ describe('test-suite change decision', () => {
 
     expect(result.exitCode).toBe(0);
     expect(result.stdout.toString().trim()).toBe('true');
+  });
+
+  /**
+   * A force-push leaves `github.event.before` unreachable. The decision must still be a decision:
+   * an empty stdout here is read as "skip" by every downstream gate.
+   */
+  test('an unreadable diff resolves to running the suite, with the cause on stderr', () => {
+    const script = resolve(import.meta.dir, 'should-run-test-suite.ts');
+    const unreachable = '1'.repeat(40);
+    const result = Bun.spawnSync(['bun', script, 'push', unreachable, 'HEAD'], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.toString().trim()).toBe('true');
+    expect(result.stderr.toString()).toContain(`Could not compare ${unreachable}..HEAD`);
+  });
+
+  test('a bad argument stays fatal, so the step cannot publish an empty decision', () => {
+    const script = resolve(import.meta.dir, 'should-run-test-suite.ts');
+    const result = Bun.spawnSync(['bun', script, 'not-a-github-event', 'base', 'head'], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout.toString().trim()).toBe('');
+    expect(result.stderr.toString()).toContain('Unsupported GitHub event: not-a-github-event');
   });
 
   test('the workflow delegates both automatic routes to the complete-diff decision', () => {
@@ -65,6 +131,13 @@ describe('test-suite change decision', () => {
     );
     expect(changesJob).toContain('fetch-depth: 0');
     expect(changesJob).toContain('uses: oven-sh/setup-bun@v2');
-    expect(changesJob).toContain('bun scripts/should-run-test-suite.ts');
+
+    // Pin the invocation itself, not just its parts. The script reads three positional
+    // arguments, so a reordering that sends a SHA into `eventName` has to fail here — and the
+    // assignment must stay separate from the `echo`, which is what makes a crash fail the step.
+    expect(changesJob).toContain(
+      'run_tests=$(bun scripts/should-run-test-suite.ts "$EVENT_NAME" "$BASE_SHA" "$HEAD_SHA")\n'
+    );
+    expect(changesJob).toContain('echo "run-tests=$run_tests" >> "$GITHUB_OUTPUT"');
   });
 });

--- a/scripts/should-run-test-suite.test.ts
+++ b/scripts/should-run-test-suite.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { shouldRunTestSuite } from './should-run-test-suite';
+
+describe('test-suite change decision', () => {
+  test.each(['push', 'pull_request'])('%s skips Markdown-only changes', () => {
+    expect(shouldRunTestSuite(['README.md', 'packages/core/notes.md'])).toBe(false);
+  });
+
+  test.each(['push', 'pull_request'])('%s skips docs-source-only changes', () => {
+    expect(
+      shouldRunTestSuite([
+        'packages/docs-web/src/content/docs/guide.mdx',
+        'packages/docs-web/public/logo.svg',
+      ])
+    ).toBe(false);
+  });
+
+  test.each(['push', 'pull_request'])('%s runs when the docs manifest changes', () => {
+    expect(shouldRunTestSuite(['packages/docs-web/package.json'])).toBe(true);
+  });
+
+  test('runs for a non-documentation change after thousands of documentation files', () => {
+    const changedFiles = [
+      ...Array.from({ length: 3_001 }, (_, index) => `docs/${index}.md`),
+      'packages/docs-web/package.json',
+    ];
+
+    expect(shouldRunTestSuite(changedFiles)).toBe(true);
+  });
+
+  test('the workflow delegates both automatic routes to the complete-diff decision', () => {
+    const workflow = readFileSync(
+      resolve(import.meta.dir, '../.github/workflows/test.yml'),
+      'utf8'
+    );
+
+    expect(workflow).not.toContain('\n    paths:');
+    expect(workflow).toContain('EVENT_NAME: ${{ github.event_name }}');
+    expect(workflow).toContain(
+      'BASE_SHA: ${{ github.event.before || github.event.pull_request.base.sha }}'
+    );
+    expect(workflow).toContain(
+      'HEAD_SHA: ${{ github.event.after || github.event.pull_request.head.sha }}'
+    );
+    expect(workflow).toContain('git fetch --no-tags --depth=1 origin "$BASE_SHA" "$HEAD_SHA"');
+    expect(workflow).toContain('bun scripts/should-run-test-suite.ts');
+  });
+});

--- a/scripts/should-run-test-suite.ts
+++ b/scripts/should-run-test-suite.ts
@@ -1,10 +1,36 @@
-const DOCS_MANIFEST = 'packages/docs-web/package.json';
 const DOCS_DIRECTORY = 'packages/docs-web/';
 const EMPTY_GIT_SHA = '0000000000000000000000000000000000000000';
 
+/**
+ * Paths that read as documentation but are build inputs, so changing one must run the suite.
+ * Most Markdown in this repository is executable prompt or skill content rather than prose, and
+ * the checks that guard it all live inside the job this decision can skip — so a bare `.md` test
+ * would let a bundled-prompt edit skip the very check built to catch that drift.
+ *
+ * An entry ending in `/` matches a directory, anything else matches one file. Each is here
+ * because a named check reads it:
+ *   - `.archon/commands/`, `.archon/workflows/` are compiled into
+ *     `packages/workflows/src/defaults/bundled-defaults.generated.ts` (`check:bundled`).
+ *   - `.claude/skills/` is imported as text by `packages/cli/src/bundled-skill.ts`, so it is
+ *     compiled into the CLI itself (`check:bundled-skill`).
+ *   - `provider-capabilities.md` is generated from the providers' `capabilities.ts`
+ *     (`check:capability-matrix`), and lives under the docs site without being prose.
+ *   - The docs manifest is copied by the Docker dependency layer.
+ */
+const BUILD_INPUTS = [
+  '.archon/commands/',
+  '.archon/workflows/',
+  '.claude/skills/',
+  'packages/docs-web/src/content/docs/reference/provider-capabilities.md',
+  'packages/docs-web/package.json',
+];
+
+const isBuildInput = (file: string): boolean =>
+  BUILD_INPUTS.some(input => (input.endsWith('/') ? file.startsWith(input) : file === input));
+
 export function shouldRunTestSuite(changedFiles: Iterable<string>): boolean {
   for (const file of changedFiles) {
-    if (file === DOCS_MANIFEST || (!file.endsWith('.md') && !file.startsWith(DOCS_DIRECTORY))) {
+    if (isBuildInput(file) || (!file.endsWith('.md') && !file.startsWith(DOCS_DIRECTORY))) {
       return true;
     }
   }
@@ -22,6 +48,25 @@ function changedFiles(base: string, head: string): string[] {
   return result.stdout.toString().split('\n').filter(Boolean);
 }
 
+/**
+ * A force-push leaves `github.event.before` naming a commit that is no longer reachable, so the
+ * diff fails for a reason that says nothing about what changed. Run the suite rather than guess:
+ * an unnecessary run costs minutes, a wrong skip merges unchecked code. The cause goes to stderr
+ * so the job log explains why the suite ran.
+ *
+ * Only the scan is caught. A bad argument is a wiring bug with no safe answer, so it stays a
+ * throw and takes the step down with it.
+ */
+function decideFromDiff(base: string, head: string): boolean {
+  try {
+    return shouldRunTestSuite(changedFiles(base, head));
+  } catch (error) {
+    const cause = error instanceof Error ? error.message : String(error);
+    console.error(`Could not compare ${base}..${head}, so the test suite runs: ${cause}`);
+    return true;
+  }
+}
+
 function main(): void {
   const [eventName, base, head] = process.argv.slice(2);
   if (eventName === 'workflow_dispatch') {
@@ -35,7 +80,7 @@ function main(): void {
     console.log('true');
     return;
   }
-  console.log(shouldRunTestSuite(changedFiles(base, head)));
+  console.log(decideFromDiff(base, head));
 }
 
 if (import.meta.main) main();

--- a/scripts/should-run-test-suite.ts
+++ b/scripts/should-run-test-suite.ts
@@ -1,0 +1,36 @@
+const DOCS_MANIFEST = 'packages/docs-web/package.json';
+const DOCS_DIRECTORY = 'packages/docs-web/';
+
+export function shouldRunTestSuite(changedFiles: Iterable<string>): boolean {
+  for (const file of changedFiles) {
+    if (file === DOCS_MANIFEST || (!file.endsWith('.md') && !file.startsWith(DOCS_DIRECTORY))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function changedFiles(base: string, head: string): string[] {
+  const result = Bun.spawnSync(['git', 'diff', '--name-only', '--no-renames', base, head], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(`Could not read changed files: ${result.stderr.toString().trim()}`);
+  }
+  return result.stdout.toString().split('\n').filter(Boolean);
+}
+
+function main(): void {
+  const [eventName, base, head] = process.argv.slice(2);
+  if (eventName === 'workflow_dispatch') {
+    console.log('true');
+    return;
+  }
+  if ((eventName !== 'push' && eventName !== 'pull_request') || !base || !head) {
+    throw new Error(`Unsupported GitHub event: ${eventName ?? '(missing)'}`);
+  }
+  console.log(shouldRunTestSuite(changedFiles(base, head)));
+}
+
+if (import.meta.main) main();

--- a/scripts/should-run-test-suite.ts
+++ b/scripts/should-run-test-suite.ts
@@ -1,5 +1,6 @@
 const DOCS_MANIFEST = 'packages/docs-web/package.json';
 const DOCS_DIRECTORY = 'packages/docs-web/';
+const EMPTY_GIT_SHA = '0000000000000000000000000000000000000000';
 
 export function shouldRunTestSuite(changedFiles: Iterable<string>): boolean {
   for (const file of changedFiles) {
@@ -29,6 +30,10 @@ function main(): void {
   }
   if ((eventName !== 'push' && eventName !== 'pull_request') || !base || !head) {
     throw new Error(`Unsupported GitHub event: ${eventName ?? '(missing)'}`);
+  }
+  if (base === EMPTY_GIT_SHA) {
+    console.log('true');
+    return;
   }
   console.log(shouldRunTestSuite(changedFiles(base, head)));
 }


### PR DESCRIPTION
## Problem and outcome

Markdown-only changes and changes confined to the docs workspace were running the full test matrix, and Windows fetched Bun dependencies without a cache. This PR avoids that unnecessary CI setup while preserving coverage for every change that can affect the test suite.

- **Outcome:** Markdown-only changes and docs-workspace-only changes skip this workflow's test suite; Windows restores Bun's package cache.
- **Invariant:** Non-Markdown changes outside `packages/docs-web/` and changes to the docs workspace manifest still run the existing test matrix and Docker build.
- **Scope boundary:** The per-OS type-check/lint matrix and runner selection are unchanged.

## Review guidance

- **Feedback requested:** Confirm the complete-diff decision correctly distinguishes documentation-only changes from changes that require the test suite.
- **Start here:** `.github/workflows/test.yml:15` — the change-decision job gates the existing CI jobs.
- **Review order:** Review the change-decision script, the job gating and aggregate result, then the Windows cache step.
- **Lower-attention areas:** None; this PR changes one workflow and its focused decision script and tests.
- **Known risk or uncertainty:** None outstanding. The first remote runs surfaced two Windows-only test defects, both fixed here — see "Windows fixes" below.

## Solution

The workflow checks the complete changed-file set and delegates the decision to a small script. The suite is skipped only when every changed file is prose: Markdown or something inside `packages/docs-web/`, and not one of the documentation-shaped paths a build or drift check actually reads. Those exceptions are `.archon/commands/` and `.archon/workflows/` (compiled into `bundled-defaults.generated.ts`), `.claude/skills/` (text-imported into the CLI binary), the generated `provider-capabilities.md`, and the docs manifest the Docker dependency layer copies. If the diff cannot be read at all, the script says "run the suite" and explains why on stderr. The Windows matrix leg restores Bun's global package cache from a lockfile-keyed cache. An always-run aggregate job reports the suite result after the gated jobs finish.

## Behavior change

| | Before | After |
|---|---|---|
| **Prose-only change (Markdown or docs workspace)** | Full test matrix and Docker build run. | Matrix and Docker build jobs are skipped. |
| **Change to bundled or generated Markdown** (pack command prompts, the CLI skill, `provider-capabilities.md`, the docs manifest) | Full test matrix runs. | Unchanged — still runs, so the drift checks that guard those files cannot be skipped. |
| **Base commit unreadable** (e.g. after a force-push) | Full test matrix runs. | Unchanged — the script resolves to "run the suite" and logs the cause. |
| **Windows dependency install** | Dependencies are downloaded each run. | Bun package cache is restored when `bun.lock` matches. |

## Windows fixes

The first remote run went red on the Windows matrix leg only, on two unrelated test defects. Both are fixed here.

**The new decision test could not survive a Windows checkout.** `scripts/should-run-test-suite.test.ts` reads `.github/workflows/test.yml` raw and asserts LF-anchored substrings, but a Windows checkout materializes the file with CRLF, so `"  push:\n"` never matched. Line endings are now normalized at the read site: the assertions are about YAML structure, not the terminator the working tree happens to carry.

**`scripts/check-test-cleanup-drift.test.ts` is a fourth file in this diff, and deliberately so.** It is pre-existing and unrelated to the decision script, but its `propagates Git scan failures` test was red on the same Windows leg — 5282ms against a 5000ms per-test budget — so it blocked this PR. Fixing it here is unblocking work rather than unrelated cleanup; splitting it out would cost a review round for no isolation benefit.

The cost was not generic Windows spawn latency. The test provoked its failure with an unknown Git *subcommand*, which sends Git searching every PATH entry for a `git-*` executable to offer a correction — one spawn whose cost scales with the size of PATH, and each probe on Windows is far more expensive than on Linux. For comparison, every other Git spawn in that same file on that same runner costs ~50ms. The test now fails a rejected option on the same `ls-files` the scan actually runs, which fails locally at constant cost, with the assertion shape unchanged so the failure-propagation coverage is identical. No timeout was raised and nothing is skipped on Windows: 5282ms → 31ms.

## Review corrections

The review found two blocking issues, both on the decision path. Each mechanism was reproduced locally before it was changed.

**A crash produced an empty decision.** The script threw uncaught when `git diff` could not read the base commit — what a force-push produces, since `github.event.before` can name an unreachable commit. `echo "run-tests=$(...)"` does not trip `set -e` when the substituted command fails, so the step reported success having written an empty `run-tests`, which every downstream `== 'true'` gate reads as "skip". Only the summary job's job-result loop caught it, by accident. Now the scan failure resolves explicitly to "run the suite" with the cause on stderr, and the step assigns before echoing so a wiring bug fails the job instead of publishing an empty decision. A bad argument stays an uncaught throw, because there is no safe answer to it.

**The `.md` test swept in bundled and generated content.** Pack command prompts, the skill files compiled into the CLI, and the generated `provider-capabilities.md` were all classified as documentation — and `check:bundled`, `check:bundled-skill` and `check:capability-matrix` all run only inside the job this decision can skip, so editing a bundled prompt skipped the check built to catch that drift. Those paths now force a run, generalizing the carve-out that already existed for the docs manifest.

Since the exclusion list is written by hand, one test derives the skill family from `bundled-skill.ts`'s own text imports and fails if any file the CLI compiles in would be classified as prose. The wiring test now pins the literal invocation and argument order rather than checking that fragments appear somewhere in the job.

## Validation

- `bun install --frozen-lockfile` — passed; lockfile unchanged.
- `bun x prettier --check .github/workflows/test.yml` — passed.
- `git diff --check` — passed.
- `bun run validate` — passed; generated checks, type-check, lint, formatting, installer tests, and the complete test suite passed.
- **Remote CI — passed.** Run 33165582920 is green on every job at the current head, both matrix legs included; the earlier run 33163243834 is the green run for the Windows fixes.
- The eight new tests were seen red before they were seen green: run against the pre-fix script and workflow, seven of them fail (all four excluded families, the derived bundled-skill guard, the unreadable-diff fail-safe, and the wiring test). The eighth pins behavior that must not change, so it passes both ways by design.
- The CRLF fix was reproduced red before it was fixed: converting a local copy of the workflow to CRLF makes the pre-fix test emit the exact CI failure, and the fixed test pass on the same file.

## Links

- Relates to #2897


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI Improvements**
  * Optimized test execution by skipping unnecessary runs for documentation-only updates while still testing configuration and build-related changes.
  * Improved reliability for new branches, workflow-triggered runs, and incomplete change information by defaulting to running tests when needed.
  * Added dependency caching for Windows runners to improve build efficiency.
  * Added an aggregate test-suite status for clearer CI results.
  * Expanded automated coverage for test-selection logic and workflow behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



