### PR TITLE
fix(cli): a detached run that fails fast is not a launch failure

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -92,6 +92,7 @@ import {
   workflowTestCommand,
   workflowInstallCommand,
   isValidEventType,
+  resolveCliExitCode,
 } from './commands/workflow';
 import { WORKFLOW_EVENT_TYPES } from '@archon/workflows/store';
 import {
@@ -1237,15 +1238,18 @@ async function main(): Promise<number> {
     return 0;
   } catch (error) {
     const err = error as Error;
+    // A detached child reports its run's own failure with a reserved status so its
+    // launcher can tell that apart from a child that died before the run started.
+    const exitCode = resolveCliExitCode(err);
     if (values.json as boolean | undefined) {
       await writeJsonLine({ ok: false, error: err.message });
-      return 1;
+      return exitCode;
     }
     console.error(`Error: ${err.message}`);
     if (process.env.DEBUG) {
       console.error(err.stack);
     }
-    return 1;
+    return exitCode;
   } finally {
     // Flush queued telemetry events before the CLI process exits.
     // Short-lived CLI commands lose buffered events if shutdown() is skipped.

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -46,6 +46,9 @@ import {
   resolveContainerBackendConfig,
   hasUnresolvedWriteback,
   buildNodeSummaries,
+  resolveCliExitCode,
+  WorkflowRunFailedError,
+  DETACHED_RUN_FAILED_EXIT_CODE,
 } from './workflow';
 
 beforeAll(async () => {
@@ -5322,6 +5325,40 @@ describe('write command --json output', () => {
   });
 });
 
+/**
+ * The launcher/child exit-status protocol behind the startup window. The window can only
+ * see that the child's process is gone; whether the run ever started is the child's to
+ * report, and this is the channel it reports on.
+ */
+describe('resolveCliExitCode', () => {
+  it('reserves a distinct status for a detached child reporting its own run failure', () => {
+    expect(resolveCliExitCode(new WorkflowRunFailedError('node failed', true))).toBe(
+      DETACHED_RUN_FAILED_EXIT_CODE
+    );
+  });
+
+  it('keeps the ordinary status for a run that failed on a terminal', () => {
+    expect(resolveCliExitCode(new WorkflowRunFailedError('node failed', false))).toBe(1);
+  });
+
+  it('reads the run outcome through a continuation command re-throw', () => {
+    // `resume`/`approve`/`reject`/`respond` re-throw with their own explanation, so the
+    // outermost error is never the run's. Losing the cause here would make every
+    // detached continuation of a fast-failing run look like a launch failure again.
+    const wrapped = new Error("Approved but failed to resume workflow 'assist': Workflow failed", {
+      cause: new WorkflowRunFailedError('node failed', true),
+    });
+    expect(resolveCliExitCode(wrapped)).toBe(DETACHED_RUN_FAILED_EXIT_CODE);
+  });
+
+  it('reports a failure that is not a run outcome as an ordinary failure', () => {
+    // The startup deaths #2914 exists to surface land here: the launcher must keep
+    // reading these as a launch that never took.
+    expect(resolveCliExitCode(new Error('Cannot determine git remote'))).toBe(1);
+    expect(resolveCliExitCode('not an error')).toBe(1);
+  });
+});
+
 describe('workflowRunCommand — detach', () => {
   let consoleSpy: ReturnType<typeof spyOn>;
   let stdoutSpy: ReturnType<typeof spyOn>;
@@ -5889,6 +5926,57 @@ describe('workflowRunCommand — detach', () => {
       spawnSpy.mockRestore();
     }
     expect(consoleSpy).toHaveBeenCalledWith("Started 'assist' in the background.");
+  });
+
+  // A one-node workflow that fails legitimately finishes inside the 500 ms startup
+  // window on a fast machine. #2914 read the child's non-zero exit as a launch failure,
+  // so the same command passed or failed depending on how quickly the machine got
+  // through the run — locally it broke `bun run validate` outright. The child now names
+  // its run's own failure, and only that reading acks it.
+  it('acks a run whose workflow failed inside the startup window', async () => {
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    const workflowDb = await import('@archon/core/db/workflows');
+    const paths = await import('@archon/paths');
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'assist', description: 'Help' })],
+      errors: [],
+    });
+    (paths.getArchonHome as ReturnType<typeof mock>).mockImplementationOnce(() => {
+      throw new Error('no home in test');
+    });
+    (workflowDb.failWorkflowRun as ReturnType<typeof mock>).mockClear();
+    const child = createDetachedChildFixture();
+    const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(child.child);
+    const savedArgv = process.argv;
+    process.argv = ['bun', '/abs/cli.ts', 'workflow', 'run', 'assist', 'hello', '--detach'];
+
+    try {
+      const commandPromise = workflowRunCommand('/test/path', 'assist', 'hello', { detach: true });
+      for (let attempt = 0; attempt < 20 && spawnSpy.mock.calls.length === 0; attempt++) {
+        await Promise.resolve();
+      }
+      expect(spawnSpy).toHaveBeenCalledTimes(1);
+      const spawnOptions = spawnSpy.mock.calls[0]?.[0] as
+        | {
+            onExit?: (
+              subprocess: ReturnType<typeof Bun.spawn>,
+              exitCode: number | null,
+              signalCode: number | null,
+              error?: Error
+            ) => void;
+          }
+        | undefined;
+      spawnOptions?.onExit?.(child.child, DETACHED_RUN_FAILED_EXIT_CODE, null);
+      await commandPromise;
+    } finally {
+      process.argv = savedArgv;
+      spawnSpy.mockRestore();
+    }
+
+    expect(consoleSpy).toHaveBeenCalledWith("Started 'assist' in the background.");
+    // The run recorded its own failure. A launcher that fails the row here would
+    // overwrite the run's reason with a launch failure that never happened.
+    expect(workflowDb.failWorkflowRun).not.toHaveBeenCalled();
   });
 
   // #2872 — the parent is the row's only owner until the child claims it. A child that

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -160,6 +160,60 @@ function getLog(): ReturnType<typeof createLogger> {
 const DETACHED_STARTUP_WINDOW_MS = 500;
 const DETACHED_LOG_TAIL_MAX_CHARS = 4_000;
 const DETACHED_LOG_TAIL_MAX_LINES = 40;
+
+/**
+ * Exit status a detached child uses to tell its launcher that the workflow RAN and
+ * reported failure, rather than dying before it started (#2914's startup window).
+ *
+ * The window observes the only thing a launcher can see — that the child's process is
+ * gone — and a bare non-zero exit cannot separate "never started" from "ran and failed".
+ * A one-node workflow that legitimately fails finishes well inside the window on a fast
+ * machine, so classifying on the window alone reports a completed run as a launch
+ * failure at some machine speed. This code is the child stating which one it was.
+ *
+ * Private to the launcher/child protocol: only a process that started under
+ * `DETACHED_RUN_OWNER_ENV` issues it, so `archon workflow run` on a terminal still exits
+ * 1 for a failed run.
+ */
+export const DETACHED_RUN_FAILED_EXIT_CODE = 90;
+
+/**
+ * The workflow ran and did not succeed — the run owns that outcome and recorded it.
+ *
+ * Distinct from every other error out of a run command, all of which mean the run never
+ * got started. Only that distinction can tell a detached launcher whether to ack the run
+ * it created or refuse the launch.
+ */
+export class WorkflowRunFailedError extends Error {
+  /**
+   * Status the process should exit with. The reserved code is issued only by a detached
+   * child, whose exit status nothing but its launcher reads; a run failing on someone's
+   * terminal still exits 1.
+   */
+  readonly exitCode: number;
+
+  constructor(reason: string | undefined, detachedChild: boolean) {
+    super(`Workflow failed: ${String(reason)}`);
+    this.name = 'WorkflowRunFailedError';
+    this.exitCode = detachedChild ? DETACHED_RUN_FAILED_EXIT_CODE : 1;
+  }
+}
+
+/**
+ * Exit status for a CLI failure: whatever a run reported about its own outcome, 1 for
+ * everything else.
+ *
+ * The commands that continue a run (`resume`, `approve`, `reject`, `respond`) re-throw
+ * with their own explanation, so the outcome is read off the `cause` chain rather than
+ * the outermost error.
+ */
+export function resolveCliExitCode(error: unknown): number {
+  for (let current: unknown = error; current instanceof Error; current = current.cause) {
+    if (current instanceof WorkflowRunFailedError) return current.exitCode;
+  }
+  return 1;
+}
+
 function parseDetachedRunConfig(payload: string | undefined): WorkflowRunConfigInput | undefined {
   if (payload === undefined) return undefined;
 
@@ -207,19 +261,24 @@ async function waitForDetachedStartup(
   execPath: string,
   conversationId: string
 ): Promise<void> {
-  const outcome = await new Promise<'completed' | 'survived'>((resolve, reject) => {
+  const outcome = await new Promise<'completed' | 'failed' | 'survived'>((resolve, reject) => {
     const cleanup = (): void => {
       clearTimeout(timer);
       child.off('exit', onExit);
       child.off('error', onStartupError);
     };
-    const settle = (result: 'completed' | 'survived' | Error): void => {
+    const settle = (result: 'completed' | 'failed' | 'survived' | Error): void => {
       cleanup();
       if (result instanceof Error) reject(result);
       else resolve(result);
     };
+    // A child that is gone before the window closes either finished the run that fast or
+    // never started it, and only the child can say which: `DETACHED_RUN_FAILED_EXIT_CODE`
+    // is it reporting its run's own failure. Everything else non-zero is a death this
+    // process could not have caused and the run cannot explain — a launch failure.
     const onExit = (code: number | null, signal: NodeJS.Signals | null): void => {
       if (code === 0) settle('completed');
+      else if (code === DETACHED_RUN_FAILED_EXIT_CODE) settle('failed');
       else settle(detachedStartupExitError(code, signal, logPath));
     };
     const onStartupError = (error: Error): void => {
@@ -3134,7 +3193,7 @@ async function runWorkflowWithOwnedSource(
     }
     console.log('\nWorkflow completed successfully.');
   } else {
-    throw new Error(`Workflow failed: ${result.error}`);
+    throw new WorkflowRunFailedError(result.error, detachedProcessOwner);
   }
 }
 
@@ -4067,7 +4126,9 @@ export async function workflowResumeCommand(
       { err, runId: resolvedId, workflowName: run.workflow_name },
       'cli.workflow_resume_run_failed'
     );
-    throw new Error(`Failed to resume workflow '${run.workflow_name}': ${err.message}`);
+    throw new Error(`Failed to resume workflow '${run.workflow_name}': ${err.message}`, {
+      cause: err,
+    });
   }
 }
 
@@ -4364,7 +4425,8 @@ export async function workflowApproveCommand(
     );
     throw new Error(
       `Approved but failed to resume workflow '${result.workflowName}': ${err.message}\n` +
-        `The approval was recorded. Run 'bun run cli workflow resume ${resolvedId}' to retry.`
+        `The approval was recorded. Run 'bun run cli workflow resume ${resolvedId}' to retry.`,
+      { cause: err }
     );
   }
 }
@@ -4501,7 +4563,8 @@ export async function workflowRejectCommand(
     );
     throw new Error(
       `Rejected but failed to resume workflow '${result.workflowName}': ${err.message}\n` +
-        `The rejection was recorded. Run 'bun run cli workflow resume ${resolvedId}' to retry.`
+        `The rejection was recorded. Run 'bun run cli workflow resume ${resolvedId}' to retry.`,
+      { cause: err }
     );
   }
 }
@@ -4626,7 +4689,8 @@ export async function workflowRespondCommand(
     );
     throw new Error(
       `Response recorded but failed to resume workflow '${result.workflowName}': ${err.message}\n` +
-        `The response was recorded. Run 'bun run cli workflow resume ${resolvedId}' to retry.`
+        `The response was recorded. Run 'bun run cli workflow resume ${resolvedId}' to retry.`,
+      { cause: err }
     );
   }
 }

--- a/packages/docs-web/src/content/docs/reference/cli.md
+++ b/packages/docs-web/src/content/docs/reference/cli.md
@@ -551,8 +551,10 @@ hands the whole command to a detached child that owns all state mutation in its 
 process group. A shell that dies mid-flight can no longer wedge the run.
 
 The parent also waits out the child's startup window before acking, so a child that
-dies immediately surfaces as an error carrying the tail of its log rather than as a
-success you only discover was false minutes later.
+dies before it starts the run surfaces as an error carrying the tail of its log rather
+than as a success you only discover was false minutes later. A run that simply finishes
+inside that window — a short workflow, or one that fails on its first node — is acked
+normally; its outcome belongs to the run, and `workflow get <run-id>` reports it.
 
 ```bash
 archon workflow approve <run-id> --detach


### PR DESCRIPTION
## Problem and outcome

A detached launch whose workflow runs and fails quickly is reported as a launch that never
happened. On `dev`, with only `DO_NOT_TRACK=1` set — no CI, no test runner — a real
`archon workflow run <fast-failing> --folder --detach --json` fails **3/3** with:

```
{ "ok": false, "error": "Detached workflow child exited during startup with exit code 1." }
```

while the run it launched actually executed, failed on its node, and wrote a correct
`failed` row. Anyone who has opted out of telemetry on a reasonably fast machine gets this.
It also breaks `CI=true bun run validate` locally, which is how it was found.

- **Outcome:** That launch now exits 0 and acks `Started …` / `Run id: <id>`, and
  `workflow get <id>` reports `status: failed` with the node error.
- **Invariant:** A detached launch either produces a queryable run id or a visible
  synchronous error — #2914's invariant, unchanged. A child that dies *before it starts the
  run* is still reported as a launch failure with the tail of its log.
- **Scope boundary:** The startup window, the pre-fork pre-flight, the pre-created run row,
  and the ack shape are untouched. The window is still 500 ms; nothing was slowed down,
  widened, retried, or skipped.
- **Root cause:** #2914 made `waitForDetachedStartup` treat any non-zero child exit inside
  `DETACHED_STARTUP_WINDOW_MS` as a startup death. A process exit code cannot separate
  "never started" from "ran and failed", so the classification is decided by whether the
  child happens to outlive a timer.

### Why it hides in plain sight

Two independent factors have to line up, which is why `dev` looks green in most
environments and why this took a while to pin down.

**1. Telemetry state changes the child's lifetime by ~430 ms.** `main()`'s `finally` awaits
`shutdownTelemetry()`, which flushes queued events to PostHog over the network. When
telemetry is disabled that client is never created and the flush is a no-op. Measured
child lifetime for the same one-node failing workflow, same machine, same `dev` commit:

| Telemetry | Child lifetime | vs. 500 ms window |
|---|---|---|
| enabled (default) | 871, 881, 854, 952 ms | outside — parent acks, correct by luck |
| disabled via `CI=true` | 435, 420, 450, 426 ms | **inside — misclassified** |
| disabled via `DO_NOT_TRACK=1` | 412, 415, 406 ms | **inside — misclassified** |

`packages/paths/src/telemetry.ts:238` disables telemetry for `CI=true`; `DO_NOT_TRACK=1`,
`ARCHON_TELEMETRY_DISABLED=1`, and a build with no embedded PostHog key do the same. This
is the only place in the repository that reads `process.env.CI` outside tests, so telemetry
is the whole of the CI effect — the test harness is incidental.

**2. Machine speed.** GitHub's runners set `CI=true` too, but are slow enough that the child
still exceeds 500 ms, so remote CI stays green. Default local `bun run validate` (telemetry
on) is green for the same reason.

Neither factor is a fault in itself. The fault is a classification that flips on them.

## Review guidance

- **Feedback requested:** Whether the reserved exit status is the right channel for the
  child to report its run's outcome, and whether `resolveCliExitCode` belongs in
  `commands/workflow.ts` rather than a CLI-wide module.
- **Start here:** `packages/cli/src/commands/workflow.ts` — `waitForDetachedStartup`'s
  `onExit`. That single branch is the defect and the fix.
- **Review order:**
  1. `waitForDetachedStartup` — the classification.
  2. `DETACHED_RUN_FAILED_EXIT_CODE`, `WorkflowRunFailedError`, `resolveCliExitCode` — the
     channel the child answers on.
  3. `runWorkflowWithOwnedSource`'s failure throw and `cli.ts`'s catch — the two ends.
  4. The `cause` additions on `resume`/`approve`/`reject`/`respond`.
- **Lower-attention areas:** The four `{ cause: err }` additions are mechanical; the
  `resolveCliExitCode` test `reads the run outcome through a continuation command re-throw`
  is what makes them load-bearing rather than cosmetic.
- **Known risk or uncertainty:** A child killed outright (SIGKILL, host crash) inside the
  window exits with a signal rather than the reserved status, so it is still read as a
  launch failure — the conservative direction, and identical to today. A `--container
  --detach` launch was not exercised on real Docker; nothing on that path is
  container-specific.

## Solution

The launcher can only observe that the child's process is gone. Whether the run started is
the child's to report, so the child now reports it.

`runWorkflowWithOwnedSource` already has the one place where "the engine ran the workflow
and it failed" becomes an exception. That throw becomes a typed `WorkflowRunFailedError`
carrying the exit status the process should leave with, and it already knows whether it is
a detached child (`detachedProcessOwner`, read a few lines earlier). `cli.ts`'s existing
catch asks `resolveCliExitCode` for that status instead of hardcoding 1.

`waitForDetachedStartup` then reads the child's answer: `DETACHED_RUN_FAILED_EXIT_CODE`
means the run ran and failed, so ack it. **Every other non-zero exit is still a launch
failure**, which is why both of #2914's startup-death tests pass unchanged — they drive
`onExit(child, 1, null)`, and exit 1 still rejects.

The reserved status is issued only by a process that started under
`DETACHED_RUN_OWNER_ENV`, so `archon workflow run` on a terminal still exits 1 for a failed
run. Nothing about the public CLI exit contract changes.

The commands that continue a run (`resume`, `approve`, `reject`, `respond`) re-throw with
their own explanation, so they now pass the original error as `cause` and
`resolveCliExitCode` reads the outcome off that chain. Without it every detached
continuation of a fast-failing run would keep hitting the same misclassification.

### Why not classify on the run row

The obvious alternative — after the child exits, ask whether its run row reached a terminal
state — cannot work. The child's own `recordDetachedChildStartupFailure` flips a genuinely
dead run's row from `pending` to `failed` before exiting, so at exit time a startup death
and a real run failure are the same row state. `working_path` is null only for a *fresh*
handed-over row, so it cannot classify continuations or the `approve/reject/resume
--detach` children either. The exit status is the only signal available uniformly.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | A detached workflow that ran and failed within 500 ms printed `Detached workflow child exited during startup with exit code 1` and exited non-zero, despite a `failed` run row carrying the real node error. | It is acked with `Started …` / `Run id: <id>`, and `workflow get <id>` reports the node failure. |
| **Failure behavior** | A child that died before starting the run was reported synchronously — and so was a completed run, whenever telemetry was off and the machine was quick. | A child that dies before starting the run is still reported synchronously with its log tail. Only the run's own outcome is acked. |

## Architecture

```mermaid
flowchart LR
  subgraph Before
    B1[child exits non-zero<br/>inside 500ms] --> B2{code == 0?}
    B2 -->|no| B3["launch failed<br/>(wrong for a fast run)"]
  end

  subgraph After
    A1[child exits non-zero<br/>inside 500ms] --> A2{"code == DETACHED_RUN_FAILED_EXIT_CODE?"}
    A2 -->|yes| A3["the run ran and failed<br/>ack the run id"]
    A2 -->|no| A4["never started<br/>launch failed"]
  end
```

### Changed seams

| Boundary or contract | Change | Evidence |
|---|---|---|
| `detached child → launcher` | New reserved exit status meaning "the workflow ran and failed"; every other non-zero exit still means the launch failed | `waitForDetachedStartup`, `workflow.test.ts` (`acks a run whose workflow failed inside the startup window`) |
| `run command → cli.ts` | The workflow-failure throw is a typed `WorkflowRunFailedError` carrying its exit status; `main()`'s catch reads it | `runWorkflowWithOwnedSource`, `cli.ts`, `workflow.test.ts` (`resolveCliExitCode`) |
| `resume/approve/reject/respond → caller` | Re-throws preserve the original error as `cause` | `workflow.test.ts` (`reads the run outcome through a continuation command re-throw`) |

## Validation

**Live, no test harness** — real CLI, scratch `ARCHON_HOME`, `DO_NOT_TRACK=1`:

- On `dev`: 3/3 launches exit 1 with `Detached workflow child exited during startup with
  exit code 1`.
- On this branch: exit 0, ack carries `runId`, and `workflow get <id>` returns
  `status: failed`.

**The spec:**

- `CI=true bun test src/commands/workflow-terminal-event.integration.spec.ts` on `dev` —
  **14 of 15 runs failed** at `spec.ts:165` after 6 `expect()` calls. On this branch —
  **0 of 10 failed**.
- The same spec without `CI=true` is green on both, as expected from the timing table
  above — so plain runs stay green.

**Deterministic red, with timing removed from the question:** raising
`DETACHED_STARTUP_WINDOW_MS` to 20 000 ms (forcing the child's exit to always land inside
the window) makes the spec fail *every* time on `dev`, with the child's own log showing the
run finishing normally (`dag_node_failed exit 42`, `dag_workflow_finished`). Green 3/3 with
that same 20 000 ms window after the fix — the fix is in the classification, not the timing.

**The other direction still holds:**

- #2914's `fails the run row it created when the detached child dies during startup` and
  `rejects an immediate non-zero child exit with the log tail and no success ack` are
  unmodified and pass — both drive a plain `exit 1` and still reject.
- The new guard was seen red: reverting only the `DETACHED_RUN_FAILED_EXIT_CODE` branch
  makes `acks a run whose workflow failed inside the startup window` fail with `exited
  during startup with exit code 90`.

**Suites:**

- `bun --cwd packages/cli test src/commands/workflow.test.ts` — 318 pass / 0 fail.
- `bun --cwd packages/cli run test` — all 12 suites, exit 0.
- `bun run validate` — exit 0 (162 suite summaries, zero failures).

**Not verified:** `--container --detach` on real Docker, and a real SIGKILL of a child
inside the window. Both keep today's behavior by construction — neither produces the
reserved status, so both take the unchanged launch-failure branch. The claim that GitHub's
runners stay green because they are slower is inference from the timing table, not a
measurement on a runner.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | None. No schema change. The reserved exit status is issued only under `DETACHED_RUN_OWNER_ENV`, so `archon workflow run` still exits 1 for a failed run on a terminal. | `WorkflowRunFailedError`'s constructor; `resolveCliExitCode` tests |
| Observability | A fast-failing detached run now reaches the operator as a run id whose row carries the node error, instead of a launcher error that contradicted the row. | Live `DO_NOT_TRACK=1` runs above |
| Documentation / communication | `reference/cli.md` said the startup window turns a child that "dies immediately" into an error; it now distinguishes dying before the run from finishing inside the window. | `packages/docs-web/src/content/docs/reference/cli.md` |

## Links

- Related #2914

---

**Post-merge disclosure correction (28 Aug, from the review round):** the Known-risk section above names only one residual direction. The mirror also exists and is tracked cross-session: with telemetry enabled, a true startup death whose teardown pushes the child past the 500ms window is falsely acked as Started — so the unqualified "a child that dies before starting the run is still reported synchronously" claim in the behavior table holds only when telemetry is off. Neither direction is worsened by this PR; both share one root — the exit-status channel cannot describe every death — and the completing mechanism is an open question, tracked in the combined startup-classification issue, #2961. The run-row route is proven unavailable: since #2914's startup-failure net, a true startup death and a fast real failure both leave the row terminally 'failed', indistinguishable at exit time.

