### PR TITLE
ci: gate workflow fixtures before merge

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -93,11 +93,6 @@ jobs:
           fi
           echo "all_success correctly failed the node"
 
-      # Declared dry-run fixtures (#2772). Exits 0 with "no fixtures found" until a
-      # fixture-bearing workflow merges; fails once any declared fixture regresses.
-      - name: Dry-run fixture suite
-        run: bun run cli workflow test --json
-
   # ─── Tier 1b: Container isolation (Docker, no API keys needed) ──────────
   # Deterministic slice of the container-isolation e2e (folder project +
   # --container). Bash-node-only, so no AI credential is required. Gated on

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,24 @@ jobs:
           run_tests=$(bun scripts/should-run-test-suite.ts "$EVENT_NAME" "$BASE_SHA" "$HEAD_SHA")
           echo "run-tests=$run_tests" >> "$GITHUB_OUTPUT"
 
+  workflow-fixtures:
+    needs: changes
+    if: needs.changes.outputs.run-tests == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run workflow fixtures
+        run: bun run cli workflow test --json
+
   test:
     needs: changes
     if: needs.changes.outputs.run-tests == 'true'
@@ -263,13 +281,14 @@ jobs:
 
   test-suite:
     name: Test Suite
-    needs: [changes, test, schema-upgrade, postgres-parity, docker-build]
+    needs: [changes, workflow-fixtures, test, schema-upgrade, postgres-parity, docker-build]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Report test-suite outcome
         env:
           RUN_TESTS: ${{ needs.changes.outputs.run-tests }}
+          WORKFLOW_FIXTURES: ${{ needs.workflow-fixtures.result }}
           TEST: ${{ needs.test.result }}
           SCHEMA_UPGRADE: ${{ needs.schema-upgrade.result }}
           POSTGRES_PARITY: ${{ needs.postgres-parity.result }}
@@ -280,7 +299,7 @@ jobs:
             exit 0
           fi
 
-          for result in "$TEST" "$SCHEMA_UPGRADE" "$POSTGRES_PARITY" "$DOCKER_BUILD"; do
+          for result in "$WORKFLOW_FIXTURES" "$TEST" "$SCHEMA_UPGRADE" "$POSTGRES_PARITY" "$DOCKER_BUILD"; do
             if [ "$result" != success ]; then
               echo "A test-suite job finished with $result."
               exit 1

--- a/scripts/should-run-test-suite.test.ts
+++ b/scripts/should-run-test-suite.test.ts
@@ -140,4 +140,25 @@ describe('test-suite change decision', () => {
     );
     expect(changesJob).toContain('echo "run-tests=$run_tests" >> "$GITHUB_OUTPUT"');
   });
+
+  test('the workflow fixture gate feeds the required test-suite result', () => {
+    const workflow = readFileSync(
+      resolve(import.meta.dir, '../.github/workflows/test.yml'),
+      'utf8'
+    ).replaceAll('\r\n', '\n');
+    const workflowFixtures = workflow.slice(
+      workflow.indexOf('  workflow-fixtures:'),
+      workflow.indexOf('  test:')
+    );
+    const testSuite = workflow.slice(workflow.indexOf('  test-suite:'));
+
+    expect(workflowFixtures).toContain('needs: changes');
+    expect(workflowFixtures).toContain("if: needs.changes.outputs.run-tests == 'true'");
+    expect(workflowFixtures).toContain('runs-on: ubuntu-latest');
+    expect(workflowFixtures).toContain('run: bun install --frozen-lockfile');
+    expect(workflowFixtures).toContain('run: bun run cli workflow test --json');
+    expect(testSuite).toContain('workflow-fixtures');
+    expect(testSuite).toContain('WORKFLOW_FIXTURES: ${{ needs.workflow-fixtures.result }}');
+    expect(testSuite).toContain('"$WORKFLOW_FIXTURES"');
+  });
 });


### PR DESCRIPTION
## Project check status

The implementation was delivered with an external environment blocker: repository rulesets `15166646` (`dev`) and `15166632` (`main`) are disabled and the active account is not a repository administrator. Attempts to configure the required `Test Suite` check returned GitHub 404. The implementation validation passed, including all 39 fixtures and `bun run validate`; this PR's own CI is still the check that decides the code result. Evidence and the exact permission failure are recorded in the implementation run artifacts.

## Problem and outcome

Fixture drift could merge undetected because the fixture bar ran only in the push-triggered E2E smoke workflow. PR #2863 merged five broken fixtures while CI was green, and PR #2950 nearly repeated the failure with 17 broken fixtures.

- **Outcome:** Relevant pull requests now run every discovered workflow fixture on Ubuntu, and a fixture failure makes the `Test Suite` aggregate fail.
- **Invariant:** The gate uses the maintainer command, `bun run cli workflow test --json`, with no AI credentials or network access.
- **Scope boundary:** The fixture suite stays Ubuntu-only; the existing Windows test leg and every other check remain unchanged.
- **Root cause:** The only CI invocation was owned by `e2e-smoke.yml`, which runs only after pushes to `main` or `dev`.

## Review guidance

- **Feedback requested:** Confirm that the fixture result is correctly made part of the PR-facing `Test Suite` aggregate.
- **Start here:** `.github/workflows/test.yml` — the new `workflow-fixtures` job and aggregate dependency make fixture failures visible before merge.
- **Review order:** Review the fixture job, then its `test-suite` aggregation, then the focused topology test.
- **Lower-attention areas:** Removing the duplicate E2E-smoke step is mechanical; `bun run cli workflow test --json` passed all 39 fixtures.
- **Known risk or uncertainty:** Repository rulesets still need an administrator to require `Test Suite` before GitHub will enforce it as merge-blocking.

## Solution

The fixture bar moves to the PR-triggered `Test Suite` workflow, which already runs for pull requests to `dev` and `main` as well as pushes. A dedicated Ubuntu job follows the existing change decision, installs the frozen lockfile, and runs the same fixture command used locally. `Test Suite` now depends on that job and rejects any non-success result, while documentation-only changes retain its existing successful aggregate path.

The push-only E2E smoke workflow no longer duplicates the command, leaving `test.yml` as its single CI owner. A focused test pins the job's command, conditions, and aggregate propagation.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Workflow fixtures ran only after a push to `main` or `dev`. | Relevant PRs run all discovered fixtures in `Test Suite`. |
| **Failure behavior** | A broken fixture could leave PR CI green. | A broken fixture fails the `workflow-fixtures` job and the `Test Suite` aggregate. |

## Validation

- `bun install --frozen-lockfile` — passed.
- `bun run cli workflow test --json` — passed: 39 fixtures, 0 failures; proves the fixture suite is deterministic and credential-free.
- `bun test ./scripts/should-run-test-suite.test.ts` — passed: 18 tests, including the fixture-job topology test.
- `bun run format:check` — passed.
- `bun run validate` — passed.
- `git diff --check 8a5c905531d9d1f2b538bc02affcbe47cbeafb16..HEAD` — passed.
- **Not verified:** Enabling required status checks in GitHub rulesets; the active account lacks repository-admin permission.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Rollout / merge protection | An administrator must enable rulesets `15166646` and `15166632` and require the GitHub Actions `Test Suite` check to make the passing aggregate merge-blocking. | GitHub rejected the documented ruleset update with 404; the active account reports `admin: false`. |
| Observability | Fixture regressions now appear as a named PR job and fail the existing aggregate. | `.github/workflows/test.yml` |

## Links

- Relates to #2870
