### PR TITLE
fix(scripts): derive the reported workflow path once, with forward slashes

### DIFF
--- a/scripts/output-format-strict.test.ts
+++ b/scripts/output-format-strict.test.ts
@@ -36,6 +36,20 @@ import { join } from 'node:path';
 const REPO_ROOT = join(import.meta.dir, '..');
 const WORKFLOWS_ROOT = join(REPO_ROOT, '.archon', 'workflows');
 
+/**
+ * A discovered file as this check reports it: repo-relative, forward slashes on every
+ * platform.
+ *
+ * `yamlFilesUnder` builds paths with `join`, so on Windows they are backslash-separated,
+ * while every expectation and rendered violation in this file is written with `/`. The two
+ * can never match, which failed 100% of Windows runs (#2954). Deriving the spelling once,
+ * here, is what keeps the next call site from reintroducing the split — patching the
+ * comparisons individually would leave the same trap for the next path added.
+ */
+function repoRelative(file: string): string {
+  return file.slice(REPO_ROOT.length + 1).replaceAll('\\', '/');
+}
+
 interface Violation {
   workflow: string;
   nodeId: string;
@@ -104,7 +118,7 @@ function findViolations(): Violation[] {
         if (outputFormat === undefined) continue;
         const nodeId = String((node as { id?: unknown }).id ?? '(unnamed)');
         for (const found of underRequiredNodes(outputFormat, 'output_format')) {
-          violations.push({ workflow: file.slice(REPO_ROOT.length + 1), nodeId, ...found });
+          violations.push({ workflow: repoRelative(file), nodeId, ...found });
         }
       }
     }
@@ -136,9 +150,7 @@ describe('bundled output_format schemas satisfy OpenAI strict mode (#1843)', () 
       for (const top of doc.nodes ?? []) {
         for (const node of withBodyNodes(top)) {
           if ((node as { output_format?: unknown }).output_format !== undefined) {
-            seen.push(
-              `${file.slice(REPO_ROOT.length + 1)}:${String((node as { id?: unknown }).id)}`
-            );
+            seen.push(`${repoRelative(file)}:${String((node as { id?: unknown }).id)}`);
           }
         }
       }


### PR DESCRIPTION
## Problem and outcome

`scripts/output-format-strict.test.ts` built its repo-relative paths from `join()` output and compared them against hardcoded forward-slash spellings. On Windows those can never match, so `the check inspects the schemas it claims to` failed **100% of Windows runs** from the moment it landed with #2944 — and every PR branched from `dev` inherited a red leg.

- **Outcome:** the Windows leg can go green again. No PR could show one while this stood.
- **Invariant:** the check reports the same path spelling on every platform.
- **Scope boundary:** one test file. No production code, no assertion loosened, no schema touched.

Closes #2954

## Solution

Both call sites now derive the path through one `repoRelative`, which slices and normalizes in a single place.

Patching the two comparisons individually would have fixed today's assertion and left the same trap for the next path someone adds. The split is between *how paths are built* (`join`, platform-native) and *how they are written down* (forward slashes, in expectations and rendered violations), so the normalization belongs where the spelling is derived, not at each place it is consumed.

The second call site — `violations[].workflow` — was only ever cosmetic, since it reaches failure messages rather than assertions. It read differently on Windows for the same reason, so it goes through the same helper.

## Validation

Windows CI is the real gate here; the failing path cannot run on macOS. What I could establish locally:

- `bun test ./scripts/output-format-strict.test.ts` — 2 pass, 0 fail
- `prettier --check` — clean
- **The fix demonstrated against a simulated Windows path**, since that is the case that matters:

  ```
  old (as merged): ".archon\\workflows\\sdlc\\implement\\archon-implement.yaml"
    matches expectation? false
  new (this fix):   ".archon/workflows/sdlc/implement/archon-implement.yaml"
    matches expectation? true
  ```

**Not run:** the full `bun run validate`. This is a fresh worktree without `node_modules`, so the rest of the `scripts/` suite fails on `Cannot find module` — unrelated to this change, and installing was not worth the delay for a P0 that blocks every Windows leg in the repo. CI runs the full suite with dependencies present, and that is the gate I am relying on.

## Why it is urgent

Second Windows CI blocker on `dev` today. Unlike #2946 — which hits most Windows runs — this one fails every time, so nothing could go green behind it, including #2953 (the fix for #2946) and #2944's own follow-ups.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cross-platform test path handling by normalizing file paths consistently across operating systems.
  * Updated violation and duplicate-detection checks to use the standardized path format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->