### PR TITLE
Prevent removal of live worktrees

### DIFF
--- a/packages/core/src/handlers/command-handler.test.ts
+++ b/packages/core/src/handlers/command-handler.test.ts
@@ -1356,6 +1356,36 @@ describe('CommandHandler', () => {
           });
           mockGetLiveRunOwningEnv.mockResolvedValue({ id: 'run-live-1234', status: 'paused' });
 
+          const result = await handleCommand(convWithWorktree, '/worktree remove');
+
+          expect(result.success).toBe(false);
+          expect(result.message).toContain('run-live');
+          expect(result.message).toContain('paused');
+          expect(mockGetLiveRunOwningEnv).toHaveBeenCalledWith('env-uuid-feat-x');
+          expect(mockIsolationDestroy).not.toHaveBeenCalled();
+          expect(mockIsolationEnvDbUpdate).not.toHaveBeenCalled();
+          expect(mockUpdateConversation).not.toHaveBeenCalled();
+        });
+
+        test('refuses forced removal of a worktree owned by a live workflow run', async () => {
+          const convWithWorktree: Conversation = {
+            ...conversationWithCodebase,
+            isolation_env_id: 'env-uuid-feat-x',
+          };
+          mockIsolationEnvDbGet.mockResolvedValue({
+            id: 'env-uuid-feat-x',
+            codebase_id: 'codebase-123',
+            workflow_type: 'task',
+            workflow_id: 'task-feat-x',
+            provider: 'worktree',
+            working_path: '/workspace/my-repo/worktrees/feat-x',
+            branch_name: 'feat-x',
+            status: 'active',
+            created_at: new Date(),
+            created_by_platform: 'test',
+          });
+          mockGetLiveRunOwningEnv.mockResolvedValue({ id: 'run-live-1234', status: 'paused' });
+
           const result = await handleCommand(convWithWorktree, '/worktree remove --force');
 
           expect(result.success).toBe(false);

--- a/packages/core/src/handlers/command-handler.test.ts
+++ b/packages/core/src/handlers/command-handler.test.ts
@@ -145,12 +145,14 @@ const mockIsolationEnvDbCreate = mock(() =>
 );
 const mockIsolationEnvDbGet = mock(() => Promise.resolve(null));
 const mockIsolationEnvDbUpdate = mock(() => Promise.resolve());
+const mockGetLiveRunOwningEnv = mock(() => Promise.resolve(null));
 
 const mockCountActiveByCodebase = mock(() => Promise.resolve(0));
 mock.module('../db/isolation-environments', () => ({
   create: mockIsolationEnvDbCreate,
   getById: mockIsolationEnvDbGet,
   getByWorkingPath: mock(() => Promise.resolve(null)),
+  getLiveRunOwningEnv: mockGetLiveRunOwningEnv,
   updateStatus: mockIsolationEnvDbUpdate,
   markDestroyed: mock(() => Promise.resolve()),
   getActiveByCodebase: mock(() => Promise.resolve([])),
@@ -278,6 +280,7 @@ function clearAllMocks(): void {
   mockIsolationEnvDbCreate.mockClear();
   mockIsolationEnvDbGet.mockClear();
   mockIsolationEnvDbUpdate.mockClear();
+  mockGetLiveRunOwningEnv.mockClear();
   // Cleanup service mocks
   mockCleanupMergedWorktrees.mockClear();
   mockCleanupStaleWorktrees.mockClear();
@@ -1332,6 +1335,36 @@ describe('CommandHandler', () => {
 
           expect(result.success).toBe(true);
           expect(mockDeactivateSession).toHaveBeenCalledWith('session-789', 'worktree-removed');
+        });
+
+        test('refuses to remove a worktree owned by a live workflow run', async () => {
+          const convWithWorktree: Conversation = {
+            ...conversationWithCodebase,
+            isolation_env_id: 'env-uuid-feat-x',
+          };
+          mockIsolationEnvDbGet.mockResolvedValue({
+            id: 'env-uuid-feat-x',
+            codebase_id: 'codebase-123',
+            workflow_type: 'task',
+            workflow_id: 'task-feat-x',
+            provider: 'worktree',
+            working_path: '/workspace/my-repo/worktrees/feat-x',
+            branch_name: 'feat-x',
+            status: 'active',
+            created_at: new Date(),
+            created_by_platform: 'test',
+          });
+          mockGetLiveRunOwningEnv.mockResolvedValue({ id: 'run-live-1234', status: 'paused' });
+
+          const result = await handleCommand(convWithWorktree, '/worktree remove --force');
+
+          expect(result.success).toBe(false);
+          expect(result.message).toContain('run-live');
+          expect(result.message).toContain('paused');
+          expect(mockGetLiveRunOwningEnv).toHaveBeenCalledWith('env-uuid-feat-x');
+          expect(mockIsolationDestroy).not.toHaveBeenCalled();
+          expect(mockIsolationEnvDbUpdate).not.toHaveBeenCalled();
+          expect(mockUpdateConversation).not.toHaveBeenCalled();
         });
       });
 

--- a/packages/core/src/handlers/command-handler.ts
+++ b/packages/core/src/handlers/command-handler.ts
@@ -592,6 +592,16 @@ async function handleWorktreeCommand(
       const forceFlag = args[1] === '--force';
 
       try {
+        const liveRun = await isolationEnvDb.getLiveRunOwningEnv(isolationEnvId);
+        if (liveRun) {
+          return {
+            success: false,
+            message:
+              `Worktree is still owned by workflow run ${liveRun.id.slice(0, 8)} ` +
+              `(${liveRun.status}). Resume or abandon it before removing the worktree.`,
+          };
+        }
+
         // Use isolation provider for removal (pass the working path, not UUID)
         const provider = getIsolationProvider();
         await provider.destroy(isolationEnv.working_path, { force: forceFlag });


### PR DESCRIPTION
## Problem and outcome

`/worktree remove` could destroy a worktree still owned by a resumable workflow run, unlike isolation cleanup. That leaves a live run without the worktree it needs to resume or be abandoned.

- **Outcome:** `/worktree remove`, including `--force`, refuses to remove a worktree owned by a live workflow run.
- **Invariant:** A live workflow run keeps its isolation environment, worktree, and branch available until the run is resumed or abandoned.
- **Scope boundary:** This changes only the chat command's removal path; workflow lifecycle ownership and isolation cleanup behavior are unchanged.
- **Root cause:** The command-handler removal path did not perform the live-run ownership check already used by isolation cleanup.

## Review guidance

- **Feedback requested:** Confirm the command now applies the same live-run protection as isolation cleanup.
- **Start here:** `packages/core/src/handlers/command-handler.ts:595` — checks for a live owner before calling the isolation provider's destructive operation.
- **Review order:** Read the guard, then its regression test in `packages/core/src/handlers/command-handler.test.ts`.
- **Lower-attention areas:** The remaining test changes wire the existing database mock into the command-handler test fixture.
- **Known risk or uncertainty:** None.

## Solution

The command handler now reuses `getLiveRunOwningEnv` before it asks the isolation provider to destroy the worktree. When a resumable run owns the environment, it returns an actionable error identifying the run and status. The check happens before provider destruction, isolation status updates, or conversation rebinding.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | `/worktree remove --force` could remove a worktree owned by a paused workflow run. | It refuses removal and tells the operator to resume or abandon the owning run. |
| **Failure behavior** | A live run could lose its required worktree and branch. | The worktree, isolation environment, and conversation binding remain unchanged. |

## Validation

- `bun test src/handlers/command-handler.test.ts` (from `packages/core`) — passed, 145 tests — proves a paused owner blocks destruction, DB status changes, and conversation rebinding.
- `bun run validate` — passed — covers generated-artifact checks, type checks, lint, format check, install test, and the full test suite.
- **Not verified:** Nothing material; the focused regression test exercises the changed command path and full validation passed.

## Links

- Closes #2893


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented `/worktree remove` from deleting a worktree currently owned by an active workflow run.
  * Added a clear message identifying the workflow and instructing users to resume or abandon it before removal.
  * Applies to both standard and `--force` removal requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->