### PR TITLE
Fix duplicate release artifact checksums

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,7 +277,7 @@ jobs:
       - name: Generate checksums
         run: |
           cd dist
-          sha256sum archon-* archon-web.tar.gz > checksums.txt
+          sha256sum archon-* > checksums.txt
           cat checksums.txt
 
       - name: Get version


### PR DESCRIPTION
## Problem and outcome

The release checksum command expands `archon-web.tar.gz` through `archon-*` and then names it again explicitly, producing two checksum rows for the same artifact. This makes the published checksum manifest redundant and potentially confusing to consumers.

- **Outcome:** Each release artifact, including `archon-web.tar.gz`, has one checksum row.
- **Invariant:** `archon-web.tar.gz` remains covered by the release checksum manifest.
- **Scope boundary:** Only the release checksum input list changed.
- **Root cause:** The command combined an inclusive glob with an explicit duplicate filename.

## Review guidance

- **Feedback requested:** Confirm the glob covers every intended release asset exactly once.
- **Start here:** `.github/workflows/release.yml:280` — this is the complete behavior change.
- **Review order:** Inspect the one-line checksum command change, then the validation evidence below.
- **Known risk or uncertainty:** None.

## Solution

Remove the redundant explicit `archon-web.tar.gz` argument and retain `archon-*` as the sole checksum input pattern. The web tarball already matches that pattern, so this preserves coverage while eliminating its second manifest row.

## Behavior change

| | Before | After |
|---|---|---|
| **Checksum manifest** | `archon-web.tar.gz` appears twice. | Every matching release artifact appears once. |
| **Web tarball coverage** | Included twice. | Included once through `archon-*`. |

## Validation

- Temporary-directory reproduction with `sha256sum archon-* archon-web.tar.gz` and `sha256sum archon-*` — confirmed the former emits two web-tarball rows and the latter emits one row per representative release asset.
- `bun x prettier --check .github/workflows/release.yml` — passed.
- `bun run validate` — passed after `bun install --frozen-lockfile`; generation checks, API types, type checks, lint, formatting, installer tests, and test suites passed.
- `git diff --check` — passed.
- **Not verified:** Nothing material; the command's glob expansion and repository validation directly cover the changed behavior.
