### PR TITLE
fix(cli): report workflow load errors in workflow test

### DIFF
--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -9226,6 +9226,60 @@ describe('workflowTestCommand', () => {
     });
   });
 
+  it('reports load failures when fixture target selection fails', async () => {
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    const fixtureRunner = await import('@archon/workflows/fixture-runner');
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [],
+      errors: [
+        {
+          filename: 'broken.yaml',
+          error: 'YAML parse error: unexpected end of document',
+          errorType: 'parse_error',
+        },
+      ],
+    });
+    (fixtureRunner.runFixtures as ReturnType<typeof mock>).mockRejectedValueOnce(
+      new Error("No fixtures found for 'missing'.")
+    );
+
+    const exit = await workflowTestCommand('/test/path', 'missing');
+
+    expect(exit).toBe(1);
+    expect(firstJsonPayload(stdoutSpy)).toContain("Error: No fixtures found for 'missing'.");
+    expect(firstJsonPayload(stdoutSpy)).toContain('1 workflow(s) failed to load:');
+    expect(firstJsonPayload(stdoutSpy)).toContain(
+      '  broken.yaml: YAML parse error: unexpected end of document'
+    );
+  });
+
+  it('includes load failures when fixture target selection fails in JSON', async () => {
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    const fixtureRunner = await import('@archon/workflows/fixture-runner');
+    const error = {
+      filename: 'broken.yaml',
+      error: 'YAML parse error: unexpected end of document',
+      errorType: 'parse_error' as const,
+    };
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [],
+      errors: [error],
+    });
+    (fixtureRunner.runFixtures as ReturnType<typeof mock>).mockRejectedValueOnce(
+      new Error("No fixtures found for 'missing'.")
+    );
+
+    const exit = await workflowTestCommand('/test/path', 'missing', { json: true });
+
+    expect(exit).toBe(1);
+    expect(stdoutSpy).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(firstJsonPayload(stdoutSpy))).toEqual({
+      ok: false,
+      error: "No fixtures found for 'missing'.",
+      errors: [error],
+    });
+  });
+
   it("freezes the repo's own command policy, not the default folders (#2851)", async () => {
     // The capture decides which directories a fixture can resolve a command from, so a
     // repo that moved `commands.folder` must have THAT folder frozen. Reading the value

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -9163,6 +9163,69 @@ describe('workflowTestCommand', () => {
     expect(fixtureRunner.formatFixtureReport).toHaveBeenCalled();
   });
 
+  it('reports load failures alongside passing fixture results and exits 1', async () => {
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    const fixtureRunner = await import('@archon/workflows/fixture-runner');
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'plan' }, 'project')],
+      errors: [
+        {
+          filename: 'broken.yaml',
+          error: 'YAML parse error: unexpected end of document',
+          errorType: 'parse_error',
+        },
+      ],
+    });
+    (fixtureRunner.runFixtures as ReturnType<typeof mock>).mockResolvedValue({
+      results: [],
+      passed: 1,
+      failed: 0,
+    });
+
+    const exit = await workflowTestCommand('/test/path', undefined);
+
+    expect(exit).toBe(1);
+    expect(fixtureRunner.runFixtures).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workflows: [makeTestWorkflowWithSource({ name: 'plan' }, 'project')],
+      })
+    );
+    expect(firstJsonPayload(stdoutSpy)).toContain('1 workflow(s) failed to load:');
+    expect(firstJsonPayload(stdoutSpy)).toContain(
+      '  broken.yaml: YAML parse error: unexpected end of document'
+    );
+  });
+
+  it('includes load failures in JSON fixture reports and exits 1', async () => {
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    const fixtureRunner = await import('@archon/workflows/fixture-runner');
+    const error = {
+      filename: 'broken.yaml',
+      error: 'YAML parse error: unexpected end of document',
+      errorType: 'parse_error' as const,
+    };
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'plan' }, 'project')],
+      errors: [error],
+    });
+    (fixtureRunner.runFixtures as ReturnType<typeof mock>).mockResolvedValue({
+      results: [],
+      passed: 1,
+      failed: 0,
+    });
+
+    const exit = await workflowTestCommand('/test/path', undefined, { json: true });
+
+    expect(exit).toBe(1);
+    expect(stdoutSpy).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(firstJsonPayload(stdoutSpy))).toEqual({
+      results: [],
+      passed: 1,
+      failed: 0,
+      errors: [error],
+    });
+  });
+
   it("freezes the repo's own command policy, not the default folders (#2851)", async () => {
     // The capture decides which directories a fixture can resolve a command from, so a
     // repo that moved `commands.folder` must have THAT folder frozen. Reading the value

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -1020,7 +1020,7 @@ export async function workflowTestCommand(
   target: string | undefined,
   options: { json?: boolean } = {}
 ): Promise<number> {
-  const { workflows } = await loadWorkflows(cwd);
+  const { workflows, errors } = await loadWorkflows(cwd);
   // The fixture runner freezes this repo's source before executing anything, exactly as
   // `workflow run` does, and this config decides which directories get frozen. A malformed
   // one would silently narrow that set, so it fails here instead; `loadConfig` returns
@@ -1046,12 +1046,30 @@ export async function workflowTestCommand(
       })),
       passed: report.passed,
       failed: report.failed,
+      errors: errors.map(e => ({
+        filename: e.filename,
+        error: e.error,
+        errorType: e.errorType,
+      })),
     });
   } else {
-    await writeStdout(`${formatFixtureReport(report)}\n`);
+    let output = `${formatFixtureReport(report)}\n`;
+    if (errors.length > 0) {
+      output += `\n${errors.length} workflow(s) failed to load:\n\n`;
+      for (const error of errors) {
+        output += `  ${error.filename}: ${error.error}\n`;
+      }
+    }
+    await writeStdout(output);
   }
 
-  if (report.failed > 0 || (target !== undefined && report.results.length === 0)) return 1;
+  if (
+    errors.length > 0 ||
+    report.failed > 0 ||
+    (target !== undefined && report.results.length === 0)
+  ) {
+    return 1;
+  }
   return 0;
 }
 

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -1013,7 +1013,7 @@ interface WorkflowJsonEntry {
  * Read-only by construction — the only execution path is `dryRunWorkflow`, so no
  * run state is created and no provider is contacted. Returns the process exit code:
  * 0 when everything passes (including the nothing-declared case), 1 when any fixture
- * fails or an explicitly named target has none.
+ * fails, a workflow cannot load, or an explicitly named target has none.
  */
 export async function workflowTestCommand(
   cwd: string,
@@ -1030,12 +1030,39 @@ export async function workflowTestCommand(
       `Cannot read the workflow source configuration in ${cwd}: ${(error as Error).message}`
     );
   });
-  const report = await runFixtures({
-    workflows,
-    cwd,
-    sourceConfig: workflowSourceConfigFrom(config),
-    ...(target !== undefined ? { target } : {}),
-  });
+  let report: Awaited<ReturnType<typeof runFixtures>>;
+  try {
+    report = await runFixtures({
+      workflows,
+      cwd,
+      sourceConfig: workflowSourceConfigFrom(config),
+      ...(target !== undefined ? { target } : {}),
+    });
+  } catch (error) {
+    if (errors.length === 0) throw error;
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      await writeJsonLine({
+        ok: false,
+        error: message,
+        errors: errors.map(e => ({
+          filename: e.filename,
+          error: e.error,
+          errorType: e.errorType,
+        })),
+      });
+    } else {
+      let output = `Error: ${message}\n`;
+      if (errors.length > 0) {
+        output += `\n${errors.length} workflow(s) failed to load:\n\n`;
+        for (const loadError of errors) {
+          output += `  ${loadError.filename}: ${loadError.error}\n`;
+        }
+      }
+      await writeStdout(output);
+    }
+    return 1;
+  }
 
   if (options.json) {
     await writeJsonLine({


### PR DESCRIPTION
## Problem and outcome

`archon workflow test` discarded workflow-discovery load errors, so an unloadable workflow could look like an unknown target or leave an otherwise passing fixture run green.

- **Outcome:** The command now reports every workflow load failure in text and JSON output, continues testing workflows that loaded successfully, and exits non-zero when any load failure occurs.
- **Invariant:** A workflow load failure is never silent.
- **Scope boundary:** Discovery, fixture target-selection rules, and `workflow list` behavior are unchanged.
- **Root cause:** `workflowTestCommand` retained only successfully loaded workflows from `loadWorkflows` and dropped its `errors` result.

## Review guidance

- **Feedback requested:** Confirm that reporting all discovery errors alongside partial fixture results preserves the intended CLI failure contract.
- **Start here:** `packages/cli/src/commands/workflow.ts:1020` — retains discovery errors, renders them in both output modes, and treats them as a failing outcome.
- **Review order:** Review the command behavior, then the focused text and JSON coverage in `packages/cli/src/commands/workflow.test.ts`.
- **Lower-attention areas:** None.
- **Known risk or uncertainty:** A passing fixture run now exits 1 when an unrelated workflow in the discovered catalog fails to load; this is intentional so failures cannot be hidden.

## Solution

The test command now keeps the workflow-discovery errors already returned by the loader while running fixtures only for successfully loaded workflows. Text output uses the same per-file diagnostics as `workflow list`; JSON adds the same structured errors. A non-empty error list produces exit code 1 without changing fixture catalog membership or target resolution.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Text and JSON fixture reports omitted workflow load failures. | Both modes include every discovery error alongside fixture results. |
| **Failure behavior** | Passing loaded fixtures could return success despite an unloadable workflow. | Any workflow load failure returns exit code 1 while successfully loaded workflows are still tested. |

## Validation

- `bun test src/commands/workflow.test.ts` (from `packages/cli`) — passed, 302 tests — covers text and JSON reports with a passing fixture result plus a workflow parse error.
- `bun x tsc --noEmit` (from `packages/cli`) — passed.
- `bun run lint` — passed.
- `bun x prettier --check src/commands/workflow.ts src/commands/workflow.test.ts` (from `packages/cli`) — passed.
- `git diff --check` — passed.
- **Not verified:** Nothing material; focused tests cover both output contracts and the changed exit status.

## Links

- Closes #2889


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Workflow testing now reports workflows that failed to load, including configuration or YAML parsing errors.
  - Load failures are shown in both human-readable and JSON output.
  - Workflow tests now return a failure status when any workflow cannot be loaded, including cases where fixture target selection also fails.
  - Successful fixture results remain visible alongside workflow-load errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->