### PR TITLE
fix(workflows): fail terminal status writes

### DIFF
--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -431,6 +431,7 @@ import {
   continueResolvedGateRun,
 } from './orchestrator-agent';
 import { buildAiProfile } from '@archon/workflows/model-validation';
+import { TerminalStatusWriteError } from '@archon/workflows/terminal-status-write';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -6287,5 +6288,44 @@ describe('continueResolvedGateRun — chat gate continuation source (#2646)', ()
       c => (c as unknown[])[1] as string
     );
     expect(messages.some(m => m.includes('digest mismatch'))).toBe(true);
+  });
+
+  // #2910: both sides of the recovery branch. An ordinary resume failure leaves the
+  // run resumable, so `/workflow resume` is right. A rejected terminal write leaves the
+  // row non-terminal — `/workflow resume` refuses those, so that advice would send the
+  // operator down a dead end for a run that may well have finished its work.
+  async function continueWithRejection(
+    platform: ReturnType<typeof makePlatform>,
+    rejection: unknown
+  ): Promise<string[]> {
+    mockExecuteWorkflow.mockRejectedValueOnce(rejection);
+    await continueResolvedGateRun(
+      platform,
+      'conv-1',
+      makeConversation({ codebase_id: 'codebase-1' }),
+      makeGateCodebase(),
+      [makeTestWorkflowWithSource({ name: 'gated', description: 'live' })],
+      makeGateRun(),
+      'approve'
+    );
+    return (platform.sendMessage as ReturnType<typeof mock>).mock.calls.map(
+      c => (c as unknown[])[1] as string
+    );
+  }
+
+  test('an ordinary resume failure points at /workflow resume', async () => {
+    const messages = await continueWithRejection(makePlatform(), new Error('resume boom'));
+
+    expect(messages.some(m => m.includes('retry with `/workflow resume run-gated`'))).toBe(true);
+  });
+
+  test('a rejected terminal write says the status is unknown, not "retry the resume"', async () => {
+    const messages = await continueWithRejection(
+      makePlatform(),
+      new TerminalStatusWriteError(new Error('db is gone'))
+    );
+
+    expect(messages.some(m => m.includes('final status could not be saved'))).toBe(true);
+    expect(messages.some(m => m.includes('retry with `/workflow resume'))).toBe(false);
   });
 });

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -52,6 +52,7 @@ import {
   recordSelectedWorkflow,
   type PreparedWorkflowSource,
 } from '@archon/workflows/executor';
+import { TerminalStatusWriteError } from '@archon/workflows/terminal-status-write';
 import { liveSourceRoots } from '@archon/workflows/workflow-discovery';
 import {
   assertWorkflowRequirementsMet,
@@ -1693,6 +1694,21 @@ export async function continueResolvedGateRun(
       );
     } catch (error) {
       const err = toError(error);
+      // The run's terminal status could not be written, so its row still says `running`
+      // and its true outcome is unknown. `/workflow resume` is the wrong advice — it
+      // refuses a non-terminal row, and the run may well have finished its work.
+      if (error instanceof TerminalStatusWriteError) {
+        getLog().error(
+          { err, conversationId, workflowRunId: run.id, action },
+          'orchestrator.gate_continuation_terminal_write_failed'
+        );
+        await notify(
+          `${decision}, and **${workflow.name}** ran, but its final status could not be saved ` +
+            `(${err.message}). The decision is recorded — check \`/workflow status ${run.id}\` ` +
+            'before starting another run on this project.'
+        );
+        return;
+      }
       getLog().error(
         { err, errorType: err.constructor.name, conversationId, workflowRunId: run.id, action },
         'orchestrator.gate_continuation_failed'

--- a/packages/core/src/orchestrator/orchestrator-isolation.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-isolation.test.ts
@@ -7,6 +7,7 @@ import type { IsolationEnvironmentRow } from '@archon/isolation';
 // (or the workflow engine) before the mock.module() calls below take effect.
 import type { WorkflowRoutingContext } from './orchestrator';
 import type { PreparedWorkflowSource } from '@archon/workflows/executor';
+import { TerminalStatusWriteError } from '@archon/workflows/terminal-status-write';
 import type { WorkflowDefinition } from '@archon/workflows/schemas/workflow';
 import {
   makeTestComposedWorkflow,
@@ -473,6 +474,39 @@ describe('dispatchBackgroundWorkflow', () => {
     await dispatchBackgroundWorkflow(makeRoutingCtx(), makeTestComposedWorkflow([own], 'own-gate'));
     expect(mockGetOrCreateConversation).toHaveBeenCalled();
     await flushBackgroundExecution();
+  });
+
+  // #2910: a rejected terminal write means the row still says 'running' and the run's
+  // real outcome is unknown. Both sides of the branch are asserted — an ordinary
+  // rejection keeps its compensating write and its "failed" card; a terminal-write
+  // rejection gets neither, because a second write over the channel that just failed
+  // would either fail again or bury the real error.
+  test('marks the run failed and says so when execution rejects with an ordinary error', async () => {
+    const workflow = makeWorkflow({ worktree: { enabled: false } });
+    mockExecuteWorkflow.mockRejectedValueOnce(new Error('exec boom'));
+
+    await dispatchBackgroundWorkflow(makeRoutingCtx(), workflow);
+    await flushBackgroundExecution();
+
+    expect(mockFailWorkflowRun).toHaveBeenCalledTimes(1);
+    expect(mockFailWorkflowRun.mock.calls[0]?.[0]).toBe('run-1');
+    const sent = platform.sendMessage.mock.calls.map(c => c[1]);
+    expect(sent.some(m => m.includes('failed: exec boom'))).toBe(true);
+  });
+
+  test('does not compensate or claim failure when the terminal write rejects', async () => {
+    const workflow = makeWorkflow({ worktree: { enabled: false } });
+    mockExecuteWorkflow.mockRejectedValueOnce(
+      new TerminalStatusWriteError(new Error('db is gone'))
+    );
+
+    await dispatchBackgroundWorkflow(makeRoutingCtx(), workflow);
+    await flushBackgroundExecution();
+
+    expect(mockFailWorkflowRun).not.toHaveBeenCalled();
+    const sent = platform.sendMessage.mock.calls.map(c => c[1]);
+    expect(sent.some(m => m.includes('final status could not be saved'))).toBe(true);
+    expect(sent.some(m => m.includes('failed: Failed to persist'))).toBe(false);
   });
 
   test('worktree.enabled: false skips isolation and runs in the parent cwd', async () => {

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -50,6 +50,7 @@ import { createIsolationStore } from '../db/isolation-environments';
 import { toError } from '../utils/error';
 import { getCodebase } from '../db/codebases';
 import { executeWorkflow } from '@archon/workflows/executor';
+import { TerminalStatusWriteError } from '@archon/workflows/terminal-status-write';
 import { resolveWorkflowSourceRoot } from '../utils/workflow-source-root';
 import {
   prepareWorkflowSource,
@@ -706,7 +707,11 @@ async function dispatchBackgroundWorkflowOwned(
         }
       } catch (error) {
         const err = toError(error);
-        if (preCreatedRun) {
+        const terminalWriteFailed = error instanceof TerminalStatusWriteError;
+        // A rejected terminal write leaves the row saying `running`. Do not compensate
+        // with a second failWorkflowRun over the write channel that just failed, and do
+        // not tell the user the workflow "failed" — its real outcome is unknown.
+        if (preCreatedRun && !terminalWriteFailed) {
           await workflowDeps.store.failWorkflowRun(preCreatedRun.id, err.message).catch(dbError => {
             getLog().error(
               { err: toError(dbError), workflowRunId: preCreatedRun.id },
@@ -720,12 +725,17 @@ async function dispatchBackgroundWorkflowOwned(
             workflowName: workflow.name,
             workerConversationId: workerPlatformId,
           },
-          'background_workflow_failed'
+          terminalWriteFailed
+            ? 'background_workflow_terminal_write_failed'
+            : 'background_workflow_failed'
         );
         // Surface error to parent conversation — include workflowResult metadata when
         // we have a pre-created run ID so the chat renders a result card with "View full logs"
         const failureRunId = preCreatedRun?.id;
-        const failureMessage = `Workflow **${workflow.name}** failed: ${err.message}`;
+        const failureMessage = terminalWriteFailed
+          ? `⚠️ Workflow **${workflow.name}** finished, but its final status could not be saved. ` +
+            'It may still show as running — check it before starting another.'
+          : `Workflow **${workflow.name}** failed: ${err.message}`;
         await ctx.platform
           .sendMessage(
             ctx.conversationId,

--- a/packages/core/src/utils/error-formatter.test.ts
+++ b/packages/core/src/utils/error-formatter.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from 'bun:test';
 import { classifyAndFormatError } from './error-formatter';
 import { WorkflowAdoptionError } from '../operations/workflow-adoption';
+import { TerminalStatusWriteError } from '@archon/workflows/terminal-status-write';
 
 describe('classifyAndFormatError', () => {
   describe('rate limit errors', () => {
@@ -713,6 +714,26 @@ describe('classifyAndFormatError', () => {
         "Cannot adopt run 'prior-run': this conversation already continues run 'x' (paused).";
       const result = classifyAndFormatError(new WorkflowAdoptionError(refusal));
       expect(result).toBe(`⚠️ ${refusal}`);
+    });
+  });
+
+  describe('terminal status write failures', () => {
+    // #2910: this is the terminus for the orchestrator's /invoke-workflow and
+    // /workflow run dispatch paths — neither has a closer catch, so handleMessage's
+    // catch formats the error here. A run whose status was never recorded must not
+    // read as a generic error the user is told to /reset away from.
+    test('names the unrecorded status instead of the generic fallback', () => {
+      const result = classifyAndFormatError(
+        new TerminalStatusWriteError(new Error('SQLITE_BUSY: database is locked'))
+      );
+      expect(result).toContain('final status could not be saved');
+      expect(result).toContain('/workflow status');
+      expect(result).not.toContain('/reset');
+    });
+
+    test('an ordinary database error still gets the generic database guidance', () => {
+      const result = classifyAndFormatError(new Error('database is locked'));
+      expect(result).not.toContain('final status could not be saved');
     });
   });
 });

--- a/packages/core/src/utils/error-formatter.ts
+++ b/packages/core/src/utils/error-formatter.ts
@@ -4,6 +4,7 @@
  * Classifies errors and provides user-friendly messages
  * without leaking sensitive information
  */
+import { TerminalStatusWriteError } from '@archon/workflows/terminal-status-write';
 import { WorkflowAdoptionError } from '../operations/workflow-adoption';
 
 /**
@@ -20,6 +21,17 @@ export function classifyAndFormatError(error: Error): string {
   // the generic fallback below.
   if (error instanceof WorkflowAdoptionError) {
     return `⚠️ ${message}`;
+  }
+
+  // The run finished but its terminal status was not recorded, so its row still says
+  // `running` and its true outcome is unknown. Distinct from an ordinary failure: the
+  // generic fallbacks below would tell the user to `/reset`, which fixes nothing and
+  // hides a run that will otherwise sit non-terminal holding its working path.
+  if (error instanceof TerminalStatusWriteError) {
+    return (
+      '⚠️ The workflow ran, but its final status could not be saved, so it may still show ' +
+      'as running. Check `/workflow status` before starting another run on this project.'
+    );
   }
 
   // AI-provider rate-limit / usage-cap classification

--- a/packages/server/src/services/workflow-resume-service.test.ts
+++ b/packages/server/src/services/workflow-resume-service.test.ts
@@ -25,9 +25,11 @@ mock.module('@archon/core/handlers', () => ({
   resolveRunContinuation: mockResolveRunContinuation,
 }));
 mock.module('@archon/core/db/codebases', () => ({ getCodebase: mock(async () => null) }));
+const mockFailWorkflowRun = mock(async () => undefined);
 mock.module('@archon/core/db/workflows', () => ({
   listDueWorkflowContinuations: mockListDueWorkflowContinuations,
   deferWorkflowContinuation: mockDeferWorkflowContinuation,
+  failWorkflowRun: mockFailWorkflowRun,
   WorkflowNotResumableError: class WorkflowNotResumableError extends Error {},
 }));
 mock.module('@archon/paths', () => ({
@@ -43,6 +45,8 @@ mock.module('@archon/workflows/executor', () => ({
   executeWorkflow: mockExecuteWorkflow,
   hydrateResumableRun: mockHydrateResumableRun,
 }));
+
+import { TerminalStatusWriteError } from '@archon/workflows/terminal-status-write';
 
 import {
   resumeWorkflowRunFromServer,
@@ -90,6 +94,90 @@ describe('workflow continuation scanner', () => {
       success: true,
       workflowRunId: 'run-1',
       summary: 'done',
+    });
+    mockFailWorkflowRun.mockReset();
+    mockFailWorkflowRun.mockResolvedValue(undefined);
+  });
+
+  // #2910: the headless scanner is the unattended path — nothing revisits a row it
+  // leaves at 'running' (listDueWorkflowContinuations selects paused/failed only).
+  // Both sides of the branch are asserted: an ordinary rejection still gets its
+  // compensating write, a rejected terminal write must not get a second one.
+  describe('rejected execution', () => {
+    const startHeadlessResume = async (rejection: unknown): Promise<void> => {
+      const paused = run('wait-headless', 'paused', {});
+      mockResolveRunContinuation.mockResolvedValueOnce({
+        ok: true,
+        workflowName: 'deliver',
+        workflow: { definition: { name: 'deliver', nodes: [] } },
+      });
+      mockHydrateResumableRun.mockResolvedValueOnce({
+        preCreatedRun: { ...paused, status: 'running' },
+        priorCompletedNodes: new Map(),
+        priorUsage: { costUsd: 0 },
+        priorNodeSessions: [],
+      });
+      mockExecuteWorkflow.mockRejectedValueOnce(rejection);
+
+      await expect(resumeWorkflowRunFromServer(paused)).resolves.toBe(true);
+      // The rejection handler runs off the voided promise.
+      await Promise.resolve();
+      await Promise.resolve();
+    };
+
+    test('marks the run failed when execution rejects with an ordinary error', async () => {
+      await startHeadlessResume(new Error('resume boom'));
+
+      expect(mockFailWorkflowRun).toHaveBeenCalledTimes(1);
+      expect(mockFailWorkflowRun.mock.calls[0]?.[0]).toBe('wait-headless');
+    });
+
+    test('does not compensate a rejected terminal write with a second failure write', async () => {
+      await startHeadlessResume(new TerminalStatusWriteError(new Error('db is gone')));
+
+      expect(mockFailWorkflowRun).not.toHaveBeenCalled();
+    });
+
+    test('tells a watching conversation the status could not be saved', async () => {
+      const paused = run('wait-headless-web', 'paused', {});
+      mockResolveRunContinuation.mockResolvedValueOnce({
+        ok: true,
+        workflowName: 'deliver',
+        workflow: { definition: { name: 'deliver', nodes: [] } },
+      });
+      mockHydrateResumableRun.mockResolvedValueOnce({
+        preCreatedRun: { ...paused, status: 'running' },
+        priorCompletedNodes: new Map(),
+        priorUsage: { costUsd: 0 },
+        priorNodeSessions: [],
+      });
+      mockExecuteWorkflow.mockRejectedValueOnce(
+        new TerminalStatusWriteError(new Error('db is gone'))
+      );
+      const platform = {
+        sendMessage: mock(async () => undefined),
+        getStreamingMode: () => 'batch' as const,
+        getPlatformType: () => 'web',
+      } satisfies IWorkflowPlatform;
+
+      await expect(
+        resumeWorkflowRunFromServer(paused, undefined, {
+          kind: 'platform',
+          destination: {
+            platform,
+            conversationId: 'web-worker-conv',
+            resultConversationId: 'visible-web-conv',
+          },
+        })
+      ).resolves.toBe(true);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockFailWorkflowRun).not.toHaveBeenCalled();
+      const message = (platform.sendMessage.mock.calls[0] as unknown[] | undefined)?.[1] as
+        | string
+        | undefined;
+      expect(message).toContain('final status could not be saved');
     });
   });
 

--- a/packages/server/src/services/workflow-resume-service.ts
+++ b/packages/server/src/services/workflow-resume-service.ts
@@ -4,6 +4,7 @@ import * as codebaseDb from '@archon/core/db/codebases';
 import * as workflowDb from '@archon/core/db/workflows';
 import { createLogger, getArchonWorkspacesPath } from '@archon/paths';
 import { executeWorkflow, hydrateResumableRun } from '@archon/workflows/executor';
+import { TerminalStatusWriteError } from '@archon/workflows/terminal-status-write';
 import type { IWorkflowPlatform } from '@archon/workflows/deps';
 import type { WorkflowRun } from '@archon/workflows/schemas/workflow-run';
 import type { WorkflowResumeCursor } from '@archon/workflows/store';
@@ -197,6 +198,34 @@ export async function resumeWorkflowRunFromServer(
           });
       },
       (error: unknown) => {
+        // A run whose terminal status could not be written is NOT an ordinary failure:
+        // its row still reads `running`, and `listDueWorkflowContinuations` only selects
+        // paused/failed rows, so nothing will revisit it. Marking it failed here would
+        // use the write channel that just failed — either it fails again, or it succeeds
+        // and buries the real error under a generic "headless resume failed". Escalate
+        // under its own tag instead and leave the row for an operator to resolve.
+        if (error instanceof TerminalStatusWriteError) {
+          log.error(
+            { err: error, runId: run.id, workflowName: run.workflow_name },
+            'workflow_resume_headless_terminal_write_failed'
+          );
+          if (destination?.resultConversationId !== undefined) {
+            void platform
+              .sendMessage(
+                destination.resultConversationId,
+                `⚠️ Run \`${run.id.slice(0, 8)}\` of **${run.workflow_name}** finished, but its ` +
+                  'final status could not be saved. The run may still show as running — check it ' +
+                  `with \`/workflow status ${run.id}\` before starting another.`
+              )
+              .catch((sendError: unknown) => {
+                log.warn(
+                  { err: sendError as Error, runId: run.id },
+                  'workflow_resume_result_surface_failed'
+                );
+              });
+          }
+          return;
+        }
         log.error(
           { err: error as Error, runId: run.id },
           'workflow_resume_headless_execute_failed'

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -9,6 +9,7 @@
     "./deprecation": "./src/deprecation.ts",
     "./router": "./src/router.ts",
     "./store": "./src/store.ts",
+    "./terminal-status-write": "./src/terminal-status-write.ts",
     "./deps": "./src/deps.ts",
     "./event-emitter": "./src/event-emitter.ts",
     "./workflow-discovery": "./src/workflow-discovery.ts",
@@ -27,7 +28,7 @@
     "./test-utils": "./src/test-utils.ts"
   },
   "scripts": {
-    "test": "bun test src/dag-executor.test.ts && bun test src/loader.test.ts src/include-expander.test.ts src/fan-out-identity.test.ts && bun test src/workflow-discovery-command-scan.test.ts && bun test src/logger.test.ts && bun test src/condition-evaluator.test.ts && bun test src/output-ref.test.ts && bun test src/event-emitter.test.ts && bun test src/executor-shared.test.ts && bun test src/load-command-prompt.test.ts && bun test src/load-command-prompt-bundled.test.ts && bun test src/executor.test.ts && bun test src/subrun.test.ts && bun test src/executor-preamble.test.ts && bun test src/defaults/ src/run-config.test.ts src/model-validation.test.ts src/router.test.ts src/utils/ src/hooks.test.ts src/workflow-inputs.test.ts && bun test src/schemas.test.ts src/deprecation.test.ts src/command-validation.test.ts src/packaged-workflow.test.ts && bun test src/validator.test.ts && bun test src/script-discovery.test.ts && bun test src/workflow-source.test.ts && bun test src/workflow-source-binary.test.ts && bun test src/bundled-script-materialization.test.ts && bun test src/runtime-check.test.ts && bun test src/script-node-deps.test.ts && bun test src/artifacts-index.test.ts && bun test src/state-migration.test.ts src/dry-run.test.ts src/fixture-runner.test.ts",
+    "test": "bun test src/dag-executor.test.ts && bun test src/loader.test.ts src/include-expander.test.ts src/fan-out-identity.test.ts && bun test src/workflow-discovery-command-scan.test.ts && bun test src/logger.test.ts src/terminal-status-write.test.ts && bun test src/condition-evaluator.test.ts && bun test src/output-ref.test.ts && bun test src/event-emitter.test.ts && bun test src/executor-shared.test.ts && bun test src/load-command-prompt.test.ts && bun test src/load-command-prompt-bundled.test.ts && bun test src/executor.test.ts && bun test src/subrun.test.ts && bun test src/executor-preamble.test.ts && bun test src/defaults/ src/run-config.test.ts src/model-validation.test.ts src/router.test.ts src/utils/ src/hooks.test.ts src/workflow-inputs.test.ts && bun test src/schemas.test.ts src/deprecation.test.ts src/command-validation.test.ts src/packaged-workflow.test.ts && bun test src/validator.test.ts && bun test src/script-discovery.test.ts && bun test src/workflow-source.test.ts && bun test src/workflow-source-binary.test.ts && bun test src/bundled-script-materialization.test.ts && bun test src/runtime-check.test.ts && bun test src/script-node-deps.test.ts && bun test src/artifacts-index.test.ts && bun test src/state-migration.test.ts src/dry-run.test.ts src/fixture-runner.test.ts",
     "type-check": "bun x tsc --noEmit"
   },
   "dependencies": {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -19162,6 +19162,35 @@ describe('executeDagWorkflow -- evidence gate (#2230)', () => {
     expect((mockStore.failWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(0);
   });
 
+  it('surfaces a failed completion write', async () => {
+    const mockStore = createMockStore();
+    (mockStore.completeWorkflowRun as ReturnType<typeof mock>).mockRejectedValueOnce(
+      new Error('terminal completion write failed')
+    );
+    const platform = createMockPlatform();
+    await mkdir(artifactsDir, { recursive: true });
+    await writeFile(join(artifactsDir, 'evidence.json'), '{"proof": "landed"}');
+
+    await expect(runEvidenceWorkflow({ store: mockStore, platform })).rejects.toThrow(
+      'terminal completion write failed'
+    );
+  });
+
+  it('surfaces a failed failure write', async () => {
+    const mockStore = createMockStore();
+    (mockStore.failWorkflowRun as ReturnType<typeof mock>).mockRejectedValueOnce(
+      new Error('terminal failure write failed')
+    );
+
+    await expect(
+      runEvidenceWorkflow({
+        store: mockStore,
+        platform: createMockPlatform(),
+        evidencePolicy: { required: true },
+      })
+    ).rejects.toThrow('terminal failure write failed');
+  });
+
   it('no evidence_policy declared -> completes without checking for evidence.json', async () => {
     const mockStore = createMockStore();
     const platform = createMockPlatform();

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -10,6 +10,7 @@ import {
   type Mock,
 } from 'bun:test';
 import { mkdir, writeFile, rm, readFile } from 'fs/promises';
+import { removeTempTree } from '@archon/paths/test-utils';
 import { unlinkSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -33448,5 +33449,103 @@ describe('executeDagWorkflow -- node-level mutates_checkout: false (#2771)', () 
       true
     );
     expect(nodeFailedError(deps, 'guarded')).toBeUndefined();
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Terminal status write ordering (#2910 R3)
+//
+// The terminal write can now reject. Everything that never depended on it —
+// the transcript, the live SSE event, telemetry, and the chat notification —
+// used to run unconditionally under the old log-and-continue catch, and must
+// keep doing so. These pin the ordering at the completion and failure sites.
+// ───────────────────────────────────────────────────────────────────────────
+describe('executeDagWorkflow -- side effects survive a failed terminal write', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = join(
+      tmpdir(),
+      `dag-terminal-order-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    await mkdir(testDir, { recursive: true });
+    mockCaptureWorkflowCompleted.mockClear();
+  });
+
+  afterEach(async () => {
+    await removeTempTree(testDir);
+  });
+
+  /** One always-succeeding bash node, so the run reaches the completion site. */
+  const okNode: ExecNode = { id: 'ok', kind: 'exec', runtime: 'sh', script: 'echo done' };
+  /** One always-failing bash node, so the run reaches the node-failure site. */
+  const badNode: ExecNode = { id: 'bad', kind: 'exec', runtime: 'sh', script: 'exit 3' };
+
+  async function run(
+    store: MockWorkflowStore,
+    platform: MockWorkflowPlatform,
+    nodes: ExecNode[],
+    emitted: string[]
+  ): Promise<unknown> {
+    const workflowRun = makeWorkflowRun('terminal-order-run');
+    const unsubscribe = getWorkflowEventEmitter().subscribe((event: WorkflowEmitterEvent) => {
+      if ('runId' in event && event.runId === workflowRun.id) emitted.push(event.type);
+    });
+    try {
+      return await executeDagWorkflow(
+        createMockDeps(store),
+        platform,
+        'conv-terminal-order',
+        testDir,
+        { name: 'terminal-order', nodes },
+        workflowRun,
+        'claude',
+        undefined,
+        join(testDir, 'artifacts'),
+        join(testDir, 'state'),
+        join(testDir, 'logs'),
+        'main',
+        'docs/',
+        minimalConfig
+      );
+    } finally {
+      unsubscribe();
+    }
+  }
+
+  it('still emits workflow_completed and telemetry when the completion write rejects', async () => {
+    const store = createMockStore();
+    store.completeWorkflowRun = mock(async () => {
+      throw new Error('completion write failed');
+    });
+    const emitted: string[] = [];
+
+    await expect(run(store, createMockPlatform(), [okNode], emitted)).rejects.toThrow(
+      'Failed to persist terminal workflow status'
+    );
+
+    expect(emitted).toContain('workflow_completed');
+    expect(mockCaptureWorkflowCompleted).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: 'completed' })
+    );
+  });
+
+  it('still emits workflow_failed and notifies the user when the failure write rejects', async () => {
+    const store = createMockStore();
+    store.failWorkflowRun = mock(async () => {
+      throw new Error('failure write failed');
+    });
+    const platform = createMockPlatform();
+    const emitted: string[] = [];
+
+    // One node succeeds and one fails, so the run reaches the node-failure site
+    // rather than the no-nodes-completed one.
+    await expect(run(store, platform, [okNode, badNode], emitted)).rejects.toThrow(
+      'Failed to persist terminal workflow status'
+    );
+
+    expect(emitted).toContain('workflow_failed');
+    const sent = platform.sendMessage.mock.calls.map(c => c[1]);
+    expect(sent.some(m => m.includes('completed with failures'))).toBe(true);
   });
 });

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -12236,11 +12236,7 @@ export async function executeDagWorkflow(
       getLog().error({ err: dbErr, workflowRunId: workflowRun.id }, 'dag.quota_resume_plan_failed');
       return undefined;
     });
-    await deps.store
-      .failWorkflowRun(workflowRun.id, failMsg, scheduledResume)
-      .catch((dbErr: Error) => {
-        getLog().error({ err: dbErr, workflowRunId: workflowRun.id }, 'dag_db_fail_failed');
-      });
+    await deps.store.failWorkflowRun(workflowRun.id, failMsg, scheduledResume);
     await logWorkflowError(logDir, workflowRun.id, failMsg).catch((logErr: Error) => {
       getLog().error(
         { err: logErr, workflowRunId: workflowRun.id },
@@ -12288,11 +12284,7 @@ export async function executeDagWorkflow(
       getLog().error({ err: dbErr, workflowRunId: workflowRun.id }, 'dag.quota_resume_plan_failed');
       return undefined;
     });
-    await deps.store
-      .failWorkflowRun(workflowRun.id, failMsg, scheduledResume)
-      .catch((dbErr: Error) => {
-        getLog().error({ err: dbErr, workflowRunId: workflowRun.id }, 'dag_db_fail_failed');
-      });
+    await deps.store.failWorkflowRun(workflowRun.id, failMsg, scheduledResume);
     await logWorkflowError(logDir, workflowRun.id, failMsg).catch((logErr: Error) => {
       getLog().error(
         { err: logErr, workflowRunId: workflowRun.id },
@@ -12372,9 +12364,7 @@ export async function executeDagWorkflow(
             'dag.evidence_metadata_write_failed'
           );
         });
-      await deps.store.failWorkflowRun(workflowRun.id, failMsg).catch((dbErr: Error) => {
-        getLog().error({ err: dbErr, workflowRunId: workflowRun.id }, 'dag_db_fail_failed');
-      });
+      await deps.store.failWorkflowRun(workflowRun.id, failMsg);
       // Persist the reason into the workflow-events log (contract: never throws).
       await deps.store.createWorkflowEvent({
         workflow_run_id: workflowRun.id,
@@ -12474,38 +12464,25 @@ export async function executeDagWorkflow(
   const duration = Date.now() - dagStartTime;
 
   // Update DB and emit completion
-  try {
-    await deps.store.completeWorkflowRun(
-      workflowRun.id,
-      { duration_ms: duration },
-      {
-        node_counts: nodeCounts,
-        // Cost and token totals are NOT written here — `persistRunUsage` already wrote
-        // them at the run tail, before this branch was chosen (#2469). Keeping a second
-        // copy here would be two writers of the same three keys, free to drift.
-        // A sub-run persists its terminal summary so the parent can thread it as
-        // `$<node>.output` on re-entry. Gated on parent_run_id to bound metadata
-        // growth to child runs only (top-level runs return the summary directly).
-        // `summary_value` is the additive logical sibling (#2637): old binaries keep
-        // reading `summary`, new parents prefer the typed value when present.
-        ...(workflowRun.parent_run_id && terminalOutput ? { summary: terminalOutput } : {}),
-        ...(workflowRun.parent_run_id && terminalOutput && terminalStructuredOutput !== undefined
-          ? { [SUBRUN_METADATA_KEYS.summaryValue]: terminalStructuredOutput }
-          : {}),
-      }
-    );
-  } catch (dbErr) {
-    getLog().error(
-      { err: dbErr as Error, workflowRunId: workflowRun.id },
-      'dag_db_complete_failed'
-    );
-    await safeSendMessage(
-      platform,
-      conversationId,
-      'Warning: workflow completed but the run status could not be saved. The workflow result may appear inconsistent.',
-      { workflowId: workflowRun.id }
-    );
-  }
+  await deps.store.completeWorkflowRun(
+    workflowRun.id,
+    { duration_ms: duration },
+    {
+      node_counts: nodeCounts,
+      // Cost and token totals are NOT written here — `persistRunUsage` already wrote
+      // them at the run tail, before this branch was chosen (#2469). Keeping a second
+      // copy here would be two writers of the same three keys, free to drift.
+      // A sub-run persists its terminal summary so the parent can thread it as
+      // `$<node>.output` on re-entry. Gated on parent_run_id to bound metadata
+      // growth to child runs only (top-level runs return the summary directly).
+      // `summary_value` is the additive logical sibling (#2637): old binaries keep
+      // reading `summary`, new parents prefer the typed value when present.
+      ...(workflowRun.parent_run_id && terminalOutput ? { summary: terminalOutput } : {}),
+      ...(workflowRun.parent_run_id && terminalOutput && terminalStructuredOutput !== undefined
+        ? { [SUBRUN_METADATA_KEYS.summaryValue]: terminalStructuredOutput }
+        : {}),
+    }
+  );
   await logWorkflowComplete(logDir, workflowRun.id, {
     // `> 0` rather than `!== undefined`, mirroring persistRunUsage above: the accumulator
     // is a plain number seeded at 0, so zero is the only way it can say "no AI usage" —

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -12249,9 +12249,6 @@ export async function executeDagWorkflow(
       getLog().error({ err: dbErr, workflowRunId: workflowRun.id }, 'dag.quota_resume_plan_failed');
       return undefined;
     });
-    await requireTerminalStatusWrite(
-      deps.store.failWorkflowRun(workflowRun.id, failMsg, scheduledResume)
-    );
     await logWorkflowError(logDir, workflowRun.id, failMsg).catch((logErr: Error) => {
       getLog().error(
         { err: logErr, workflowRunId: workflowRun.id },
@@ -12269,7 +12266,16 @@ export async function executeDagWorkflow(
     await safeSendMessage(platform, conversationId, `\u274c ${failMsg}`, {
       workflowId: workflowRun.id,
     });
-    // DO NOT throw — outer executor.ts catch would duplicate workflow_failed events
+    // Terminal write LAST: nothing above depends on it and all of it used to run
+    // unconditionally, so a rejection must not silence the log file, the live event,
+    // the telemetry, or the user's notification.
+    await requireTerminalStatusWrite(
+      deps.store.failWorkflowRun(workflowRun.id, failMsg, scheduledResume),
+      { workflowRunId: workflowRun.id, site: 'dag.no_nodes_completed_fail' }
+    );
+    // The ordinary path does NOT throw — the outer executor.ts catch would duplicate the
+    // workflow_failed event emitted above. A rejected terminal write DOES throw, and that
+    // catch recognizes the marker and rethrows without re-emitting.
     return;
   }
 
@@ -12299,9 +12305,6 @@ export async function executeDagWorkflow(
       getLog().error({ err: dbErr, workflowRunId: workflowRun.id }, 'dag.quota_resume_plan_failed');
       return undefined;
     });
-    await requireTerminalStatusWrite(
-      deps.store.failWorkflowRun(workflowRun.id, failMsg, scheduledResume)
-    );
     await logWorkflowError(logDir, workflowRun.id, failMsg).catch((logErr: Error) => {
       getLog().error(
         { err: logErr, workflowRunId: workflowRun.id },
@@ -12319,7 +12322,16 @@ export async function executeDagWorkflow(
     await safeSendMessage(platform, conversationId, `\u274c ${failMsg}`, {
       workflowId: workflowRun.id,
     });
-    // DO NOT throw — outer executor.ts catch would duplicate workflow_failed events
+    // Terminal write LAST: nothing above depends on it and all of it used to run
+    // unconditionally, so a rejection must not silence the log file, the live event,
+    // the telemetry, or the user's notification.
+    await requireTerminalStatusWrite(
+      deps.store.failWorkflowRun(workflowRun.id, failMsg, scheduledResume),
+      { workflowRunId: workflowRun.id, site: 'dag.node_failure_fail' }
+    );
+    // The ordinary path does NOT throw — the outer executor.ts catch would duplicate the
+    // workflow_failed event emitted above. A rejected terminal write DOES throw, and that
+    // catch recognizes the marker and rethrows without re-emitting.
     return;
   }
 
@@ -12381,7 +12393,6 @@ export async function executeDagWorkflow(
             'dag.evidence_metadata_write_failed'
           );
         });
-      await requireTerminalStatusWrite(deps.store.failWorkflowRun(workflowRun.id, failMsg));
       // Persist the reason into the workflow-events log (contract: never throws).
       await deps.store.createWorkflowEvent({
         workflow_run_id: workflowRun.id,
@@ -12405,7 +12416,18 @@ export async function executeDagWorkflow(
       await safeSendMessage(platform, conversationId, `❌ ${failMsg}`, {
         workflowId: workflowRun.id,
       });
-      // DO NOT throw — outer executor.ts catch would duplicate workflow_failed events
+      // Terminal write LAST: nothing above depends on it and all of it used to run
+      // unconditionally, so a rejection must not silence the evidence event, the log
+      // file, the live event, or the user's notification. The metadata merge above
+      // still precedes it, so `metadata.evidence_validation` is present the moment the
+      // run reads as failed.
+      await requireTerminalStatusWrite(deps.store.failWorkflowRun(workflowRun.id, failMsg), {
+        workflowRunId: workflowRun.id,
+        site: 'dag.evidence_gate_fail',
+      });
+      // The ordinary path does NOT throw — the outer executor.ts catch would duplicate the
+      // workflow_failed event emitted above. A rejected terminal write DOES throw, and that
+      // catch recognizes the marker and rethrows without re-emitting.
       return;
     }
     getLog().info({ workflowRunId: workflowRun.id, evidencePath }, 'dag.evidence_gate_passed');
@@ -12480,28 +12502,9 @@ export async function executeDagWorkflow(
 
   const duration = Date.now() - dagStartTime;
 
-  // Update DB and emit completion
-  await requireTerminalStatusWrite(
-    deps.store.completeWorkflowRun(
-      workflowRun.id,
-      { duration_ms: duration },
-      {
-        node_counts: nodeCounts,
-        // Cost and token totals are NOT written here — `persistRunUsage` already wrote
-        // them at the run tail, before this branch was chosen (#2469). Keeping a second
-        // copy here would be two writers of the same three keys, free to drift.
-        // A sub-run persists its terminal summary so the parent can thread it as
-        // `$<node>.output` on re-entry. Gated on parent_run_id to bound metadata
-        // growth to child runs only (top-level runs return the summary directly).
-        // `summary_value` is the additive logical sibling (#2637): old binaries keep
-        // reading `summary`, new parents prefer the typed value when present.
-        ...(workflowRun.parent_run_id && terminalOutput ? { summary: terminalOutput } : {}),
-        ...(workflowRun.parent_run_id && terminalOutput && terminalStructuredOutput !== undefined
-          ? { [SUBRUN_METADATA_KEYS.summaryValue]: terminalStructuredOutput }
-          : {}),
-      }
-    )
-  );
+  // Emit completion, then record it. The transcript, the live event, and the telemetry
+  // do not depend on the status write and used to run whether or not it succeeded, so
+  // the (now-throwing) write goes last.
   await logWorkflowComplete(logDir, workflowRun.id, {
     // `> 0` rather than `!== undefined`, mirroring persistRunUsage above: the accumulator
     // is a plain number seeded at 0, so zero is the only way it can say "no AI usage" —
@@ -12530,6 +12533,29 @@ export async function executeDagWorkflow(
     ...runUsageProps,
   });
   emitter.unregisterRun(workflowRun.id);
+
+  await requireTerminalStatusWrite(
+    deps.store.completeWorkflowRun(
+      workflowRun.id,
+      { duration_ms: duration },
+      {
+        node_counts: nodeCounts,
+        // Cost and token totals are NOT written here — `persistRunUsage` already wrote
+        // them at the run tail, before this branch was chosen (#2469). Keeping a second
+        // copy here would be two writers of the same three keys, free to drift.
+        // A sub-run persists its terminal summary so the parent can thread it as
+        // `$<node>.output` on re-entry. Gated on parent_run_id to bound metadata
+        // growth to child runs only (top-level runs return the summary directly).
+        // `summary_value` is the additive logical sibling (#2637): old binaries keep
+        // reading `summary`, new parents prefer the typed value when present.
+        ...(workflowRun.parent_run_id && terminalOutput ? { summary: terminalOutput } : {}),
+        ...(workflowRun.parent_run_id && terminalOutput && terminalStructuredOutput !== undefined
+          ? { [SUBRUN_METADATA_KEYS.summaryValue]: terminalStructuredOutput }
+          : {}),
+      }
+    ),
+    { workflowRunId: workflowRun.id, site: 'dag_db_complete_failed' }
+  );
 
   // terminalOutput (computed above, before the completion write) is the run's
   // summary for the parent conversation and the `workflow:` re-entry path.

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -101,6 +101,7 @@ import { formatToolCall } from './utils/tool-formatter';
 import { createLogger, captureWorkflowCompleted } from '@archon/paths';
 import type { WorkflowErrorClass, WorkflowNodeType } from '@archon/paths';
 import { getWorkflowEventEmitter } from './event-emitter';
+import { requireTerminalStatusWrite } from './terminal-status-write';
 import { evaluateCondition } from './condition-evaluator';
 import {
   declaredFieldsFromSchema,
@@ -12236,7 +12237,9 @@ export async function executeDagWorkflow(
       getLog().error({ err: dbErr, workflowRunId: workflowRun.id }, 'dag.quota_resume_plan_failed');
       return undefined;
     });
-    await deps.store.failWorkflowRun(workflowRun.id, failMsg, scheduledResume);
+    await requireTerminalStatusWrite(
+      deps.store.failWorkflowRun(workflowRun.id, failMsg, scheduledResume)
+    );
     await logWorkflowError(logDir, workflowRun.id, failMsg).catch((logErr: Error) => {
       getLog().error(
         { err: logErr, workflowRunId: workflowRun.id },
@@ -12284,7 +12287,9 @@ export async function executeDagWorkflow(
       getLog().error({ err: dbErr, workflowRunId: workflowRun.id }, 'dag.quota_resume_plan_failed');
       return undefined;
     });
-    await deps.store.failWorkflowRun(workflowRun.id, failMsg, scheduledResume);
+    await requireTerminalStatusWrite(
+      deps.store.failWorkflowRun(workflowRun.id, failMsg, scheduledResume)
+    );
     await logWorkflowError(logDir, workflowRun.id, failMsg).catch((logErr: Error) => {
       getLog().error(
         { err: logErr, workflowRunId: workflowRun.id },
@@ -12364,7 +12369,7 @@ export async function executeDagWorkflow(
             'dag.evidence_metadata_write_failed'
           );
         });
-      await deps.store.failWorkflowRun(workflowRun.id, failMsg);
+      await requireTerminalStatusWrite(deps.store.failWorkflowRun(workflowRun.id, failMsg));
       // Persist the reason into the workflow-events log (contract: never throws).
       await deps.store.createWorkflowEvent({
         workflow_run_id: workflowRun.id,
@@ -12464,24 +12469,26 @@ export async function executeDagWorkflow(
   const duration = Date.now() - dagStartTime;
 
   // Update DB and emit completion
-  await deps.store.completeWorkflowRun(
-    workflowRun.id,
-    { duration_ms: duration },
-    {
-      node_counts: nodeCounts,
-      // Cost and token totals are NOT written here — `persistRunUsage` already wrote
-      // them at the run tail, before this branch was chosen (#2469). Keeping a second
-      // copy here would be two writers of the same three keys, free to drift.
-      // A sub-run persists its terminal summary so the parent can thread it as
-      // `$<node>.output` on re-entry. Gated on parent_run_id to bound metadata
-      // growth to child runs only (top-level runs return the summary directly).
-      // `summary_value` is the additive logical sibling (#2637): old binaries keep
-      // reading `summary`, new parents prefer the typed value when present.
-      ...(workflowRun.parent_run_id && terminalOutput ? { summary: terminalOutput } : {}),
-      ...(workflowRun.parent_run_id && terminalOutput && terminalStructuredOutput !== undefined
-        ? { [SUBRUN_METADATA_KEYS.summaryValue]: terminalStructuredOutput }
-        : {}),
-    }
+  await requireTerminalStatusWrite(
+    deps.store.completeWorkflowRun(
+      workflowRun.id,
+      { duration_ms: duration },
+      {
+        node_counts: nodeCounts,
+        // Cost and token totals are NOT written here — `persistRunUsage` already wrote
+        // them at the run tail, before this branch was chosen (#2469). Keeping a second
+        // copy here would be two writers of the same three keys, free to drift.
+        // A sub-run persists its terminal summary so the parent can thread it as
+        // `$<node>.output` on re-entry. Gated on parent_run_id to bound metadata
+        // growth to child runs only (top-level runs return the summary directly).
+        // `summary_value` is the additive logical sibling (#2637): old binaries keep
+        // reading `summary`, new parents prefer the typed value when present.
+        ...(workflowRun.parent_run_id && terminalOutput ? { summary: terminalOutput } : {}),
+        ...(workflowRun.parent_run_id && terminalOutput && terminalStructuredOutput !== undefined
+          ? { [SUBRUN_METADATA_KEYS.summaryValue]: terminalStructuredOutput }
+          : {}),
+      }
+    )
   );
   await logWorkflowComplete(logDir, workflowRun.id, {
     // `> 0` rather than `!== undefined`, mirroring persistRunUsage above: the accumulator

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -101,7 +101,7 @@ import { formatToolCall } from './utils/tool-formatter';
 import { createLogger, captureWorkflowCompleted } from '@archon/paths';
 import type { WorkflowErrorClass, WorkflowNodeType } from '@archon/paths';
 import { getWorkflowEventEmitter } from './event-emitter';
-import { requireTerminalStatusWrite } from './terminal-status-write';
+import { TerminalStatusWriteError, requireTerminalStatusWrite } from './terminal-status-write';
 import { evaluateCondition } from './condition-evaluator';
 import {
   declaredFieldsFromSchema,
@@ -8097,6 +8097,8 @@ async function executeWorkflowNode(
     // freshly-run child uses (interpret handles both).
     return await interpret(childOutcomeFromRun(existing));
   } catch (err) {
+    if (err instanceof TerminalStatusWriteError) throw err;
+
     return failResult(`Sub-run '${node.workflow}' errored: ${(err as Error).message}`);
   }
 }
@@ -8834,8 +8836,14 @@ async function executeFanOutWorkflowNode(
     }
   );
 
-  // mapWithLimit never rejects here (runChild honors the never-throws contract), but be
-  // defensive: a rejected slot becomes a synthetic failed outcome.
+  const terminalWriteFailure = settled.find(
+    (result): result is PromiseRejectedResult =>
+      result.status === 'rejected' && result.reason instanceof TerminalStatusWriteError
+  );
+  if (terminalWriteFailure) throw terminalWriteFailure.reason;
+
+  // Terminal status-write failures propagate above. Other unexpected rejections become a
+  // synthetic failed outcome.
   const outcomes: ChildWorkflowOutcome[] = settled.map((r, i) =>
     r.status === 'fulfilled'
       ? r.value
@@ -11038,6 +11046,8 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
 
             return { nodeId: node.id, output, sessionProvider: provider };
           } catch (error) {
+            if (error instanceof TerminalStatusWriteError) throw error;
+
             const err = error as Error;
             getLog().error({ err, nodeId: node.id }, 'dag_node_pre_execution_failed');
             deps.store
@@ -11176,6 +11186,8 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
         }
         if (output.state === 'failed') layerHadFailure = true;
       } else {
+        if (result.reason instanceof TerminalStatusWriteError) throw result.reason;
+
         // Should not happen — all errors are caught in the inner try-catch
         // Handle defensively: log the unexpected rejection
         getLog().error({ err: result.reason as Error, layerIdx }, 'dag_node_unexpected_rejection');

--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -2959,6 +2959,27 @@ describe('telemetry wiring', () => {
     );
   });
 
+  it('surfaces a failed terminal failure write', async () => {
+    mockExecuteDagWorkflow.mockRejectedValueOnce(new Error('dag boom'));
+    const store = makeStore({
+      failWorkflowRun: mock(async () => {
+        throw new Error('terminal failure write failed');
+      }),
+    });
+
+    await expect(
+      executeWorkflow(
+        makeDeps(store),
+        makePlatform(),
+        'conv-1',
+        '/tmp',
+        makeWorkflow(),
+        'msg',
+        'db-conv-1'
+      )
+    ).rejects.toThrow('terminal failure write failed');
+  });
+
   it('reports feature-adoption booleans on workflow_invoked', async () => {
     mockCaptureWorkflowInvoked.mockClear();
     const store = makeStore();

--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -173,6 +173,7 @@ import type { WorkflowDefinition, WorkflowRun, WorkflowRunNodeSession } from './
 import { RUN_METADATA_KEYS, workflowDefinitionSchema } from './schemas';
 import type { WorkflowRunConfigMetadata } from './schemas/run-config';
 import { substituteWorkflowVariables } from './executor-shared';
+import { TerminalStatusWriteError } from './terminal-status-write';
 
 // --- Helpers ---
 
@@ -2978,6 +2979,28 @@ describe('telemetry wiring', () => {
         'db-conv-1'
       )
     ).rejects.toThrow('terminal failure write failed');
+  });
+
+  it('does not recover a rejected DAG terminal write with a second failure write', async () => {
+    mockExecuteDagWorkflow.mockRejectedValueOnce(
+      new TerminalStatusWriteError(new Error('terminal completion write failed'))
+    );
+    const failWorkflowRun = mock(async () => {});
+    const store = makeStore({ failWorkflowRun });
+
+    await expect(
+      executeWorkflow(
+        makeDeps(store),
+        makePlatform(),
+        'conv-1',
+        '/tmp',
+        makeWorkflow(),
+        'msg',
+        'db-conv-1'
+      )
+    ).rejects.toThrow('terminal completion write failed');
+
+    expect(failWorkflowRun).not.toHaveBeenCalled();
   });
 
   it('reports feature-adoption booleans on workflow_invoked', async () => {

--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -2977,6 +2977,154 @@ describe('executeWorkflow', () => {
   });
 });
 
+// ───────────────────────────────────────────────────────────────────────────
+// Terminal status writes outside the DAG (#2910)
+//
+// executeWorkflow records a run's terminal status from ten places, not just the
+// four inside executeDagWorkflow. These cover the distinct shapes: a setup guard
+// that would otherwise RETURN an ordinary failure, one that would otherwise
+// RETHROW its own error, and the two main-path writes whose interaction decides
+// whether the finally backstop fires a second, masking write.
+// ───────────────────────────────────────────────────────────────────────────
+describe('terminal status writes in executor setup', () => {
+  beforeEach(() => {
+    mockExecuteDagWorkflow.mockClear();
+    mockExecuteDagWorkflow.mockImplementation(async () => undefined);
+  });
+
+  it('rejects instead of returning an ordinary failure when a setup guard cannot record it', async () => {
+    // Invocation-metadata persistence fails, and so does the failWorkflowRun that
+    // exists to recover it. Without the marker this returned `{ success: false }` —
+    // a normal failed run, over a row still saying pending/running.
+    const store = makeStore({
+      updateWorkflowRun: mock(async () => {
+        throw new Error('metadata write failed');
+      }),
+      failWorkflowRun: mock(async () => {
+        throw new Error('recovery write failed');
+      }),
+    });
+
+    await expect(
+      executeWorkflow(
+        makeDeps(store),
+        makePlatform(),
+        'conv-1',
+        '/tmp',
+        makeWorkflow(),
+        'msg',
+        'db-conv-1',
+        { preCreatedRun: makeRun({ id: 'pending-run', status: 'pending' }) }
+      )
+    ).rejects.toThrow('Failed to persist terminal workflow status');
+
+    expect(mockExecuteDagWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('still returns an ordinary failure when the setup guard CAN record it', async () => {
+    // The other side of the branch: the recovery write succeeds, so the caller keeps
+    // getting a plain failed result rather than a rejection.
+    const store = makeStore({
+      updateWorkflowRun: mock(async () => {
+        throw new Error('metadata write failed');
+      }),
+    });
+
+    const result = await executeWorkflow(
+      makeDeps(store),
+      makePlatform(),
+      'conv-1',
+      '/tmp',
+      makeWorkflow(),
+      'msg',
+      'db-conv-1',
+      { preCreatedRun: makeRun({ id: 'pending-run', status: 'pending' }) }
+    );
+
+    expect(result.success).toBe(false);
+    expect(store.failWorkflowRun).toHaveBeenCalledTimes(1);
+  });
+
+  it('replaces a rethrown setup error with the marker when its record write fails', async () => {
+    // The run-config guard rethrows its own error after recording it. A failed record
+    // has to win: the caller must learn the status is unwritten, not just that config
+    // sealing was unavailable.
+    const store = makeStore({
+      failWorkflowRun: mock(async () => {
+        throw new Error('recovery write failed');
+      }),
+    });
+
+    await expect(
+      executeWorkflow(
+        makeDeps(store),
+        makePlatform(),
+        'conv-1',
+        '/tmp',
+        makeWorkflow(),
+        'msg',
+        'db-conv-1',
+        {
+          preCreatedRun: makeRun({ id: 'pending-run', status: 'pending' }),
+          // No `sealRunConfig` on the test deps, so the guard throws.
+          runConfig: { layer: {}, source: 'cli' },
+        } as unknown as Parameters<typeof executeWorkflow>[7]
+      )
+    ).rejects.toThrow('Failed to persist terminal workflow status');
+  });
+
+  it('does not let the finally backstop mask a failed catch-path write', async () => {
+    // The catch's own failWorkflowRun fails. The backstop sees a row still at
+    // 'running' and would fire a second write over the same channel — masking the
+    // real error with "exited without finalizing". The flag has to stop it.
+    mockExecuteDagWorkflow.mockRejectedValueOnce(new Error('dag boom'));
+    const failWorkflowRun = mock(async () => {
+      throw new Error('terminal failure write failed');
+    });
+    const store = makeStore({
+      failWorkflowRun,
+      getWorkflowRunStatus: mock(async () => 'running' as const),
+    });
+
+    await expect(
+      executeWorkflow(
+        makeDeps(store),
+        makePlatform(),
+        'conv-1',
+        '/tmp',
+        makeWorkflow(),
+        'msg',
+        'db-conv-1'
+      )
+    ).rejects.toThrow('terminal failure write failed');
+
+    expect(failWorkflowRun).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces a failed backstop write instead of exiting cleanly', async () => {
+    // The backstop is the last thing standing between a zombie row and a clean exit.
+    // If its write fails, the process must not report a finished run.
+    const store = makeStore({
+      getWorkflowRunStatus: mock(async () => 'running' as const),
+      failWorkflowRun: mock(async () => {
+        throw new Error('backstop write failed');
+      }),
+    });
+
+    await expect(
+      executeWorkflow(
+        makeDeps(store),
+        makePlatform(),
+        'conv-1',
+        '/tmp',
+        makeWorkflow(),
+        'msg',
+        'db-conv-1'
+      )
+    ).rejects.toThrow('Failed to persist terminal workflow status');
+  });
+});
+
 describe('finally backstop', () => {
   it('calls failWorkflowRun when run is still running at finally', async () => {
     const failSpy = mock(async () => {});

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -69,6 +69,7 @@ import { logWorkflowStart, logWorkflowError } from './logger';
 import { formatDuration, parseDbTimestamp } from './utils/duration';
 import { keepAwake } from './utils/keep-awake';
 import { getWorkflowEventEmitter } from './event-emitter';
+import { TerminalStatusWriteError, requireTerminalStatusWrite } from './terminal-status-write';
 import { isRegisteredProvider, getRegisteredProviders } from '@archon/providers';
 import type { ExecutionContext } from '@archon/providers/types';
 import type { ContainerRunContext } from './container-context';
@@ -1559,10 +1560,9 @@ async function runChildWorkflow(
  *  - the parent's gate isn't a `child_workflow` gate, or
  *  - a DIFFERENT child of the same parent terminated (childRunId mismatch).
  *
- * Never throws — the child's own result must not be corrupted by a parent-resume
- * failure. Every await is guarded here (a parent-side failure is logged, and a
- * post-CAS failure marks the parent 'failed' so it stays resumable); the caller's
- * `.catch` is a belt-and-braces backstop, not the contract.
+ * Failures before the parent resumes leave the child result intact. Once the parent
+ * has resumed, a rejected terminal status write propagates because the child cannot
+ * report an ordinary result while the parent remains running.
  *
  * `resolveChildIsolation` is a plain parameter rather than part of the resume state:
  * {@link ResumePayload} carries what was RECORDED about the prior run, and a resolver
@@ -1736,9 +1736,11 @@ async function maybeResumeParentRun(
       { err: err as Error, parentRunId, childRunId: childRun.id },
       'workflow.parent_auto_resume_execute_failed'
     );
-    await deps.store.failWorkflowRun(
-      parentRunId,
-      `Auto-resume after sub-run failed: ${(err as Error).message}`
+    await requireTerminalStatusWrite(
+      deps.store.failWorkflowRun(
+        parentRunId,
+        `Auto-resume after sub-run failed: ${(err as Error).message}`
+      )
     );
   }
 }
@@ -3036,8 +3038,7 @@ export async function executeWorkflow(
     const finalStatus = await deps.store.getWorkflowRun(workflowRun.id);
     // Sub-run re-entry (#2121 Phase 2): if this run is a `workflow:` child that just
     // reached a terminal state, re-enter its paused parent in-process. Guarded to be
-    // a no-op on the synchronous first-run path (parent still 'running'). Wrapped in
-    // catch — a parent-resume failure must not corrupt the child's own result.
+    // a no-op on the synchronous first-run path (parent still 'running').
     if (
       finalStatus?.parent_run_id &&
       (finalStatus.status === 'completed' ||
@@ -3055,16 +3056,7 @@ export async function executeWorkflow(
         // did inject. Same resolver the child ran with — it is codebase-bound and the
         // child shares the parent's codebase.
         resolveChildIsolation
-      ).catch((err: unknown) => {
-        getLog().error(
-          {
-            err: err as Error,
-            childRunId: workflowRun.id,
-            parentRunId: finalStatus.parent_run_id,
-          },
-          'workflow.parent_auto_resume_failed'
-        );
-      });
+      );
     }
     if (finalStatus?.status === 'completed') {
       return { success: true, workflowRunId: workflowRun.id, summary: dagSummary };
@@ -3078,6 +3070,8 @@ export async function executeWorkflow(
       };
     }
   } catch (error) {
+    if (error instanceof TerminalStatusWriteError) throw error;
+
     // Top-level error handler: ensure workflow is marked as failed
     const err = error as Error;
     getLog().error(

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -1159,9 +1159,9 @@ async function gatherDescendantRunIds(deps: WorkflowDeps, rootId: string): Promi
  * does not cover runtime targets). The child shares the parent's checkout;
  * executeWorkflow derives the ancestor chain from the child's own parent_run_id
  * to exclude it from the path-lock.
- * Never throws — every failure is returned as a `{ status: 'failed' }` outcome so
- * the calling node fails cleanly rather than the whole DAG throwing. (Every step,
- * including the recursive executeWorkflow call, is guarded — keep it that way.)
+ * Ordinary failures return a `{ status: 'failed' }` outcome so the calling node
+ * fails cleanly rather than the whole DAG throwing. Terminal status-write failures
+ * propagate because the child has no trustworthy terminal outcome to return.
  */
 async function runChildWorkflow(
   deps: WorkflowDeps,
@@ -1525,6 +1525,8 @@ async function runChildWorkflow(
     }
     return childOutcomeFromRun(finalChild);
   } catch (err) {
+    if (err instanceof TerminalStatusWriteError) throw err;
+
     // Honor the never-throws contract: executeWorkflow can throw from its early
     // setup (before its own failWorkflowRun catch-all), and the read-back can
     // throw on a DB error — both must surface as a failed node outcome, not an
@@ -1726,6 +1728,8 @@ async function maybeResumeParentRun(
       }
     );
   } catch (err) {
+    if (err instanceof TerminalStatusWriteError) throw err;
+
     // The hydrate CAS above already flipped the parent paused→running, and
     // executeWorkflow's own failWorkflowRun catch-all doesn't cover its early
     // setup (config load, env/credential resolution). Without this handler a
@@ -2733,6 +2737,7 @@ export async function executeWorkflow(
   // early-return validation paths above never leak an unpaired acquire; the
   // matching release is the first statement of this try's finally.
   keepAwake.acquire();
+  let terminalStatusWriteFailed = false;
   try {
     getLog().info(
       {
@@ -3070,7 +3075,10 @@ export async function executeWorkflow(
       };
     }
   } catch (error) {
-    if (error instanceof TerminalStatusWriteError) throw error;
+    if (error instanceof TerminalStatusWriteError) {
+      terminalStatusWriteFailed = true;
+      throw error;
+    }
 
     // Top-level error handler: ensure workflow is marked as failed
     const err = error as Error;
@@ -3141,7 +3149,7 @@ export async function executeWorkflow(
     // calling failWorkflowRun (e.g. a generator cleanup that exits without
     // throwing). Only fires when the process stays alive long enough to run
     // this finally — see #1561 for the originating zombie-state incident.
-    if (workflowRun) {
+    if (workflowRun && !terminalStatusWriteFailed) {
       const runId = workflowRun.id;
       const backstopStatus = await deps.store.getWorkflowRunStatus(runId).catch(() => null);
       if (backstopStatus === 'running') {

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -1753,7 +1753,8 @@ async function maybeResumeParentRun(
       deps.store.failWorkflowRun(
         parentRunId,
         `Auto-resume after sub-run failed: ${(err as Error).message}`
-      )
+      ),
+      { workflowRunId: parentRunId, site: 'workflow.parent_auto_resume_fail_mark_failed' }
     );
   }
 }
@@ -1861,8 +1862,11 @@ export async function executeWorkflow(
       'CLI in the same project (`archon workflow approve/reject/resume <id>`), where the ' +
       'container is rediscovered — chat/web resume cannot rewire it.';
     getLog().warn({ workflowRunId: preCreatedRun.id }, 'workflow.container_resume_without_backend');
-    await deps.store.failWorkflowRun(preCreatedRun.id, msg);
     await safeSendMessage(platform, conversationId, `⚠️ ${msg}`);
+    await requireTerminalStatusWrite(deps.store.failWorkflowRun(preCreatedRun.id, msg), {
+      workflowRunId: preCreatedRun.id,
+      site: 'workflow.container_resume_guard_fail_failed',
+    });
     return { success: false, workflowRunId: preCreatedRun.id, error: msg };
   }
 
@@ -1891,7 +1895,10 @@ export async function executeWorkflow(
     }
   } catch (error) {
     if (preCreatedRun) {
-      await deps.store.failWorkflowRun(preCreatedRun.id, (error as Error).message);
+      await requireTerminalStatusWrite(
+        deps.store.failWorkflowRun(preCreatedRun.id, (error as Error).message),
+        { workflowRunId: preCreatedRun.id, site: 'workflow.run_config_fail_db_record_failed' }
+      );
     }
     throw error;
   }
@@ -2042,7 +2049,10 @@ export async function executeWorkflow(
     // lock indefinitely just because validation happens before the executor's main
     // lifecycle catch.
     if (preCreatedRun) {
-      await deps.store.failWorkflowRun(preCreatedRun.id, (error as Error).message);
+      await requireTerminalStatusWrite(
+        deps.store.failWorkflowRun(preCreatedRun.id, (error as Error).message),
+        { workflowRunId: preCreatedRun.id, site: 'workflow.model_overrides_fail_db_record_failed' }
+      );
     }
     throw error;
   }
@@ -2223,14 +2233,22 @@ export async function executeWorkflow(
         { err, workflowRunId: preCreatedRun.id },
         'workflow.invocation_metadata_persist_failed'
       );
-      await deps.store.failWorkflowRun(
-        preCreatedRun.id,
-        'Database error recording workflow invocation settings'
-      );
+      // Notify before the terminal write: the write can now reject, and the operator
+      // must still learn why the run stopped when it does.
       await sendCriticalMessage(
         platform,
         conversationId,
         '❌ **Workflow failed**: Unable to record the run invocation settings. Please try again later.'
+      );
+      await requireTerminalStatusWrite(
+        deps.store.failWorkflowRun(
+          preCreatedRun.id,
+          'Database error recording workflow invocation settings'
+        ),
+        {
+          workflowRunId: preCreatedRun.id,
+          site: 'workflow.invocation_metadata_failure_record_failed',
+        }
       );
       return {
         success: false,
@@ -2495,14 +2513,17 @@ export async function executeWorkflow(
       { err, artifactsDir, stateDir, workflowRunId: workflowRun.id },
       'workflow.artifacts_dir_create_failed'
     );
-    await deps.store.failWorkflowRun(
-      workflowRun.id,
-      `Artifacts directory creation failed: ${err.message}`
-    );
     await sendCriticalMessage(
       platform,
       conversationId,
       `❌ **Workflow failed**: Could not create artifacts directory \`${artifactsDir}\`: ${err.message}`
+    );
+    await requireTerminalStatusWrite(
+      deps.store.failWorkflowRun(
+        workflowRun.id,
+        `Artifacts directory creation failed: ${err.message}`
+      ),
+      { workflowRunId: workflowRun.id, site: 'workflow.artifacts_dir_fail_db_record_failed' }
     );
     return {
       success: false,
@@ -2574,8 +2595,11 @@ export async function executeWorkflow(
 
   const failRunOnSource = async (message: string): Promise<WorkflowExecutionResult> => {
     getLog().error({ workflowRunId: workflowRun.id, message }, 'workflow.source_unavailable');
-    await deps.store.failWorkflowRun(workflowRun.id, message);
     await sendCriticalMessage(platform, conversationId, `❌ **Workflow failed**: ${message}`);
+    await requireTerminalStatusWrite(deps.store.failWorkflowRun(workflowRun.id, message), {
+      workflowRunId: workflowRun.id,
+      site: 'workflow.source_fail_db_record_failed',
+    });
     return { success: false, workflowRunId: workflowRun.id, error: message };
   };
 
@@ -2716,12 +2740,15 @@ export async function executeWorkflow(
       { err, workflowRunId: workflowRun.id },
       'workflow.user_provider_files_cleanup_failed'
     );
-    await deps.store.failWorkflowRun(workflowRun.id, message);
     await sendCriticalMessage(
       platform,
       conversationId,
       'Workflow blocked: Unable to safely prepare provider credentials. Please retry.'
     );
+    await requireTerminalStatusWrite(deps.store.failWorkflowRun(workflowRun.id, message), {
+      workflowRunId: workflowRun.id,
+      site: 'workflow.user_provider_files_cleanup_fail_db_record_failed',
+    });
     return { success: false, workflowRunId: workflowRun.id, error: message };
   }
 
@@ -2755,6 +2782,10 @@ export async function executeWorkflow(
   // early-return validation paths above never leak an unpaired acquire; the
   // matching release is the first statement of this try's finally.
   keepAwake.acquire();
+  // Set by every path that observes a rejected terminal status write — one arriving
+  // from the DAG or a sub-run (the catch below), and the catch's own recovery write.
+  // The finally-block backstop reads it: a second write over a channel that just
+  // failed would either fail again or mask the real error.
   let terminalStatusWriteFailed = false;
   try {
     getLog().info(
@@ -3105,10 +3136,11 @@ export async function executeWorkflow(
       'workflow_execution_unhandled_error'
     );
 
-    // A terminal status write is part of the result: if it fails, reject instead of
-    // reporting a completed process for a row that still says running.
-    await deps.store.failWorkflowRun(workflowRun.id, err.message);
-
+    // Everything below is independent of the terminal write and used to run whether
+    // or not it succeeded (it was try/caught here before #2910). The write moved to
+    // the end of this block so a rejection cannot silence the log file, the live
+    // event, telemetry, or the user's failure notification.
+    //
     // Log to file (separate from database - non-blocking)
     try {
       await logWorkflowError(logDir, workflowRun.id, err.message);
@@ -3154,6 +3186,21 @@ export async function executeWorkflow(
         'user_failure_notification_failed'
       );
     }
+
+    // A terminal status write is part of the result: if it fails, reject instead of
+    // reporting a completed process for a row that still says running. Record that it
+    // failed so the finally-block backstop below does not fire a second write over a
+    // write channel that just proved unreliable — that write would mask this error.
+    try {
+      await requireTerminalStatusWrite(deps.store.failWorkflowRun(workflowRun.id, err.message), {
+        workflowRunId: workflowRun.id,
+        site: 'db_record_failure_failed',
+      });
+    } catch (writeError) {
+      terminalStatusWriteFailed = true;
+      throw writeError;
+    }
+
     // Return failure result instead of re-throwing
     return { success: false, workflowRunId: workflowRun.id, error: err.message };
   } finally {
@@ -3172,7 +3219,10 @@ export async function executeWorkflow(
       const backstopStatus = await deps.store.getWorkflowRunStatus(runId).catch(() => null);
       if (backstopStatus === 'running') {
         getLog().warn({ workflowRunId: runId }, 'executor.backstop_triggered');
-        await deps.store.failWorkflowRun(runId, 'Workflow exited without finalizing — see logs');
+        await requireTerminalStatusWrite(
+          deps.store.failWorkflowRun(runId, 'Workflow exited without finalizing — see logs'),
+          { workflowRunId: runId, site: 'executor.backstop_fail_failed' }
+        );
       }
     }
   }

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -1736,14 +1736,10 @@ async function maybeResumeParentRun(
       { err: err as Error, parentRunId, childRunId: childRun.id },
       'workflow.parent_auto_resume_execute_failed'
     );
-    await deps.store
-      .failWorkflowRun(parentRunId, `Auto-resume after sub-run failed: ${(err as Error).message}`)
-      .catch((failErr: unknown) => {
-        getLog().error(
-          { err: failErr as Error, parentRunId },
-          'workflow.parent_auto_resume_fail_mark_failed'
-        );
-      });
+    await deps.store.failWorkflowRun(
+      parentRunId,
+      `Auto-resume after sub-run failed: ${(err as Error).message}`
+    );
   }
 }
 
@@ -1850,12 +1846,7 @@ export async function executeWorkflow(
       'CLI in the same project (`archon workflow approve/reject/resume <id>`), where the ' +
       'container is rediscovered — chat/web resume cannot rewire it.';
     getLog().warn({ workflowRunId: preCreatedRun.id }, 'workflow.container_resume_without_backend');
-    await deps.store.failWorkflowRun(preCreatedRun.id, msg).catch((err: unknown) => {
-      getLog().error(
-        { err, workflowRunId: preCreatedRun.id },
-        'workflow.container_resume_guard_fail_failed'
-      );
-    });
+    await deps.store.failWorkflowRun(preCreatedRun.id, msg);
     await safeSendMessage(platform, conversationId, `⚠️ ${msg}`);
     return { success: false, workflowRunId: preCreatedRun.id, error: msg };
   }
@@ -1885,14 +1876,7 @@ export async function executeWorkflow(
     }
   } catch (error) {
     if (preCreatedRun) {
-      await deps.store
-        .failWorkflowRun(preCreatedRun.id, (error as Error).message)
-        .catch((dbError: Error) => {
-          getLog().error(
-            { err: dbError, workflowRunId: preCreatedRun.id },
-            'workflow.run_config_fail_db_record_failed'
-          );
-        });
+      await deps.store.failWorkflowRun(preCreatedRun.id, (error as Error).message);
     }
     throw error;
   }
@@ -2043,14 +2027,7 @@ export async function executeWorkflow(
     // lock indefinitely just because validation happens before the executor's main
     // lifecycle catch.
     if (preCreatedRun) {
-      await deps.store
-        .failWorkflowRun(preCreatedRun.id, (error as Error).message)
-        .catch((dbError: Error) => {
-          getLog().error(
-            { err: dbError, workflowRunId: preCreatedRun.id },
-            'workflow.model_overrides_fail_db_record_failed'
-          );
-        });
+      await deps.store.failWorkflowRun(preCreatedRun.id, (error as Error).message);
     }
     throw error;
   }
@@ -2222,14 +2199,10 @@ export async function executeWorkflow(
         { err, workflowRunId: preCreatedRun.id },
         'workflow.invocation_metadata_persist_failed'
       );
-      await deps.store
-        .failWorkflowRun(preCreatedRun.id, 'Database error recording workflow invocation settings')
-        .catch((dbError: Error) => {
-          getLog().error(
-            { err: dbError, workflowRunId: preCreatedRun.id },
-            'workflow.invocation_metadata_failure_record_failed'
-          );
-        });
+      await deps.store.failWorkflowRun(
+        preCreatedRun.id,
+        'Database error recording workflow invocation settings'
+      );
       await sendCriticalMessage(
         platform,
         conversationId,
@@ -2498,14 +2471,10 @@ export async function executeWorkflow(
       { err, artifactsDir, stateDir, workflowRunId: workflowRun.id },
       'workflow.artifacts_dir_create_failed'
     );
-    await deps.store
-      .failWorkflowRun(workflowRun.id, `Artifacts directory creation failed: ${err.message}`)
-      .catch((dbErr: Error) => {
-        getLog().error(
-          { err: dbErr, workflowRunId: workflowRun.id },
-          'workflow.artifacts_dir_fail_db_record_failed'
-        );
-      });
+    await deps.store.failWorkflowRun(
+      workflowRun.id,
+      `Artifacts directory creation failed: ${err.message}`
+    );
     await sendCriticalMessage(
       platform,
       conversationId,
@@ -2581,12 +2550,7 @@ export async function executeWorkflow(
 
   const failRunOnSource = async (message: string): Promise<WorkflowExecutionResult> => {
     getLog().error({ workflowRunId: workflowRun.id, message }, 'workflow.source_unavailable');
-    await deps.store.failWorkflowRun(workflowRun.id, message).catch((dbErr: Error) => {
-      getLog().error(
-        { err: dbErr, workflowRunId: workflowRun.id },
-        'workflow.source_fail_db_record_failed'
-      );
-    });
+    await deps.store.failWorkflowRun(workflowRun.id, message);
     await sendCriticalMessage(platform, conversationId, `❌ **Workflow failed**: ${message}`);
     return { success: false, workflowRunId: workflowRun.id, error: message };
   };
@@ -2728,12 +2692,7 @@ export async function executeWorkflow(
       { err, workflowRunId: workflowRun.id },
       'workflow.user_provider_files_cleanup_failed'
     );
-    await deps.store.failWorkflowRun(workflowRun.id, message).catch((dbErr: Error) => {
-      getLog().error(
-        { err: dbErr, workflowRunId: workflowRun.id },
-        'workflow.user_provider_files_cleanup_fail_db_record_failed'
-      );
-    });
+    await deps.store.failWorkflowRun(workflowRun.id, message);
     await sendCriticalMessage(
       platform,
       conversationId,
@@ -3126,15 +3085,9 @@ export async function executeWorkflow(
       'workflow_execution_unhandled_error'
     );
 
-    // Record failure in database (non-blocking - log but don't re-throw on DB error)
-    try {
-      await deps.store.failWorkflowRun(workflowRun.id, err.message);
-    } catch (dbError) {
-      getLog().error(
-        { err: dbError as Error, workflowId: workflowRun.id, originalError: err.message },
-        'db_record_failure_failed'
-      );
-    }
+    // A terminal status write is part of the result: if it fails, reject instead of
+    // reporting a completed process for a row that still says running.
+    await deps.store.failWorkflowRun(workflowRun.id, err.message);
 
     // Log to file (separate from database - non-blocking)
     try {
@@ -3199,11 +3152,7 @@ export async function executeWorkflow(
       const backstopStatus = await deps.store.getWorkflowRunStatus(runId).catch(() => null);
       if (backstopStatus === 'running') {
         getLog().warn({ workflowRunId: runId }, 'executor.backstop_triggered');
-        await deps.store
-          .failWorkflowRun(runId, 'Workflow exited without finalizing — see logs')
-          .catch((err: unknown) => {
-            getLog().error({ err, workflowRunId: runId }, 'executor.backstop_fail_failed');
-          });
+        await deps.store.failWorkflowRun(runId, 'Workflow exited without finalizing — see logs');
       }
     }
   }

--- a/packages/workflows/src/subrun.test.ts
+++ b/packages/workflows/src/subrun.test.ts
@@ -13,6 +13,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach, afterAll, mock } from 'bun:test';
 import { mkdir, writeFile, rm, cp, readdir } from 'fs/promises';
+import { removeTempTree } from '@archon/paths/test-utils';
 import { existsSync } from 'fs';
 import { join, sep } from 'path';
 import { tmpdir } from 'os';
@@ -6294,5 +6295,121 @@ nodes:
     } finally {
       forceRenameFailure = false;
     }
+  });
+});
+
+// #2910: a child's own setup guards record its terminal status too. When one of
+// those writes fails, the child has no trustworthy outcome — and the parent must
+// not be handed an ordinary "the sub-run errored" node result over a child row
+// still sitting at pending/running.
+describe("a child's terminal status write fails during setup (#2910)", () => {
+  let cwd: string;
+  const originalArchonHome = process.env.ARCHON_HOME;
+
+  async function writeWorkflow(name: string, yaml: string): Promise<void> {
+    await writeFile(join(cwd, '.archon', 'workflows', `${name}.yaml`), yaml);
+  }
+
+  async function discover(name: string): Promise<WorkflowDefinition> {
+    const result = await discoverWorkflows(cwd, { loadDefaults: false });
+    const wf = result.workflows.find(w => w.workflow.name === name);
+    if (!wf) throw new Error(`workflow ${name} not found: ${JSON.stringify(result.errors)}`);
+    return wf.workflow;
+  }
+
+  beforeEach(async () => {
+    cwd = join(tmpdir(), `subrun-setup-write-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(join(cwd, '.archon', 'workflows'), { recursive: true });
+    process.env.ARCHON_HOME = join(cwd, 'home');
+  });
+
+  afterEach(async () => {
+    await removeTempTree(cwd);
+    if (originalArchonHome === undefined) delete process.env.ARCHON_HOME;
+    else process.env.ARCHON_HOME = originalArchonHome;
+  });
+
+  async function writeSubRunPair(): Promise<WorkflowDefinition> {
+    await writeWorkflow(
+      'child-setup-write',
+      `
+name: child-setup-write
+description: child whose invocation-metadata write is forced to fail
+nodes:
+- id: work
+  prompt: "work"
+`
+    );
+    await writeWorkflow(
+      'parent-setup-write',
+      `
+name: parent-setup-write
+description: parent composing child-setup-write
+nodes:
+- id: sub
+  workflow: child-setup-write
+  input: the-goal
+- id: after
+  prompt: "downstream reads $sub.output"
+  depends_on: [sub]
+`
+    );
+    return discover('parent-setup-write');
+  }
+
+  /** Fail the child's invocation-metadata persist — the write its recovery covers. */
+  function breakChildMetadataWrite(store: InMemoryStore): void {
+    const realUpdate = store.updateWorkflowRun.bind(store);
+    store.updateWorkflowRun = (id, updates) => {
+      const row = store.runs.get(id);
+      if (row?.parent_run_id && updates.metadata) {
+        return Promise.reject(new Error('child metadata write failed'));
+      }
+      return realUpdate(id, updates);
+    };
+  }
+
+  it('fails the parent run rather than reporting an ordinary failed child', async () => {
+    const parent = await writeSubRunPair();
+    const store = new InMemoryStore();
+    breakChildMetadataWrite(store);
+    const realFail = store.failWorkflowRun.bind(store);
+    store.failWorkflowRun = (id, error) => {
+      const row = store.runs.get(id);
+      if (row?.parent_run_id) return Promise.reject(new Error('child recovery write failed'));
+      return realFail(id, error);
+    };
+
+    await expect(
+      executeWorkflow(makeDeps(store), makePlatform(), 'conv-plat', cwd, parent, 'goal', 'conv-db')
+    ).rejects.toThrow('Failed to persist terminal workflow status');
+
+    // The parent must not have carried on past the sub-run node.
+    const afterCompleted = store.events.some(
+      e => e.event_type === 'node_completed' && e.step_name?.includes('after')
+    );
+    expect(afterCompleted).toBe(false);
+  });
+
+  it('reports an ordinary failed child when the recovery write succeeds', async () => {
+    // The other side of the branch: the child's status IS recorded, so the parent
+    // gets a normal failed-sub-run outcome instead of a rejection.
+    const parent = await writeSubRunPair();
+    const store = new InMemoryStore();
+    breakChildMetadataWrite(store);
+
+    const result = await executeWorkflow(
+      makeDeps(store),
+      makePlatform(),
+      'conv-plat',
+      cwd,
+      parent,
+      'goal',
+      'conv-db'
+    );
+
+    expect(result.success).toBe(false);
+    const child = [...store.runs.values()].find(r => r.workflow_name === 'child-setup-write');
+    expect(child?.status).toBe('failed');
   });
 });

--- a/packages/workflows/src/subrun.test.ts
+++ b/packages/workflows/src/subrun.test.ts
@@ -988,6 +988,77 @@ nodes:
     expect(String(finalParent?.metadata.error)).toContain('Auto-resume after sub-run failed');
   });
 
+  it('surfaces a rejected parent terminal write after the child completes', async () => {
+    await writeWorkflow(
+      'child-gated',
+      `
+name: child-gated
+description: child with an approval gate
+interactive: true
+nodes:
+  - id: implement
+    prompt: "implement $ARGUMENTS"
+  - id: review-gate
+    approval:
+      message: "review the sub-run"
+    depends_on: [implement]
+`
+    );
+    await writeWorkflow(
+      'parent-gated',
+      `
+name: parent-gated
+description: parent composing a gated child
+interactive: true
+nodes:
+  - id: sub
+    workflow: child-gated
+    input: "goal"
+`
+    );
+
+    const store = new InMemoryStore();
+    const deps = makeDeps(store);
+    const parent = await discover('parent-gated');
+    await executeWorkflow(deps, makePlatform(), 'conv-plat', cwd, parent, 'goal', 'conv-db');
+
+    const parentRun = [...store.runs.values()].find(r => r.workflow_name === 'parent-gated');
+    const child = [...store.runs.values()].find(r => r.workflow_name === 'child-gated');
+    expect(parentRun?.status).toBe('paused');
+
+    parentRun!.codebase_id = 'cb-1';
+    store.getCodebaseEnvVars = () => Promise.reject(new Error('env lookup exploded'));
+    const failWorkflowRun = store.failWorkflowRun.bind(store);
+    const parentFailureWrites: string[] = [];
+    store.failWorkflowRun = (runId, error) => {
+      if (runId === parentRun!.id) {
+        parentFailureWrites.push(error);
+        return Promise.reject(new Error('parent terminal write failed'));
+      }
+      return failWorkflowRun(runId, error);
+    };
+
+    store.approveGate(child!.id);
+    const hydrated = await hydrateResumableRun(deps, (await store.getWorkflowRun(child!.id))!);
+    const childWf = await discover('child-gated');
+    await expect(
+      executeWorkflow(
+        deps,
+        makePlatform(),
+        'conv-plat',
+        cwd,
+        childWf,
+        child!.user_message,
+        'conv-db',
+        { ...hydrated! }
+      )
+    ).rejects.toThrow('parent terminal write failed');
+
+    expect((await store.getWorkflowRun(child!.id))?.status).toBe('completed');
+    expect((await store.getWorkflowRun(parentRun!.id))?.status).toBe('running');
+    expect(parentFailureWrites).toHaveLength(1);
+  });
+
   it('child failure fails the sub node and the parent run', async () => {
     await writeWorkflow(
       'child-fail',

--- a/packages/workflows/src/subrun.test.ts
+++ b/packages/workflows/src/subrun.test.ts
@@ -704,6 +704,108 @@ nodes:
     expect(child?.conversation_id).toBe('conv-db');
   });
 
+  it('propagates a child terminal write failure through a workflow node', async () => {
+    await writeWorkflow(
+      'child-terminal-write',
+      `
+name: child-terminal-write
+description: child whose completion write fails
+nodes:
+  - id: work
+    prompt: "work"
+`
+    );
+    await writeWorkflow(
+      'parent-terminal-write',
+      `
+name: parent-terminal-write
+description: parent that invokes the child
+nodes:
+  - id: sub
+    workflow: child-terminal-write
+`
+    );
+
+    const store = new InMemoryStore();
+    const completeWorkflowRun = store.completeWorkflowRun.bind(store);
+    const failWorkflowRun = store.failWorkflowRun.bind(store);
+    const parentFailureWrites: string[] = [];
+    store.completeWorkflowRun = (runId, completion, metadata) => {
+      if (store.runs.get(runId)?.workflow_name === 'child-terminal-write') {
+        return Promise.reject(new Error('child terminal write failed'));
+      }
+      return completeWorkflowRun(runId, completion, metadata);
+    };
+    store.failWorkflowRun = (runId, error) => {
+      if (store.runs.get(runId)?.workflow_name === 'parent-terminal-write') {
+        parentFailureWrites.push(error);
+      }
+      return failWorkflowRun(runId, error);
+    };
+
+    await expect(
+      executeWorkflow(
+        makeDeps(store),
+        makePlatform(),
+        'conv-plat',
+        cwd,
+        await discover('parent-terminal-write'),
+        'goal',
+        'conv-db'
+      )
+    ).rejects.toThrow('child terminal write failed');
+
+    expect(parentFailureWrites).toEqual([]);
+  });
+
+  it('propagates a child terminal write failure through a fan-out node', async () => {
+    await writeWorkflow(
+      'fan-child-terminal-write',
+      `
+name: fan-child-terminal-write
+description: read-only child whose completion write fails
+mutates_checkout: false
+nodes:
+  - id: work
+    prompt: "work"
+`
+    );
+    await writeWorkflow(
+      'fan-parent-terminal-write',
+      `
+name: fan-parent-terminal-write
+description: parent that fans out to the child
+nodes:
+  - id: work
+    workflow: fan-child-terminal-write
+    mutates_checkout: false
+    fan_out:
+      items: '["one"]'
+`
+    );
+
+    const store = new InMemoryStore();
+    const completeWorkflowRun = store.completeWorkflowRun.bind(store);
+    store.completeWorkflowRun = (runId, completion, metadata) => {
+      if (store.runs.get(runId)?.workflow_name === 'fan-child-terminal-write') {
+        return Promise.reject(new Error('fan-out child terminal write failed'));
+      }
+      return completeWorkflowRun(runId, completion, metadata);
+    };
+
+    await expect(
+      executeWorkflow(
+        makeDeps(store),
+        makePlatform(),
+        'conv-plat',
+        cwd,
+        await discover('fan-parent-terminal-write'),
+        'goal',
+        'conv-db'
+      )
+    ).rejects.toThrow('fan-out child terminal write failed');
+  });
+
   it('propagates sparse model bindings into a child run and its effective profile', async () => {
     await writeWorkflow(
       'child-model-binding',

--- a/packages/workflows/src/terminal-status-write.test.ts
+++ b/packages/workflows/src/terminal-status-write.test.ts
@@ -1,0 +1,67 @@
+/**
+ * The wrapper is the only place a terminal status-write failure is diagnosed.
+ *
+ * It replaced ~14 per-site `.catch()` handlers that each logged their own tagged
+ * line; if the wrapper stops logging, the original database error travels silently
+ * inside `.cause` until some caller frames away happens to log the rejection.
+ */
+import { describe, it, expect, mock, beforeEach } from 'bun:test';
+
+const logError = mock((..._args: unknown[]) => undefined);
+const realArchonPaths = await import('@archon/paths');
+mock.module('@archon/paths', () => ({
+  ...realArchonPaths,
+  createLogger: mock(() => ({
+    fatal: mock(() => undefined),
+    error: logError,
+    warn: mock(() => undefined),
+    info: mock(() => undefined),
+    debug: mock(() => undefined),
+    trace: mock(() => undefined),
+  })),
+}));
+
+const { TerminalStatusWriteError, requireTerminalStatusWrite } =
+  await import('./terminal-status-write');
+
+describe('requireTerminalStatusWrite', () => {
+  beforeEach(() => {
+    logError.mockClear();
+  });
+
+  it('passes a successful write through untouched and logs nothing', async () => {
+    await expect(
+      requireTerminalStatusWrite(Promise.resolve('ok'), {
+        workflowRunId: 'run-1',
+        site: 'test.site',
+      })
+    ).resolves.toBe('ok');
+
+    expect(logError).not.toHaveBeenCalled();
+  });
+
+  it('logs the original error with its run id and site, then rethrows the marker', async () => {
+    const cause = new Error('SQLITE_BUSY: database is locked');
+
+    const rejection = requireTerminalStatusWrite(Promise.reject(cause), {
+      workflowRunId: 'run-1',
+      site: 'executor.backstop_fail_failed',
+    });
+    await expect(rejection).rejects.toBeInstanceOf(TerminalStatusWriteError);
+
+    expect(logError).toHaveBeenCalledTimes(1);
+    const [context, tag] = logError.mock.calls[0] as [Record<string, unknown>, string];
+    expect(context.err).toBe(cause);
+    expect(context.workflowRunId).toBe('run-1');
+    expect(context.site).toBe('executor.backstop_fail_failed');
+    expect(tag).toBe('workflow.terminal_status_write_failed');
+  });
+
+  it('keeps the original error reachable as the marker cause', async () => {
+    const cause = new Error('disk full');
+
+    await expect(
+      requireTerminalStatusWrite(Promise.reject(cause), { workflowRunId: 'r', site: 's' })
+    ).rejects.toMatchObject({ cause });
+  });
+});

--- a/packages/workflows/src/terminal-status-write.ts
+++ b/packages/workflows/src/terminal-status-write.ts
@@ -1,0 +1,21 @@
+export class TerminalStatusWriteError extends Error {
+  readonly cause: unknown;
+
+  constructor(cause: unknown) {
+    super(
+      `Failed to persist terminal workflow status: ${
+        cause instanceof Error ? cause.message : String(cause)
+      }`
+    );
+    this.name = 'TerminalStatusWriteError';
+    this.cause = cause;
+  }
+}
+
+export async function requireTerminalStatusWrite<T>(write: Promise<T>): Promise<T> {
+  try {
+    return await write;
+  } catch (error) {
+    throw new TerminalStatusWriteError(error);
+  }
+}

--- a/packages/workflows/src/terminal-status-write.ts
+++ b/packages/workflows/src/terminal-status-write.ts
@@ -1,3 +1,20 @@
+import { createLogger } from '@archon/paths';
+
+/** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
+let cachedLog: ReturnType<typeof createLogger> | undefined;
+function getLog(): ReturnType<typeof createLogger> {
+  if (!cachedLog) cachedLog = createLogger('workflow.terminal-status-write');
+  return cachedLog;
+}
+
+/**
+ * A run's terminal status (completed / failed / cancelled) could not be recorded.
+ *
+ * Recovery boundaries branch on this type to keep the run distinguishable from one
+ * that merely failed: the process finished, but the row still says `running`, so no
+ * ordinary outcome can be reported for it and no compensating write should be tried
+ * over the same write channel.
+ */
 export class TerminalStatusWriteError extends Error {
   readonly cause: unknown;
 
@@ -12,10 +29,31 @@ export class TerminalStatusWriteError extends Error {
   }
 }
 
-export async function requireTerminalStatusWrite<T>(write: Promise<T>): Promise<T> {
+/** Identifies which terminal write failed, for the diagnostic log below. */
+export interface TerminalStatusWriteContext {
+  workflowRunId: string;
+  /** Greppable call-site tag, e.g. `executor.backstop_fail_failed`. */
+  site: string;
+}
+
+/**
+ * Await a terminal run-status write and convert a rejection into the typed marker.
+ *
+ * Logs the original database error here so no call site has to remember to. `site`
+ * carries what the per-call `.catch()` handlers this wrapper replaced used to carry:
+ * which of the ~14 terminal writes is the one that failed.
+ */
+export async function requireTerminalStatusWrite<T>(
+  write: Promise<T>,
+  context: TerminalStatusWriteContext
+): Promise<T> {
   try {
     return await write;
   } catch (error) {
+    getLog().error(
+      { err: error as Error, workflowRunId: context.workflowRunId, site: context.site },
+      'workflow.terminal_status_write_failed'
+    );
     throw new TerminalStatusWriteError(error);
   }
 }


### PR DESCRIPTION
## Problem and outcome

Terminal status writes were best-effort: a failed `completeWorkflowRun` or `failWorkflowRun` could let an already-finished execution return normally while its row remained `running`. That made the run appear live, held its worktree lock, and obscured the failed write for unattended runs.

- **Outcome:** Every terminal workflow-status write now propagates its failure, so the executor never reports success or an ordinary failure result after it cannot persist the terminal state.
- **Invariant:** A workflow may reach a terminal result only after its terminal database status write succeeds; a failed terminal write rejects the execution.
- **Scope boundary:** This changes error propagation for existing terminal status writes only; it adds no retry, notification channel, or persistence format.
- **Root cause:** The DAG and top-level executors caught and logged rejected terminal status writes, then continued through terminal completion or failure handling.

## Review guidance

- **Feedback requested:** Confirm that propagating all listed terminal status-write failures is the intended lifecycle contract.
- **Start here:** `packages/workflows/src/dag-executor.ts:12481` — successful DAG completion uses a terminal-write wrapper, so a failed write remains distinct and propagates without a second failure write.
- **Review order:** Review `dag-executor.ts` terminal completion and failure paths, then `executor.ts` setup, parent-resume, top-level failure, and finally-backstop paths; finish with the regression tests.
- **Lower-attention areas:** The test additions use injected-store rejection cases; the focused suites and repository validation passed.
- **Known risk or uncertainty:** A terminal persistence outage now rejects the process instead of returning a result while the run remains `running`; this is deliberate so callers and supervisors can observe the failure.

## Solution

Removed the local catch-and-log handlers from every terminal `completeWorkflowRun` and `failWorkflowRun` site identified in #2910. The terminal-write wrapper lets terminal persistence failures bypass ordinary failure handling, preventing an erroneous second terminal write; a failed failure write rejects rather than producing a false terminal result. Non-terminal logging and notification failures retain their existing best-effort handling.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | A terminal database write failure could return or emit a terminal result while the run row stayed `running`. | The execution rejects when a terminal status write fails. |
| **Failure behavior** | The error was only logged, and one completion path attempted a chat warning. | The write failure reaches the caller or process supervisor; no false successful or ordinary failed result is returned. |

## Validation

- `bun test src/dag-executor.test.ts` — passed (686 tests) — proves rejected completion and DAG failure writes surface.
- `bun test src/executor.test.ts` — passed (126 tests) — proves a rejected top-level failure write surfaces.
- `bun run type-check` in `packages/workflows` — passed.
- `bun run lint --max-warnings 0` — passed.
- `bun run validate` — passed — includes generated-artifact checks, type checks, lint, formatting, install check, and the test suite.
- **Not verified:** Nothing material; focused tests exercise the new rejection behavior and the repository validation suite passed.

## Links

- Closes #2910

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workflow completion and failure update errors are now surfaced instead of being silently logged.
  * Prevented workflows from reporting misleading terminal states when status updates fail.
  * Improved error handling for nested, gated, and fan-out workflows, avoiding duplicate failure handling.
  * Added clearer notifications directing you to check workflow status when the final status cannot be saved.

* **Tests**
  * Added coverage for terminal status update failures across standard, nested, gated, and fan-out workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->