### PR TITLE
Clarify invalid Pi model references

### DIFF
--- a/packages/providers/src/community/pi/config.test.ts
+++ b/packages/providers/src/community/pi/config.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import { parsePiConfig, resolvePiExtensionSettings } from './config';
+import { parsePiConfig, parsePiRunConfig, resolvePiExtensionSettings } from './config';
 
 describe('parsePiConfig', () => {
   test('parses valid model string', () => {
@@ -238,6 +238,14 @@ describe('parsePiConfig', () => {
     expect(parsePiConfig({ nodes: 'implement' })).toEqual({});
     expect(parsePiConfig({ nodes: ['implement'] })).toEqual({});
     expect(parsePiConfig({ nodes: null })).toEqual({});
+  });
+});
+
+describe('parsePiRunConfig', () => {
+  test('explains that invalid models need a Pi vendor prefix', () => {
+    expect(() => parsePiRunConfig({ model: 'minimax-m3' })).toThrow(
+      "expected a Pi vendor/model reference such as 'minimax/minimax-m3'"
+    );
   });
 });
 

--- a/packages/providers/src/community/pi/config.ts
+++ b/packages/providers/src/community/pi/config.ts
@@ -200,7 +200,7 @@ export function parsePiRunConfig(raw: Record<string, unknown>): ParsedPiConfig {
   if (model !== undefined) {
     const parsedModel = parsePiModelRef(model);
     if (parsedModel === undefined) {
-      invalidRunConfigValue('model', "'<provider>/<model>'");
+      invalidRunConfigValue('model', "a Pi vendor/model reference such as 'minimax/minimax-m3'");
     }
     model = `${parsedModel.provider}/${parsedModel.modelId}`;
   }

--- a/packages/workflows/src/model-validation.test.ts
+++ b/packages/workflows/src/model-validation.test.ts
@@ -354,7 +354,7 @@ describe('per-run model bindings', () => {
     });
   });
 
-  test('registered agent refs switch provider and Pi refs validate their nested model', () => {
+  test('registered agent refs switch provider and Pi refs require their vendor prefix', () => {
     expect(
       resolveRunModelOverrides(base, { tiers: { large: 'codex/gpt-5.6-sol' } }).tiers?.large
     ).toEqual({ provider: 'codex', model: 'gpt-5.6-sol' });
@@ -362,7 +362,7 @@ describe('per-run model bindings', () => {
       resolveRunModelOverrides(base, { tiers: { large: 'pi/openrouter/qwen/qwen3' } }).tiers?.large
     ).toEqual({ provider: 'pi', model: 'openrouter/qwen/qwen3' });
     expect(() => resolveRunModelOverrides(base, { tiers: { large: 'pi/not-a-model' } })).toThrow(
-      /expected '<provider>\/<model>'/
+      "Pi overrides need a vendor prefix, e.g. 'pi/minimax/minimax-m3'"
     );
   });
 

--- a/packages/workflows/src/model-validation.ts
+++ b/packages/workflows/src/model-validation.ts
@@ -356,6 +356,12 @@ function resolveRunOverrideSpec(
     if (remainder.length === 0) {
       throw new Error(`Model override '${targetName}' has an empty model id.`);
     }
+    if (prefix === 'pi' && !parsePiModelRef(remainder)) {
+      throw new Error(
+        `Model override '${targetName}' has invalid Pi model '${remainder}'. ` +
+          "Pi overrides need a vendor prefix, e.g. 'pi/minimax/minimax-m3'."
+      );
+    }
     return normalizeRunOverridePreset(targetName, { provider: prefix, model: remainder });
   }
 


### PR DESCRIPTION
## Problem and outcome

Pi validation rejected model references without a vendor prefix, but the error repeated a format that the rejected input already appeared to satisfy. That left users without a useful correction.

- **Outcome:** Invalid Pi model references now name the missing vendor segment and show a valid example for each input boundary.
- **Invariant:** An error message never describes the input it rejects as its own remedy.
- **Scope boundary:** Validation semantics and non-Pi provider diagnostics are unchanged.
- **Root cause:** Both Pi validation boundaries surfaced a generic two-segment format message even though Pi model references require a vendor/model value after the `pi/` provider prefix.

## Review guidance

- **Feedback requested:** Correctness and clarity of the two Pi validation diagnostics.
- **Start here:** `packages/workflows/src/model-validation.ts:359` — explicit run-level Pi overrides now fail before provider normalization with a Pi-specific remedy.
- **Review order:** Review the explicit override validation and regression test, then the Pi-local run config validation and regression test.
- **Lower-attention areas:** Test-description wording changes only; the focused tests and full validation suite passed.
- **Known risk or uncertainty:** None.

## Solution

The explicit override path recognizes invalid Pi model references and explains that the required form includes a Pi vendor prefix, using `pi/minimax/minimax-m3`. Pi-local run config now gives the corresponding local `minimax/minimax-m3` example. Existing parsing remains the source of truth, so valid references and every non-Pi diagnostic retain their behavior.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Invalid Pi references received a generic format error. | Invalid Pi references identify the missing vendor segment and provide a valid example. |
| **Failure behavior** | The suggested format could describe the rejected input. | The suggested format distinguishes the required Pi vendor/model structure. |

## Validation

- `bun test src/model-validation.test.ts` (from `packages/workflows`) — passed, 72 tests — proves explicit Pi overrides report the actionable vendor-prefix diagnostic.
- `bun test src/community/pi/config.test.ts` (from `packages/providers`) — passed, 46 tests — proves Pi-local config reports its matching vendor/model diagnostic.
- `bun run validate` — passed — proves generated artifacts, types, lint, formatting, installer tests, and the full test suite remain valid.
- **Not verified:** Nothing material; both changed validation boundaries have focused coverage and the full repository validation passed.

## Links

- Closes #2819

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for Pi model overrides.
  * Invalid Pi model references now show a clearer error with the required vendor/model format.
  * Prevented malformed Pi overrides from being accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->