### PR TITLE
Fix duplicate release checksum entry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,7 +277,7 @@ jobs:
       - name: Generate checksums
         run: |
           cd dist
-          sha256sum archon-* archon-web.tar.gz > checksums.txt
+          sha256sum archon-* > checksums.txt
           cat checksums.txt
 
       - name: Get version

--- a/scripts/release-checksums.test.ts
+++ b/scripts/release-checksums.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { trackTempRoots } from '@archon/paths/test-utils';
+
+const RELEASE_WORKFLOW = join(import.meta.dir, '..', '.github', 'workflows', 'release.yml');
+const RELEASE_ARTIFACTS = [
+  'archon-darwin-arm64',
+  'archon-darwin-x64',
+  'archon-linux-arm64',
+  'archon-linux-x64',
+  'archon-windows-x64.exe',
+  'archon-web.tar.gz',
+];
+const trackTempRoot = trackTempRoots();
+
+function checksumCommand(): string {
+  const workflow = Bun.YAML.parse(readFileSync(RELEASE_WORKFLOW, 'utf8')) as {
+    jobs: { release: { steps: Array<{ name?: string; run?: string }> } };
+  };
+  const command = workflow.jobs.release.steps.find(step => step.name === 'Generate checksums')?.run;
+  if (command === undefined) throw new Error('Release workflow has no checksum generation command');
+  return command;
+}
+
+test('release checksum command lists every released artifact exactly once (#2377)', () => {
+  const root = trackTempRoot(mkdtempSync(join(tmpdir(), 'release-checksums-')));
+  const dist = join(root, 'dist');
+  mkdirSync(dist);
+  for (const artifact of RELEASE_ARTIFACTS) writeFileSync(join(dist, artifact), artifact);
+
+  const result = Bun.spawnSync(['bash', '-c', checksumCommand()], { cwd: root });
+  expect(result.exitCode).toBe(0);
+
+  const filenames = readFileSync(join(dist, 'checksums.txt'), 'utf8')
+    .trim()
+    .split('\n')
+    .map(line => {
+      const match = /^([a-f\d]{64})  (.+)$/.exec(line);
+      if (match === null) throw new Error(`Malformed checksum row: ${line}`);
+      return match[2];
+    });
+
+  expect([...filenames].sort()).toEqual([...RELEASE_ARTIFACTS].sort());
+  expect(new Set(filenames).size).toBe(RELEASE_ARTIFACTS.length);
+});


### PR DESCRIPTION
## Problem and outcome

`checksums.txt` in the v0.7.0 release listed `archon-web.tar.gz` twice. This is a security-adjacent integrity artifact, so its entries must match the release assets exactly.

- **Outcome:** The release job writes one checksum row for each of the six current release artifacts.
- **Invariant:** `checksums.txt` contains exactly one entry for `archon-darwin-arm64`, `archon-darwin-x64`, `archon-linux-arm64`, `archon-linux-x64`, `archon-windows-x64.exe`, and `archon-web.tar.gz`.
- **Scope boundary:** The release artifact set, upload step, and checksum algorithm are unchanged.
- **Root cause:** `archon-*` already matches `archon-web.tar.gz`, which was also passed explicitly to `sha256sum`.

## Review guidance

- **Feedback requested:** Confirm the glob covers the complete uploaded release-artifact set while removing the duplicate row.
- **Start here:** `.github/workflows/release.yml:280` — the only behavior change is checksum input selection.
- **Review order:** Review the checksum-command change and its focused regression test, then compare the command with the release upload list immediately below it.
- **Lower-attention areas:** None; the PR changes one workflow command and adds a focused regression test.
- **Known risk or uncertainty:** None. The release job still uploads the same six artifacts and `checksums.txt`.

## Solution

Checksum generation now passes only `archon-*` to `sha256sum`. That glob covers the five platform binaries and `archon-web.tar.gz`, so removing the redundant explicit operand preserves complete checksum coverage while preventing the second web-tarball row.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | `checksums.txt` had seven rows, including `archon-web.tar.gz` twice. | `checksums.txt` has six rows, one for each release artifact. |
| **Integrity coverage** | All six artifacts were covered, but one was duplicated. | All six artifacts remain covered exactly once. |

## Validation

- Fixture reproduction of the prior checksum command — produced seven rows and a duplicate `archon-web.tar.gz` entry.
- Fixture run of the updated command — produced exactly the six unique artifact names in the invariant above.
- `bun install --frozen-lockfile` — passed.
- `bun run format:check` — passed.
- `bun run lint --max-warnings 0` — passed.
- `bun run validate` — passed, including generated-artifact checks, API types, type checks, lint, formatting, installer tests, and the full test suite.
- **Not verified:** A GitHub release run has not been triggered locally; this PR's CI remains the release-workflow environment check.

## Links

- Closes #2377