### PR TITLE
test(workflows): exec-code fixture tests stop building a git repo per test

### DIFF
--- a/packages/workflows/src/fixture-runner.test.ts
+++ b/packages/workflows/src/fixture-runner.test.ts
@@ -38,7 +38,7 @@ mock.module('@archon/paths', () => ({
   getDefaultCommandsPath: () => join(bundledDefaultsRoot, 'defaults'),
 }));
 
-import { execFileAsync } from '@archon/git';
+import { execFileAsync, resolveBashPath } from '@archon/git';
 import { parseWorkflow } from './loader';
 import { expandWorkflowIncludes } from './include-expander';
 import type { WorkflowWithSource } from './schemas/workflow';
@@ -595,6 +595,18 @@ describe('runFixtures', () => {
 describe('runFixtures exec-code isolation (#2851)', () => {
   const COMMITTED_YAML = 'committed-file\n';
 
+  /**
+   * The probe body {@link GUARD_YAML} runs.
+   *
+   * Captured and tested separately, not as `[ -z "$(git status --porcelain)" ]`: a git
+   * that FAILS also prints nothing, so the inline form reads its silence as a clean tree
+   * and the guard passes without having observed anything.
+   *
+   * Shared with the test that proves that, rather than restated there — a second copy
+   * would keep passing after this one was reverted, which is the whole failure mode.
+   */
+  const GUARD_PROBE = ['status="$(git status --porcelain)" || exit 1', '[ -z "$status" ]'];
+
   /** A bash node whose success depends ONLY on the cleanliness of the checkout it executes in. */
   const GUARD_YAML = [
     'name: test-wf',
@@ -602,11 +614,7 @@ describe('runFixtures exec-code isolation (#2851)', () => {
     'nodes:',
     '  - id: probe',
     '    bash: |',
-    // Captured and tested separately, not as `[ -z "$(git status --porcelain)" ]`: a git
-    // that FAILS also prints nothing, so the inline form reads its silence as a clean
-    // tree and the guard passes without having observed anything.
-    '      status="$(git status --porcelain)" || exit 1',
-    '      [ -z "$status" ]',
+    ...GUARD_PROBE.map(line => `      ${line}`),
   ].join('\n');
 
   const WRITER_YAML = [
@@ -691,6 +699,29 @@ describe('runFixtures exec-code isolation (#2851)', () => {
     writeFileSync(join(cwd, 'scratch.txt'), 'untracked stray\n');
     const dirtyReport = await runFixtures({ workflows, cwd });
     expect(dirtyReport.passed).toBe(1);
+  });
+
+  it('fails the guard when git cannot report status, rather than passing on its silence', async () => {
+    // What the test above rests on: the guard must distinguish "the tree is clean" from
+    // "I never got to look". A failing `git status` prints nothing, so the shorter
+    // `[ -z "$(git status --porcelain)" ]` reads that silence as cleanliness — measured,
+    // not supposed: with the scratch worktree replaced by a plain empty directory, the
+    // inline form passed BOTH halves above, certifying a checkout that never happened.
+    //
+    // `GIT_DIR` pointing nowhere reproduces exactly that condition — git exits non-zero
+    // having written nothing to stdout — and needs no repository, no scratch worktree and
+    // no process beyond the one the guard itself runs in.
+    const cwd = makeTempProject();
+    const exit = await execFileAsync(resolveBashPath(), ['-c', GUARD_PROBE.join('\n')], {
+      cwd,
+      env: { ...process.env, GIT_DIR: join(cwd, 'no-such-git-dir') },
+    }).then(
+      () => 'the guard passed',
+      (error: { code?: unknown }) => error.code
+    );
+    // Bash's exit status, so specifically the guard's own `|| exit 1`. A string here would
+    // be a spawn failure — bash never ran — which must not read as the guard working.
+    expect(exit).toBe(1);
   });
 
   it('keeps executed writes out of the caller checkout (#2851)', async () => {

--- a/packages/workflows/src/fixture-runner.test.ts
+++ b/packages/workflows/src/fixture-runner.test.ts
@@ -1,18 +1,19 @@
 /** Tests for the declared-data dry-run fixture runner (#2772). */
-import { describe, it, expect, afterEach, afterAll, mock } from 'bun:test';
+import { describe, it, expect, beforeAll, afterAll, mock } from 'bun:test';
 import {
+  cpSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
   readdirSync,
   readFileSync,
-  rmSync,
   symlinkSync,
   writeFileSync,
 } from 'node:fs';
-import { mkdir, rm } from 'node:fs/promises';
+import { mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { removeTempTree, trackTempRoots } from '@archon/paths/test-utils';
 
 // Capture-cost control, same lever and same reason as `subrun.test.ts` (#2882): every
 // `runFixtures` call takes one source capture, and a capture copies and digests the
@@ -29,9 +30,7 @@ import { join } from 'node:path';
 // dirname(getDefault*Path()), so the getter's PARENT must be the owned empty tree.
 const bundledDefaultsRoot = join(tmpdir(), `fixture-runner-test-empty-bundled-${process.pid}`);
 await mkdir(join(bundledDefaultsRoot, 'defaults'), { recursive: true });
-afterAll(async () => {
-  await rm(bundledDefaultsRoot, { recursive: true, force: true }).catch(() => {});
-});
+afterAll(() => removeTempTree(bundledDefaultsRoot));
 const realArchonPaths = await import('@archon/paths');
 mock.module('@archon/paths', () => ({
   ...realArchonPaths,
@@ -72,8 +71,10 @@ import {
   type RunFixturesOptions,
 } from './fixture-runner';
 
-function makeTempProject(): string {
-  return mkdtempSync(join(tmpdir(), 'fixture-runner-'));
+/** The file's one temp-root creator, so every fixture tree is tracked for teardown. */
+const trackTempRoot = trackTempRoots();
+function makeTempProject(prefix = 'fixture-runner-'): string {
+  return trackTempRoot(mkdtempSync(join(tmpdir(), prefix)));
 }
 
 function isolatedSourceRoots(cwd: string): WorkflowSourceRoots {
@@ -102,22 +103,18 @@ async function runFixtures(
   });
 }
 
-const cleanups: string[] = [];
-afterEach(() => {
-  for (const dir of cleanups.splice(0)) rmSync(dir, { recursive: true, force: true });
-});
-
 interface TempFixtureOptions {
   workflowName?: string;
   fixtureName?: string;
   body: string;
   /** Workflow yaml written next to fixtures/ — defaults to a one-node stub target. */
   workflowYaml?: string;
+  /** Existing directory to write into, for a tree whose lifetime is not one test. */
+  cwd?: string;
 }
 
 function writeTempProject(options: TempFixtureOptions): { cwd: string; fixturePath: string } {
-  const cwd = makeTempProject();
-  cleanups.push(cwd);
+  const cwd = options.cwd ?? makeTempProject();
   const packDir = join(cwd, '.archon', 'workflows', 'pack');
   const fixturesDir = join(packDir, 'fixtures');
   mkdirSync(fixturesDir, { recursive: true });
@@ -270,7 +267,6 @@ describe('runFixtures', () => {
 
   it('returns zero results and no failure when nothing is declared', async () => {
     const cwd = makeTempProject();
-    cleanups.push(cwd);
     const report = await runFixtures({ workflows: [], cwd });
     expect(report.results).toHaveLength(0);
     expect(report.passed).toBe(0);
@@ -339,7 +335,6 @@ describe('runFixtures', () => {
 
   it('says no workflow declares fixtures when discovery found no fixtures at all', async () => {
     const cwd = makeTempProject();
-    cleanups.push(cwd);
     const packDir = join(cwd, '.archon', 'workflows', 'pack');
     mkdirSync(packDir, { recursive: true });
     writeFileSync(
@@ -400,7 +395,6 @@ describe('runFixtures', () => {
   /** Pack layout like the bundled SDLC pack: `<pack>/<workflow-folder>/fixtures/`, plus a sibling pack whose name extends `sdlc` so the path-containment anchor cannot drift. */
   function writeNestedPackProject(): { cwd: string } {
     const cwd = makeTempProject();
-    cleanups.push(cwd);
     for (const folder of ['plan', 'ship']) {
       const workflowDir = join(cwd, '.archon', 'workflows', 'sdlc', folder);
       mkdirSync(join(workflowDir, 'fixtures'), { recursive: true });
@@ -480,7 +474,6 @@ describe('runFixtures', () => {
 
   it('selects by the union of workflow name and folder: a target that is both picks both', async () => {
     const cwd = makeTempProject();
-    cleanups.push(cwd);
     // Workflow `ship` inside folder `plan`: its fixture matches by name only.
     const planDir = join(cwd, '.archon', 'workflows', 'sdlc', 'plan');
     mkdirSync(join(planDir, 'fixtures'), { recursive: true });
@@ -520,7 +513,6 @@ describe('runFixtures', () => {
 
   it('rejects a target naming a workflow that is on disk but not in the catalog', async () => {
     const cwd = makeTempProject();
-    cleanups.push(cwd);
     // `broken-wf` parses far enough to declare a name but never reaches the catalog — the
     // shape of an unfinished or unloadable workflow file that still has fixtures beside it.
     const brokenDir = join(cwd, '.archon', 'workflows', 'broken');
@@ -563,9 +555,7 @@ describe('runFixtures', () => {
 
   it('lets a project fixture shadow the bundled fixture it overrides', async () => {
     const cwd = makeTempProject();
-    cleanups.push(cwd);
     const bundled = makeTempProject();
-    cleanups.push(bundled);
     // The same relative fixture in two scopes: a project that copied a bundled workflow
     // folder to customize it. Both declare the same workflow name, so both would be checked
     // against the same catalog entry and print the same label — indistinguishable in output.
@@ -612,7 +602,11 @@ describe('runFixtures exec-code isolation (#2851)', () => {
     'nodes:',
     '  - id: probe',
     '    bash: |',
-    '      [ -z "$(git status --porcelain)" ]',
+    // Captured and tested separately, not as `[ -z "$(git status --porcelain)" ]`: a git
+    // that FAILS also prints nothing, so the inline form reads its silence as a clean
+    // tree and the guard passes without having observed anything.
+    '      status="$(git status --porcelain)" || exit 1',
+    '      [ -z "$status" ]',
   ].join('\n');
 
   const WRITER_YAML = [
@@ -629,11 +623,13 @@ describe('runFixtures exec-code isolation (#2851)', () => {
     execFileAsync('git', args, { cwd });
 
   /**
-   * Turn a plain temp project into a git repo with one committed file besides the project's own.
+   * Turn a plain temp project into a git repo, committing everything already in it plus
+   * one file of its own.
    *
    * Three git processes, not five: the identity travels as `-c` overrides on the commit
-   * itself rather than as two separate `git config` writes. Every test in this block pays
-   * this cost, and process creation is the expensive part on Windows CI (#2882).
+   * itself rather than as two separate `git config` writes. Only the prepared repos below
+   * and the one test whose premise is what HEAD holds pay this; process creation is the
+   * expensive part on Windows CI (#2882).
    */
   async function initGitWithCommittedFile(cwd: string): Promise<void> {
     await git(cwd, 'init', '-q');
@@ -642,25 +638,58 @@ describe('runFixtures exec-code isolation (#2851)', () => {
     await git(cwd, '-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-qm', 'init');
   }
 
+  /**
+   * Caller checkouts prepared once for the block and copied per test (#2882).
+   *
+   * `git worktree add` has nothing to check out without a HEAD commit, so every exec-code
+   * test needs its caller to be a real repository. Built in place that is three git
+   * processes per test, and process creation is what this block costs on a contended
+   * Windows runner — the parity test below spent 5015ms of a 5000ms budget there. A plain
+   * repository's metadata holds no absolute paths, so copying a prepared one is an
+   * independent repository at file-copy price: ~0.8ms measured locally against ~50ms for
+   * the three processes.
+   *
+   * Two shapes, because what HEAD holds is part of some tests' premise. `trackedOnlyRepo`
+   * commits `tracked.txt` alone, for tests whose own project files may sit untracked
+   * beside it. `guardRepo` commits the guard workflow and its fixture as well, so a caller
+   * copied from it is genuinely clean — the state the parity test contrasts dirt against.
+   */
+  let trackedOnlyRepo: string;
+  let guardRepo: string;
+
+  beforeAll(async () => {
+    trackedOnlyRepo = mkdtempSync(join(tmpdir(), 'fixture-runner-repo-'));
+    await initGitWithCommittedFile(trackedOnlyRepo);
+    guardRepo = mkdtempSync(join(tmpdir(), 'fixture-runner-repo-'));
+    writeTempProject({ cwd: guardRepo, workflowYaml: GUARD_YAML, body: execFixtureBody });
+    await initGitWithCommittedFile(guardRepo);
+  });
+
+  // Outlives the per-test roots `trackTempRoots` tears down, so it needs its own hook.
+  afterAll(async () => {
+    for (const repo of [trackedOnlyRepo, guardRepo]) await removeTempTree(repo);
+  });
+
+  /** A caller checkout copied from a prepared repo — a HEAD commit with no git process. */
+  function callerFrom(template: string, cwd = makeTempProject()): string {
+    cpSync(template, cwd, { recursive: true });
+    return cwd;
+  }
+
   it('gives clean and pre-dirtied callers the same verdict (#2851)', async () => {
-    const clean = writeTempProject({ workflowYaml: GUARD_YAML, body: execFixtureBody });
-    await initGitWithCommittedFile(clean.cwd);
-    const cleanReport = await runFixtures({
-      workflows: [workflowsOnDisk(clean.cwd, ['test-wf'])[0]],
-      cwd: clean.cwd,
-    });
+    // One caller, invoked twice: the dirt is then the ONLY difference between the two
+    // verdicts. Two separately built repos would also differ in identity and history.
+    const cwd = callerFrom(guardRepo);
+    const workflows = [workflowsOnDisk(cwd, ['test-wf'])[0]];
+
+    const cleanReport = await runFixtures({ workflows, cwd });
     expect(cleanReport.failed).toBe(0);
 
-    const dirty = writeTempProject({ workflowYaml: GUARD_YAML, body: execFixtureBody });
-    await initGitWithCommittedFile(dirty.cwd);
     // Exactly the operator-tree state the issue reports: one modified tracked file,
     // one untracked stray.
-    writeFileSync(join(dirty.cwd, 'tracked.txt'), `${COMMITTED_YAML}edited\n`);
-    writeFileSync(join(dirty.cwd, 'scratch.txt'), 'untracked stray\n');
-    const dirtyReport = await runFixtures({
-      workflows: [workflowsOnDisk(dirty.cwd, ['test-wf'])[0]],
-      cwd: dirty.cwd,
-    });
+    writeFileSync(join(cwd, 'tracked.txt'), `${COMMITTED_YAML}edited\n`);
+    writeFileSync(join(cwd, 'scratch.txt'), 'untracked stray\n');
+    const dirtyReport = await runFixtures({ workflows, cwd });
     expect(dirtyReport.passed).toBe(1);
   });
 
@@ -670,7 +699,7 @@ describe('runFixtures exec-code isolation (#2851)', () => {
       workflowYaml: WRITER_YAML,
       body: execFixtureBody,
     });
-    await initGitWithCommittedFile(cwd);
+    callerFrom(trackedOnlyRepo, cwd);
     const report = await runFixtures({
       workflows: [workflowsOnDisk(cwd, ['writer-wf'])[0]],
       cwd,
@@ -709,7 +738,7 @@ describe('runFixtures exec-code isolation (#2851)', () => {
       cwd,
       `import { writeFileSync } from 'node:fs';\nwriteFileSync(${JSON.stringify(probe)}, import.meta.path);\n`
     );
-    await initGitWithCommittedFile(cwd);
+    callerFrom(trackedOnlyRepo, cwd);
 
     const report = await runFixtures({
       workflows: [workflowsOnDisk(cwd, ['script-wf'])[0]],
@@ -743,7 +772,7 @@ describe('runFixtures exec-code isolation (#2851)', () => {
       cwd,
       `import { appendFileSync } from 'node:fs';\nappendFileSync(${JSON.stringify(probe)}, import.meta.path + '\\n');\n`
     );
-    await initGitWithCommittedFile(cwd);
+    callerFrom(trackedOnlyRepo, cwd);
 
     const report = await runFixtures({
       workflows: [workflowsOnDisk(cwd, ['script-wf'])[0]],
@@ -769,7 +798,9 @@ describe('runFixtures exec-code isolation (#2851)', () => {
       workflowYaml: SCRIPT_YAML,
       body: execFixtureBody,
     });
-    // Committed — and therefore the only version a scratch worktree of HEAD holds.
+    // Committed — and therefore the only version a scratch worktree of HEAD holds. This
+    // test builds its repo in place rather than copying a prepared one precisely because
+    // what HEAD holds is its premise.
     writeScript(cwd, 'process.exit(1);\n');
     await initGitWithCommittedFile(cwd);
     // Uncommitted: the edit an author is iterating on when they run `workflow test`.
@@ -824,10 +855,8 @@ describe('runFixtures exec-code isolation (#2851)', () => {
   });
 
   it('disposes both the scratch worktree and the source capture (#2851)', async () => {
-    const { cwd } = writeTempProject({ workflowYaml: GUARD_YAML, body: execFixtureBody });
-    await initGitWithCommittedFile(cwd);
-    const home = mkdtempSync(join(tmpdir(), 'fixture-runner-home-'));
-    cleanups.push(home);
+    const cwd = callerFrom(guardRepo);
+    const home = makeTempProject('fixture-runner-home-');
     const previousHome = process.env.ARCHON_HOME;
     process.env.ARCHON_HOME = home;
     try {

--- a/scripts/check-test-cleanup-drift.ts
+++ b/scripts/check-test-cleanup-drift.ts
@@ -379,7 +379,6 @@ export const LEGACY_RECURSIVE_CLEANUP: ReadonlyMap<string, number> = buildLedger
   ['packages/workflows/src/dry-run.test.ts', 1],
   ['packages/workflows/src/executor-preamble.test.ts', 1],
   ['packages/workflows/src/executor.test.ts', 3],
-  ['packages/workflows/src/fixture-runner.test.ts', 2],
   ['packages/workflows/src/load-command-prompt.test.ts', 3],
   ['packages/workflows/src/loader.test.ts', 7],
   ['packages/workflows/src/logger.test.ts', 1],


### PR DESCRIPTION
## Problem and outcome

`@archon/workflows` runs at the Windows 5000ms per-test budget, and a different test dies each run (#2882). On dev merge `fb33fe32` it was `runFixtures exec-code isolation (#2851) > gives clean and pre-dirtied callers the same verdict`, at 5015ms. That test spent most of its budget building git repositories, not exercising the isolation it is named after: each of its two halves ran `git init`, `git add`, and `git commit` before the behavior under test started. Sixteen spawned processes in one test body, six of them pure setup.

- **Outcome:** the parity test spawns 10 processes instead of 16 and runs in ~103ms instead of ~187ms locally; the whole exec-code block spawns 42 instead of 54 and runs in ~500ms instead of ~770ms.
- **Invariant:** a test spawns a subprocess only when the subprocess is the behavior under test, and at most the minimum number that proves it (#2882's stated invariant). Every remaining spawn in the parity test is the isolation mechanism itself — `git worktree add`, the executed node, its observation of the workspace, `git worktree remove`.
- **Scope boundary:** no budget was raised, no test was skipped on Windows, no coverage was deleted, and `fixture-runner.ts` is unchanged. The C5 `migrate-state-dir` lane on #2882 is untouched.
- **Root cause:** repository construction, not the isolation mechanism, was the cost. Measured locally, `git init` + `add` + `commit` is ~50ms of a ~90ms half; copying a prepared repository instead is ~0.8ms. Process creation is what multiplies on a contended Windows runner.

## Review guidance

- **Feedback requested:** whether the coverage is genuinely unchanged — specifically whether a caller copied from a prepared repository still represents the scenarios these tests claim.
- **Start here:** `packages/workflows/src/fixture-runner.test.ts:641` (the block comment) and `:660` — the two prepared caller repositories and the `callerFrom` copy that replaces three git processes per test.
- **Review order:** the `beforeAll`/`callerFrom` block, then the parity test just below it, then the four sibling tests that switch to `callerFrom`, then the `GUARD_YAML` change, then the cleanup migration.
- **Lower-attention areas:** the `cleanups.push` removals throughout the file are mechanical — `makeTempProject` now registers every root with `trackTempRoots` at creation.
- **Known risk or uncertainty:** the fix cannot be proven on Windows from a macOS worktree. It is argued by cost class: the removed work is process creation and the remaining work is not, and the numbers below are before/after on the same machine, interleaved to cancel drift.

## Solution

Two caller repositories are prepared once per block and copied per test. `git worktree add` has nothing to check out without a HEAD commit, so every exec-code test needs its caller to be a real repository — but a plain repository's metadata holds no absolute paths, so a directory copy of one is an independent repository. `trackedOnlyRepo` commits just `tracked.txt`, for tests whose own project files may sit untracked beside it; `guardRepo` commits the guard workflow and its fixture too, so a caller copied from it is genuinely clean, which is the state the parity test contrasts dirt against.

The parity test then invokes one caller twice — clean, then dirtied — rather than building two repositories. That is both cheaper and a tighter claim: the dirt becomes the only difference between the two verdicts, where two separately built repositories also differed in identity and history.

One test keeps building its repository in place. `captures the working tree, so an uncommitted script edit is what runs` needs the superseded script version committed, because what HEAD holds is its premise.

Separately, the guard workflow now captures `git status --porcelain` output and tests it, instead of testing `$(git status --porcelain)` inline. A git that *fails* also prints nothing, so the inline form read that silence as a clean tree. Verified: with the workspace replaced by an empty non-repository directory, the old guard passed both halves; the new one fails.

Temp cleanup moves to `trackTempRoots`/`removeTempTree`, which retry while Windows still holds a handle inside the tree. The file leaves `LEGACY_RECURSIVE_CLEANUP`.

## Validation

- `bun test src/fixture-runner.test.ts` — 32 pass, 0 fail — the restructured file is green.
- `bun run test` in `packages/workflows` — 2526 pass, 0 fail.
- `bun run lint` — green, including the test-cleanup drift check with the ledger entry removed.
- `bun run validate` — exit 0.
- **Mutation, isolation removed** (`withExecWorkspace` returns `fn(cwd)`, executing in the caller's own checkout): the parity test fails, as does `keeps executed writes out of the caller checkout`. The parity coverage still bites.
- **Mutation, capture removed** (fixtures resolve `liveSourceRoots(cwd)` instead of the frozen capture): `executes the captured copy of a named script`, `shares one capture across every fixture`, and `captures the command folder` all fail. The four tests that moved to `trackedOnlyRepo` did not lose their teeth by having their project files untracked.
- **Mutation, scripts resolved from the HEAD worktree**: `captures the working tree, so an uncommitted script edit is what runs` fails — the reason that one test keeps a real commit.
- **Mutation, workspace is an empty non-repository**: the new guard fails; the previous inline guard passed. This is why the guard changed.
- **Measurements**, interleaved AFTER/BEFORE blocks of three, nine runs each, same machine:

  | | Before | After |
  |---|---|---|
  | parity test, spawned processes | 16 | 10 (+6 in `beforeAll`, amortized across the block and outside every test's budget) |
  | parity test, wall time | ~187ms | ~103ms |
  | exec-code block, spawned processes | 54 | 42 |
  | exec-code block, wall time | ~770ms | ~500ms |

  Process counts come from `git`/`bash` shims on `PATH` and `ARCHON_BASH_PATH` that log every invocation. Bun charges `beforeAll` to no test: a 400ms `beforeAll` leaves the first test at 0.2ms in the junit reporter.
- **Not verified:** that Windows CI is now consistently green. One run cannot establish that, which is why this does not close #2882.

## Links

- Related #2882
- Related #2851


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test isolation and temporary-file cleanup for more reliable test execution.
  * Streamlined repository-based test setup to reduce unnecessary setup work.
  * Added clearer handling for Git command failures during test checks.
* **Chores**
  * Updated cleanup validation to reflect the current test setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->