### PR TITLE
fix(workflows): keep exec-code PWD in scratch worktree

### DIFF
--- a/packages/workflows/src/dry-run.ts
+++ b/packages/workflows/src/dry-run.ts
@@ -683,6 +683,8 @@ async function executeCodeNode(
       timeout: node.timeout ?? 300_000,
       env: {
         ...process.env,
+        PWD: ctx.execWorkspace,
+        OLDPWD: ctx.execWorkspace,
         ...inputEnv,
         USER_MESSAGE: ctx.userMessage,
         ARGUMENTS: ctx.userMessage,

--- a/packages/workflows/src/fixture-runner.test.ts
+++ b/packages/workflows/src/fixture-runner.test.ts
@@ -838,6 +838,41 @@ describe('runFixtures exec-code isolation (#2851)', () => {
     expect(readFileSync(join(cwd, 'tracked.txt'), 'utf8')).toBe(COMMITTED_YAML);
   });
 
+  it('keeps PWD and OLDPWD-based inline code writes in the scratch worktree (#2890)', async () => {
+    const writerYaml = [
+      'name: pwd-writer-wf',
+      'description: writes through the working-directory environment',
+      'nodes:',
+      '  - id: writer',
+      '    script: |',
+      "      for (const dir of [process.env.PWD, process.env.OLDPWD]) await Bun.write(`${dir}/leak.txt`, 'executed');",
+      '    runtime: bun',
+    ].join('\n');
+    const { cwd } = writeTempProject({
+      workflowName: 'pwd-writer-wf',
+      workflowYaml: writerYaml,
+      body: execFixtureBody,
+    });
+    callerFrom(trackedOnlyRepo, cwd);
+    const previousPwd = process.env.PWD;
+    const previousOldPwd = process.env.OLDPWD;
+    process.env.PWD = cwd;
+    process.env.OLDPWD = cwd;
+    try {
+      const report = await runFixtures({
+        workflows: [workflowsOnDisk(cwd, ['pwd-writer-wf'])[0]],
+        cwd,
+      });
+      expect(report.results[0].outcome).toBe('completed');
+      expect(existsSync(join(cwd, 'leak.txt'))).toBe(false);
+    } finally {
+      if (previousPwd === undefined) delete process.env.PWD;
+      else process.env.PWD = previousPwd;
+      if (previousOldPwd === undefined) delete process.env.OLDPWD;
+      else process.env.OLDPWD = previousOldPwd;
+    }
+  });
+
   const SCRIPT_YAML = [
     'name: script-wf',
     'description: runs a named script',


### PR DESCRIPTION
## Problem and outcome

Inline `exec-code` nodes run with `cwd` set to the scratch worktree, but inherited the caller process's `PWD` and `OLDPWD`. Code that uses either environment variable could therefore write into the caller checkout and bypass fixture isolation.

- **Outcome:** Inline code now receives the scratch worktree through both its process working directory and its working-directory environment variables.
- **Invariant:** During isolated fixture execution, every ambient working-directory signal names the scratch workspace.
- **Scope boundary:** This changes only the environment supplied to inline code execution; workflow semantics and the scratch-worktree lifecycle are unchanged.
- **Root cause:** `executeCodeNode` set `cwd: ctx.execWorkspace` while spreading the parent environment unchanged.

## Review guidance

- **Feedback requested:** Confirm that normalizing `PWD` and `OLDPWD` at the execution boundary is the correct ownership point for scratch-worktree isolation.
- **Start here:** `packages/workflows/src/dry-run.ts:681` — the inline-code process is spawned here.
- **Review order:** Inspect the environment construction, then the fixture regression that simulates stale caller values.
- **Lower-attention areas:** The test fixture YAML is local setup; its completed outcome and absence of `leak.txt` in the caller checkout verify the behavior.
- **Known risk or uncertainty:** None.

## Solution

The inline-code executor now overrides inherited `PWD` and `OLDPWD` with `ctx.execWorkspace` alongside its existing `cwd` setting. This keeps code that relies on environment variables in the same scratch worktree as code that relies on the process working directory. The regression test sets both caller values to the real fixture checkout, executes inline Bun code that writes through each variable, and verifies neither write reaches that checkout.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Inline code saw the caller's `PWD` and `OLDPWD` even though its process working directory was the scratch worktree. | Inline code sees the scratch worktree through `cwd`, `PWD`, and `OLDPWD`. |
| **Failure behavior** | Code that used either environment variable could write outside the scratch worktree. | Those writes stay in the scratch worktree. |

## Validation

- `bun test src/fixture-runner.test.ts` — passed (38 tests) — covers stale `PWD` and `OLDPWD` through a real inline-code fixture.
- `bun test src/dry-run.test.ts` — passed (66 tests).
- `bun run test` and `bun run type-check` in `packages/workflows` — passed.
- `bun run validate` from the repository root — passed.
- **Not verified:** Nothing material; the focused fixture exercises the affected subprocess environment and verifies the caller checkout remains untouched.

## Links

- Closes #2890


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Code executed in workflow runs now correctly recognizes the run’s working directory.
  * Prevented inline scripts from accidentally writing files to the caller’s project directory.

* **Tests**
  * Added coverage to verify file operations remain contained within the workflow’s temporary workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->