### PR TITLE
fix(ci): the strict-schema guard now passes on Windows

### DIFF
--- a/scripts/output-format-strict.test.ts
+++ b/scripts/output-format-strict.test.ts
@@ -34,6 +34,12 @@ import { readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
 const REPO_ROOT = join(import.meta.dir, '..');
+
+// join() emits backslashes on Windows; reported paths and the fixture assertion
+// below use one spelling so the test means the same thing on every platform (#2954).
+function relativePath(file: string): string {
+  return file.slice(REPO_ROOT.length + 1).replaceAll('\\', '/');
+}
 const WORKFLOWS_ROOT = join(REPO_ROOT, '.archon', 'workflows');
 
 interface Violation {
@@ -104,7 +110,7 @@ function findViolations(): Violation[] {
         if (outputFormat === undefined) continue;
         const nodeId = String((node as { id?: unknown }).id ?? '(unnamed)');
         for (const found of underRequiredNodes(outputFormat, 'output_format')) {
-          violations.push({ workflow: file.slice(REPO_ROOT.length + 1), nodeId, ...found });
+          violations.push({ workflow: relativePath(file), nodeId, ...found });
         }
       }
     }
@@ -136,9 +142,7 @@ describe('bundled output_format schemas satisfy OpenAI strict mode (#1843)', () 
       for (const top of doc.nodes ?? []) {
         for (const node of withBodyNodes(top)) {
           if ((node as { output_format?: unknown }).output_format !== undefined) {
-            seen.push(
-              `${file.slice(REPO_ROOT.length + 1)}:${String((node as { id?: unknown }).id)}`
-            );
+            seen.push(`${relativePath(file)}:${String((node as { id?: unknown }).id)}`);
           }
         }
       }


### PR DESCRIPTION
## Problem

The output-format strict-mode guard (landed with #2944) builds workflow paths with `join()` and asserts a forward-slash spelling, so its completeness test fails on every `windows-latest` run of `dev` — deterministically. Every PR since inherits a red Windows leg, and four dogfood runs died tonight at their CI gates on it. Filed as #2954.

## Solution

One `relativePath()` helper normalizes the separator at both slice sites (the violation reports and the completeness assertion), so the test means the same thing on every platform. No behavior change to what the guard checks.

## Validation

- `bun test ./scripts/output-format-strict.test.ts` — 2 pass / 0 fail (the normalize is a no-op on POSIX; the Windows leg of this PR is the real proof).
- Prettier clean.

Closes #2954

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized workflow path formatting across platforms.
  * Fixed path reporting on Windows by using consistent forward-slash separators.
  * Updated related validation to recognize the normalized path format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->