### PR TITLE
test(cli): stop re-asserting a probe that can misread a live endpoint

### DIFF
--- a/packages/cli/src/commands/workflow-terminal-event.integration.spec.ts
+++ b/packages/cli/src/commands/workflow-terminal-event.integration.spec.ts
@@ -1,11 +1,14 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
-import { createConnection } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { removeTempTree } from '@archon/paths/test-utils';
-import { detachedRunControlPath, requestDetachedRunStop } from '../utils/detached-run-control';
+import {
+  canConnect,
+  detachedRunControlPath,
+  requestDetachedRunStop,
+} from '../utils/detached-run-control';
 
 const cleanupPaths: string[] = [];
 const activeRunIds = new Set<string>();
@@ -46,25 +49,6 @@ async function waitFor<T>(
   }
   const detail = lastError instanceof Error ? `: ${lastError.message}` : '';
   throw new Error(`Timed out waiting for detached workflow${detail}`);
-}
-
-async function endpointIsReachable(runId: string): Promise<boolean> {
-  return await new Promise(resolveReachability => {
-    const socket = createConnection(detachedRunControlPath(runId));
-    const settle = (reachable: boolean): void => {
-      socket.destroy();
-      resolveReachability(reachable);
-    };
-    socket.setTimeout(250, () => {
-      settle(false);
-    });
-    socket.once('connect', () => {
-      settle(true);
-    });
-    socket.once('error', () => {
-      settle(false);
-    });
-  });
 }
 
 function readRun(
@@ -162,8 +146,14 @@ describe('detached workflow terminal database events', () => {
 
       const created = await waitFor(() => readRun(databasePath, fixture.workflow));
       activeRunIds.add(created.id);
-      await waitFor(async () => ((await endpointIsReachable(created.id)) ? undefined : true));
-      expect(await endpointIsReachable(created.id)).toBe(false);
+      // `canConnect` is the owner's own probe. The copy that used to live here timed the
+      // connect out after 250ms and reported a live endpoint as gone whenever CI starved
+      // the loop past that. Returning from this wait is the assertion that the owner
+      // released its endpoint; re-asserting the same reading on the next line could only
+      // turn one such misread into a failure, which is how it failed on Windows.
+      await waitFor(async () =>
+        (await canConnect(detachedRunControlPath(created.id))) ? undefined : true
+      );
       activeRunIds.delete(created.id);
 
       const terminal = await waitFor(() => {


### PR DESCRIPTION
## Problem and outcome

`detached workflow terminal database events > persists one matching event before successful and failed owners exit` fails intermittently on the Windows CI leg, on branches that never touch the detached path. It is the regression coverage for #2830, so every unrelated PR pays for it.

- **Outcome:** the spec no longer contains an assertion that can fail on a correct system. It asks the owner's own probe whether the control endpoint is still there, once, inside the retry.
- **Invariant:** the spec still fails if a detached owner exits without persisting its terminal event, and still requires exactly one matching event row.
- **Scope boundary:** no product code changed, no timeout or budget raised, no Windows skip, no coverage removed. The detached launch is the subject under test and is still launched twice, once per terminal outcome.
- **Root cause:** the spec waited for the endpoint to become unreachable and then asserted the same reading again on the next line. Its probe was a hand-rolled copy of `canConnect` with the connect timeout cut from 2000 ms to 250 ms. libuv runs the timers phase before the poll phase, so on a starved runner the expired 250 ms timeout settles `false` even though the connect had already completed. The wait accepted that misread and returned; the duplicate assertion then re-probed, connected, and failed with `Expected: false, Received: true`.

The endpoint cannot actually come back: `startDetachedRunControlServer` calls `listen` exactly once and `close()` is memoised with no restart path. A `live → gone → live` transition is impossible, so the `false` the wait accepted was always a false negative rather than a state change.

Sampled from Windows CI logs, this signature appeared twice:

| Run | Duration | Error |
|---|---|---|
| [33114089904](https://github.com/coleam00/Archon/actions/runs/33114089904) | 9672 ms | `spec.ts:165` `Expected: false / Received: true` |
| [33120507898](https://github.com/coleam00/Archon/actions/runs/33120507898) | 15797 ms | `spec.ts:165` `Expected: false / Received: true` |

Both sit inside the normal 6.6–16.4 s pass band measured across 27 sampled Windows runs, so this was never a timeout — the test failed at full speed. The failures cluster at the slow end of that band, which is what a latency-threshold false negative predicts.

The four other failures sampled in the same window were a different signature (`SQLiteError: disk I/O error` out of `readTerminalEvents`), already fixed on `dev` by e250a58b.

## Review guidance

- **Feedback requested:** correctness of the claim that dropping the re-assertion loses no regression value.
- **Start here:** `packages/cli/src/commands/workflow-terminal-event.integration.spec.ts:149` — the wait, and the comment explaining why nothing asserts after it.
- **Review order:** the single file; the deleted local `endpointIsReachable` helper is the other half of the change.
- **Lower-attention areas:** none, this is a ten-line net deletion in one spec.
- **Known risk or uncertainty:** a false negative can still end the wait early, which would mean the owner had not quite exited yet. That cannot make the test pass wrongly — the terminal-status and event-row waits that follow still have to succeed — it only means the "endpoint released" step is tolerant rather than exact. Making it exact would need consecutive-reading machinery that buys nothing the later waits do not already prove.

## Solution

`canConnect` is exported from `detached-run-control.ts` specifically so specs do not carry their own copy; its doc comment says "a second copy of this probe would be free to drift from this one." The sibling spec `detached-run-control.integration.spec.ts` already imports it. This one had drifted, with an 8× tighter connect timeout.

The wait now calls `canConnect`, and the assertion after it is gone. Returning from the wait is already the proof that the endpoint was released — the wait throws `Timed out waiting for detached workflow` if it never happens. Re-asserting the same volatile reading outside the retry could only ever restate what the wait established, or fail. It did the latter.

Widening 250 ms to 2000 ms alone would not have been a fix, only a longer odds. Removing the duplicate assertion is what makes a single transient misread a non-event.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Waits for the endpoint to go, then asserts it is gone a second time | Waits for the endpoint to go |
| **Failure behavior** | One slow connect on a loaded runner fails the test at full speed | A slow connect costs one more 25 ms poll |

## Validation

- `bun test src/commands/workflow-terminal-event.integration.spec.ts` (packages/cli) — 5/5 consecutive passes, 2.77–3.02 s, 8 expect() calls (was 10 at ~3.0 s). Behaviour and cost unchanged; two assertions removed.
- Root cause reproduced deterministically against a real `startDetachedRunControlServer` endpoint: issue the 250 ms probe, stall the loop 300 ms, and it returns `false` while `canConnect` on the same path returns `true`. Staging the spec's exact pair then prints `WAIT ITERATION OBSERVED reachable=false -> waitFor returns` followed by `RE-PROBE AFTER "UNREACHABLE" WAIT: true`, which is the CI error. The reproduction was a throwaway probe and is not committed.
- Regression value re-checked by mutation: with the `workflow_completed` insert removed from `completeWorkflowRun`, the spec fails at the event wait (`Timed out waiting for detached workflow`, 16.5 s). Mutation reverted.
- `bun run test` (packages/cli) — exit 0, all 12 segments report 0 fail.
- `bun run lint` — exit 0, including the test-cleanup drift check.
- `bun run type-check` (packages/cli) — exit 0. `.spec.ts` files are type-checked in this package.
- **Not verified:** the fix is not proven on a Windows runner; only this PR's own CI leg can do that. The failure being an assertion rather than a timeout, and the assertion being gone, makes that signature unreachable by construction.

## Phase attribution

Recorded while diagnosing, since the brief asked where the ~8 s goes. It is not accidental test cost and nothing here was changed:

| Phase | macOS, per case |
|---|---|
| Launcher spawn → exit | 1567 ms / 1452 ms |
| Everything the test does after (run row, endpoint, terminal status, event rows) | ~5 ms total across both cases |

Each launcher is a CLI cold boot (`bun src/cli.ts --version` measures 0.77–1.08 s) plus the production `DETACHED_STARTUP_WINDOW_MS = 500` acknowledgement wait. The file starts four processes: two launchers, each forking one detached owner. Both terminal outcomes are load-bearing and the detached launch is the subject under test, so there is nothing to amortise. Windows CI scales the same shape to 6.6–16.4 s.

## Links

- Related #2830


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved workflow terminal event integration coverage by using the standard connection-checking utility.
  * Removed redundant endpoint probing and simplified validation of detached run control behavior.
  * Tests now more consistently verify that control is released before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->