### PR TITLE
fix(cli): preserve explicit worktree branch names

### DIFF
--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -2458,7 +2458,11 @@ describe('workflowRunCommand', () => {
       expect.objectContaining({
         workflowType: 'task',
         identifier: 'test-adapters',
-        taskBranch: { kind: 'new', fromBranch: 'feature/extract-adapters' },
+        taskBranch: {
+          kind: 'new',
+          branch: 'test-adapters',
+          fromBranch: 'feature/extract-adapters',
+        },
       })
     );
   });

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -2704,9 +2704,17 @@ async function runWorkflowWithOwnedSource(
         identifier: branchIdentifier,
         taskBranch: adoptedTaskBranch
           ? adoptedTaskBranch
-          : options.fromBranch?.trim()
-            ? { kind: 'new', fromBranch: git.toBranchName(options.fromBranch.trim()) }
-            : undefined,
+          : options.branchName
+            ? {
+                kind: 'new',
+                branch: git.toBranchName(options.branchName),
+                ...(options.fromBranch?.trim()
+                  ? { fromBranch: git.toBranchName(options.fromBranch.trim()) }
+                  : {}),
+              }
+            : options.fromBranch?.trim()
+              ? { kind: 'new', fromBranch: git.toBranchName(options.fromBranch.trim()) }
+              : undefined,
         baseBranch: codebaseDefaultBranch ? git.toBranchName(codebaseDefaultBranch) : undefined,
         baseOverride: flagBase ? git.toBranchName(flagBase) : undefined,
         codebaseId: codebase.id,

--- a/packages/isolation/src/providers/worktree.test.ts
+++ b/packages/isolation/src/providers/worktree.test.ts
@@ -259,6 +259,18 @@ describe('WorktreeProvider', () => {
       expect(provider.generateBranchName(request)).toBe('archon/task-add-dark-mode');
     });
 
+    test('uses an explicit task branch name verbatim', () => {
+      const request: IsolationRequest = {
+        codebaseId: 'cb-123',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
+        workflowType: 'task',
+        identifier: 'archon/task-fix-2926',
+        taskBranch: { kind: 'new', branch: git.toBranchName('archon/task-fix-2926') },
+      };
+
+      expect(provider.generateBranchName(request)).toBe('archon/task-fix-2926');
+    });
+
     test('slugifies task identifiers properly', () => {
       const request: IsolationRequest = {
         codebaseId: 'cb-123',

--- a/packages/isolation/src/providers/worktree.ts
+++ b/packages/isolation/src/providers/worktree.ts
@@ -609,6 +609,9 @@ export class WorktreeProvider implements IIsolationProvider {
         if (request.taskBranch?.kind === 'existing') {
           return request.taskBranch.branch;
         }
+        if (request.taskBranch?.branch) {
+          return request.taskBranch.branch;
+        }
         return `archon/task-${this.slugify(request.identifier)}`;
     }
   }

--- a/packages/isolation/src/types.ts
+++ b/packages/isolation/src/types.ts
@@ -116,12 +116,12 @@ export interface ThreadIsolationRequest extends IsolationRequestBase {
 }
 
 export type TaskBranchSelection =
-  | { kind: 'new'; fromBranch?: BranchName }
+  | { kind: 'new'; branch?: BranchName; fromBranch?: BranchName }
   | { kind: 'existing'; branch: BranchName };
 
 export interface TaskIsolationRequest extends IsolationRequestBase {
   workflowType: 'task';
-  /** Task identifier (will be slugified for branch name, max 50 chars) */
+  /** Task identifier (will be slugified for branch name unless a branch is specified). */
   identifier: string;
   /** Whether this task creates a branch or continues an exact existing branch. */
   taskBranch?: TaskBranchSelection;


### PR DESCRIPTION
## Problem and outcome

`archon workflow run --branch <name>` prefixed an operator-supplied branch with `archon/task-`, producing a different worktree branch than requested. Explicit branch names now reach the worktree provider unchanged.

- **Outcome:** `--branch archon/task-fix-2926` creates `archon/task-fix-2926`, not `archon/task-archon-task-fix-2926`.
- **Invariant:** When `--branch` is absent, task runs still derive `archon/task-<slug>` names.
- **Scope boundary:** Existing-branch adoption and all non-task worktree naming are unchanged.
- **Root cause:** The task-branch contract retained only the source branch for new worktrees, so the worktree provider always derived and prefixed a name from the identifier.

## Review guidance

- **Feedback requested:** Correctness of the explicit-versus-derived task branch contract.
- **Start here:** `packages/isolation/src/providers/worktree.ts:612` — explicit new task branches return their provided name before the derived-name fallback.
- **Review order:** 1. `packages/cli/src/commands/workflow.ts` passes `--branch` into the task-branch contract. 2. `packages/isolation/src/providers/worktree.ts` consumes it. 3. The CLI and provider tests pin the handoff and final branch name.
- **Known risk or uncertainty:** None.

## Solution

The CLI now records `--branch` as the exact name for a newly created task branch, while retaining `--from-branch` as its optional source. The worktree provider uses that exact name when present and otherwise keeps its existing `archon/task-<slug>` fallback. Regression tests cover both the CLI-to-provider handoff and a fully prefixed name that previously doubled its prefix.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | `--branch archon/task-fix-2926` created `archon/task-archon-task-fix-2926`. | It creates `archon/task-fix-2926` verbatim. |
| **Default naming** | No `--branch` derived `archon/task-<slug>`. | Unchanged. |

## Validation

- `bun test src/providers/worktree.test.ts` — passed (164 tests) — proves explicit task branch names are not prefixed and derived task names remain covered.
- `bun test src/commands/workflow.test.ts` — passed (322 tests) — proves `--branch` reaches the isolation provider as an explicit new branch.
- `bun run type-check`, `bun run lint --max-warnings 0`, and `bun run validate` — passed.
- **Not verified:** Nothing material; targeted tests cover the changed handoff and naming behavior, and the full validation suite passed.

## Links

- Closes #2926


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying an explicit branch name when starting a workflow task.
  - Preserves the requested branch name instead of generating one automatically.
  - Supports creating the named branch from an optional base branch.

- **Bug Fixes**
  - Fixed workflow runs so the provided branch option is correctly passed through and used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->