### PR TITLE
test(cli): remove the accidental workflow-source capture from the main-catch envelope test

### DIFF
--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1019,11 +1019,22 @@ describe('main catch --json error envelope', () => {
     // An unknown workflow name makes workflowRunCommand throw with no local
     // handling, so the error escapes to main()'s outer catch — the last route
     // that could still leak bare stderr text under --json.
+    //
+    // `--dry-run` is not part of the contract; it is how this test avoids
+    // paying for one. A real run freezes the workflow source BEFORE resolving
+    // the name (workflow.ts: prepareWorkflowSource precedes
+    // resolveWorkflowName, deliberately — discovery must read the frozen
+    // bytes, #2660/#2747), so without the flag this single spawn copies and
+    // digests every project, global, and bundled workflow file this repository
+    // has — thousands of filesystem operations, and growing — then deletes
+    // them, only to report that the workflow does not exist. The throw, its
+    // route to main()'s catch, and the envelope are identical either way.
     const { status, envelope } = spawnJsonError([
       'workflow',
       'run',
       'definitely-not-a-workflow',
       '--json',
+      '--dry-run',
       '--cwd',
       repoRoot,
     ]);

--- a/scripts/migrate-state-dir.test.ts
+++ b/scripts/migrate-state-dir.test.ts
@@ -37,6 +37,20 @@
  * measured on windows-latest and ruled out. What was left was accidental cost:
  * their fixture spawned a SECOND cold `bun` process purely to write one registry
  * row, which is now an in-process write. The budget still has not moved.
+ *
+ * It recurred a third time (#2882, both C5 cases in one windows-latest run at
+ * 6266/5016 ms, carrying Bun's body-timeout message rather than its hook-timeout
+ * one). This time the body was phase-attributed and nothing accidental was left
+ * to remove: spawning the migration script is 88% of it (61-68 ms of a 69-74 ms
+ * body locally), and that subprocess IS the contract. The registry fixture is
+ * the remaining 8-11%; building it once and copying the file per test measured
+ * 2-3 ms cheaper and would have to either share one database across the two
+ * cases — the cross-test coupling the paragraph above exists to prevent — or
+ * rewrite the row anyway, because `default_cwd` is the per-test sandbox path.
+ * The other 17 tests in this file sit at the same one-spawn floor (58-65 ms), so
+ * the C5 pair are not special; they are ~15% above a floor that a contended
+ * Windows runner puts at the budget line. That is a runner-capacity question,
+ * not a cost this file can spend less of. Still do not reach for the timeout.
  */
 import { describe, test, expect } from 'bun:test';
 import { mkdtemp, mkdir, writeFile, readFile, readdir } from 'fs/promises';


### PR DESCRIPTION
## Problem and outcome

Two `packages/cli`-adjacent tests keep timing out on `windows-latest` against Bun's 5000 ms
per-test budget — most recently `main catch --json error envelope` at 6266 ms on a PR that
only touched pack prompts and a doc. Both carry Bun's *body*-timeout message, so the time is
being spent inside the test, not in teardown. The standing rule for this class is that a
budget bump is never the fix: if a test blows the budget, it is spending on something it
should not be.

One of the two was. The other was not, and this PR says so rather than inventing surgery.

- **Outcome:** `main catch --json error envelope` no longer copies and digests the whole
  workflow-source tree — every project, global, and bundled workflow file in this repository,
  383 files and 2.37 MB at this head — before reporting that the workflow name it invented
  does not exist. Its body drops from 543 ms to 373 ms median locally, and the removed term
  is filesystem operations, which is the term that hurts most on Windows.
- **Invariant:** every test still fails if its contract breaks. The main-catch test must
  still be the *only* thing in `cli.test.ts` that covers `main()`'s top-level catch, and it
  must still assert both halves — exit code 1 and a parseable `{ ok: false }` on stdout.
- **Scope boundary:** no timeout raised, no Windows skip, no coverage removed, and no
  production code changed. Two test files, +24 lines, no deletions.
- **Root cause (family 1):** `workflowRunCommand` freezes the workflow source
  (`prepareWorkflowSource`) *before* it resolves the workflow name (`resolveWorkflowName`).
  That order is deliberate and correct — discovery has to read the frozen bytes, or a
  workflow edited between capture and execution runs the new graph against the old command
  bytes (#2660/#2747). The consequence is that an unknown *name* is only discovered after the
  whole tree has been copied and hashed, and this test's entire purpose is to supply an
  unknown name.

## Review guidance

- **Feedback requested:** whether `--dry-run` is an honest way to reach the same catch, and
  whether the family-2 verdict (nothing left to remove) is convincing.
- **Start here:** `packages/cli/src/cli.test.ts:1017` — the one behavioural change is the
  added `--dry-run`.
- **Review order:** `packages/cli/src/cli.test.ts`, then the docblock in
  `scripts/migrate-state-dir.test.ts`.
- **Known risk or uncertainty:** none of this can be reproduced on Windows from macOS. The
  argument is cost class plus local before/after, and one green Windows leg would not prove
  the class closed — which is why there is no closing keyword on #2882 below.

## Solution

**Family 1 — `main catch --json error envelope` (fixed).**

The test's body is one `spawnSync` of the CLI, which spawns one child of its own
(`git rev-parse --show-toplevel`, from the git gate). Decomposed with 5-run means under
`CI=true` — which is what GitHub Actions sets and what `resolveDisabledReason()` reads as a
telemetry opt-out, so local numbers taken this way are CI-shaped:

| invocation | cost | isolates |
| --- | --- | --- |
| `boguscmd --json` | 302 ms | bun boot + `cli.ts`'s full static module graph |
| `workflow list --json --cwd <minimal repo>` | 327 ms | + the git gate |
| `workflow list --json --cwd <this repo>` | 350 ms | + host-repo discovery |
| `workflow run <unknown> --json --cwd <minimal repo>` | 394 ms | + the run path |
| `workflow run <unknown> --json --cwd <this repo>` **(the test)** | 480 ms | + host-repo scale |

458 ms in the junit reporter — the second-most-expensive of the file's 95 tests, against
250–275 ms for the ten sibling `--json` envelope tests that spawn the same binary and return
before dispatch.

The capture is what the extra buys. Its own debug log on this invocation:

```
"module":"workflow.source","fileCount":383,"byteCount":2372240,
"scopes":["project","global","bundled"],"msg":"workflow.source_captured"
```

`prepareWorkflowSource` is guarded by `!options.dryRun`, so adding `--dry-run` skips it.
Discovery falls to `loadWorkflows`, the same `if (!workflow)` block throws the same error, the
error still leaves `workflowRunCommand` with no local handling, and `main()`'s outer catch
still writes the envelope and returns 1. Verified: `source_captured` appears once without the
flag and zero times with it, and `~/.archon/staged-source/` stays empty.

**Family 2 — `migrate-state-dir > subdirectory invocation (C5)` (no change, and why).**

Two tests, 6266 ms and 5016 ms in one Windows run. Phase-attributed with an instrumented copy
of the body, three iterations:

| phase | cost | share |
| --- | --- | --- |
| `mkdtemp` + sandbox mkdirs | 0.5–0.6 ms | 1% |
| `SqliteAdapter` open + schema apply + INSERT + close | 5.8–8.7 ms | 8–11% |
| `seedLegacy` | 0.3–0.5 ms | <1% |
| **spawn of the migration script** | **61.2–67.5 ms** | **88%** |
| `removeTempTree` | 0.8–1.0 ms | 1% |
| **body total** | **68.8–78.2 ms** | |

The subprocess is the contract — the script's exit code, its `resolved to the registered
project root` line, and what ends up on disk — and it is 88% of the body. The registry
fixture is the only other term, and it does not amortise: `default_cwd` is the per-test
sandbox path, so a database prepared once still has to have its row rewritten. Measured both
ways, that saves 2–3 ms (`6.1/8.1/6.8 ms` fresh against `4.2/5.2/3.9 ms` copied-then-updated).
Removing the term entirely would mean sharing one database across both cases, which is the
cross-test coupling that file's docblock already records as a live past bug (#2306, and a dry
run that appeared to move a file on PR #2513).

The other seventeen tests in that file sit at the same one-spawn floor of 58–65 ms, so the C5
pair are not special: they are ~15% above a floor that a contended Windows runner puts at the
budget line. That is runner capacity, not a cost the file can spend less of. The finding goes
into the file's own BUDGET docblock, which exists precisely to stop the next person reaching
for the timeout.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | The main-catch test's spawn copies and digests 383 files (2.37 MB) into `~/.archon/staged-source/`, then deletes them, before throwing | No capture occurs; the same error is thrown by the same block |
| **Failure behavior** | Unchanged | Unchanged — exit 1 and `{ ok: false }` on stdout, from `main()`'s top-level catch |

No shipped behavior changes; both files are tests.

## Validation

- `bun /tmp/ab.mjs` (interleaved A/B, 10 runs each, alternating, both variants asserting the
  real contract so a faster-but-broken variant could not read as a win) — **543.0 ms → 372.5 ms
  median (−31%)** on this head; two earlier sessions on a less loaded machine gave −22% and
  −26%. Process count is unchanged at 2; what was removed is I/O.
- **Mutation M1** — delete the `if (values.json) { writeJsonLine…; return 1 }` branch from
  `main()`'s outer catch, leaving only `console.error`: `(fail)` on the target test,
  **94 pass / 1 fail**. This is the discriminating mutation. Exactly one of 95 tests goes red
  and it is the target, which proves the test still routes through `main()`'s top-level catch
  under `--dry-run` rather than the pre-dispatch `fail()` helper its eight siblings use, and
  that nothing else in the file covers that catch.
- **Mutation M2** — the same branch returns `0` instead of `1`: `(fail)` on the target test,
  **94 pass / 1 fail**. The exit-code half still has teeth.
- Both mutations were reverted and `git diff packages/cli/src/cli.ts` confirmed clean.
- `bun test ./scripts/` — **145 pass, 0 fail** across 8 files.
- `bun run type-check` in `packages/cli` — exit 0.
- `bun run lint` — exit 0, including `Test-cleanup drift check passed.`
- `bun run validate` — **exit 1**, with exactly one failing test across the whole repository:
  `workflow-terminal-event.integration.spec.ts > persists one matching event before successful
  and failed owners exit`. See the note below — it is pre-existing and reproduces without any
  of these changes.
- `bun run test` in `packages/cli` — 11 of 12 segments pass with `0 fail`. The twelfth,
  `workflow-terminal-event.integration.spec.ts > persists one matching event before successful
  and failed owners exit`, fails **identically on a clean `origin/dev` worktree at `fec7899a`
  with none of these changes applied**, so it is not caused by this PR. `dev`'s own CI is
  green on that commit, so it appears to be a local-timing reproduction rather than a CI
  break. Reported separately; deliberately not folded into this PR or into #2882, whose class
  is budget-edge body timeouts and this is not one.
- **Not verified:** anything on Windows. This cannot be reproduced from macOS, and one green
  Windows leg would not prove the class closed either — which is why #2882 is linked as
  related evidence with no closing keyword.

## Links

- Related #2882


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated CLI error-envelope coverage to use dry-run mode, reducing unnecessary workflow processing during validation.
- **Documentation**
  - Added context about recurring Windows timeout behavior and subprocess timing in state-directory migration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->