### PR TITLE
fix(workflows): a composed command node keeps its own with: binding

### DIFF
--- a/packages/workflows/src/compiled-command.ts
+++ b/packages/workflows/src/compiled-command.ts
@@ -1,4 +1,4 @@
-import type { TriggerRule } from './schemas';
+import type { BindingDirective, TriggerRule } from './schemas';
 import type { JsonValue } from './output-ref';
 
 /** Engine-private per-node metadata attached during load-time include expansion.
@@ -17,6 +17,38 @@ export type CompiledLoopCommand =
 
 export interface LoopWithCompiledCommand {
   [COMPILED_LOOP_COMMAND]?: CompiledLoopCommand;
+}
+
+/**
+ * The node-local `with:` map a command node carried before include expansion compiled
+ * its body into an inline prompt (#2964).
+ *
+ * Composition materializes a command node so the block's refs can be namespaced and its
+ * declared inputs bound, which leaves `with:` — a field the schema admits only on the
+ * `command` source variant, so an author cannot write it on a prompt node (#2478) —
+ * with nowhere to live on the result. Dropping it silently unbound every name the node
+ * supplied itself: the compiled body's `$INPUTS.<name>` reached the model as a literal
+ * token, or as an empty string when a decoy input had been declared to get past the
+ * missing-input check. The executor and the dry-run simulator resolve this payload for a
+ * materialized node exactly as they resolve `source.with` for an unmaterialized one, so
+ * a binding means the same thing standalone and composed.
+ */
+export const COMPOSED_BINDINGS = Symbol('archon.composed-bindings');
+
+export type ComposedBindings = Record<string, JsonValue | BindingDirective>;
+
+export interface NodeWithComposedBindings {
+  [COMPOSED_BINDINGS]?: ComposedBindings;
+}
+
+/** Read a node's surviving node-local bindings. One accessor, so the cast lives in one place. */
+export function readComposedBindings(node: object): ComposedBindings | undefined {
+  return (node as NodeWithComposedBindings)[COMPOSED_BINDINGS];
+}
+
+/** Attach the bindings a materialized command node must keep. @see COMPOSED_BINDINGS */
+export function attachComposedBindings(node: object, bindings: ComposedBindings): void {
+  (node as NodeWithComposedBindings)[COMPOSED_BINDINGS] = bindings;
 }
 
 /** @see ComposedNodeMeta */

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -118,6 +118,7 @@ import { buildTruncationMarker } from './utils/output-truncation';
 import { writeNodeArtifact, readNodeArtifacts } from './artifacts-index';
 import {
   COMPILED_LOOP_COMMAND,
+  readComposedBindings,
   readComposedMeta,
   type LoopWithCompiledCommand,
   type IncludeCommandContent,
@@ -2090,7 +2091,10 @@ async function executeNodeInternal(
   // Command file name when this agent node is command-sourced, undefined for an
   // inline prompt — replaces the old `node.command` field access throughout.
   const commandName = node.source.kind === 'command' ? node.source.name : undefined;
-  const nodeWith = node.source.kind === 'command' ? node.source.with : undefined;
+  // Include expansion compiles a command body into an inline prompt and moves the node's
+  // `with:` map to the engine-private payload, so a composed node binds exactly as the
+  // same node does standalone (#2964).
+  const nodeWith = node.source.kind === 'command' ? node.source.with : readComposedBindings(node);
   // Persisted step_name is namespaced ('<groupId>.' prefix) for loop_group bodies;
   // '' for the top-level DAG → identical to node.id. The in-process emitter payloads
   // below stay raw (node.id) — live SSE/CLI consumers key off those. See #2090.

--- a/packages/workflows/src/dry-run.test.ts
+++ b/packages/workflows/src/dry-run.test.ts
@@ -1668,6 +1668,59 @@ describe('dryRunWorkflow — node-local with: bindings (#2637)', () => {
     expect(gate?.state).toBe('failed');
     expect(gate?.reason).toContain("'corrections' failed");
   });
+
+  test('a composed command node resolves its own binding, not an empty caller input (#2964)', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'archon-dry-run-composed-binding-'));
+    temporaryDirectories.push(cwd);
+    mkdirSync(join(cwd, '.archon', 'commands'), { recursive: true });
+    writeFileSync(join(cwd, '.archon', 'commands', 'sync-pr-body.md'), 'Update PR $INPUTS.number');
+
+    // The shape from the issue: the block opens a PR, then a command node reads the number
+    // that node produced. The caller has nothing to pass at launch — the PR does not exist
+    // yet — so the value can only come from the node's own binding.
+    const deliver = makeTestWorkflow({
+      name: 'deliver',
+      nodes: [
+        {
+          id: 'pr',
+          prompt: 'Open the PR',
+          output_format: { type: 'object', properties: { number: { type: 'number' } } },
+        },
+        {
+          id: 'sync',
+          command: 'sync-pr-body',
+          depends_on: ['pr'],
+          with: { number: '$pr.output.number' },
+        },
+      ],
+    });
+    const ship = makeTestWorkflow({
+      name: 'ship',
+      nodes: [{ id: 'deliver', include: 'deliver' }],
+    });
+    const { workflows, errors } = expandWorkflowIncludes(
+      new Map([
+        ['deliver', deliver],
+        ['ship', ship],
+      ]),
+      new Map([['sync-pr-body', 'Update PR $INPUTS.number']])
+    );
+    expect(errors).toHaveLength(0);
+
+    const result = await dryRunWorkflow({
+      workflow: workflows.get('ship')!,
+      userMessage: '',
+      cwd,
+      stubs: { deliver__pr: { number: 2964 }, deliver__sync: 'done' },
+    });
+
+    expect(result.outcome).toBe('completed');
+    // Composition materializes the body into an inline prompt, so this proves the moved
+    // binding still reaches resolveNodeBindings — the channel a real run uses.
+    expect(result.trace.find(t => t.nodeId === 'deliver__sync')?.resolvedText).toBe(
+      'Update PR 2964'
+    );
+  });
 });
 
 describe('dryRunWorkflow — effective provider/model per node', () => {

--- a/packages/workflows/src/dry-run.ts
+++ b/packages/workflows/src/dry-run.ts
@@ -15,7 +15,11 @@ import {
   type ShellInputContext,
 } from './dag-executor';
 import { evaluateCondition } from './condition-evaluator';
-import { COMPILED_LOOP_COMMAND, type LoopWithCompiledCommand } from './compiled-command';
+import {
+  COMPILED_LOOP_COMMAND,
+  readComposedBindings,
+  type LoopWithCompiledCommand,
+} from './compiled-command';
 import { declaredFieldsFromSchema, canonicalValueText, type JsonValue } from './output-ref';
 import { discoverScriptsForCwd } from './script-discovery';
 import {
@@ -1043,7 +1047,6 @@ async function simulateNode(
       return;
     }
 
-    const isCommandSourced = isAgentNode(node) && node.source.kind === 'command';
     const sourceText = isAgentNode(node)
       ? node.source.kind === 'command'
         ? await loadDryRunCommand(ctx, node.source.name)
@@ -1056,17 +1059,21 @@ async function simulateNode(
     // on (unknown producer, skipped without if_skipped) fails the simulated node
     // with the executor's own error, via the catch below. Command bindings merge
     // over run inputs into the `$INPUTS` bag; script bindings ride the exec env.
+    // A composed command node carries its map in the engine-private payload, having
+    // been materialized into an inline prompt at expansion (#2964).
     const nodeWith = isExecNode(node)
       ? node.with
-      : isCommandSourced && isAgentNode(node) && node.source.kind === 'command'
-        ? node.source.with
+      : isAgentNode(node)
+        ? node.source.kind === 'command'
+          ? node.source.with
+          : readComposedBindings(node)
         : undefined;
     const nodeBindings =
       nodeWith !== undefined
         ? resolveNodeBindings(node.id, nodeWith, bindingShellContext(ctx, outputs), ctx.inputs)
         : undefined;
     const commandInputs =
-      isCommandSourced && nodeBindings !== undefined
+      isAgentNode(node) && nodeBindings !== undefined
         ? { ...(ctx.inputs ?? {}), ...nodeBindings }
         : undefined;
     const resolvedText =

--- a/packages/workflows/src/include-expander.test.ts
+++ b/packages/workflows/src/include-expander.test.ts
@@ -1429,6 +1429,44 @@ describe('expandWorkflowIncludes — included command compilation', () => {
     expect(composedBindings(sync)).toEqual({ pr_number: '$ship__deliver__pr.output.number' });
   });
 
+  test('rejects a caller ref forwarded into a binding that skips depends_on', () => {
+    const block = wf('refblk', [{ id: 'sync', command: 'ref-cmd', with: { v: '$INPUTS.src' } }]);
+    block.inputs = { src: { required: true } };
+    // `other` is a real parent node, but nothing makes it run before the block.
+    const parent = wf('parent', [
+      { id: 'other', bash: 'echo x' },
+      { id: 'inc', include: 'refblk', with: { src: '$other.output' } },
+    ]);
+    const { workflows, errors } = expandWorkflowIncludes(
+      mapOf(block, parent),
+      new Map([['ref-cmd', 'Use $INPUTS.v.']])
+    );
+    // The block was proven hermetic before the caller's value was inserted, so the scan
+    // over the FLATTENED graph is the only one that can see this ref. Without it the
+    // binding reaches the executor and fails the node mid-run instead of at load.
+    expect(workflows.has('parent')).toBe(false);
+    expect(errors.find(error => error.filename === 'parent')?.error).toContain(
+      "add 'other' to 'inc__sync'.depends_on"
+    );
+  });
+
+  test('accepts the same forwarded ref when the include declares the dependency', () => {
+    const block = wf('refblk-ok', [{ id: 'sync', command: 'ref-ok', with: { v: '$INPUTS.src' } }]);
+    block.inputs = { src: { required: true } };
+    const parent = wf('parent', [
+      { id: 'other', bash: 'echo x' },
+      { id: 'inc', include: 'refblk-ok', depends_on: ['other'], with: { src: '$other.output' } },
+    ]);
+    const { workflows, errors } = expandWorkflowIncludes(
+      mapOf(block, parent),
+      new Map([['ref-ok', 'Use $INPUTS.v.']])
+    );
+    expect(errors).toHaveLength(0);
+    expect(composedBindings(nodeById(workflows.get('parent')!, 'inc__sync'))).toEqual({
+      v: '$other.output',
+    });
+  });
+
   test('materializes loop.command and binds its declared include input', () => {
     const block = wf('loopblk', [
       { id: 'repeat', loop: { command: 'loop-cmd', until: 'DONE', max_iterations: 1 } },

--- a/packages/workflows/src/include-expander.test.ts
+++ b/packages/workflows/src/include-expander.test.ts
@@ -6,6 +6,8 @@ import { COMPOSE_FAN_OUT_STEP_MARKER } from './fan-out-identity';
 import {
   COMPILED_LOOP_COMMAND,
   COMPOSED_NODE,
+  readComposedBindings,
+  type ComposedBindings,
   type ComposedBlockBoundary,
   type ComposedNodeMeta,
   type LoopWithCompiledCommand,
@@ -49,6 +51,11 @@ function composedOrigin(node: DagNode | undefined): string | undefined {
 
 function composedBoundaries(node: DagNode | undefined): ComposedBlockBoundary[] | undefined {
   return composedMeta(node)?.boundaries;
+}
+
+/** The node-local `with:` bindings a materialized command node kept (#2964). */
+function composedBindings(node: DagNode | undefined): ComposedBindings | undefined {
+  return node === undefined ? undefined : readComposedBindings(node);
 }
 
 function compiledLoopPrompt(node: DagNode | undefined): string | undefined {
@@ -1319,6 +1326,107 @@ describe('expandWorkflowIncludes — included command compilation', () => {
     const message = errors.find(error => error.filename === 'parent')?.error;
     expect(message).toContain("command 'my-cmd' is empty");
     expect(message).toContain('non-whitespace prompt body');
+  });
+
+  // #2964 — a command node's own `with:` map is a RUNTIME channel: the executor resolves
+  // it against sibling outputs and merges it over the run inputs into the `$INPUTS` bag.
+  // Composition used to drop it while materializing the body, then report every name it
+  // supplied as a missing caller input — advice no caller could follow, because the value
+  // does not exist until a sibling three steps earlier has run.
+  test('keeps a command node own with: binding through composition', () => {
+    const block = wf('archon-deliver', [
+      { id: 'pr', bash: 'echo open-pr' },
+      {
+        id: 'sync',
+        command: 'sync-pr-body',
+        depends_on: ['pr'],
+        with: { pr_number: '$pr.output.number' },
+      },
+    ]);
+    const parent = wf('archon-ship', [{ id: 'deliver', include: 'archon-deliver' }]);
+    const { workflows, errors } = expandWorkflowIncludes(
+      mapOf(block, parent),
+      new Map([['sync-pr-body', 'Update PR $INPUTS.pr_number.']])
+    );
+    expect(errors).toHaveLength(0);
+    const sync = nodeById(workflows.get('archon-ship')!, 'deliver__sync');
+    // The token stays standing for the executor's own `$INPUTS` pass — splicing anything
+    // here would freeze a value that only exists mid-run.
+    expect(inlinePrompt(sync)).toBe('Update PR $INPUTS.pr_number.');
+    // …and the binding survives with its producer ref namespaced into the flat DAG.
+    expect(composedBindings(sync)).toEqual({ pr_number: '$deliver__pr.output.number' });
+  });
+
+  test('a command node own binding wins over a caller-supplied input of the same name', () => {
+    const block = wf('bindblk', [
+      { id: 'pr', bash: 'echo open-pr' },
+      {
+        id: 'sync',
+        command: 'sync-cmd',
+        depends_on: ['pr'],
+        with: { pr_number: '$pr.output.number' },
+      },
+    ]);
+    block.inputs = { pr_number: { default: '' } };
+    const parent = wf('parent', [
+      { id: 'inc', include: 'bindblk', with: { pr_number: 'caller value' } },
+    ]);
+    const { workflows, errors } = expandWorkflowIncludes(
+      mapOf(block, parent),
+      new Map([['sync-cmd', 'Update PR $INPUTS.pr_number.']])
+    );
+    expect(errors).toHaveLength(0);
+    // Nearest source wins, matching the executor's merge order. Splicing the caller value
+    // (or the empty default a block declares to get past the old check) would silently
+    // hand the agent a value the author never meant it to read.
+    expect(inlinePrompt(nodeById(workflows.get('parent')!, 'inc__sync'))).toBe(
+      'Update PR $INPUTS.pr_number.'
+    );
+  });
+
+  test('still reports a command input no binding and no caller supplies', () => {
+    const block = wf('partialblk', [
+      { id: 'pr', bash: 'echo open-pr' },
+      {
+        id: 'sync',
+        command: 'partial-cmd',
+        depends_on: ['pr'],
+        with: { pr_number: '$pr.output.number' },
+      },
+    ]);
+    const parent = wf('parent', [{ id: 'inc', include: 'partialblk' }]);
+    const { workflows, errors } = expandWorkflowIncludes(
+      mapOf(block, parent),
+      new Map([['partial-cmd', 'Update PR $INPUTS.pr_number for $INPUTS.repo.']])
+    );
+    // The shield is per-name, not a blanket exemption for a node that binds anything.
+    expect(workflows.has('parent')).toBe(false);
+    const message = errors.find(error => error.filename === 'parent')?.error;
+    expect(message).toContain('$INPUTS.repo');
+    expect(message).not.toContain('$INPUTS.pr_number');
+  });
+
+  test('carries a surviving binding through two include levels', () => {
+    const inner = wf('inner', [
+      { id: 'pr', bash: 'echo open-pr' },
+      {
+        id: 'sync',
+        command: 'nested-sync',
+        depends_on: ['pr'],
+        with: { pr_number: '$pr.output.number' },
+      },
+    ]);
+    const middle = wf('middle', [{ id: 'deliver', include: 'inner' }]);
+    const outer = wf('outer', [{ id: 'ship', include: 'middle' }]);
+    const { workflows, errors } = expandWorkflowIncludes(
+      mapOf(inner, middle, outer),
+      new Map([['nested-sync', 'Update PR $INPUTS.pr_number.']])
+    );
+    expect(errors).toHaveLength(0);
+    // The payload rides a symbol, which structuredClone drops — a miss in either the
+    // clone or the walker works at one level and silently vanishes at two.
+    const sync = nodeById(workflows.get('outer')!, 'ship__deliver__sync');
+    expect(composedBindings(sync)).toEqual({ pr_number: '$ship__deliver__pr.output.number' });
   });
 
   test('materializes loop.command and binds its declared include input', () => {

--- a/packages/workflows/src/include-expander.ts
+++ b/packages/workflows/src/include-expander.ts
@@ -63,7 +63,9 @@ import { mapNodeTemplateSlots, mapNodeTemplateValueSlots } from './template-walk
 import {
   COMPILED_LOOP_COMMAND,
   COMPOSED_NODE,
+  attachComposedBindings,
   isIncludeCommandReadError,
+  readComposedBindings,
   readComposedMeta,
   type ComposedBlockBoundary,
   type ComposedNodeMeta,
@@ -516,8 +518,19 @@ function applyInputsMacro(
   missing: Set<string>,
   includeNode: IncludeDirective
 ): void {
-  const substitute = (text: string): string =>
+  // Names the node supplies itself. Only the compiled command body reads them: the
+  // executor merges a command node's resolved bindings OVER the run inputs into the
+  // `$INPUTS` bag it builds for the prompt, and nothing else (dag-executor.ts). So the
+  // shield is scoped to that one surface — a `when:` or `systemPrompt:` naming the same
+  // input still reads the run's bag, and a caller who never supplied it still gets the
+  // load error.
+  const boundLocally = new Set(Object.keys(readComposedBindings(node) ?? {}));
+  const substitute = (text: string, shielded?: ReadonlySet<string>): string =>
     text.replace(INPUTS_REF, (match, name: string) => {
+      // A name the node's own `with:` binds is neither the caller's to supply nor the
+      // caller's to override — it resolves at run time from the nearest source in the
+      // documented precedence order, so it is left standing for the executor (#2964).
+      if (shielded?.has(name) === true) return match;
       // `Object.hasOwn` rather than a plain `args[name]` lookup: a bare index read reaches
       // Object.prototype, so an unsupplied `$INPUTS.toString` / `$INPUTS.constructor`
       // would resolve to an inherited member and splice a native function body into the
@@ -571,7 +584,8 @@ function applyInputsMacro(
       slot.name === 'composed.inputs.*'
     )
       return slot.value;
-    return slot.surface === 'condition' ? substituteWhen(slot.value) : substitute(slot.value);
+    if (slot.surface === 'condition') return substituteWhen(slot.value);
+    return substitute(slot.value, slot.name === 'agent.prompt' ? boundLocally : undefined);
   });
   const valueMapped = mapNodeTemplateValueSlots(textMapped, slot => {
     const value = substituteValue(slot.value);
@@ -641,6 +655,8 @@ function cloneNodeForInclude<T extends DagNode | IncludeDirective>(node: T): T {
     if (meta !== undefined) {
       (target as DagNode & NodeWithComposedMeta)[COMPOSED_NODE] = structuredClone(meta);
     }
+    const bindings = readComposedBindings(source);
+    if (bindings !== undefined) attachComposedBindings(target, structuredClone(bindings));
     if (isLoopNode(source) && isLoopNode(target)) {
       const compiled = (source.loop as typeof source.loop & LoopWithCompiledCommand)[
         COMPILED_LOOP_COMMAND
@@ -980,11 +996,14 @@ function materializeBlockCommandPrompts(
   if (isAgentNode(node) && node.source.kind === 'command') {
     const compiled = compile(node.source.name);
     if (compiled.error !== undefined) throw new IncludeExpansionError(compiled.error);
-    // `with:` on a command node is already inert past this point at runtime today —
-    // `executeNodeInternal`'s binding resolution gates on the node still carrying a
-    // `command` reference (dag-executor.ts), which a materialized node no longer
-    // does — so dropping it here is behavior-preserving, not a regression.
-    return { ...node, source: { kind: 'inline', prompt: compiled.prompt } };
+    // The node's own `with:` map has no home on the inline variant, so it moves to the
+    // engine-private payload the executor resolves for a materialized node (#2964).
+    // It cannot be resolved here: a binding reads a sibling's output mid-run, which is
+    // exactly the case composition used to reject as an unpassable missing input.
+    const bindings = node.source.with;
+    const materialized: DagNode = { ...node, source: { kind: 'inline', prompt: compiled.prompt } };
+    if (bindings !== undefined) attachComposedBindings(materialized, bindings);
+    return materialized;
   }
 
   if (isLoopNode(node) && node.loop.command !== undefined) {

--- a/packages/workflows/src/loader.ts
+++ b/packages/workflows/src/loader.ts
@@ -68,6 +68,7 @@ import { workflowNodeHooksSchema } from './schemas/hooks';
 import { parseLoopPrevWhenAtom, parseWhenAtom, whenAtoms, WHEN_INPUTS_SCOPE } from './when-atom';
 import { declaredFieldsFromSchema, OUTPUT_REF_SOURCE, parseWholeOutputRef } from './output-ref';
 import { isBindingDirective } from './schemas/dag-node';
+import { readComposedBindings } from './compiled-command';
 import { visitNodeTemplateSlots } from './template-walker';
 import { z } from '@hono/zod-openapi';
 
@@ -1083,6 +1084,12 @@ export function validateDagStructure(
   // runs, so binding resolution needs no new scheduling. Only same-scope producers are
   // enforced — a loop_group body node may read the enclosing scope, whose outputs are
   // settled before the group starts (existing body-ref semantics).
+  //
+  // A composed command node is scanned through the payload its bindings moved to when
+  // expansion compiled its body (#2964). This run over the FLATTENED graph is the only
+  // one that can see a caller ref forwarded into a binding through `with:` — the child
+  // was proven before that value was inserted, so a ref naming a parent node outside the
+  // block's dependencies would otherwise reach the executor and fail the node mid-run.
   for (const node of nodes) {
     // Same capture-before-narrowing as the scan above: the include guard below would
     // otherwise filter a compose_fan_out node out of the binding check entirely.
@@ -1090,8 +1097,10 @@ export function validateDagStructure(
     if (isIncludeDirective(node)) continue;
     const nodeWith = isExecNode(node)
       ? node.with
-      : isAgentNode(node) && node.source.kind === 'command'
-        ? node.source.with
+      : isAgentNode(node)
+        ? node.source.kind === 'command'
+          ? node.source.with
+          : readComposedBindings(node)
         : composeFanOut
           ? composeFanOut.with
           : undefined;

--- a/packages/workflows/src/template-walker.ts
+++ b/packages/workflows/src/template-walker.ts
@@ -16,7 +16,9 @@ import {
 import {
   COMPOSED_NODE,
   COMPILED_LOOP_COMMAND,
+  attachComposedBindings,
   type LoopWithCompiledCommand,
+  readComposedBindings,
   readComposedMeta,
   type NodeWithComposedMeta,
 } from './compiled-command';
@@ -205,6 +207,12 @@ function walk(
     if (node.source.kind === 'inline') {
       const source = node.source;
       slot('agent.prompt', 'prompt', source.prompt, value => (source.prompt = value));
+      // A materialized command node keeps its bindings in the engine-private payload
+      // (#2964); they are the same template surface as an unmaterialized `with:` map, so
+      // an enclosing include namespaces their refs and forwards its own inputs into them.
+      const composedBindings = readComposedBindings(node);
+      if (composedBindings !== undefined)
+        walkBindings(composedBindings, (name, value) => (composedBindings[name] = value));
     } else {
       walkBindings(node.source.with, (name, value) => {
         if (node.source.kind === 'command' && node.source.with !== undefined)
@@ -367,6 +375,8 @@ function preserveInternalMetadata(source: DagNode, target: DagNode): void {
   const meta = readComposedMeta(source);
   if (meta !== undefined)
     (target as DagNode & NodeWithComposedMeta)[COMPOSED_NODE] = structuredClone(meta);
+  const bindings = readComposedBindings(source);
+  if (bindings !== undefined) attachComposedBindings(target, structuredClone(bindings));
   if (isLoopNode(source) && isLoopNode(target)) {
     const compiled = (source.loop as typeof source.loop & LoopWithCompiledCommand)[
       COMPILED_LOOP_COMMAND


### PR DESCRIPTION
## Problem and outcome

A command node's `with:` map is a runtime channel: the executor resolves it against sibling outputs and merges it over the run's inputs into the `$INPUTS` bag. Composition threw that map away and then rejected the workflow for the names it supplied — so a block that ran fine on its own became unloadable the moment another workflow included it, with an error whose advice no caller could follow.

- **Outcome:** A block whose command node binds a mid-run value now composes. `archon-ship`, `archon-stabilize` and `archon-upkeep` load, and the composed node resolves the real PR number instead of the empty string a decoy input was supplying.
- **Invariant:** A binding means the same thing standalone and composed. Node-local bindings stay the nearest input layer, winning over a composed block's inputs, which win over the run's `$INPUTS` — the order the authoring guide already documents.
- **Scope boundary:** The SDLC pack still declares its `pr_number` / `pr_head` decoy inputs. This change makes them unnecessary and inert; #2968 deletes them. Script (`exec`) nodes were never affected — their `with:` map survives materialization untouched and rides the `INPUTS_*` env channel.
- **Root cause:** `materializeBlockCommandPrompts` compiles a command body into an inline prompt so the block's refs can be namespaced and its declared inputs bound. The inline source variant has no `with:` field — the schema admits it only on the `command` variant (#2478) — so expansion dropped the map. `applyInputsMacro` then walked the compiled body, found `$INPUTS.<name>` with nothing in the include's resolved inputs, and reported it missing.

## Review guidance

- **Feedback requested:** Correctness of the carrier choice, and whether the shield in `applyInputsMacro` is scoped to the right surface.
- **Start here:** `packages/workflows/src/include-expander.ts:996` — the drop that became a move. The comment it replaces claimed dropping was "behavior-preserving"; it was, but only relative to an executor that could no longer see the field.
- **Review order:** `include-expander.ts` (materialization + the missing-input shield) → `compiled-command.ts` (the payload and why it exists) → `template-walker.ts` (so both rewrite passes reach it) → `dag-executor.ts` / `dry-run.ts` / `loader.ts` (one read each, at the sites that already read `source.with`).
- **Two commits, read in order.** The second closes a path the first made reachable — see the last paragraph of Solution. It is separable and independently tested.
- **Lower-attention areas:** The `dry-run.ts` change is mechanical — `isCommandSourced` collapsed into the `isAgentNode` check it always implied.
- **Known risk or uncertainty:** The payload rides a symbol, which `structuredClone` drops. That is the trap `compiled-command.ts` documents at the top of the file: a payload missed in the clone or either rewrite pass works at one nesting level and silently vanishes at two. `carries a surviving binding through two include levels` is the test that closes it, and the real pack confirms it — see Validation.

## Solution

The bindings move to `COMPOSED_BINDINGS`, an engine-private per-node payload alongside the two that already exist for exactly this purpose (`COMPOSED_NODE`, `COMPILED_LOOP_COMMAND`). Both the executor and the dry-run simulator read it wherever they already read `source.with`, so preview and execution resolve a composed binding through the same `resolveNodeBindings` — `if_skipped`, the failed-producer guard and strict whole-ref resolution all keep working.

Keeping the node command-sourced instead was the alternative, and it is worse: `stepName` for a composed command node would change from the node id to the command name, and that string is persisted in `workflow_events`. Widening the inline source variant to accept `with:` was the other, and it re-admits the authoring mistake #2478 deliberately made a type error. The payload keeps the authored type invariant intact — `with:` is still only writable on a command node.

The missing-input check consults the surviving map, and the substitution shield is scoped to the compiled body alone. That is not incidental: the binding bag reaches `buildPromptWithContext(rawPrompt, …)` and nothing else, so a `when:` or `systemPrompt:` naming the same input still reads the run's bag and still errors when nobody supplied it.

The second commit closes a path the first one made reachable. The loader's binding scan enforces that a bound producer is reachable through `depends_on`, and it keys off `source.with` — which a composed node no longer has. So a caller ref forwarded into a binding (`with: { src: $other.output }` on the include, spliced into the block's `$INPUTS.src`) reached the executor unchecked and failed the node mid-run. The child is proven hermetic *before* the caller's value is inserted, so the scan over the flattened graph is the only one that can see it; it now reads the same payload the executor does. Both the rejection and the legitimate-dependency case have tests.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Including a block whose command node binds a mid-run value fails the load: `included block 'archon-deliver' references missing inputs $INPUTS.pr_head, $INPUTS.pr_number. Pass them through 'with:'` | The block composes; the node's binding resolves at run time |
| **Failure behavior** | Declaring the names as inputs with empty defaults silenced the error, then spliced the empty default into the prompt — a silent wrong value, and a caller could override it | The node's binding wins over any caller value; a name nothing binds still fails the load with the same error |

## Validation

- `bun run validate` — exit 0, 8878 tests passing, 0 failures.
- `bun run lint`, `bun run type-check`, `bun run format:check` — all clean.
- `archon workflow test` on this repo's SDLC pack — **39 passed, 0 failed**, the number the issue reports dropping to 28/39 under the load failures.
- Seven new tests, each seen red against the unfixed code before its fix landed. The two that matter most: `a command node own binding wins over a caller-supplied input of the same name` failed with `"Update PR caller value."` — the silent override the issue warned about — and `still reports a command input no binding and no caller supplies` failed because the old error named `$INPUTS.pr_number` alongside `$INPUTS.repo`, proving the shield is per-name rather than a blanket exemption.
- Real-pack inspection of the expanded graph: `archon-deliver` standalone keeps its command-sourced node and `with:` map unchanged, while `archon-ship`, `archon-stabilize` and `archon-upkeep` each carry `pr_number: $deliver__pr__pr.output.number` — correctly re-namespaced through two include levels — with the `$INPUTS.pr_number` token left standing in the prompt for the executor.
- One Windows CI sample on the first commit — `cli.test.ts` `emits { ok: false } … outside a git repository`, 6313ms against a 5000ms budget — is the tracked budget-edge class (#2924). Attributed rather than reran: the log carries the BODY-timeout string, and the seven sibling tests that spawn the same CLI all landed at 828-1062ms on that runner. The test does reach this diff (`workflow list` runs discovery + expansion), so the path was measured: `workflow list --json` against a scratch tmpdir over 5 runs is 0.63-0.71s on this branch versus 0.65-0.71s with `packages/workflows/src` at `origin/dev`. No cost added; a 4-second overshoot is not attributable here, and the same commit's Ubuntu leg passed.
- **Not verified:** No live agent run. The dry-run simulator shares `resolveNodeBindings` with the executor by construction (#2637 R2), and the executor's read is the same one-line expression, so the resolution path is covered without spending a real run.

## Links

- Closes #2964
- Related #2968
