### PR TITLE
fix(cli): archon serve can no longer hang extracting the web UI on windows

### DIFF
--- a/packages/cli/src/commands/serve.test.ts
+++ b/packages/cli/src/commands/serve.test.ts
@@ -210,11 +210,22 @@ describe('downloadWebDist', () => {
     consoleLogSpy.mockRestore();
   });
 
+  // The spawn-shape and cleanup assertions ride along here rather than in tests
+  // of their own: each call to downloadWebDist costs a real `tar` spawn, and
+  // spawn count on windows is the whole reason this file gets attention.
   it('verifies against the embedded hash without fetching checksums.txt', async () => {
     fetchSpy.mockImplementation(async () => new Response(tarballBytes));
     const targetDir = join(tmpRoot, 'target-embedded-ok');
+    const spawnSpy = spyOn(Bun, 'spawn');
+    let extractorStdin: unknown;
 
-    await downloadWebDist('9.9.9', targetDir, tarballHash);
+    try {
+      await downloadWebDist('9.9.9', targetDir, tarballHash);
+      // Read before restoring — mockRestore() clears the recorded calls.
+      extractorStdin = (spawnSpy.mock.calls[0]?.[1] as { stdin?: unknown } | undefined)?.stdin;
+    } finally {
+      spawnSpy.mockRestore();
+    }
 
     // Content, not just existence — a truncated or corrupt fixture still yields
     // an index.html and a `tar` exit 0, so only this assertion catches it.
@@ -222,6 +233,13 @@ describe('downloadWebDist', () => {
     // Only the tarball is fetched — checksums.txt must NOT be requested.
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(String(fetchSpy.mock.calls[0]?.[0])).toContain('archon-web.tar.gz');
+    // `tar` must inherit a file descriptor. Passing the bytes as `stdin` instead
+    // leaves the parent owning a channel it has to pump and close, and a stalled
+    // pump blocks `tar` forever — the windows hang in #2924. A BunFile is a Blob;
+    // a Uint8Array is not, which is exactly the regression this catches.
+    expect(extractorStdin).toBeInstanceOf(Blob);
+    // The staged archive is ~2 MB in production — it must not survive extraction.
+    expect(existsSync(`${targetDir}.tmp.tar.gz`)).toBe(false);
   });
 
   it('hard-fails on embedded hash mismatch with a clear error', async () => {

--- a/packages/cli/src/commands/serve.test.ts
+++ b/packages/cli/src/commands/serve.test.ts
@@ -255,6 +255,26 @@ describe('downloadWebDist', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
+  // The mismatch test above cannot reach this path: verification runs before
+  // anything is staged, so it never leaves temp state behind. Checksum-valid
+  // bytes that are not a gzip stream are the only cheap way in — staging happens,
+  // then `tar` exits non-zero.
+  it('leaves nothing behind when tar exits non-zero', async () => {
+    const notAnArchive = new TextEncoder().encode('checksum-valid, but not gzip');
+    const hasher = new Bun.CryptoHasher('sha256');
+    hasher.update(notAnArchive);
+    fetchSpy.mockImplementation(async () => new Response(notAnArchive));
+    const targetDir = join(tmpRoot, 'target-tar-failure');
+
+    await expect(downloadWebDist('9.9.9', targetDir, hasher.digest('hex'))).rejects.toThrow(
+      'tar extraction failed'
+    );
+
+    expect(existsSync(`${targetDir}.tmp.tar.gz`)).toBe(false);
+    expect(existsSync(`${targetDir}.tmp`)).toBe(false);
+    expect(existsSync(targetDir)).toBe(false);
+  });
+
   it('falls back to remote checksums.txt when the embedded hash is empty', async () => {
     fetchSpy.mockImplementation(async (url: string | URL | Request) => {
       if (String(url).includes('checksums.txt')) {

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -12,6 +12,16 @@ const log = createLogger('cli.serve');
 
 const GITHUB_REPO = 'coleam00/Archon';
 
+/**
+ * Upper bound on the `tar` child. Extracting the ~2 MB release archive takes
+ * tens of milliseconds, so this leaves three orders of magnitude of headroom for
+ * a slow disk. Its only job is to stop a stalled child from turning
+ * `archon serve` into a silent permanent hang: the parent-owned stdin channel
+ * that caused the observed stall is gone (#2924), but filesystem-side stalls on
+ * windows were never ruled out, and there is no budget in production to end one.
+ */
+const EXTRACTION_TIMEOUT_MS = 60_000;
+
 function toError(err: unknown): Error {
   return err instanceof Error ? err : new Error(String(err));
 }
@@ -173,10 +183,12 @@ export async function downloadWebDist(
   // (#2924). Reading `-` keeps the archive path off the command line, where a
   // windows drive letter is ambiguous with `tar`'s own `host:path` syntax.
   await Bun.write(tarballPath, tarballBuffer);
+  const extractionStartedAt = performance.now();
   try {
     const proc = Bun.spawn(['tar', 'xzf', '-', '-C', tmpDir, '--strip-components=1'], {
       stdin: Bun.file(tarballPath),
       stderr: 'pipe',
+      timeout: EXTRACTION_TIMEOUT_MS,
     });
     // Drain stderr while waiting rather than after: a pipe nobody reads is the
     // same deadlock in the other direction once `tar` fills its buffer.
@@ -184,8 +196,20 @@ export async function downloadWebDist(
       proc.exited,
       new Response(proc.stderr).text(),
     ]);
+    const details = stderrText.trim();
+    // A signal means `tar` never finished. `proc.killed` cannot say so — it is
+    // true after any exit — and a signal can also come from outside this process,
+    // so report how long it actually ran instead of asserting the bound fired.
+    if (proc.signalCode !== null) {
+      const elapsedMs = Math.round(performance.now() - extractionStartedAt);
+      cleanupAndThrow(
+        tmpDir,
+        `tar extraction was killed by ${proc.signalCode} after ${elapsedMs}ms without finishing ` +
+          `(limit ${EXTRACTION_TIMEOUT_MS}ms): ${details}`
+      );
+    }
     if (exitCode !== 0) {
-      cleanupAndThrow(tmpDir, `tar extraction failed (exit ${exitCode}): ${stderrText.trim()}`);
+      cleanupAndThrow(tmpDir, `tar extraction failed (exit ${exitCode}): ${details}`);
     }
   } finally {
     rmSync(tarballPath, { force: true });

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -159,20 +159,36 @@ export async function downloadWebDist(
 
   // Extract to temp dir, then atomic rename
   const tmpDir = `${targetDir}.tmp`;
+  const tarballPath = `${tmpDir}.tar.gz`;
 
   // Clean up any previous failed attempt
   rmSync(tmpDir, { recursive: true, force: true });
   mkdirSync(tmpDir, { recursive: true });
 
-  // Extract tarball using tar (available on macOS/Linux)
-  const proc = Bun.spawn(['tar', 'xzf', '-', '-C', tmpDir, '--strip-components=1'], {
-    stdin: new Uint8Array(tarballBuffer),
-    stderr: 'pipe',
-  });
-  const exitCode = await proc.exited;
-  if (exitCode !== 0) {
-    const stderrText = await new Response(proc.stderr).text();
-    cleanupAndThrow(tmpDir, `tar extraction failed (exit ${exitCode}): ${stderrText.trim()}`);
+  // Stage the archive on disk so `tar` inherits a file descriptor. Passing the
+  // bytes as `stdin` instead makes the parent own a channel it has to pump and
+  // close, and on windows that pump can stall with no upper bound: two spawns in
+  // one process sat with `tar` blocked on an unfed stdin until the test runner
+  // killed them, on a runner where the same extraction took 16 ms minutes later
+  // (#2924). Reading `-` keeps the archive path off the command line, where a
+  // windows drive letter is ambiguous with `tar`'s own `host:path` syntax.
+  await Bun.write(tarballPath, tarballBuffer);
+  try {
+    const proc = Bun.spawn(['tar', 'xzf', '-', '-C', tmpDir, '--strip-components=1'], {
+      stdin: Bun.file(tarballPath),
+      stderr: 'pipe',
+    });
+    // Drain stderr while waiting rather than after: a pipe nobody reads is the
+    // same deadlock in the other direction once `tar` fills its buffer.
+    const [exitCode, stderrText] = await Promise.all([
+      proc.exited,
+      new Response(proc.stderr).text(),
+    ]);
+    if (exitCode !== 0) {
+      cleanupAndThrow(tmpDir, `tar extraction failed (exit ${exitCode}): ${stderrText.trim()}`);
+    }
+  } finally {
+    rmSync(tarballPath, { force: true });
   }
 
   // Verify extraction produced expected layout


### PR DESCRIPTION
## Problem and outcome

`archon serve` downloads the web UI tarball and extracts it by piping the bytes into `tar xzf -` as `stdin: <Uint8Array>`. On windows that hands Bun a channel the parent must write and close before the child can make progress, and that pump can stall with no upper bound — leaving `tar` blocked forever. The Windows CI lane only made it visible: two `downloadWebDist` tests died at the 5000ms per-test budget on PR #2919's lane, with `tar` reported as a killed dangling process. In production nothing ends the wait; `archon serve` would sit there with no output and no error.

- **Outcome:** extraction can no longer block on a channel the parent owns, in either direction.
- **Invariant:** the extractor is handed an inherited file descriptor, never bytes Bun has to pump; and its `stderr` is drained concurrently with the wait on exit.
- **Scope boundary:** `tar` is still the extractor and the command line is unchanged apart from staging. No timeout, retry, or in-process untar was added.
- **Root cause:** `Bun.spawn(..., { stdin: <Uint8Array> })` makes Bun responsible for feeding and closing the child's stdin. A local probe shows the shape directly — with a `Uint8Array` the child's fd 0 is neither a regular file nor a pipe (a parent-pumped socketpair), while with `Bun.file(path)` it is a regular file the kernel serves:

  ```
  Uint8Array stdin  ->  ls -l /dev/stdin: NOT_REGULAR
  Bun.file() stdin  ->  ls -l /dev/stdin: REGULAR
  ```

  On the failing run both spawns in the same bun process hung and were killed at the budget; the same two tests took 156ms and 16ms on the same runner image half an hour later, so the extraction itself is not slow — it never started.

## Review guidance

- **Feedback requested:** correctness of the staging and cleanup path, and whether the staged archive belongs beside `targetDir` rather than inside the extraction directory.
- **Start here:** `packages/cli/src/commands/serve.ts:160` — the staging, spawn, and concurrent stderr drain.
- **Review order:** `serve.ts` first, then the guard folded into the happy-path test in `serve.test.ts`.
- **Known risk or uncertainty:** the windows hang cannot be reproduced on macOS, so the causal chain rests on the CI evidence plus the local fd-shape probe rather than on a red-to-green run on windows. See **Not verified**.

## Solution

Write the verified tarball to `${targetDir}.tmp.tar.gz` and pass `Bun.file(tarballPath)` as stdin. `tar` then inherits a plain descriptor and reads at its own pace, with no parent-side step left to stall. A `finally` removes the staged archive on every path, including the checksum and extraction failure paths.

The archive stays off the command line deliberately: `tar` keeps reading `-`, so a windows drive letter never has to be disambiguated from `tar`'s own `host:path` remote syntax.

`stderr` is now drained with `Promise.all` alongside `proc.exited` instead of only after a non-zero exit. An unread pipe is the same deadlock in the output direction once `tar` fills the buffer, and the previous code could only read it after the process had already exited.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Tarball piped to `tar` through a Bun-managed stdin channel | Tarball staged to a temp file; `tar` inherits its descriptor and the file is removed afterwards |
| **Failure behavior** | On windows, `tar` could block on an unfed stdin indefinitely — no error, no timeout | The child has nothing parent-owned to block on; a `tar` failure still reports its exit code and stderr |

## Validation

- `bun test src/commands/serve.test.ts` in `packages/cli` — 20 pass, 0 fail, 33 expect() calls — proves extraction, checksum handling, the descriptor invariant, and staged-archive cleanup.
- Guard seen red: reverting the single line to `stdin: new Uint8Array(tarballBuffer)` fails the new assertion with `Received value: Uint8Array(131) [ 31, 139, 8, ... ]`. It is a real guard, not a passing decoration.
- Real artifact, not just the 131-byte fixture: the shipped v0.9.0 `archon-web.tar.gz` (2.1 MB compressed, 8.5 MB extracted) was fed through `downloadWebDist` and extracted correctly — `["index.html","favicon.png","assets"]` with all three asset files under `assets/`, after `--strip-components=1`.
- Cost of staging, same real artifact, three runs each on macOS: **before 20.6 / 20.0 / 18.7 ms, after 21.1 / 22.3 / 23.0 ms**. The change buys hang-immunity for roughly 2 ms of disk write; it is not a speedup and is not claimed as one.
- `bun run test` in `packages/cli` — all 12 file groups green.
- `bun run lint` and `bun run validate` at the repo root — validate exits 0, 163 test groups reporting `0 fail`.
- **Not verified:** that the windows hang is gone, because it is intermittent and cannot be forced. A green windows lane on this PR is not proof. The claim this PR does support is narrower and checkable: after this change no parent-owned channel remains for the child to block on, in either direction.

## Links

- Related #2924
- Related #2306


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when downloading and extracting the web interface.
  * Added a timeout for extraction processes to prevent hangs.
  * Improved error reporting when extraction fails.
  * Ensured temporary files and directories are cleaned up after successful or failed extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->