### PR TITLE
fix(test): restore a green dev by routing discovery-report temp dirs through the tracked cleanup helper

### DIFF
--- a/packages/workflows/src/defaults/discovery-report.test.ts
+++ b/packages/workflows/src/defaults/discovery-report.test.ts
@@ -1,9 +1,10 @@
-import { afterAll, describe, expect, it } from 'bun:test';
+import { describe, expect, it } from 'bun:test';
 import { randomUUID } from 'node:crypto';
 import { readFileSync } from 'node:fs';
-import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { trackTempRoots } from '@archon/paths/test-utils';
 
 const REPO_ROOT = join(import.meta.dir, '..', '..', '..', '..');
 /** Every SDLC tail whose terminal report can carry the discovery section (#2884). */
@@ -28,7 +29,7 @@ function count(haystack: string, needle: string): number {
   return haystack.split(needle).length - 1;
 }
 
-const createdDirs: string[] = [];
+const trackTempRoot = trackTempRoots();
 
 /**
  * Start the interpreter once, for one input.
@@ -62,14 +63,10 @@ async function artifactsDir(discoveries?: string): Promise<string> {
   const dir = join(tmpdir(), `archon-discoveries-${randomUUID()}`);
   if (discoveries === undefined) return dir; // never created: the "no sidecar" case
   await mkdir(dir, { recursive: true });
-  createdDirs.push(dir);
+  trackTempRoot(dir);
   await writeFile(join(dir, 'discoveries.json'), discoveries);
   return dir;
 }
-
-afterAll(async () => {
-  await Promise.all(createdDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })));
-});
 
 describe('SDLC discovery terminal reports (#2884)', () => {
   it('every tail carries the same helper, reports through it, and pins its streams', () => {


### PR DESCRIPTION
## Problem and outcome

`dev` is red. Two individually green PRs merged in sequence and composed red: #2886 added the repo-wide test-cleanup drift checker and wired it in as the first step of `bun run lint`, and #2887 merged right after with a new test file whose `afterAll` removes temp dirs with a raw `rm(dir, { recursive: true, force: true })`. The checker bans exactly that in test cleanup, and #2887's last CI run predates the checker's existence, so nothing on either PR could have caught it. Every `bun run lint` and every CI Test Suite run on `dev` now fails before linting a single file.

- **Outcome:** `bun run lint` passes on `dev` again. The drift checker prints `Test-cleanup drift check passed.` instead of flagging `packages/workflows/src/defaults/discovery-report.test.ts:71`.
- **Invariant:** every temp dir the test file creates is still torn down, and the "sidecar was never created" case still creates nothing to tear down.
- **Scope boundary:** no `LEGACY_RECURSIVE_CLEANUP` ledger entry. That ledger freezes the pre-existing inventory from before the shared helpers; a file added after them is not legacy and gets the helpers. The discovery-report behavior under test is untouched.
- **Root cause:** the checker is repository-wide by design (a diff-scoped check would accept drift an earlier merge introduced), but a merge queue can still compose two green branches into a red base when the rule and its first violation land in that order.

## Review guidance

- **Feedback requested:** correctness of the teardown swap — specifically that moving from one `afterAll` to the helper's per-test `afterEach` cannot tear a fixture down while a test still needs it.
- **Start here:** `packages/workflows/src/defaults/discovery-report.test.ts:66` — the one load-bearing line: the creation helper now registers each dir as it is made.
- **Review order:** the whole diff is one file and about ten lines; read the import change, then `artifactsDir`, then the deleted hook.
- **Lower-attention areas:** none; there is no generated or mechanical change here.
- **Known risk or uncertainty:** None. Each test creates its own dir inside its own body and no dir outlives the test that made it, so per-test teardown is safe here.

## Solution

`artifactsDir` is already the file's single creation helper — every fixture in the file goes through it — which is the precondition `trackTempRoots` documents. So the fix is to keep that helper and change what it does after `mkdir`: register the dir with the tracker instead of pushing it onto a module-level array, and delete the hand-written `afterAll`.

Two things improve as a side effect rather than by extra machinery. Registration happens at creation, so a test that fails mid-body still has its fixture removed — the old array was appended at creation too, but the trailing `afterAll` meant a hard failure that aborted the file left the tree behind. And `removeTempTree` retries while the OS still holds a handle inside the tree, which is what the raw `rm` could not do: these tests spawn a real Python interpreter against the dir, and a just-exited child on Windows is exactly the case (#2306) the retry exists for.

The same-shaped precedent in this package is `packages/workflows/src/workflow-source.test.ts:60`.

## Validation

- `bun scripts/check-test-cleanup-drift.ts` — failed with `packages/workflows/src/defaults/discovery-report.test.ts:71 recursive rm test cleanup must use removeTempTree or trackTempRoots` before the change, prints `Test-cleanup drift check passed.` after — proves this is the check that is red on `dev` and that it is now green.
- `bun run lint` — exit code 0 — proves the red check reported in CI passes end to end, not just the drift step.
- `bun test src/defaults/ src/run-config.test.ts src/model-validation.test.ts src/router.test.ts src/utils/ src/hooks.test.ts src/workflow-inputs.test.ts` from `packages/workflows` (the package test script's own batch containing this file) — 284 pass, 0 fail across 16 files — proves the file and its batch-mates still pass under the isolation the package script uses.
- `bun run type-check` in `packages/workflows` — exit 0 — this package type-checks `src/**/*` including test files, so it covers the new import.
- Teardown proved load-bearing, not just present: with the tracking line disabled, the run left 5 `archon-discoveries-*` trees in the temp dir (one per test that creates one) and still reported 7 pass; with it restored, 0 remain. A cleanup that silently tracked nothing would have looked identical in the test output alone.
- **Not verified:** the Windows retry path itself. It is `removeTempTree`'s own documented and separately tested behavior (#2306), inherited here rather than introduced.

## Links

- Related #2886
- Related #2887


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved temporary test-directory cleanup for discovery report tests.
  * Centralized cleanup handling to reduce leftover temporary files after test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->