### PR TITLE
feat(workflows): the engine retains what every exec node printed

### DIFF
--- a/.claude/skills/archon-cli/manage-run/troubleshooting.md
+++ b/.claude/skills/archon-cli/manage-run/troubleshooting.md
@@ -18,9 +18,10 @@ Each line is a structured event. The discriminator is the `type` field. Values (
 | `node_start` / `node_complete` / `node_error` / `node_skipped` | Node lifecycle |
 | `assistant` | AI assistant message — has `content` field with the full AI output |
 | `tool` | SDK tool invocation — has `tool_name` and `tool_input` |
+| `exec_output` | What a `bash`/`script` node or `until_bash` probe printed — `stdout_tail`, `stderr_tail`, `exit_code` |
 | `validation` | Historical compatibility only; current runs do not emit this type |
 
-> **Loop iterations and per-attempt retry events are NOT in the JSONL file.** They go through the workflow event emitter (WebSocket / `workflow_events` DB table) under `loop_iteration_started` / `loop_iteration_completed` etc. To see them, query the DB or the Web UI dashboard — not the JSONL log.
+> **Loop iteration lifecycle events are NOT in the JSONL file.** `loop_iteration_started` / `loop_iteration_completed` go through the workflow event emitter (WebSocket / `workflow_events` DB table) — query the DB or the Web UI dashboard for those. Per-iteration rows that DO reach the JSONL are keyed `<node-id>-iteration-<n>`: a loop's `node_complete` row, and the `exec_output` row for each `until_bash` probe.
 
 Find the run ID from `archon workflow runs --status failed` (or `archon workflow runs` for the most recent run of any status; `workflow status` only shows active runs). Then:
 
@@ -30,6 +31,9 @@ jq -sr 'map(select(.type == "assistant") | .content) | last // empty' <log-file>
 
 # All error events (node failures + workflow-level failures)
 jq 'select(.type == "node_error" or .type == "workflow_error")' <log-file>
+
+# What a specific node actually printed (evidence for "did this really do X?")
+jq 'select(.type == "exec_output" and .step == "<node-id>")' <log-file>
 
 # Full event stream
 cat <log-file> | jq .

--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -1103,6 +1103,36 @@ This works on **every** node type (`bash`/`script` produce typed outputs too, ju
 
 Successful bash stdout is retained by default on the completed run as a bounded audit preview in `node_completed.data.node_output`. Output over 32 KiB (32,768 UTF-8 bytes) ends with a truncation marker, and the event also includes `node_output_truncated: true` plus `node_output_original_bytes`. Because stdout is persisted, never print secrets or credentials from bash nodes. This preview is separate from `output_type`: declaring `output_type` opts into a best-effort file sidecar that may contain the full output and is not required for ordinary bash audit retention.
 
+### Retained subprocess evidence
+
+Separately from the value channel above, the engine retains **what each subprocess printed** in
+the run's own transcript (`~/.archon/workspaces/<project>/logs/<run-id>.jsonl`), as one
+`exec_output` row per subprocess:
+
+| Field | Meaning |
+| --- | --- |
+| `step` | The node id. An `until_bash` probe uses `<node>-iteration-<n>`. |
+| `content` | `<bash>`, `<script>`, or `<until_bash>`. |
+| `exit_code` | `0` on success. On failure, the process exit code — or a symbol when there is none: `ENOENT`, `ERR_CHILD_PROCESS_STDIO_MAXBUFFER`, or the signal name (`SIGTERM`) for a timeout kill. |
+| `stdout_tail` / `stderr_tail` | Last 2000 characters of each stream. Absent means that stream was empty. |
+
+This covers every `bash:` and `script:` node and both loop variants' `until_bash` probes, on
+success and failure alike — including a probe's *tolerated* non-zero exit, which is otherwise
+unrecorded. Workflows do not need to build their own logging to answer "what did this node
+actually do?".
+
+Three properties worth knowing:
+
+- **Streams stay separate.** `stderr` is never merged into `stdout`, so a `git` or `gh` warning
+  cannot be mistaken for the value a node returned.
+- **It is capped; `$nodeId.output` is not.** A tail over 2000 characters is marked in place with
+  `…[truncated to last 2000 chars]`. The cap applies only to this evidence copy — a node's output
+  still reaches its consumers whole.
+- **Credentials are removed on write.** Values the engine put in the subprocess environment
+  (keys ending in `TOKEN`/`KEY`/`SECRET`/`PASSWORD`, `DATABASE_URL`, and credentials Archon
+  injected) are replaced with `[REDACTED]` before the row is written. This protects the
+  transcript, not the `node_output` preview above — the "never print secrets" rule still stands.
+
 ---
 
 ## Cross-Run State with `$STATE_DIR`

--- a/packages/docs-web/src/content/docs/guides/script-nodes.md
+++ b/packages/docs-web/src/content/docs/guides/script-nodes.md
@@ -81,6 +81,10 @@ The file `.archon/scripts/fetch-github-pages.ts` is loaded and executed with
    remainder, and a label prefixes each stream only when both are populated.
    With stderr empty, the stdout tail becomes the diagnostic. The script body
    is never echoed back to users.
+5. **Retain.** Regardless of outcome, capped and credential-redacted tails of
+   both streams are written to the run transcript as an `exec_output` row — see
+   [Retained subprocess evidence](/guides/authoring-workflows#retained-subprocess-evidence).
+   That retention is evidence only; it never caps `$nodeId.output`.
 
 ## YAML Schema
 

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -31813,6 +31813,103 @@ describe('#2707 step 3: gate-terminated loop_group pause escalation', () => {
     ).toBe(1);
   });
 
+  it("retains the resumed until_bash probe under the resumed iteration's own key (#2967)", async () => {
+    // The resume branch runs its own probe, separate from the per-iteration one, and
+    // it is the only exec site in a run that completes straight off a human's answer.
+    // `iteration: 2` in the gate context makes the label discriminating: the resumed
+    // iteration is 2, while a fresh one would be 3 and a hardcoded fallback would be 1.
+    mockSendQueryDag.mockClear();
+    mockSendQueryDag.mockImplementation(async function* () {
+      yield { type: 'assistant', content: 'should not run' };
+      yield { type: 'result', sessionId: 'unexpected-session' };
+    });
+
+    const logDir = join(testDir, 'resume-probe-logs');
+    const store = createEscalationStore('run-escalation-retention');
+    const platform = createMockPlatform();
+    const approvedDecision = { decision: 'approve', text: '' };
+    const priorCompletedNodes = new Map<string, PersistedNodeOutput>([
+      ['grp.work', { output: 'work output' }],
+      [
+        'grp.check',
+        { output: JSON.stringify(approvedDecision), structuredOutput: approvedDecision },
+      ],
+    ]);
+    const workflowRun = makeWorkflowRun('run-escalation-retention', {
+      metadata: {
+        approval: {
+          nodeId: 'grp',
+          message: 'Continue?',
+          type: 'approval',
+          bodyGateId: 'check',
+          iteration: 2,
+          decisions: [{ id: 'approve' }, { id: 'revise' }],
+          decisionsAuthored: true,
+        } satisfies ApprovalContext,
+      },
+    });
+
+    const talkativeProbeWorkflow: WorkflowDefinition = {
+      ...gateTerminatedLoopGroupWorkflow(),
+      nodes: [
+        dagNodeSchema.parse({
+          id: 'grp',
+          loop_group: {
+            until_bash:
+              'printf "resume probe ran\\n"; printf "recheck note\\n" >&2; [ $check.output.decision = "approve" ]',
+            max_iterations: 5,
+            nodes: [
+              { id: 'work', prompt: 'do work' },
+              {
+                id: 'check',
+                depends_on: ['work'],
+                approval: {
+                  message: 'Continue?',
+                  decisions: [{ id: 'approve' }, { id: 'revise' }],
+                },
+              },
+            ],
+          },
+        }),
+      ],
+    };
+
+    await executeDagWorkflow(
+      createMockDeps(store),
+      platform,
+      'conv-dag',
+      testDir,
+      ready(talkativeProbeWorkflow),
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'artifacts'),
+      join(testDir, 'state'),
+      logDir,
+      'main',
+      'docs/',
+      minimalConfig,
+      undefined,
+      undefined,
+      priorCompletedNodes
+    );
+
+    // Zero provider calls means no fresh iteration ran, so the single retained row
+    // below can only have come from the resume branch's probe — not the ordinary
+    // per-iteration site, which would have needed a body execution first.
+    expect(mockSendQueryDag.mock.calls.length).toBe(0);
+
+    const probeRows = (await readTranscript(logDir, workflowRun.id)).filter(
+      row => row.type === 'exec_output'
+    );
+    expect(probeRows).toHaveLength(1);
+    expect(probeRows[0].step).toBe('grp-iteration-2');
+    expect(probeRows[0].content).toBe('<until_bash>');
+    expect(probeRows[0].stdout_tail).toBe('resume probe ran');
+    expect(probeRows[0].stderr_tail).toBe('recheck note');
+    expect(probeRows[0].exit_code).toBe(0);
+  });
+
   it('falls through without erroring when a human resolves the original pause before the rewrite lands (CAS loss)', async () => {
     mockSendQueryDag.mockImplementation(async function* () {
       yield { type: 'assistant', content: 'work done' };

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -27545,6 +27545,386 @@ describe('subprocess credential redaction', () => {
       }
     }
   });
+
+  it('removes a credential a SUCCESSFUL subprocess echoed, before it reaches the retained evidence', async () => {
+    // The failure path has been redacting since #2431. Retention (#2967) writes on the
+    // success path too, and a node that echoes a token while exiting 0 is the ordinary
+    // case (`set -x`, a remote URL, a debug print) — so the evidence copy has to be
+    // scrubbed with the SAME credential set, not a weaker one.
+    const suffixNamedSecret = 'success-path-openai-secret';
+    const explicitlyProtectedSecret = 'success-path-file-delivered-secret';
+    const logDir = join(testDir, 'success-redaction-logs');
+    const workflowRun = makeWorkflowRun('success-redaction-run', {
+      workflow_name: 'success-redaction',
+      conversation_id: 'conv-success-redaction',
+    });
+    const store = createMockStore();
+
+    await executeDagWorkflow(
+      createMockDeps(store),
+      createMockPlatform(),
+      workflowRun.conversation_id,
+      testDir,
+      {
+        name: workflowRun.workflow_name,
+        nodes: [
+          {
+            id: 'leaky',
+            kind: 'exec',
+            runtime: 'sh',
+            // Real subprocess, both streams, exit 0.
+            script: 'printf "%s\\n" "$OPENAI_API_KEY"; printf "%s\\n" "$SIDECAR_AUTH" >&2',
+          },
+        ],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'success-redaction-artifacts'),
+      join(testDir, 'success-redaction-state'),
+      logDir,
+      'main',
+      'docs/',
+      {
+        ...minimalConfig,
+        envVars: {
+          OPENAI_API_KEY: suffixNamedSecret,
+          SIDECAR_AUTH: explicitlyProtectedSecret,
+          BASE_BRANCH: 'main',
+        },
+        protectedCredentialValues: [explicitlyProtectedSecret],
+      }
+    );
+
+    const transcriptText = await readFile(join(logDir, `${workflowRun.id}.jsonl`), 'utf-8');
+    expect(transcriptText).not.toContain(suffixNamedSecret);
+    expect(transcriptText).not.toContain(explicitlyProtectedSecret);
+
+    // Not vacuous: the node really ran, really printed both secrets, and the retained
+    // row really exists — the values were replaced, not merely absent.
+    const row = (await readTranscript(logDir, workflowRun.id)).find(
+      candidate => candidate.type === 'exec_output' && candidate.step === 'leaky'
+    );
+    expect(row?.stdout_tail).toBe('[REDACTED]');
+    expect(row?.stderr_tail).toBe('[REDACTED]');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Engine-retained exec output (#2967)
+// ---------------------------------------------------------------------------
+
+describe('retained exec output', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = join(
+      tmpdir(),
+      `dag-retained-exec-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    await mkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await removeTempTree(testDir);
+  });
+
+  /** Run one workflow against a fresh log dir and return its parsed transcript. */
+  const runAndReadTranscript = async (
+    runId: string,
+    nodes: DagNode[]
+  ): Promise<{
+    logDir: string;
+    rows: Array<Record<string, unknown>>;
+    store: MockWorkflowStore;
+  }> => {
+    const logDir = join(testDir, `${runId}-logs`);
+    const store = createMockStore();
+    const workflowRun = makeWorkflowRun(runId);
+    await executeDagWorkflow(
+      createMockDeps(store),
+      createMockPlatform(),
+      'conv-retained',
+      testDir,
+      { name: runId, nodes },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, `${runId}-artifacts`),
+      join(testDir, `${runId}-state`),
+      logDir,
+      'main',
+      'docs/',
+      minimalConfig
+    );
+    return { logDir, rows: await readTranscript(logDir, workflowRun.id), store };
+  };
+
+  it('retains stdout and stderr as SEPARATE fields on a successful exec node', async () => {
+    const { rows } = await runAndReadTranscript('retain-success', [
+      {
+        id: 'work',
+        kind: 'exec',
+        runtime: 'sh',
+        script: 'printf "did the thing\\n"; printf "a warning\\n" >&2',
+      },
+    ]);
+
+    const row = rows.find(
+      candidate => candidate.type === 'exec_output' && candidate.step === 'work'
+    );
+    expect(row).toBeDefined();
+    expect(row?.content).toBe('<bash>');
+    expect(row?.exit_code).toBe(0);
+    // Separate, not merged: merging stderr into stdout is how a `git` warning becomes
+    // the value a node returns — the bug #2967 exists to stop every node re-earning.
+    expect(row?.stdout_tail).toBe('did the thing');
+    expect(row?.stderr_tail).toBe('a warning');
+  });
+
+  it('retains the same evidence when the node FAILS, with its exit code', async () => {
+    const { rows } = await runAndReadTranscript('retain-failure', [
+      {
+        id: 'work',
+        kind: 'exec',
+        runtime: 'sh',
+        script: 'printf "got this far\\n"; printf "then broke\\n" >&2; exit 3',
+      },
+    ]);
+
+    const row = rows.find(
+      candidate => candidate.type === 'exec_output' && candidate.step === 'work'
+    );
+    expect(row?.exit_code).toBe(3);
+    expect(row?.stdout_tail).toBe('got this far');
+    expect(row?.stderr_tail).toBe('then broke');
+    // Symmetry is the point: the same row shape on both outcomes, next to the
+    // lifecycle row that says which outcome it was.
+    expect(
+      rows.some(candidate => candidate.type === 'node_error' && candidate.step === 'work')
+    ).toBe(true);
+  });
+
+  it('writes a row for a silent node, so an absent tail means "printed nothing"', async () => {
+    const { rows } = await runAndReadTranscript('retain-silent', [
+      { id: 'quiet', kind: 'exec', runtime: 'sh', script: 'true' },
+    ]);
+
+    const row = rows.find(
+      candidate => candidate.type === 'exec_output' && candidate.step === 'quiet'
+    );
+    expect(row).toBeDefined();
+    expect(row?.exit_code).toBe(0);
+    expect(row?.stdout_tail).toBeUndefined();
+    expect(row?.stderr_tail).toBeUndefined();
+  });
+
+  it('caps each retained stream while the $node.output value channel stays complete', async () => {
+    // The binding invariant: retention caps the EVIDENCE copy only. A node's output is
+    // its contract with its consumers, and it must still arrive whole — well past both
+    // the 2000-char retention budget and the 32KB persistence preview.
+    const paddingBytes = 40_000;
+    const { rows, store } = await runAndReadTranscript('retain-cap', [
+      {
+        id: 'producer',
+        kind: 'exec',
+        runtime: 'sh',
+        script: `printf 'HEAD'; printf '%${String(paddingBytes)}s' '' | tr ' ' x; printf 'TAIL'`,
+      },
+      {
+        id: 'consumer',
+        kind: 'exec',
+        runtime: 'sh',
+        script: 'value=$producer.output; printf "%s" "${#value}"',
+        depends_on: ['producer'],
+      },
+    ]);
+
+    const producerRow = rows.find(
+      candidate => candidate.type === 'exec_output' && candidate.step === 'producer'
+    );
+    const stdoutTail = producerRow?.stdout_tail as string;
+    // Tail-preserving and marked, so a reader can tell truncation from absence.
+    expect(stdoutTail.startsWith('…[truncated to last 2000 chars]\n')).toBe(true);
+    expect(stdoutTail.endsWith('TAIL')).toBe(true);
+    expect(stdoutTail).not.toContain('HEAD');
+    expect(stdoutTail.split('\n')[1].length).toBe(2000);
+
+    // The value channel is untouched: the downstream consumer measured the WHOLE
+    // 40,008-character output, not the 2000-char evidence tail nor a 32KB preview.
+    const consumerEvent = (
+      store.createWorkflowEvent as Mock<IWorkflowStore['createWorkflowEvent']>
+    ).mock.calls.find(
+      ([event]) => event.event_type === 'node_completed' && event.step_name === 'consumer'
+    );
+    expect((consumerEvent?.[0].data as { node_output: string }).node_output).toBe(
+      String(paddingBytes + 8)
+    );
+  });
+
+  it('retains an until_bash probe per iteration it runs in', async () => {
+    // The probe is exactly the case the hand-rolled substitute could not cover: a
+    // non-zero exit is TOLERATED ("not done yet"), so nothing else in the run records
+    // why the loop kept going.
+    const logDir = join(testDir, 'until-bash-logs');
+    const counterPath = join(testDir, 'iterations');
+    mockSendQueryDag.mockImplementation(async function* () {
+      yield { type: 'assistant', content: 'working' };
+      yield { type: 'result', sessionId: 's-1' };
+    });
+    const workflowRun = makeWorkflowRun('retain-until-bash');
+
+    await executeDagWorkflow(
+      createMockDeps(),
+      createMockPlatform(),
+      'conv-retained-probe',
+      testDir,
+      {
+        name: 'retain-until-bash',
+        nodes: [
+          {
+            id: 'poll',
+            kind: 'loop',
+            loop: {
+              fresh_context: false,
+              prompt: 'Keep working.',
+              max_iterations: 2,
+              // Iteration 1 prints and exits 1 (keep looping); iteration 2 exits 0.
+              until_bash: `printf 'x' >> ${JSON.stringify(counterPath)}; printf 'checked\\n'; printf 'not ready\\n' >&2; test "$(wc -c < ${JSON.stringify(counterPath)} | tr -d ' ')" -ge 2`,
+            },
+          },
+        ],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'until-bash-artifacts'),
+      join(testDir, 'until-bash-state'),
+      logDir,
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    const rows = await readTranscript(logDir, workflowRun.id);
+    const probeRows = rows.filter(candidate => candidate.type === 'exec_output');
+    expect(probeRows.map(row => row.step)).toEqual(['poll-iteration-1', 'poll-iteration-2']);
+    for (const row of probeRows) {
+      expect(row.content).toBe('<until_bash>');
+      expect(row.stdout_tail).toBe('checked');
+      expect(row.stderr_tail).toBe('not ready');
+    }
+    // The tolerated non-zero exit is retained as such, not flattened into the success
+    // shape — that difference IS the answer to "why did the loop run again?".
+    expect(probeRows[0].exit_code).toBe(1);
+    expect(probeRows[1].exit_code).toBe(0);
+  });
+
+  it("labels a script node's retained evidence as <script>, not <bash>", async () => {
+    // Same seat, different node executor. The label is what tells a reader which
+    // executor produced the row, so a copy-paste of the wrong constant is the failure
+    // this catches.
+    const { rows } = await runAndReadTranscript('retain-script', [
+      {
+        id: 'measure',
+        kind: 'exec',
+        runtime: 'bun',
+        script: 'console.log("from bun"); console.error("bun warning");',
+      },
+    ]);
+
+    const row = rows.find(
+      candidate => candidate.type === 'exec_output' && candidate.step === 'measure'
+    );
+    expect(row?.content).toBe('<script>');
+    expect(row?.exit_code).toBe(0);
+    expect(row?.stdout_tail).toBe('from bun');
+    expect(row?.stderr_tail).toBe('bun warning');
+  });
+
+  it("retains a loop_group's until_bash probe under the group's own iteration key", async () => {
+    // loop_group resolves its own probe at a different call site than `loop:`, with its
+    // own iteration variable — a site that writes no per-iteration transcript row of any
+    // other kind, so this row is the only per-iteration evidence the group produces.
+    const logDir = join(testDir, 'group-probe-logs');
+    const counterPath = join(testDir, 'group-iterations');
+    const workflowRun = makeWorkflowRun('retain-group-probe');
+
+    await executeDagWorkflow(
+      createMockDeps(),
+      createMockPlatform(),
+      'conv-group-probe',
+      testDir,
+      {
+        name: 'retain-group-probe',
+        nodes: [
+          {
+            id: 'group',
+            kind: 'loop_group',
+            loop_group: {
+              max_iterations: 2,
+              fresh_context: false,
+              until_bash: `printf 'x' >> ${JSON.stringify(counterPath)}; printf 'probe spoke\\n'; test "$(wc -c < ${JSON.stringify(counterPath)} | tr -d ' ')" -ge 2`,
+              nodes: [
+                { id: 'body', kind: 'exec', runtime: 'sh', script: 'printf body', depends_on: [] },
+              ],
+            },
+            depends_on: [],
+          },
+        ],
+      },
+      workflowRun,
+      'claude',
+      undefined,
+      join(testDir, 'group-probe-artifacts'),
+      join(testDir, 'group-probe-state'),
+      logDir,
+      'main',
+      'docs/',
+      minimalConfig
+    );
+
+    const rows = await readTranscript(logDir, workflowRun.id);
+    const probeRows = rows.filter(
+      candidate => candidate.type === 'exec_output' && candidate.content === '<until_bash>'
+    );
+    expect(probeRows.map(row => row.step)).toEqual(['group-iteration-1', 'group-iteration-2']);
+    expect(probeRows.map(row => row.exit_code)).toEqual([1, 0]);
+    for (const row of probeRows) expect(row.stdout_tail).toBe('probe spoke');
+
+    // The group's body node is retained too, under its own bare id.
+    expect(
+      rows.filter(candidate => candidate.type === 'exec_output' && candidate.step === 'body')
+    ).toHaveLength(2);
+  });
+
+  it('names the signal when a timed-out subprocess reports no exit code', async () => {
+    // Node reports a timeout kill as `code: null` with the signal set. Falling back
+    // straight to 'unknown' would erase the most operationally interesting failure —
+    // and an `until_bash` probe has no sibling node_error row to say it timed out.
+    const execSpy = spyOn(git, 'execFileAsync').mockImplementation(async () => {
+      throw Object.assign(new Error('Command failed: bash -c sleep 999'), {
+        code: null,
+        signal: 'SIGTERM',
+        killed: true,
+        stdout: 'started work',
+        stderr: '',
+      });
+    });
+
+    try {
+      const { rows } = await runAndReadTranscript('retain-timeout', [
+        { id: 'slow', kind: 'exec', runtime: 'sh', script: 'sleep 999' },
+      ]);
+      const row = rows.find(
+        candidate => candidate.type === 'exec_output' && candidate.step === 'slow'
+      );
+      expect(row?.exit_code).toBe('SIGTERM');
+      expect(row?.stdout_tail).toBe('started work');
+    } finally {
+      execSpy.mockRestore();
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -129,6 +129,7 @@ import {
   logNodeSkip,
   logNodeError,
   logAssistant,
+  logExecOutput,
   logTool,
   logWorkflowComplete,
   logWorkflowError,
@@ -155,6 +156,7 @@ import {
   stripCompletionTags,
   isInlineScript,
   formatSubprocessFailure,
+  retainStreamTail,
   safeSendMessage,
   type SendMessageContext,
 } from './executor-shared';
@@ -3443,6 +3445,13 @@ type RawSubprocessRejection = Error & {
   stderr?: string;
   cmd?: string;
   spawnargs?: string[];
+  /**
+   * Numeric exit code, or a symbol (`'ENOENT'`, `'ERR_CHILD_PROCESS_STDIO_MAXBUFFER'`).
+   * `null` on a timeout kill — Node reports that one through `signal` instead.
+   */
+  code?: number | string | null;
+  /** Set (with `code: null`) when the child was killed, which for `execFile` is a timeout. */
+  signal?: string | null;
 };
 
 const CREDENTIAL_ENV_KEY_SUFFIX = /(?:TOKEN|KEY|SECRET|PASSWORD)$/i;
@@ -3512,6 +3521,30 @@ function redactSubprocessError(
   return e;
 }
 
+/**
+ * Who a retained subprocess-output row belongs to (#2967).
+ *
+ * Required on every `runSubprocess` call, so a new deterministic-exec call site cannot
+ * silently opt out of retention — the type carries the invariant instead of a comment.
+ */
+interface SubprocessRetention {
+  logDir: string;
+  workflowRunId: string;
+  /**
+   * Transcript step id. Loop probes use `<node>-iteration-<i>`, matching the loop's own
+   * transcript rows.
+   *
+   * A node body uses the bare `node.id`, NOT the namespaced `stepName` the persisted
+   * events carry. That is a deliberate trade: it keeps this row correlated with the
+   * `node_start`/`node_complete` rows beside it, which have always used the bare id, at
+   * the cost of collapsing fan-out instances and loop_group body iterations of one node
+   * onto the same `step` — those are then told apart by row order.
+   */
+  nodeId: string;
+  /** `<bash>` / `<script>` / `<until_bash>`, matching the transcript's other rows. */
+  label: string;
+}
+
 async function runSubprocess(
   execContext: ExecutionContext,
   cmd: string,
@@ -3522,33 +3555,64 @@ async function runSubprocess(
     env: NodeJS.ProcessEnv;
     protectedEnvKeys?: readonly string[];
     protectedCredentialValues?: readonly string[];
+    retention: SubprocessRetention;
   }
 ): Promise<{ stdout: string; stderr: string }> {
   const subprocessEnv =
     execContext.kind === 'container' ? options.env : { ...process.env, ...options.env };
+  // Both outcomes redact against the same values, so the credential set is resolved
+  // once here rather than separately per path — a success path that redacted less than
+  // the failure path would be the security hole, not a style difference.
+  const credentialValues = collectSubprocessCredentialValues(
+    subprocessEnv,
+    options.protectedEnvKeys,
+    options.protectedCredentialValues
+  );
+  const { logDir, workflowRunId, nodeId, label } = options.retention;
+  // Container env is delivered in argv, while either execution mode can echo a
+  // credential in output. Sanitize at the shared boundaries below so every downstream
+  // reader — the rejection's consumers and the retained evidence alike — sees the same
+  // safe text.
   try {
-    if (execContext.kind === 'container') {
-      const dockerArgs = buildSubprocessDockerArgs(execContext, cmd, args, {
-        cwd: options.cwd,
-        env: options.env,
-      });
-      // Container env is delivered in argv, while either execution mode can echo a
-      // credential in output. Sanitize at the shared throw boundary so every
-      // downstream reader receives the same safe rejection.
-      return await execFileAsync('docker', dockerArgs, { timeout: options.timeout });
-    }
-    return await execFileAsync(cmd, args, {
-      cwd: options.cwd,
-      timeout: options.timeout,
-      env: subprocessEnv,
+    const result =
+      execContext.kind === 'container'
+        ? await execFileAsync(
+            'docker',
+            buildSubprocessDockerArgs(execContext, cmd, args, {
+              cwd: options.cwd,
+              env: options.env,
+            }),
+            { timeout: options.timeout }
+          )
+        : await execFileAsync(cmd, args, {
+            cwd: options.cwd,
+            timeout: options.timeout,
+            env: subprocessEnv,
+          });
+
+    // Retention is the EVIDENCE copy, taken from a redacted-then-capped copy of the
+    // streams. `result` itself is returned untouched: the caller's `stdout` is the
+    // node's value channel and keeps its full-fidelity semantics (#2726).
+    await logExecOutput(logDir, workflowRunId, nodeId, label, {
+      stdoutTail: retainStreamTail(redactCredentialValues(result.stdout, credentialValues)),
+      stderrTail: retainStreamTail(redactCredentialValues(result.stderr, credentialValues)),
+      exitCode: 0,
     });
+    return result;
   } catch (err) {
-    const credentialValues = collectSubprocessCredentialValues(
-      subprocessEnv,
-      options.protectedEnvKeys,
-      options.protectedCredentialValues
-    );
-    throw redactSubprocessError(err as RawSubprocessRejection, credentialValues);
+    const rejection = redactSubprocessError(err as RawSubprocessRejection, credentialValues);
+    // `redactSubprocessError` already scrubbed these fields in place, so retention reads
+    // the same safe values every other failure consumer sees.
+    await logExecOutput(logDir, workflowRunId, nodeId, label, {
+      stdoutTail: retainStreamTail(rejection.stdout),
+      stderrTail: retainStreamTail(rejection.stderr),
+      // A timeout kill reports `code: null` and names the signal instead. An
+      // `until_bash` probe has no sibling `node_error` row to say so, and a probe that
+      // was killed is exactly the case a reader needs distinguished from one that
+      // simply answered "not yet".
+      exitCode: rejection.code ?? rejection.signal ?? 'unknown',
+    });
+    throw rejection;
   }
 }
 
@@ -3786,6 +3850,12 @@ async function executeBashNode(
       env: subprocessEnv,
       protectedEnvKeys,
       protectedCredentialValues,
+      retention: {
+        logDir,
+        workflowRunId: workflowRun.id,
+        nodeId: node.id,
+        label: '<bash>',
+      },
     });
 
     // Trim trailing newline from stdout (common shell behavior)
@@ -4177,6 +4247,12 @@ async function executeScriptNode(
       env: subprocessEnv,
       protectedEnvKeys,
       protectedCredentialValues,
+      retention: {
+        logDir,
+        workflowRunId: workflowRun.id,
+        nodeId: node.id,
+        label: '<script>',
+      },
     });
 
     // Trim trailing newline from stdout (common shell behavior)
@@ -4764,6 +4840,12 @@ async function executeLoopGroupNode(
             timeout: SUBPROCESS_DEFAULT_TIMEOUT,
             protectedEnvKeys: config.protectedEnvKeys,
             protectedCredentialValues: config.protectedCredentialValues,
+            retention: {
+              logDir,
+              workflowRunId: workflowRun.id,
+              nodeId: `${node.id}-iteration-${String(resumedIteration)}`,
+              label: '<until_bash>',
+            },
             env: {
               ...(config.envVars ?? {}),
               USER_MESSAGE: workflowRun.user_message,
@@ -5235,6 +5317,12 @@ async function executeLoopGroupNode(
           timeout: SUBPROCESS_DEFAULT_TIMEOUT,
           protectedEnvKeys: config.protectedEnvKeys,
           protectedCredentialValues: config.protectedCredentialValues,
+          retention: {
+            logDir,
+            workflowRunId: workflowRun.id,
+            nodeId: `${node.id}-iteration-${String(i)}`,
+            label: '<until_bash>',
+          },
           // Archon-managed env only (no process.env spread) — runSubprocess
           // layers the host env for host runs, or delivers ONLY this bag into
           // the container. Configured project env spreads FIRST so the reserved
@@ -6792,6 +6880,12 @@ async function executeLoopNode(
           timeout: SUBPROCESS_DEFAULT_TIMEOUT,
           protectedEnvKeys: config.protectedEnvKeys,
           protectedCredentialValues: config.protectedCredentialValues,
+          retention: {
+            logDir,
+            workflowRunId: workflowRun.id,
+            nodeId: `${node.id}-iteration-${String(i)}`,
+            label: '<until_bash>',
+          },
           // Archon-managed env only (no process.env spread) — runSubprocess
           // layers the host env for host runs, or delivers ONLY this bag into
           // the container. Configured project env (managed per-project vars +

--- a/packages/workflows/src/executor-shared.test.ts
+++ b/packages/workflows/src/executor-shared.test.ts
@@ -28,6 +28,7 @@ import {
   stripCompletionTags,
   isInlineScript,
   formatSubprocessFailure,
+  retainStreamTail,
   classifyError,
   isQuotaExhaustionError,
   extractQuotaResetAt,
@@ -1189,5 +1190,29 @@ describe('describeUnmetCompletion', () => {
     const described = describeUnmetCompletion({});
     expect(described).toBe('without a completion channel');
     expect(described).not.toContain('undefined');
+  });
+});
+
+describe('retainStreamTail', () => {
+  it('returns a stream at the exact budget whole and unmarked', () => {
+    // The boundary an off-by-one would move: 2000 characters is retained in full, so a
+    // reader never sees a truncation marker on output that was not truncated.
+    const exact = 'y'.repeat(2000);
+    expect(retainStreamTail(exact)).toBe(exact);
+  });
+
+  it('keeps the tail and marks the dropped head one character over budget', () => {
+    const overBudget = `HEAD${'y'.repeat(2000)}`;
+    const retained = retainStreamTail(overBudget);
+    expect(retained).toBe(`…[truncated to last 2000 chars]\n${'y'.repeat(2000)}`);
+    expect(retained).not.toContain('HEAD');
+  });
+
+  it('reports an empty or whitespace-only stream as absent, not as an empty string', () => {
+    // `undefined` is what makes an absent tail field mean "this stream was empty"
+    // rather than "retention did not happen".
+    expect(retainStreamTail('')).toBeUndefined();
+    expect(retainStreamTail('   \n  ')).toBeUndefined();
+    expect(retainStreamTail(undefined)).toBeUndefined();
   });
 });

--- a/packages/workflows/src/executor-shared.ts
+++ b/packages/workflows/src/executor-shared.ts
@@ -200,6 +200,27 @@ function streamTail(text: string, max: number): string | undefined {
 }
 
 /**
+ * The retained evidence copy of ONE subprocess stream (#2967): a tail on the same
+ * budget the failure diagnostic spends, marked in place when the head was dropped so
+ * a reader can tell truncation from absence. `undefined` for an empty stream.
+ *
+ * The budget applies per stream here, while `formatSubprocessFailure` splits it
+ * across both — that one produces a single diagnostic string, whereas retention keeps
+ * stdout and stderr apart (merging them is the bug the workflow-side substitute this
+ * replaces had to fix), so a chatty stdout must not evict stderr evidence.
+ *
+ * Callers pass ALREADY-REDACTED text. This caps; it does not sanitize.
+ */
+export function retainStreamTail(text: string | undefined): string | undefined {
+  const trimmed = (text ?? '').trim();
+  if (trimmed.length === 0) return undefined;
+  if (trimmed.length <= SUBPROCESS_ERROR_MAX_CHARS) return trimmed;
+  return `…[truncated to last ${String(SUBPROCESS_ERROR_MAX_CHARS)} chars]\n${trimmed.slice(
+    -SUBPROCESS_ERROR_MAX_CHARS
+  )}`;
+}
+
+/**
  * Raw ExecFileException shape from Node's `child_process.execFile`. For inline
  * scripts via `bash -c <body>` / `bun -e <body>` the entire script body is
  * embedded in `err.message`, `err.cmd`, and the first line of `err.stack` —

--- a/packages/workflows/src/logger.ts
+++ b/packages/workflows/src/logger.ts
@@ -33,7 +33,8 @@ export interface WorkflowEvent {
     | 'node_start'
     | 'node_complete'
     | 'node_skipped'
-    | 'node_error';
+    | 'node_error'
+    | 'exec_output';
   workflow_id: string;
   workflow_name?: string;
   step?: string;
@@ -46,6 +47,16 @@ export interface WorkflowEvent {
   check?: string;
   result?: 'pass' | 'fail' | 'warn' | 'unknown';
   error?: string;
+  /** `exec_output` only — see {@link logExecOutput}. Absent means the stream was empty. */
+  stdout_tail?: string;
+  /** `exec_output` only — see {@link logExecOutput}. Absent means the stream was empty. */
+  stderr_tail?: string;
+  /**
+   * `exec_output` only. `0` on success. On failure: the process exit code, or a symbol
+   * when there is none — `'ENOENT'`, `'ERR_CHILD_PROCESS_STDIO_MAXBUFFER'`, the signal
+   * name for a timeout kill, or `'unknown'`.
+   */
+  exit_code?: number | string;
   ts: string;
 }
 
@@ -260,5 +271,50 @@ export async function logNodeError(
     // Spread whole: the caller already omitted every unreported axis, and a guard here
     // would have to re-decide that per field — which is how `0` becomes absent.
     ...usage,
+  });
+}
+
+/** What one deterministic subprocess printed, already redacted and capped. */
+export interface RetainedExecOutput {
+  stdoutTail?: string;
+  stderrTail?: string;
+  exitCode: number | string;
+}
+
+/**
+ * Retain what a deterministic subprocess printed, in the run's own transcript (#2967).
+ *
+ * The reader is a human auditing the run — "what did this node actually do?" — which is
+ * why the evidence lives here and not under `$ARTIFACTS_DIR`, where a workflow would
+ * start depending on it as a contract surface.
+ *
+ * Three properties this row must keep:
+ *
+ * - **Streams stay separate.** Merging stderr into stdout is how a `git` warning becomes
+ *   the branch name a node returns; that bug is the reason this capability exists.
+ * - **Both tails arrive redacted and capped.** `runSubprocess` owns both, because it owns
+ *   the credential material. An artifact written once and read many times has to be safe
+ *   at rest.
+ * - **A row is written even when nothing was printed.** Absence of a row would be
+ *   ambiguous between "printed nothing" and "not retained"; an absent tail FIELD means
+ *   exactly "that stream was empty".
+ *
+ * This is the evidence copy, never the value channel — `$node.output` keeps its own
+ * full-fidelity semantics and is unaffected by the cap applied here.
+ */
+export async function logExecOutput(
+  logDir: string,
+  workflowRunId: string,
+  nodeId: string,
+  commandName: string,
+  output: RetainedExecOutput
+): Promise<void> {
+  await logWorkflowEvent(logDir, workflowRunId, {
+    type: 'exec_output',
+    step: nodeId,
+    content: commandName,
+    exit_code: output.exitCode,
+    ...(output.stdoutTail !== undefined ? { stdout_tail: output.stdoutTail } : {}),
+    ...(output.stderrTail !== undefined ? { stderr_tail: output.stderrTail } : {}),
   });
 }


### PR DESCRIPTION
## Problem and outcome

A `bash:` or `script:` node's stdout and stderr were never retained anywhere, so when an irreversible action was later questioned the evidence of what it actually did was gone — #2909 records a four-step diagnosis that one retained stdout line would have closed. The one workflow that needed the evidence hand-rolled a `record`/`record_read`/`fail` harness inside a single node, and that harness took two corrections in one session: it merged stderr into a captured value, and it turned a *tolerated* probe into a hard failure. Both bugs were in the logging, not in the action being logged.

- **Outcome:** Every deterministic subprocess the engine runs — `bash:` nodes, `script:` nodes, and `until_bash` probes in both loop variants — writes one `exec_output` row into the run's transcript (`~/.archon/workspaces/<project>/logs/<run-id>.jsonl`), on success and failure alike. The row carries `stdout_tail`, `stderr_tail`, and `exit_code`. Workflows no longer have to build their own logging to answer "what did this node actually do?".
- **Invariant:** Retention caps the evidence copy and nothing else. `$node.output` keeps its existing full-fidelity semantics — a large value still substitutes whole in-run and still resumes from its spill. Nothing the engine put in the subprocess environment may reach the transcript.
- **Scope boundary:** The sdlc pack is untouched. `flip-ready`'s hand-rolled harness deletes under #2968 item 3, sequenced separately.

## Review guidance

- **Feedback requested:** Security (is there a path by which a credential reaches the transcript?) and the placement decision.
- **Start here:** `packages/workflows/src/dag-executor.ts:3548` — `runSubprocess` is the whole change. It is the single choke point all five deterministic-exec call sites already pass through, and it already owned the credential material.
- **Review order:** `dag-executor.ts` `runSubprocess` → `executor-shared.ts` `retainStreamTail` → `logger.ts` `logExecOutput` → the five call sites → tests.
- **Lower-attention areas:** The five call sites are identical four-field literals; `retention` is a **required** option, so the type — not review — proves none was missed.
- **Known risk or uncertainty:** `exec_output` is a new row type in the run transcript. Nothing in production code parses that file today, the `WorkflowEvent` union is not exported from the package, and there is no exhaustive switch over its `type`, so no reader can break. If that is wrong, this is where.

## Solution

Retention lives in `runSubprocess` rather than at the five call sites. That seat gives symmetry by construction instead of by five parallel edits, and it is where `collectSubprocessCredentialValues` already ran for the failure path.

The credential set is now resolved **once, before** the try block, and both outcomes redact against it. A success path that scrubbed less than the failure path is no longer something you can write. The failure path reads `rejection.stdout`/`rejection.stderr` after `redactSubprocessError` has already scrubbed them in place, so retention sees exactly what every other failure consumer sees. Redaction happens **before** capping — in the other order, a credential straddling the cut would survive as an unredacted fragment.

Three decisions worth naming:

- **Where.** The operator's decision was "engine-owned run log area, not `$ARTIFACTS_DIR`… files in the run log area, not DB rows", naming #2614 (surface the per-run transcript) as the viewer. The transcript satisfies both and needs no new file naming, no node-id path sanitization, and no second reader for #2614 to grow.
- **Separate streams.** `stdout_tail` and `stderr_tail` are distinct fields. Merging them is precisely how a `git` warning becomes the branch name a node returns.
- **Cap per stream.** Same tail-preserving approach and the same `SUBPROCESS_ERROR_MAX_CHARS` (2000) as the failure diagnostic, but spent per stream rather than split across both. `formatSubprocessFailure` splits its budget because it builds one string; retention keeps the streams apart, so a chatty stdout must not evict stderr evidence. The divergence is documented at the branch.

A row is written even when the node printed nothing, so an absent tail *field* means "that stream was empty" rather than "retention did not happen".

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Nothing recorded what an exec node printed. On failure, a jointly-capped diagnostic reached the error message; on success, output survived only as `$node.output`. | One `exec_output` transcript row per subprocess, both outcomes, with separate capped and redacted stdout/stderr tails and the exit code. |
| **Failure behavior** | An `until_bash` probe's tolerated non-zero exit left no trace at all — nothing said why the loop ran again. | The probe's row records its output and its exit code per iteration (`<node>-iteration-<n>`). A timeout kill reports the signal name rather than a bare "unknown". |

## Changed seams

| Boundary or contract | Change | Evidence |
|---|---|---|
| `runSubprocess → run transcript` | New required `retention` option; writes an `exec_output` row on both paths | `packages/workflows/src/dag-executor.ts:3548`; `retained exec output` suite |
| `WorkflowEvent` | New `'exec_output'` type plus `stdout_tail` / `stderr_tail` / `exit_code` | `packages/workflows/src/logger.ts` |
| `runSubprocess → caller` | Unchanged — `result` is returned untouched; tails are taken from a redacted copy | `caps each retained stream while the $node.output value channel stays complete` |

## Validation

- `bun run validate` — passed — full suite, all packages.
- `bun run lint`, `bun run type-check`, `bun run format:check` — passed.
- `cd packages/workflows && bun run test` — passed — 25 isolated groups, every one `0 fail`.
- **Redaction seen red.** Removing `redactCredentialValues` from the success path put both a suffix-named (`OPENAI_API_KEY`) and an explicitly-protected credential verbatim into the transcript, and `removes a credential a SUCCESSFUL subprocess echoed` caught it. Restored, it asserts `stdout_tail === '[REDACTED]'` on a row it first proves exists — so "wrote no row" cannot pass it.
- **Contract channel proven unaffected.** `caps each retained stream while the $node.output value channel stays complete` runs a real 40,008-character producer into a downstream consumer that measures `${#value}`. The consumer's persisted output is `"40008"` while the producer's evidence tail is capped at 2000 with a truncation marker. A regression that capped the value channel, or that handed the consumer the 32 KB preview instead of the spill-backed full value, fails that assertion.
- **Timeout seen red.** Removing the signal fallback produced `Received: "unknown"` instead of `"SIGTERM"`.
- Coverage: success, failure, silent node, cap + contract channel, `loop:` probe per iteration, `loop_group:` probe under the group's own iteration key, `<script>` labelling, timeout signal.
- **Not verified:** the `loop_group` **resume** probe branch has no test. It shares this same seat and differs only in which iteration variable it reads.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | Additive. A new JSONL row type in a file nothing parses; no schema, API, or persisted-shape change. | `WorkflowEvent` is not exported from the package; no exhaustive switch over its `type` |
| Security / permissions / data | Enlarges the secret surface (every node's output is now retained), which is why redaction is on the write path and shares the failure path's credential set. Known limit: this protects the transcript, not the `node_output` DB preview — the existing "never print secrets from bash nodes" rule still stands, and the docs say so. | `subprocess credential redaction` suite; `packages/workflows/src/dag-executor.ts:3566` |
| Observability | This *is* the observability change. | — |
| Documentation / communication | New "Retained subprocess evidence" section in the authoring guide, a capture step in the script-nodes guide, and the `archon-cli` troubleshooting reference — whose transcript row table and "per-iteration events are not in the JSONL" claim this change made stale. | `packages/docs-web/src/content/docs/guides/authoring-workflows.md`, `.claude/skills/archon-cli/manage-run/troubleshooting.md` |

## Links

- Closes #2967
- Related #2909, #2825, #2726, #2614
- Unblocks #2968 item 3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added retained subprocess evidence to run transcripts, including separate stdout and stderr tails, exit codes, and timeout signals.
  * Captured output for bash, script, and loop probe executions on success and failure.
  * Added credential redaction and capped retained stream tails at 2,000 characters.
  * Added guidance for viewing node execution output.

* **Documentation**
  * Updated workflow and script-node documentation to explain retained execution evidence and transcript behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->