### PR TITLE
fix(cli): the workflow-wait spec no longer guesses that a detached run is ready

### DIFF
--- a/packages/cli/src/commands/workflow-wait.integration.spec.ts
+++ b/packages/cli/src/commands/workflow-wait.integration.spec.ts
@@ -104,6 +104,19 @@ function expectWaitExit(
 }
 
 interface PendingWait {
+  /**
+   * Resolve once the wait has said, on stderr, that it is watching the run.
+   *
+   * This is the ordering a caller cannot otherwise establish. `waitForRunAttention`
+   * is durable, so a waiter that attaches after a transition reports exactly the same
+   * payload as one that was watching when it happened — which means a test can only
+   * claim the wake half of the contract if it knows the watch had begun. Sleeping
+   * first only made that likely; this makes it true or fails loudly.
+   *
+   * Rejects with everything the process wrote when it exits without announcing,
+   * rather than leaving the caller to time out on a promise that will never settle.
+   */
+  attached(): Promise<{ observedStatus: string }>;
   settled(): Promise<{ exitCode: number; payload: Record<string, unknown> }>;
 }
 
@@ -127,12 +140,66 @@ function startWait(fixture: Fixture, runId: string, timeoutSeconds: number): Pen
       stderr: 'pipe',
     }
   );
+
+  let announce: ((progress: { observedStatus: string }) => void) | undefined;
+  let abandon: ((error: Error) => void) | undefined;
+  const attached = new Promise<{ observedStatus: string }>((resolve, reject) => {
+    announce = resolve;
+    abandon = reject;
+  });
+  // A test that never asks about the attachment must not turn a legitimately
+  // unannounced exit into an unhandled rejection.
+  attached.catch(() => undefined);
+
+  // One drain owns stderr: it hands the progress line over as it arrives and keeps
+  // the whole text for `settled()`'s diagnostics. Two readers of the same stream
+  // would leave which one saw what up to scheduling.
+  const stderrText = (async (): Promise<string> => {
+    const decoder = new TextDecoder();
+    let text = '';
+    let scanned = 0;
+    const scan = (): void => {
+      for (
+        let newline = text.indexOf('\n', scanned);
+        announce && newline !== -1;
+        newline = text.indexOf('\n', scanned)
+      ) {
+        const line = text.slice(scanned, newline).trim();
+        scanned = newline + 1;
+        // Scan lines rather than assume the first one: `--json` silences logging, so
+        // the progress envelope is normally alone here, but a diagnostic on stderr
+        // must not be mistaken for it.
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        const progress = parsed as { result?: unknown; observedStatus?: unknown };
+        if (progress.result === 'waiting' && typeof progress.observedStatus === 'string') {
+          announce({ observedStatus: progress.observedStatus });
+          announce = undefined;
+        }
+      }
+    };
+    for await (const chunk of child.stderr) {
+      text += decoder.decode(chunk, { stream: true });
+      scan();
+    }
+    text += decoder.decode();
+    scan();
+    // Only when nothing was announced — `announce` is cleared the moment it fires.
+    if (announce) abandon?.(new Error(`wait exited without announcing that it attached: ${text}`));
+    return text;
+  })();
+
   return {
+    attached: (): Promise<{ observedStatus: string }> => attached,
     async settled(): Promise<{ exitCode: number; payload: Record<string, unknown> }> {
       const [exitCode, stdout, stderr] = await Promise.all([
         child.exited,
         new Response(child.stdout).text(),
-        new Response(child.stderr).text(),
+        stderrText,
       ]);
       // `--json` silences logging, so stdout is exactly one (pretty-printed) document.
       let payload: Record<string, unknown>;
@@ -202,8 +269,25 @@ function readRunId(archonHome: string, workflowName: string): string | undefined
   }
 }
 
+/** The status of one run, read straight from the database file. */
+function readRunStatus(archonHome: string, runId: string): string | undefined {
+  const databasePath = join(archonHome, 'archon.db');
+  if (!existsSync(databasePath)) return undefined;
+  const database = new Database(databasePath, { readonly: true });
+  try {
+    return database
+      .query<{ status: string }, [string]>(
+        `SELECT status FROM remote_agent_workflow_runs
+         WHERE id = ?`
+      )
+      .get(runId)?.status;
+  } finally {
+    database.close();
+  }
+}
+
 /**
- * Poll `read` until it produces a value.
+ * Poll `read` until it produces a value, naming `what` if it never does.
  *
  * The catch is load bearing, not defensive: an owner process creates `archon.db`
  * BEFORE it applies the schema, so a reader that opens the file inside that window
@@ -212,7 +296,7 @@ function readRunId(archonHome: string, workflowName: string): string | undefined
  * (#2306). `workflow-terminal-event.integration.spec.ts` catches for exactly this
  * reason; a bare loop here would surface a startup race as a test failure.
  */
-async function waitFor<T>(read: () => T | undefined, timeoutMs = 30_000): Promise<T> {
+async function waitFor<T>(what: string, read: () => T | undefined, timeoutMs = 30_000): Promise<T> {
   const deadline = Date.now() + timeoutMs;
   let lastError: unknown;
   while (Date.now() < deadline) {
@@ -225,7 +309,7 @@ async function waitFor<T>(read: () => T | undefined, timeoutMs = 30_000): Promis
     await Bun.sleep(50);
   }
   const detail = lastError instanceof Error ? `: ${lastError.message}` : '';
-  throw new Error(`Timed out waiting for the run row${detail}`);
+  throw new Error(`Timed out waiting for ${what}${detail}`);
 }
 
 describe('archon workflow wait against a detached run', () => {
@@ -292,7 +376,9 @@ describe('archon workflow wait against a detached run', () => {
 
     // Discovering the id is test setup, not the contract under test — the launcher
     // above has no `--detach --json` ack to carry one.
-    const runId = await waitFor(() => readRunId(fixture.archonHome, 'wait-gated'));
+    const runId = await waitFor('the gated run row', () =>
+      readRunId(fixture.archonHome, 'wait-gated')
+    );
     activeRunIds.add(runId);
 
     // Attached while the warm-up node is still running, so the gate is a WAKE.
@@ -334,10 +420,23 @@ describe('archon workflow wait against a detached run', () => {
     });
     const { runId } = await launchDetached(fixture, 'wait-slow');
 
+    // `cancel` stops LIVE work: it refuses a run that is still 'pending' outright, and
+    // the tree it terminates has to exist. The forked owner starts its control endpoint
+    // before it executes anything, so the row reaching 'running' is one observation
+    // that covers both. Guessing 1.5s here instead is what failed on Windows — as
+    // "Cannot actively cancel run with status 'pending'" and as a taskkill walking a
+    // tree that was still spawning (#2982).
+    await waitFor('the detached owner to start running', () =>
+      readRunStatus(fixture.archonHome, runId) === 'running' ? true : undefined
+    );
+
     const waiter = startWait(fixture, runId, 90);
-    // Let the waiter attach before the run is stopped, so what ends this wait is the
-    // wake and not a durable read of an already-cancelled row.
-    await Bun.sleep(1500);
+    // The wait announces itself once it has read the row and found nothing to report,
+    // so cancelling after this line is a WAKE and not a durable read of an
+    // already-cancelled row. The status it announces is the proof it attached to a run
+    // that was still live.
+    expect(await waiter.attached()).toEqual({ observedStatus: 'running' });
+
     const cancelled = await runCli(fixture, ['workflow', 'cancel', runId]);
     if (cancelled.exitCode !== 0) {
       throw new Error(`cancel failed: ${cancelled.stderr || cancelled.stdout}`);

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -122,8 +122,10 @@ mock.module(
 // workflow-wait.integration.spec.ts. Here the command's OWN responsibilities are
 // under test: prefix resolution, both output modes, and the exit code per outcome.
 const mockWaitForRunAttention = mock(
-  (_runId: string, _opts?: { onAttached?: (observedStatus: string) => void }): Promise<unknown> =>
-    Promise.resolve({ kind: 'not_found', runId: 'unset' })
+  (
+    _runId: string,
+    _opts?: { onAttached?: (observedStatus: string) => void | Promise<void> }
+  ): Promise<unknown> => Promise.resolve({ kind: 'not_found', runId: 'unset' })
 );
 mock.module('@archon/core/services/run-attention-watch', () => ({
   waitForRunAttention: mockWaitForRunAttention,
@@ -478,6 +480,15 @@ mock.module('@archon/core/db/workflow-node-sessions', () => ({
  */
 function spyOnJsonStdout(): ReturnType<typeof spyOn> {
   return spyOn(process.stdout, 'write').mockImplementation((...args: unknown[]) => {
+    const callback = args.find(arg => typeof arg === 'function');
+    if (typeof callback === 'function') (callback as () => void)();
+    return true;
+  });
+}
+
+/** The same delivery-confirming shim for stderr, where progress lines go. */
+function spyOnStderr(): ReturnType<typeof spyOn> {
+  return spyOn(process.stderr, 'write').mockImplementation((...args: unknown[]) => {
     const callback = args.find(arg => typeof arg === 'function');
     if (typeof callback === 'function') (callback as () => void)();
     return true;
@@ -10171,10 +10182,10 @@ describe('workflowWaitCommand', () => {
   });
 
   it('announces the attachment on stderr, leaving stdout one --json document', async () => {
-    const errorSpy = spyOn(console, 'error').mockImplementation(() => {});
-    mockWaitForRunAttention.mockImplementationOnce((_runId, opts) => {
-      opts?.onAttached?.('running');
-      return Promise.resolve(terminal('cancelled'));
+    const stderrSpy = spyOnStderr();
+    mockWaitForRunAttention.mockImplementationOnce(async (_runId, opts) => {
+      await opts?.onAttached?.('running');
+      return terminal('cancelled');
     });
 
     const code = await workflowWaitCommand(FULL_ID, true, '/repo');
@@ -10183,29 +10194,57 @@ describe('workflowWaitCommand', () => {
     // stderr is the whole point: a progress line on stdout would break the --json
     // contract that a consumer gets exactly one document.
     expect(stdoutSpy.mock.calls).toHaveLength(1);
-    expect(JSON.parse(String(errorSpy.mock.calls[0]?.[0]))).toEqual({
+    expect(JSON.parse(String(stderrSpy.mock.calls[0]?.[0]))).toEqual({
       ok: true,
       action: 'wait',
       runId: FULL_ID,
       result: 'waiting',
       observedStatus: 'running',
     });
-    errorSpy.mockRestore();
+    stderrSpy.mockRestore();
   });
 
   it('names the run and the status it attached on in human mode', async () => {
-    const errorSpy = spyOn(console, 'error').mockImplementation(() => {});
-    mockWaitForRunAttention.mockImplementationOnce((_runId, opts) => {
-      opts?.onAttached?.('paused');
-      return Promise.resolve(terminal('completed'));
+    const stderrSpy = spyOnStderr();
+    mockWaitForRunAttention.mockImplementationOnce(async (_runId, opts) => {
+      await opts?.onAttached?.('paused');
+      return terminal('completed');
     });
 
     await workflowWaitCommand(FULL_ID, undefined, '/repo');
 
-    expect(String(errorSpy.mock.calls[0]?.[0])).toBe(
-      `Waiting on run ${FULL_ID} — currently paused.`
+    expect(String(stderrSpy.mock.calls[0]?.[0])).toBe(
+      `Waiting on run ${FULL_ID} — currently paused.\n`
     );
-    errorSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  it('fails the wait when the attachment line cannot be delivered', async () => {
+    // The line carries an ordering, so losing it silently is the one outcome that
+    // defeats it — and `console.error` to a closed pipe is exactly that no-op.
+    const stderrSpy = spyOn(process.stderr, 'write').mockImplementation((...args: unknown[]) => {
+      const callback = args.find(arg => typeof arg === 'function');
+      if (typeof callback === 'function') {
+        (callback as (error: Error) => void)(
+          Object.assign(new Error('write EPIPE'), { code: 'EPIPE' })
+        );
+      }
+      return true;
+    });
+    mockWaitForRunAttention.mockImplementationOnce(async (_runId, opts) => {
+      await opts?.onAttached?.('running');
+      return terminal('completed');
+    });
+
+    const code = await workflowWaitCommand(FULL_ID, true, '/repo');
+
+    expect(code).toBe(1);
+    expect(JSON.parse(firstJsonPayload(stdoutSpy))).toMatchObject({
+      ok: false,
+      action: 'wait',
+      error: 'write EPIPE',
+    });
+    stderrSpy.mockRestore();
   });
 
   it('waits indefinitely when no timeout is given', async () => {

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -122,7 +122,8 @@ mock.module(
 // workflow-wait.integration.spec.ts. Here the command's OWN responsibilities are
 // under test: prefix resolution, both output modes, and the exit code per outcome.
 const mockWaitForRunAttention = mock(
-  (): Promise<unknown> => Promise.resolve({ kind: 'not_found', runId: 'unset' })
+  (_runId: string, _opts?: { onAttached?: (observedStatus: string) => void }): Promise<unknown> =>
+    Promise.resolve({ kind: 'not_found', runId: 'unset' })
 );
 mock.module('@archon/core/services/run-attention-watch', () => ({
   waitForRunAttention: mockWaitForRunAttention,
@@ -10163,7 +10164,48 @@ describe('workflowWaitCommand', () => {
       result: 'deadline',
       observedStatus: 'running',
     });
-    expect(mockWaitForRunAttention).toHaveBeenCalledWith(FULL_ID, { deadlineMs: 5000 });
+    expect(mockWaitForRunAttention).toHaveBeenCalledWith(FULL_ID, {
+      deadlineMs: 5000,
+      onAttached: expect.any(Function),
+    });
+  });
+
+  it('announces the attachment on stderr, leaving stdout one --json document', async () => {
+    const errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+    mockWaitForRunAttention.mockImplementationOnce((_runId, opts) => {
+      opts?.onAttached?.('running');
+      return Promise.resolve(terminal('cancelled'));
+    });
+
+    const code = await workflowWaitCommand(FULL_ID, true, '/repo');
+
+    expect(code).toBe(0);
+    // stderr is the whole point: a progress line on stdout would break the --json
+    // contract that a consumer gets exactly one document.
+    expect(stdoutSpy.mock.calls).toHaveLength(1);
+    expect(JSON.parse(String(errorSpy.mock.calls[0]?.[0]))).toEqual({
+      ok: true,
+      action: 'wait',
+      runId: FULL_ID,
+      result: 'waiting',
+      observedStatus: 'running',
+    });
+    errorSpy.mockRestore();
+  });
+
+  it('names the run and the status it attached on in human mode', async () => {
+    const errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+    mockWaitForRunAttention.mockImplementationOnce((_runId, opts) => {
+      opts?.onAttached?.('paused');
+      return Promise.resolve(terminal('completed'));
+    });
+
+    await workflowWaitCommand(FULL_ID, undefined, '/repo');
+
+    expect(String(errorSpy.mock.calls[0]?.[0])).toBe(
+      `Waiting on run ${FULL_ID} — currently paused.`
+    );
+    errorSpy.mockRestore();
   });
 
   it('waits indefinitely when no timeout is given', async () => {
@@ -10171,7 +10213,9 @@ describe('workflowWaitCommand', () => {
 
     await workflowWaitCommand(FULL_ID, undefined, '/repo');
 
-    expect(mockWaitForRunAttention).toHaveBeenCalledWith(FULL_ID, {});
+    expect(mockWaitForRunAttention).toHaveBeenCalledWith(FULL_ID, {
+      onAttached: expect.any(Function),
+    });
   });
 
   it('exits 1 with an {ok:false} line for an unknown run', async () => {
@@ -10231,7 +10275,9 @@ describe('workflowWaitCommand', () => {
     const code = await workflowWaitCommand('0b1ee8da', undefined, '/repo');
 
     expect(code).toBe(0);
-    expect(mockWaitForRunAttention).toHaveBeenCalledWith(FULL_ID, {});
+    expect(mockWaitForRunAttention).toHaveBeenCalledWith(FULL_ID, {
+      onAttached: expect.any(Function),
+    });
   });
 
   it('never throws in --json mode when the wait itself fails', async () => {

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -142,7 +142,7 @@ import type { WorkflowEventRow } from '@archon/core/db/workflow-events';
 import * as userDb from '@archon/core/db/users';
 import * as git from '@archon/git';
 import { CLIAdapter } from '../adapters/cli-adapter';
-import { writeJsonLine, writeStdout } from '../utils/stdout';
+import { writeJsonLine, writeStderr, writeStdout } from '../utils/stdout';
 import { exitWithDrain } from '../utils/exit-with-drain';
 import {
   assertDetachedRunProcessOwner,
@@ -3602,23 +3602,27 @@ function formatWaitOutcome(watchedRunId: string, result: RunWaitResult): string 
  * stderr, not stdout, because `--json` promises exactly one document on stdout. The
  * shape follows the same split as the answer itself: the JSON envelope for a machine,
  * one plain sentence for a person.
+ *
+ * Through `writeStderr` rather than `console.error`/`console.warn`, and awaited: this
+ * line exists to tell a host when the watch began, and `console.error` to a pipe whose
+ * reader has gone is a silent no-op under Bun. A line that can vanish without a trace
+ * cannot carry an ordering.
  */
 function announceWaitAttached(
   watchedRunId: string,
   observedStatus: WorkflowRunStatus,
   json?: boolean
-): void {
-  console.error(
-    json
-      ? JSON.stringify({
-          ok: true,
-          action: 'wait',
-          runId: watchedRunId,
-          result: 'waiting',
-          observedStatus,
-        })
-      : `Waiting on run ${watchedRunId} — currently ${observedStatus}.`
-  );
+): Promise<void> {
+  const line = json
+    ? JSON.stringify({
+        ok: true,
+        action: 'wait',
+        runId: watchedRunId,
+        result: 'waiting',
+        observedStatus,
+      })
+    : `Waiting on run ${watchedRunId} — currently ${observedStatus}.`;
+  return writeStderr(`${line}\n`);
 }
 
 /**
@@ -3647,9 +3651,7 @@ export async function workflowWaitCommand(
       // No timeout by default: a wait that ends on its own clock would answer a
       // question only the run can answer.
       ...(timeoutSeconds === undefined ? {} : { deadlineMs: timeoutSeconds * 1000 }),
-      onAttached: observedStatus => {
-        announceWaitAttached(resolvedId, observedStatus, json);
-      },
+      onAttached: observedStatus => announceWaitAttached(resolvedId, observedStatus, json),
     });
   } catch (error) {
     const err = error as Error;

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -3591,6 +3591,37 @@ function formatWaitOutcome(watchedRunId: string, result: RunWaitResult): string 
 }
 
 /**
+ * Say once, on stderr, that the wait is now watching the run.
+ *
+ * Until this line the command is completely silent, and neither a human nor a host
+ * can tell an attached wait from one still resolving the id — or from one that died
+ * on the way. It also fixes the instant the watch began: a transition after this line
+ * reached the caller as a wake, where the same transition before it would have been
+ * an ordinary read of an already-settled row.
+ *
+ * stderr, not stdout, because `--json` promises exactly one document on stdout. The
+ * shape follows the same split as the answer itself: the JSON envelope for a machine,
+ * one plain sentence for a person.
+ */
+function announceWaitAttached(
+  watchedRunId: string,
+  observedStatus: WorkflowRunStatus,
+  json?: boolean
+): void {
+  console.error(
+    json
+      ? JSON.stringify({
+          ok: true,
+          action: 'wait',
+          runId: watchedRunId,
+          result: 'waiting',
+          observedStatus,
+        })
+      : `Waiting on run ${watchedRunId} — currently ${observedStatus}.`
+  );
+}
+
+/**
  * Block until a run finishes or parks on a gate awaiting a response, then say which.
  *
  * The point of the verb: a host that launched a run with `--detach` waits on one
@@ -3616,6 +3647,9 @@ export async function workflowWaitCommand(
       // No timeout by default: a wait that ends on its own clock would answer a
       // question only the run can answer.
       ...(timeoutSeconds === undefined ? {} : { deadlineMs: timeoutSeconds * 1000 }),
+      onAttached: observedStatus => {
+        announceWaitAttached(resolvedId, observedStatus, json);
+      },
     });
   } catch (error) {
     const err = error as Error;

--- a/packages/cli/src/utils/stdout.ts
+++ b/packages/cli/src/utils/stdout.ts
@@ -1,5 +1,5 @@
 /**
- * Guaranteed-delivery stdout writes for machine-readable CLI output.
+ * Guaranteed-delivery writes for CLI output that must not be silently dropped.
  *
  * ## Why this exists
  *
@@ -20,6 +20,18 @@
  * asymmetry is the signature of this class of bug.
  */
 
+function writeStream(stream: NodeJS.WriteStream, text: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    stream.write(text, error => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
 /**
  * Write `text` to stdout and resolve only once the bytes have been handed to
  * the OS in full.
@@ -28,15 +40,23 @@
  * @throws The underlying stream error if the write fails (e.g. EPIPE).
  */
 export function writeStdout(text: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    process.stdout.write(text, error => {
-      if (error) {
-        reject(error);
-        return;
-      }
-      resolve();
-    });
-  });
+  return writeStream(process.stdout, text);
+}
+
+/**
+ * The same guaranteed delivery for stderr.
+ *
+ * `console.error` is not equivalent for anything that has to arrive. Writing it
+ * to a pipe whose reader has already gone is a SILENT no-op under Bun — no throw,
+ * no error, exit 0 — measured with `bun … 2>&1 | head -c 1`, where the callback
+ * below reports `EPIPE` on the same closed pipe. A line whose whole job is to tell
+ * a host something cannot be allowed to disappear that way.
+ *
+ * @param text - Exact bytes to emit (include any trailing newline yourself).
+ * @throws The underlying stream error if the write fails (e.g. EPIPE).
+ */
+export function writeStderr(text: string): Promise<void> {
+  return writeStream(process.stderr, text);
 }
 
 /**

--- a/packages/core/src/services/run-attention-watch.test.ts
+++ b/packages/core/src/services/run-attention-watch.test.ts
@@ -107,6 +107,34 @@ describe('waitForRunAttention', () => {
     expect(mockGetWorkflowRun).toHaveBeenCalledTimes(1);
   });
 
+  test('announces the attachment once, with the status the opening read saw', async () => {
+    // The one moment a caller cannot infer for itself. A transition after it reached
+    // the caller as a wake; the same transition before it would have been an ordinary
+    // read of a row that had already settled. Several re-reads happen inside this
+    // deadline, and none of them is a second attachment.
+    putRun('r1', { status: 'running' });
+    const attached: string[] = [];
+
+    const result = await waitForRunAttention('r1', {
+      pollIntervalMs: 5,
+      deadlineMs: 40,
+      onAttached: status => attached.push(status),
+    });
+
+    expect(result).toMatchObject({ kind: 'deadline', observedStatus: 'running' });
+    expect(attached).toEqual(['running']);
+  });
+
+  test('says nothing about attaching when the first read already has an answer', async () => {
+    // Nothing was ever waited for, so there is no watch to announce.
+    const attached: string[] = [];
+    putRun('r1', { status: 'completed', completed_at: new Date('2026-08-28T11:00:00.000Z') });
+
+    await wait('r1', { onAttached: (status: string) => attached.push(status) });
+
+    expect(attached).toEqual([]);
+  });
+
   test.each(['completed', 'failed', 'cancelled'] as const)(
     'wakes on a %s written after the wait began',
     async status => {

--- a/packages/core/src/services/run-attention-watch.test.ts
+++ b/packages/core/src/services/run-attention-watch.test.ts
@@ -118,7 +118,9 @@ describe('waitForRunAttention', () => {
     const result = await waitForRunAttention('r1', {
       pollIntervalMs: 5,
       deadlineMs: 40,
-      onAttached: status => attached.push(status),
+      onAttached: status => {
+        attached.push(status);
+      },
     });
 
     expect(result).toMatchObject({ kind: 'deadline', observedStatus: 'running' });
@@ -130,7 +132,11 @@ describe('waitForRunAttention', () => {
     const attached: string[] = [];
     putRun('r1', { status: 'completed', completed_at: new Date('2026-08-28T11:00:00.000Z') });
 
-    await wait('r1', { onAttached: (status: string) => attached.push(status) });
+    await wait('r1', {
+      onAttached: (status: string) => {
+        attached.push(status);
+      },
+    });
 
     expect(attached).toEqual([]);
   });

--- a/packages/core/src/services/run-attention-watch.ts
+++ b/packages/core/src/services/run-attention-watch.ts
@@ -69,6 +69,16 @@ export interface RunAttentionWaitOptions {
   deadlineMs?: number;
   /** Backstop re-read cadence. Defaults to `DEFAULT_ATTENTION_POLL_INTERVAL_MS`. */
   pollIntervalMs?: number;
+  /**
+   * Called once, with the status the opening read saw, when that read finds nothing
+   * to report and the wait settles in to watch. It does not fire when the run already
+   * has something to say, because then nothing was ever waited for.
+   *
+   * This is the moment the wait becomes live, and it is the only moment a caller
+   * cannot infer: a run that goes terminal after it produces a WAKE, while the same
+   * transition before it would have been an ordinary durable read of a settled row.
+   */
+  onAttached?: (observedStatus: WorkflowRunStatus) => void;
 }
 
 /** What woke a re-read. Logged at debug so a slow wake is diagnosable. */
@@ -219,6 +229,7 @@ export async function waitForRunAttention(
 
   try {
     let wakeSource: WakeSource = 'immediate';
+    let attached = false;
     for (;;) {
       const run = await workflowDb.getWorkflowRun(runId);
       if (!run) return { kind: 'not_found', runId };
@@ -232,6 +243,10 @@ export async function waitForRunAttention(
       if (signal?.aborted) return { kind: 'aborted', runId };
       if (deadlineAt !== undefined && Date.now() >= deadlineAt) {
         return { kind: 'deadline', runId, observedStatus: run.status };
+      }
+      if (!attached) {
+        attached = true;
+        opts.onAttached?.(run.status);
       }
       wakeSource = await nextWake();
     }

--- a/packages/core/src/services/run-attention-watch.ts
+++ b/packages/core/src/services/run-attention-watch.ts
@@ -77,8 +77,11 @@ export interface RunAttentionWaitOptions {
    * This is the moment the wait becomes live, and it is the only moment a caller
    * cannot infer: a run that goes terminal after it produces a WAKE, while the same
    * transition before it would have been an ordinary durable read of a settled row.
+   *
+   * Awaited, so a host that has to deliver this somewhere can report a failed
+   * delivery instead of dropping it. A rejection ends the wait.
    */
-  onAttached?: (observedStatus: WorkflowRunStatus) => void;
+  onAttached?: (observedStatus: WorkflowRunStatus) => void | Promise<void>;
 }
 
 /** What woke a re-read. Logged at debug so a slow wake is diagnosable. */
@@ -246,7 +249,7 @@ export async function waitForRunAttention(
       }
       if (!attached) {
         attached = true;
-        opts.onAttached?.(run.status);
+        await opts.onAttached?.(run.status);
       }
       wakeSource = await nextWake();
     }

--- a/packages/docs-web/src/content/docs/reference/cli.md
+++ b/packages/docs-web/src/content/docs/reference/cli.md
@@ -526,6 +526,18 @@ Two pauses deliberately do **not** wake a waiter, because neither is owed a resp
 gate that has already been approved or rejected and is awaiting auto-resume, and a
 [`wait:` node](/guides/authoring-workflows/) whose timer or event has not fired.
 
+Once the wait is watching, it says so once on **stderr** — one plain sentence, or the
+same envelope with `"result": "waiting"` and the status it attached on under `--json`:
+
+```json
+{ "ok": true, "action": "wait", "runId": "…", "result": "waiting", "observedStatus": "running" }
+```
+
+Until that line the command is completely silent, so a host cannot tell a watch that
+has begun from one still resolving the id. It is on stderr precisely so stdout keeps
+carrying exactly one document. A run that already has something to say answers on the
+first read, and never prints it.
+
 The run id may be the short prefix printed by `workflow runs`. Once the wait returns,
 inspect the run normally with `workflow get <run-id>`.
 

--- a/packages/docs-web/src/content/docs/reference/cli.md
+++ b/packages/docs-web/src/content/docs/reference/cli.md
@@ -499,7 +499,7 @@ its own clock would be answering a question only the run can answer. `--timeout
 | --- | --- |
 | `0` | The run said something — it finished (`completed`, `failed`, or `cancelled`) or it is waiting for a response. The status is data on stdout. |
 | `3` | The timeout passed with the run still live. The `--json` payload carries `observedStatus`. |
-| `1` | The wait itself failed — unknown run id, database unreachable. |
+| `1` | The wait itself failed — unknown run id, database unreachable, or output that could not be delivered. |
 
 A `failed` or `cancelled` run is still exit `0`: mapping run state onto the process
 exit code would make a legitimately cancelled run look like a broken command.


### PR DESCRIPTION
## Problem and outcome

`workflow-wait.integration.spec.ts` slept a fixed 1500 ms before cancelling a detached
run, hoping two unrelated things had finished inside it. It is the worst cross-branch
flake in the repository: 12 Windows failures across 8 unrelated branches, 5687 ms to
17640 ms, and the file cost 22.18 s for 6 tests at 31% CPU.

- **Outcome:** the case waits on two observations instead of a clock — the run row
  reaching `running`, and the waiter's own attachment line. Injecting a 2.5 s owner
  startup reproduces the CI failure exactly on the old file; the fixed file survives a
  10 s one.
- **Invariant:** the cancellation still has to land while the waiter is watching, so
  what ends the wait is a wake and not a durable read of an already-cancelled row.
- **Scope boundary:** all six cases still run `wait` as a real second OS process against
  a real SQLite database. Nothing became a unit test, and no timeout was widened.
- **Root cause:** 1500 ms was not enough on a contended Windows runner for the forked
  owner to get from a `pending` row to a running one. `workflow cancel` refuses a
  `pending` run outright, and `taskkill /PID … /T /F` walking a tree that is still
  spawning fails on descendants that are already gone. Both messages appear verbatim in
  the CI logs.

## Review guidance

- **Feedback requested:** whether the stderr progress line is the right shape for a
  public CLI contract.
- **Start here:** `packages/core/src/services/run-attention-watch.ts:81` — the new
  `onAttached` option is the load-bearing idea; everything else consumes it.
- **Review order:** the core option, then `announceWaitAttached` in
  `packages/cli/src/commands/workflow.ts:3606`, then `startWait` in the spec, then the
  rewritten case at `packages/cli/src/commands/workflow-wait.integration.spec.ts:412`.
- **Lower-attention areas:** the three `toHaveBeenCalledWith` updates in
  `workflow.test.ts` are mechanical — the option is now always passed.
- **Known risk or uncertainty:** `--json` now writes one line to stderr. stdout still
  carries exactly one document, and under `2>&1` the extra line is itself valid JSON, so
  a `jq` stream consumer is unaffected. A consumer that treats any stderr output as
  failure would see a change.

## Solution

The sleep stood in for a signal that did not exist. `waitForRunAttention` is documented
as durable rather than live-only: a host that attaches after a transition gets the same
answer as one that was watching when it happened. That makes the moment the watch begins
the one thing a caller cannot infer, and the only thing the sleep was really buying.

`waitForRunAttention` now takes `onAttached`, called once with the status the opening
read saw, when that read finds nothing to report. It does not fire when the run already
has an answer, because then nothing was ever waited for. `archon workflow wait` turns
that into one line on stderr, which also closes a real gap: until now the command
printed nothing between launch and settling, so neither a person nor a host could tell
an attached wait from one still resolving the id.

The test then needs no clock. It waits for the run row to reach `running` — the forked
owner starts its control endpoint before it executes anything, so that single reading
also covers the endpoint `cancel` has to reach — and then waits for the attachment line
before cancelling.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | `archon workflow wait` printed nothing until it settled. | It writes one line to stderr once the watch begins: a plain sentence, or `{"ok":true,"action":"wait","runId":"…","result":"waiting","observedStatus":"running"}` under `--json`. stdout is unchanged. |
| **Failure behavior** | A wait that died during startup was indistinguishable from one still waiting. | The absence of that line now separates the two. |

## Validation

- `bun run validate` — exit 0, zero failing tests across every package.
- `bun test src/commands/workflow-wait.integration.spec.ts` ×20 sequential — 20/20 green,
  19.58 s to 21.78 s. The file drops from 22.20 s to 20.00 s, and the cancelled-run case
  from 5.08 s to 3.09 s (junit reporter, same machine).
- **Reproduction.** Injecting `await new Promise(r => setTimeout(r, 2500))` into the
  detached owner's startup, immediately after `startDetachedRunControlServer`, models a
  contended runner. On the pre-fix file that fails with the exact CI message:
  `cancel failed: Error: Cannot actively cancel run with status 'pending'. Only a running
  detached CLI run has live work to stop.` — byte-identical to jobs 99114831350 and
  99083403564. The fixed file passes against the same probe, and against a 10 s one.
- **Seen red, wake path.** Returning `deadline` immediately after the opening read, so
  only a durable read can answer, fails the case with
  `wait exited 3, expected 0 — payload: {…"result":"deadline"…}`. The case cannot be
  satisfied without a real wake.
- **Seen red, attachment gate.** Removing the `onAttached` call fails the case with
  `wait exited without announcing that it attached`, rather than hanging.
- **The coupling was real.** With the waiter's first read delayed 8 s, the pre-fix
  ordering cancelled at 1.5 s and the waiter took the durable-read path — it never woke
  on anything, and the case named "wakes on a cancelled run" still passed green. Under
  the same delay the fixed case still exercises the wake, because it waits for the
  attachment instead of guessing at it.
- **Not verified:** no Windows machine here, so the reproduction is an injected startup
  delay standing in for a contended runner rather than the runner itself. Six copies of
  the spec in parallel, three rounds, stayed green on macOS both before and after the
  fix — this flake is 113-of-122 Windows, and local load does not reach it.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility | `--json` stdout is unchanged at exactly one document; the new line is on stderr. | `workflow.test.ts` asserts `stdoutSpy.mock.calls` has length 1 while the envelope lands on `console.error` |
| Documentation | The `workflow wait` reference now describes the progress line and where it goes. | `packages/docs-web/src/content/docs/reference/cli.md` |

## Links

- Relates to #2982 (step 3: the `workflow-wait.integration.spec.ts` sleep, top offender 1
  in the audit's bucket 3). Other steps remain open.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `workflow wait` now announces when it has attached to a run and begun waiting.
  - Human-readable output includes the run and status; JSON mode emits a waiting acknowledgment on stderr while preserving stdout for the final result.
  - Runs already requiring attention continue to respond immediately without an attachment message.
  - Undeliverable output is now reported as a command failure.

- **Documentation**
  - Updated CLI documentation to describe the waiting acknowledgment and output behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->