### PR TITLE
test(core): stop orchestrator.test.ts opening a real database on every test

### DIFF
--- a/packages/core/src/orchestrator/orchestrator.test.ts
+++ b/packages/core/src/orchestrator/orchestrator.test.ts
@@ -89,6 +89,24 @@ mock.module('../db/sessions', () => ({
   transitionSession: mockTransitionSession,
 }));
 
+// handleMessage persists the assistant reply for every non-web platform, and the
+// fixture adapter reports 'mock'. Without this stub those calls reach the real
+// lazy getDatabase() singleton on every test — and both call sites swallow the
+// resulting error (addMessage into a .catch, getRecentWorkflowResultMessages into
+// its own try/catch), so the I/O is invisible rather than red. #2982
+mock.module('../db/messages', () => ({
+  addMessage: mock(() => Promise.resolve()),
+  listMessages: mock(() => Promise.resolve([])),
+  getRecentWorkflowResultMessages: mock(() => Promise.resolve([])),
+}));
+
+// Same shape as the messages gap above: the chat path loads per-codebase env
+// vars for any conversation carrying a codebase_id, and its failure lands in a
+// `codebase_env_vars_load_failed` warn on the mocked logger. #2982
+mock.module('../db/env-vars', () => ({
+  getCodebaseEnvVars: mock(() => Promise.resolve({})),
+}));
+
 // Command handler mock
 const mockHandleCommand = mock(() =>
   Promise.resolve({ message: '', modified: false, success: true })


### PR DESCRIPTION
## Problem and outcome

`packages/core/src/orchestrator/orchestrator.test.ts` stubs twenty modules around `handleMessage`, but not `../db/messages` or `../db/env-vars`. The fixture platform adapter reports `'mock'`, so every test took the non-web branch that persists the assistant reply and loads per-codebase env vars, and both reached the real lazy `getDatabase()` singleton — 108 attempts per run, each one invisible.

- **Outcome:** the file makes zero `getDatabase()` calls instead of 108. Locally it also drops from 3.52 s to 0.31 s, but see the wall-clock note below before treating that as a CI win — it is not one.
- **Invariant:** no test in this file performs undeclared database I/O. All 16 modules under `packages/core/src/db` route through `./connection`, so a zero `getDatabase()` count proves this for every one of them, not just the two stubbed here.
- **Scope boundary:** no product code changed, no test was added, removed, or reshaped. The other offenders in #2982 are separate steps.
- **Root cause:** both call sites swallow their own failure — `messageDb.addMessage(...)` into a `.catch` (`orchestrator-agent.ts:2899`, `:3162`) and `getCodebaseEnvVars` into a `try/catch` (`orchestrator-agent.ts:2443`) — each warning through the mocked logger. `getArchonHome` is mocked to a path that does not exist, so each attempt threw `SQLiteError: unable to open database file` and nothing printed. The file was not opening a database handle 108 times; it was failing to open one 108 times, silently.

### Correcting the wall-clock attribution

#2982 ranks this file by cost: 3.51 s for 75 tests, 47 ms per test. That number is real but it is not SQLite, and it does not reproduce off macOS.

The mocked `getArchonHome` returns `/home/test/.archon`. On macOS `/home` is an autofs mount, so every failed open pays an automounter lookup. Measured directly: 108 failed `new Database()` calls under `/home/test` cost **3403 ms**; the same 108 failed opens under a plain missing directory cost **1 ms**. In situ, the *unfixed* file with only the mocked home path moved off `/home` runs in 321–429 ms — indistinguishable from the fixed file.

So the 3.2 s was automounter resolution on one developer platform. On the Linux and Windows runners those 108 failed opens are plain `ENOENT` and cost approximately nothing, and this file was never a meaningful CI cost.

That does not make the fix optional, it just changes why it is worth making:

- Undeclared I/O in a test is a defect on its own terms, and AGENTS.md asks for it to be removed rather than tolerated.
- It is a live landmine. The tests only stay clean because `/home/test/.archon` happens not to exist. On any machine where it does, or after any change to that mock, these 75 tests would open and write a real SQLite database.
- It is exactly the failure shape #2982 itself argues against: a path whose failure no test can see.

## Review guidance

- **Feedback requested:** correctness of the claim that nothing in this file depended on the real handle, and whether the corrected attribution above should change this file's ranking in #2982.
- **Start here:** `packages/core/src/orchestrator/orchestrator.test.ts:96` — the two `mock.module` blocks, placed with the other DB stubs and before the module under test is imported.
- **Lower-attention areas:** none; the diff is 18 added lines in one test file.
- **Known risk or uncertainty:** none in the change. Both stubs return exactly what the swallowed real calls already produced (`{}` env vars, `[]` workflow-result messages, a resolved `addMessage`), so no observable behavior in these tests changes.

## Solution

Add the two `mock.module` blocks the sibling `orchestrator-agent.test.ts` already carries, mirroring its shapes:

- `../db/messages` — `addMessage`, `listMessages`, `getRecentWorkflowResultMessages`
- `../db/env-vars` — `getCodebaseEnvVars`

`../db/env-vars` is not named in the issue. It surfaced while verifying the fix: after stubbing `../db/messages`, tracing `getDatabase()` still showed five calls, all from `getCodebaseEnvVars` on the same `handleMessage` path with the same swallowed-failure shape. It is the same defect in the same file, found by the same measurement, so it is fixed in the same pass rather than left to reappear as a second ticket.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | 108 `new SqliteAdapter('/home/test/.archon/archon.db')` attempts per run | Zero `getDatabase()` calls |
| **Failure behavior** | `SQLiteError: unable to open database file`, caught and warned to a mocked logger — invisible to the run | No database is reached, so there is no failure to hide |
| **Local wall clock (macOS)** | 3.52 s | 0.31 s — automounter cost, see the attribution note |

## Validation

- `bun test src/orchestrator/orchestrator.test.ts` in `packages/core` — 75 pass, 0 fail, 142 expect() calls, eight consecutive runs between 279 and 378 ms. Same command on the parent commit: 75 pass, 0 fail, 142 expect() calls, three runs at 3.54/3.52/3.49 s. Identical pass count and identical assertion count on both sides proves no test went red and none silently changed shape.
- Mechanism proof: a temporary `process.stderr.write` in `getDatabase()` and in the `SqliteAdapter` constructor (reverted, not committed) counted 108 calls before, 5 after the messages stub, 0 after the env-vars stub. Every one of the 108 reported `cached=false`, which is how the failing-open behavior was established; the five intermediate stack traces all read `getCodebaseEnvVars → handleMessage`, which is how the second offender was found.
- Attribution proof for the wall clock: 108 failed `new Database()` calls measured at 3403 ms under `/home/test` versus 1 ms under `/private/tmp/<missing>`; and the unfixed file, with only the mocked `getArchonHome` repointed off `/home`, running at 321/337/429 ms. Both reverted, neither committed.
- No test in the file asserted on the affected paths: `grep -n "persist_failed\|workflow_result_messages\|addMessage\|listMessages\|getRecentWorkflowResult\|remote_agent_messages"` returns nothing, and the file's only two logger assertions (`:1508`, `:1618`) are `toHaveBeenCalledWith` on unrelated messages, not call counts, so removing the swallowed warns cannot affect them.
- `bun run test` in `packages/core` — exit 0, 43 batteries, 0 fail.
- `bun run validate` at the repository root — exit 0 (bundled checks, API types, `type-check` across all eleven packages, `lint --max-warnings 0`, `format:check`, install test, full test suite).
- **Not verified:** `packages/core/tsconfig.json` excludes `**/*.test.ts`, so `type-check` does not read the edited file. That hole is #2407's scope and step 1 of #2982, not this PR's. ESLint and Prettier did run over it, through the lint wrapper and the pre-commit hook. No before/after measurement was taken on the CI runners themselves; the claim that the saving does not transfer rests on the local isolation above, not on a runner measurement.

## Links

- Related #2982 (suggested-order step 2)
