### PR TITLE
docs(craft): simplification at review is corrected on the change, not deferred

### DIFF
--- a/.archon/engineering.md
+++ b/.archon/engineering.md
@@ -63,3 +63,4 @@ A change in these areas gets adversarial review depth: an explicit attempt to re
 - A defect that violates the same invariant through the same mechanism as the change under review is in scope: a correction, not a discovery.
 - Tests prove a decision by varying the input it turns on, against the real primitive. A test that stubs the deciding function passes under every mutation of it and proves nothing.
 - Two individually green changes can compose into a failure. A composition is its own change; checks that passed on the parts are claims about the parts.
+- Simplification found at review is corrected on the produced change, not deferred. Code is cheap to regenerate; merged complexity compounds into drift that every later change pays for. A concrete smaller shape that preserves behavior is a correction-round finding, and a verdict may rest on simplification alone. A simplification that is speculative or risks behavior stays a suggestion.


### PR DESCRIPTION
## Problem and outcome

Review verdicts have been filing concrete simplification findings as non-blocking suggestions that carry forward past merge, where the complexity they name starts compounding. In agentic engineering that trade is inverted: code is cheap to regenerate, so applying a simplification on the produced change costs minutes, while merged complexity turns into drift that every later change pays for.

- **Outcome:** `.archon/engineering.md` gains one review-posture rule: a concrete, behavior-preserving smaller shape found at review is a correction-round finding, and a verdict may rest on simplification alone; speculative or behavior-risking simplifications remain suggestions.
- **Invariant:** the craft doc stays judgment-only, operator-authored, and free of changing facts.
- **Scope boundary:** no other section changes; the lens and synthesize prompts that consume this posture are #2898/#2899 work, not this PR.

## Review guidance

- **Feedback requested:** wording only — whether the rule reads as a checkable posture in the doc's voice.
- **Start here:** `.archon/engineering.md` — one bullet appended to Review posture.
- **Known risk or uncertainty:** None.

## Solution

One bullet in the Review posture section, phrased rule-then-mechanism like its neighbors. The routing consequence for the review workflow (simplify findings feed the `correct` verdict) is recorded on #2899, which owns that implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified review guidance to require actionable simplifications to be addressed in the current change.
  * Distinguished concrete, behavior-preserving improvements from speculative or behavior-risking suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->