### PR TITLE
fix(cli): a Windows cancel no longer fails for a run whose process tree already stopped

### DIFF
--- a/packages/cli/src/utils/detached-run-control.integration.spec.ts
+++ b/packages/cli/src/utils/detached-run-control.integration.spec.ts
@@ -77,6 +77,31 @@ async function rejectedError(action: () => Promise<unknown>): Promise<Error> {
   throw new Error('Expected the operation to reject');
 }
 
+/**
+ * A control endpoint that hands out `pid` and commits the termination lease.
+ *
+ * The handshake is not what these tests are about: committing it puts the terminator
+ * itself in front of a PID the test chose, which is the only way to stage a target
+ * that is already gone, or one that is alive and out of reach.
+ */
+function stubOwner(pid: number): Server {
+  return createServer((socket: Socket): void => {
+    socket.setEncoding('utf8');
+    let request = '';
+    socket.on('data', (chunk: string): void => {
+      request += chunk;
+      if (request.includes('stop\n')) {
+        socket.write(`${JSON.stringify({ pid })}\n`);
+        request = request.replace('stop\n', '');
+      }
+      if (request.includes('terminate\n')) {
+        socket.write('ready\n');
+        request = request.replace('terminate\n', '');
+      }
+    });
+  });
+}
+
 describe('detached run control integration', () => {
   it('stops the detached owner process group before its descendant can leak work', async () => {
     const runId = `tree-${crypto.randomUUID()}`;
@@ -121,6 +146,69 @@ describe('detached run control integration', () => {
         }
       }
       if (process.platform !== 'win32') rmSync(detachedRunControlPath(runId), { force: true });
+    }
+  });
+
+  it('treats an already-gone target as a stopped tree, not a failed stop', async () => {
+    // #2946: `taskkill /T` walks the tree PID by PID and exits non-zero when one of
+    // them is already gone. Reading that exit code as failure made `archon workflow
+    // cancel` report a failure on Windows for a run whose tree had in fact stopped,
+    // and left the run row saying `running`. POSIX has always tolerated the same
+    // condition as ESRCH; the contract is one tree-is-gone outcome on both branches.
+    const runId = `already-gone-${crypto.randomUUID()}`;
+    const path = detachedRunControlPath(runId);
+    const doomed = spawn(process.execPath, ['-e', 'process.exit(0)'], { stdio: 'ignore' });
+    if (doomed.pid === undefined) throw new Error('Failed to spawn the short-lived target');
+    const gonePid = doomed.pid;
+    await waitForExit(doomed);
+    // The premise, asserted rather than assumed: the terminator is aimed at nothing.
+    await waitFor(() => !processExists(gonePid));
+
+    const server = stubOwner(gonePid);
+    await listen(server, path);
+    try {
+      const target = await requestDetachedRunStop(runId);
+      // Resolving IS the assertion, and letting a rejection through reports the real
+      // reason rather than a matcher's. The old Windows branch rejected here, carrying
+      // taskkill's "There is no running instance of the task" as a stop failure.
+      await target.stop();
+    } finally {
+      await close(server);
+      if (process.platform !== 'win32') rmSync(path, { force: true });
+    }
+  });
+
+  it('still fails when the target is alive and the kill cannot reach it', async () => {
+    // The guardrail for the tolerance above: an unreachable kill must never read as a
+    // stopped tree, or the terminator stops protecting anything. Staged on POSIX,
+    // where a live process that is not a group leader makes `kill(-pid)` raise the
+    // same ESRCH that an entirely absent group raises — so only the follow-up check
+    // on the process itself can tell the two apart. The Windows equivalent, a live
+    // root that survives `taskkill /F`, needs a process the runner is not permitted
+    // to kill and is not worth staging in CI.
+    if (process.platform === 'win32') return;
+
+    const runId = `alive-${crypto.randomUUID()}`;
+    const path = detachedRunControlPath(runId);
+    // Not `detached`, so it joins this spec's process group and no process group
+    // carrying its own PID exists for the terminator to signal.
+    const survivor = spawn(process.execPath, ['-e', 'setInterval(() => undefined, 1000)'], {
+      stdio: 'ignore',
+    });
+    if (survivor.pid === undefined) throw new Error('Failed to spawn the surviving target');
+    const survivorPid = survivor.pid;
+
+    const server = stubOwner(survivorPid);
+    await listen(server, path);
+    try {
+      const target = await requestDetachedRunStop(runId);
+      const error = await rejectedError(async (): Promise<void> => target.stop());
+      expect(error.message).toContain('does not own process group');
+      expect(processExists(survivorPid)).toBe(true);
+    } finally {
+      survivor.kill('SIGKILL');
+      await close(server);
+      rmSync(path, { force: true });
     }
   });
 

--- a/packages/cli/src/utils/detached-run-control.test.ts
+++ b/packages/cli/src/utils/detached-run-control.test.ts
@@ -1,11 +1,26 @@
 import { describe, expect, it } from 'bun:test';
+import { execFile } from 'node:child_process';
 import { createConnection } from 'node:net';
+import { promisify } from 'node:util';
 import {
+  commandTerminatedBySignal,
   detachedRunControlPath,
   DetachedRunOwnerUnavailableError,
   requestDetachedRunStop,
   startDetachedRunControlServer,
 } from './detached-run-control';
+
+const execFileAsync = promisify(execFile);
+
+/** The real rejection `execFile` produces for `run`, so no error shape is hand-built. */
+async function rejectionFrom(run: () => Promise<unknown>): Promise<unknown> {
+  try {
+    await run();
+  } catch (error) {
+    return error;
+  }
+  throw new Error('Expected the command to reject');
+}
 
 describe('detached run control', () => {
   it('treats a connection as a harmless probe and refuses to replace a live owner', async () => {
@@ -41,5 +56,53 @@ describe('detached run control', () => {
     await expect(requestDetachedRunStop(runId)).rejects.toBeInstanceOf(
       DetachedRunOwnerUnavailableError
     );
+  });
+});
+
+/**
+ * The Windows termination path tolerates a kill command that ran and reported a
+ * failure, because `taskkill /T` reports every tree member that had already exited.
+ * It must never tolerate one that was cut off part-way, because then the tree was
+ * only partly walked and the root going quiet says nothing about the descendants.
+ *
+ * Every error below is the genuine object Node produces, not a hand-built stand-in,
+ * so this stays true if Node changes the shape.
+ */
+describe('commandTerminatedBySignal', () => {
+  it('is true for a timeout, which cuts the command off part-way', async () => {
+    const error = await rejectionFrom(() =>
+      execFileAsync(process.execPath, ['-e', 'setTimeout(() => undefined, 30_000)'], {
+        timeout: 100,
+      })
+    );
+
+    // The distinction is structural, so assert the shape the classification rests on
+    // rather than only its verdict — a Node change that moved it would surface here.
+    expect(error).toMatchObject({ killed: true, signal: 'SIGTERM' });
+    expect(commandTerminatedBySignal(error)).toBe(true);
+  });
+
+  it('is false for an ordinary non-zero exit, which is a completed walk', async () => {
+    const error = await rejectionFrom(() =>
+      execFileAsync(process.execPath, ['-e', 'process.exit(3)'])
+    );
+
+    expect(error).toMatchObject({ killed: false, code: 3 });
+    expect(commandTerminatedBySignal(error)).toBe(false);
+  });
+
+  it('is false for a command that never started, which killed nothing', async () => {
+    // Tolerated on purpose: nothing was signalled, so the root check that follows is
+    // a conservative verdict — a live root still throws.
+    const error = await rejectionFrom(() => execFileAsync('archon-no-such-binary-xyz', []));
+
+    expect(error).toMatchObject({ code: 'ENOENT' });
+    expect(commandTerminatedBySignal(error)).toBe(false);
+  });
+
+  it('is false for anything that is not an error object', () => {
+    expect(commandTerminatedBySignal(undefined)).toBe(false);
+    expect(commandTerminatedBySignal('killed')).toBe(false);
+    expect(commandTerminatedBySignal({ signal: 1 })).toBe(false);
   });
 });

--- a/packages/cli/src/utils/detached-run-control.ts
+++ b/packages/cli/src/utils/detached-run-control.ts
@@ -478,6 +478,25 @@ async function waitUntilGone(exists: () => boolean, timeoutMs: number): Promise<
   return true;
 }
 
+/**
+ * Did a child command die by signal instead of exiting with a status of its own?
+ *
+ * This is the line between a command that ran to completion and reported something,
+ * and one that was cut off part-way. Node makes it structural rather than textual:
+ * a `timeout` kill sets `killed: true` with `signal: 'SIGTERM'`, an ordinary non-zero
+ * exit reports `killed: false` with a numeric `code`, and a command that never started
+ * carries neither. Nothing here reads message text, so it holds under any locale.
+ *
+ * Exported for testing: the Windows termination path tolerates a completed-but-failed
+ * command and must never tolerate an interrupted one, and that decision cannot be
+ * exercised from a platform where the path does not run.
+ */
+export function commandTerminatedBySignal(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  const { killed, signal } = error as { killed?: unknown; signal?: unknown };
+  return killed === true || typeof signal === 'string';
+}
+
 /** Terminate the process tree while its exact-run owner holds the IPC lease open. */
 async function terminateDetachedProcessTree(
   pid: number,
@@ -495,10 +514,15 @@ async function terminateDetachedProcessTree(
     // already gone — the outcome this function wants, reached early. Nothing in that
     // exit code separates it from a kill that genuinely failed, so it is not the
     // proof: the confirmation below is, the same way the POSIX branch tolerates ESRCH
-    // and then re-checks. A tree still running, or a taskkill that never ran, still
-    // throws here, carrying the command's own error as the evidence. `/T` is what
-    // takes the descendants with the root; that they actually die is proved by the
-    // descendant-leak case in the integration spec, not by this exit code.
+    // and then re-checks. A tree that is still running throws there, carrying the
+    // command's own error as the evidence.
+    //
+    // A walk that never finished is a different case and is rethrown here. The root
+    // check can only stand in for the whole tree when every descendant was visited,
+    // and a `timeout` kill leaves taskkill part-way through: the root can be gone
+    // while a descendant the walk never reached is still alive. `/T` is what takes
+    // the descendants with the root, and that they actually die is proved by the
+    // descendant-leak case in the integration spec, not by any exit code.
     let killFailure: Error | undefined;
     try {
       await execFileAsync('taskkill', ['/PID', String(pid), '/T', '/F'], {
@@ -506,6 +530,7 @@ async function terminateDetachedProcessTree(
         windowsHide: true,
       });
     } catch (error) {
+      if (commandTerminatedBySignal(error)) throw error;
       killFailure = error instanceof Error ? error : new Error(String(error));
     }
     if (!(await waitUntilGone(() => processExists(pid), TERMINATION_CONFIRM_MS))) {

--- a/packages/cli/src/utils/detached-run-control.ts
+++ b/packages/cli/src/utils/detached-run-control.ts
@@ -491,15 +491,28 @@ async function terminateDetachedProcessTree(
   }
 
   if (process.platform === 'win32') {
-    // A zero exit from taskkill /T is the platform's positive tree-termination
-    // result. Never translate a timeout or partial failure into success merely
-    // because the root disappeared; descendants are part of this contract.
-    await execFileAsync('taskkill', ['/PID', String(pid), '/T', '/F'], {
-      timeout: TERMINATION_GRACE_MS,
-      windowsHide: true,
-    });
+    // `taskkill /T` walks the tree PID by PID and exits non-zero when any of them is
+    // already gone — the outcome this function wants, reached early. Nothing in that
+    // exit code separates it from a kill that genuinely failed, so it is not the
+    // proof: the confirmation below is, the same way the POSIX branch tolerates ESRCH
+    // and then re-checks. A tree still running, or a taskkill that never ran, still
+    // throws here, carrying the command's own error as the evidence. `/T` is what
+    // takes the descendants with the root; that they actually die is proved by the
+    // descendant-leak case in the integration spec, not by this exit code.
+    let killFailure: Error | undefined;
+    try {
+      await execFileAsync('taskkill', ['/PID', String(pid), '/T', '/F'], {
+        timeout: TERMINATION_GRACE_MS,
+        windowsHide: true,
+      });
+    } catch (error) {
+      killFailure = error instanceof Error ? error : new Error(String(error));
+    }
     if (!(await waitUntilGone(() => processExists(pid), TERMINATION_CONFIRM_MS))) {
-      throw new Error(`Detached workflow process tree ${String(pid)} is still running`);
+      throw new Error(
+        `Detached workflow process tree ${String(pid)} is still running` +
+          (killFailure ? `: ${killFailure.message}` : '')
+      );
     }
     return;
   }


### PR DESCRIPTION
## Problem and outcome

On Windows, `archon workflow cancel <run-id>` failed for detached runs whose process tree had in fact stopped, left the run row marked `running`, and pointed the operator at `abandon` for an orphan that did not exist. Full diagnosis on #2946.

- **Outcome:** a cancel whose tree is gone now succeeds on Windows, matching POSIX.
- **Invariant:** a tree that is still running must still throw.
- **Scope boundary:** the Windows branch of `detached-run-control.ts` only. POSIX untouched — it already handled the equivalent case. No test loosened.

## Review guidance

- **Start here:** `packages/cli/src/utils/detached-run-control.ts:493` — the entire behavior change is this one branch.
- **Known risk, and why it is acceptable:** the non-zero exit was also, incidentally, the only runtime signal that a *live descendant* had survived. This change removes it. That is safe for three reasons.
  1. It was not functioning as a guard. It fired overwhelmingly on the benign race, so anything acting on it was acting on noise — a signal that is wrong most of the time it fires is not protection.
  2. Reconstructing it would mean scraping PIDs out of localized `taskkill` stderr. Third-party output is fair to classify in this repo, but not when the classification breaks silently on a locale CI never exercises.
  3. **The descendant guarantee did not disappear — it moved from an incidental signal to an explicit test.** `stops the detached owner process group before its descendant can leak work` runs on Windows, arms a live descendant, waits for its observable death, and then proves it can no longer act. It consults no exit code, so it protects this contract independently of anything `taskkill` reports. It passes on the Windows leg of this PR (job 98969157875, 422 ms).

## Solution

`taskkill` was the wrong thing to read. It walks the tree PID by PID and exits non-zero when any of them has already exited on its own — the outcome we want, reached early — and nothing in that exit code separates it from a kill that genuinely failed. Because `promisify(execFile)` rejects on any non-zero exit, the rejection fired before the `waitUntilGone` confirmation three lines below, making the only real proof unreachable.

The command still runs the same way; a *completed* walk that reported a failure is captured instead of thrown, and the confirmation decides. A tree still running still throws, now carrying `taskkill`'s own error rather than discarding it, so a missing binary reads as `…is still running: <real error>` instead of a bare symptom.

An **interrupted** walk is not tolerated. On a `timeout` Node kills `taskkill` part-way through the tree, so a descendant it never reached can still be alive while the root happens to be gone — and the root check cannot see that. Those rejections are rethrown, the same shape as the POSIX branch rethrowing anything that is not `ESRCH`. The distinction is structural rather than textual, so it holds under any locale: a timeout is `killed: true` / `signal: 'SIGTERM'`, an ordinary non-zero exit is `killed: false` with a numeric `code`, and a command that never started carries neither.

The comment above the call, which asserted the wrong invariant, is replaced and now states what happens to a timeout.

## Validation

- **Windows CI, job 98969157875** — `wakes on a cancelled run stopped from a third process` **passes** (8750 ms). That is the test that was failing on unrelated PRs. `stops the detached owner process group before its descendant can leak work` also passes, so the descendant guarantee survives the change.
- `bun run validate` — exit 0. `bun --cwd packages/cli run test:integration` — 7 + 1 + 6 pass.
- **The failure case still fails, observed red.** New test `treats an already-gone target as a stopped tree` stages a real already-exited PID behind a stub control endpoint; new test `still fails when the target is alive and the kill cannot reach it` stages a live non-group-leader process, where `kill(-pid)` raises the same `ESRCH` an absent group raises, so only the follow-up check on the process itself separates them.
- **The timeout rethrow is proved, not asserted.** `commandTerminatedBySignal` is unit-tested against the genuine rejection objects Node produces — a real 100 ms timeout, a real `process.exit(3)`, a real `ENOENT` — asserting the shape the classification rests on (`killed`/`signal`/`code`) and not only the verdict, so a Node change that moved it surfaces here. The wiring was then observed flipping on a single variable: forcing the Windows branch with a command that genuinely times out, the already-gone test **fails** with `signal: "SIGTERM"` when the rethrow is present, and **passes** when the one rethrow line is removed — which is exactly the false success R1 identified. (The missing-binary forcing technique cannot reach this path: `ENOENT` carries `killed: undefined`, so it is correctly not a timeout.)
- The Windows branch cannot run on macOS, so I forced it (`taskkill` is absent there, so `execFileAsync` rejects exactly as a non-zero exit does) and ran the suite twice. With the **old** bare-`await` shape the already-gone test **fails**. With the new shape it passes, and a live target still throws:

  ```
  Detached workflow process tree 77370 is still running: Executable not found in $PATH: "taskkill"
  ```

  Both halves of the contract observed, and the kill error confirmed to survive into the message.
- **Not verified:** the real `taskkill` race, which needs a Windows descendant to exit at the wrong moment and cannot be staged deterministically. The green Windows leg above is the proof that matters.

## Links

- Closes #2946
- Related #2923


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows process termination so stopping an already-closed process completes successfully.
  - Preserved clear errors when a live process cannot be reached or does not belong to the expected process group.
  - Improved handling of command timeouts and interrupted termination attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->