### PR TITLE
Ensure release artifacts have one checksum each

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,7 +277,7 @@ jobs:
       - name: Generate checksums
         run: |
           cd dist
-          sha256sum archon-* archon-web.tar.gz > checksums.txt
+          sha256sum archon-* > checksums.txt
           cat checksums.txt
 
       - name: Get version

--- a/scripts/release-checksums.test.ts
+++ b/scripts/release-checksums.test.ts
@@ -1,43 +1,38 @@
 import { expect, test } from 'bun:test';
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
-import { trackTempRoots } from '@archon/paths/test-utils';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
-const trackTempRoot = trackTempRoots();
-const releaseArtifacts = [
-  'archon-darwin-arm64',
-  'archon-darwin-x64',
-  'archon-linux-arm64',
-  'archon-linux-x64',
-  'archon-windows-x64.exe',
-  'archon-web.tar.gz',
-];
+// `* text=auto` checks this workflow out with CRLF on Windows CI. Normalizing here lets every
+// pattern below anchor on LF, so a stray `\r` can never reach a capture.
+const workflow = readFileSync(
+  resolve(import.meta.dir, '../.github/workflows/release.yml'),
+  'utf8'
+).replace(/\r\n/g, '\n');
 
 test('release checksums include each release artifact once', () => {
-  const workflow = readFileSync(
-    resolve(import.meta.dir, '../.github/workflows/release.yml'),
-    'utf8'
+  // The release uploads one binary per build-matrix entry plus the packaged web dist.
+  const binaries = [...workflow.matchAll(/^ +binary: (\S+)$/gm)].map(match => match[1]);
+  const webDist = workflow.match(/^ *-czf dist\/(\S+) /m)?.[1];
+  const checksumOperands = workflow.match(/^ *sha256sum (.+) > checksums\.txt$/m)?.[1];
+
+  // A missed derivation would leave nothing to compare and pass vacuously.
+  if (binaries.length === 0 || webDist === undefined || checksumOperands === undefined) {
+    throw new Error('release.yml no longer declares the artifacts or checksum command read here');
+  }
+
+  const releaseArtifacts = [...binaries, webDist];
+  const operands = checksumOperands.split(/\s+/).map(operand => new Bun.Glob(operand));
+
+  // `sha256sum` writes one row per operand that names a file, so an artifact covered by two
+  // operands is checksummed twice (#2377) and one covered by no operand is missing entirely.
+  const rowsPerArtifact = Object.fromEntries(
+    releaseArtifacts.map(artifact => [
+      artifact,
+      operands.filter(operand => operand.match(artifact)).length,
+    ])
   );
-  const checksumCommand = workflow.match(/^\s*(sha256sum .+ > checksums\.txt)$/m)?.[1];
 
-  expect(checksumCommand).toBe('sha256sum archon-* > checksums.txt');
-  if (checksumCommand === undefined) throw new Error('release workflow has no checksum command');
-
-  const dist = trackTempRoot(mkdtempSync(join(tmpdir(), 'release-checksums-')));
-  for (const artifact of releaseArtifacts) writeFileSync(join(dist, artifact), artifact);
-
-  const result = Bun.spawnSync(['sh', '-c', checksumCommand], {
-    cwd: dist,
-    stderr: 'pipe',
-  });
-  expect(result.exitCode).toBe(0);
-  expect(result.stderr.toString()).toBe('');
-
-  const manifestFiles = readFileSync(join(dist, 'checksums.txt'), 'utf8')
-    .trim()
-    .split('\n')
-    .map(line => line.match(/^[a-f0-9]{64}  (.+)$/)?.[1]);
-  expect(manifestFiles.sort()).toEqual(releaseArtifacts.sort());
-  expect(manifestFiles.filter(artifact => artifact === 'archon-web.tar.gz')).toHaveLength(1);
+  expect(rowsPerArtifact).toEqual(
+    Object.fromEntries(releaseArtifacts.map(artifact => [artifact, 1]))
+  );
 });

--- a/scripts/release-checksums.test.ts
+++ b/scripts/release-checksums.test.ts
@@ -1,6 +1,18 @@
 import { expect, test } from 'bun:test';
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { trackTempRoots } from '@archon/paths/test-utils';
+
+const trackTempRoot = trackTempRoots();
+const releaseArtifacts = [
+  'archon-darwin-arm64',
+  'archon-darwin-x64',
+  'archon-linux-arm64',
+  'archon-linux-x64',
+  'archon-windows-x64.exe',
+  'archon-web.tar.gz',
+];
 
 test('release checksums include each release artifact once', () => {
   const workflow = readFileSync(
@@ -8,18 +20,24 @@ test('release checksums include each release artifact once', () => {
     'utf8'
   );
   const checksumCommand = workflow.match(/^\s*(sha256sum .+ > checksums\.txt)$/m)?.[1];
-  const releaseArtifacts = [
-    'archon-darwin-arm64',
-    'archon-darwin-x64',
-    'archon-linux-arm64',
-    'archon-linux-x64',
-    'archon-windows-x64.exe',
-    'archon-web.tar.gz',
-  ];
 
   expect(checksumCommand).toBe('sha256sum archon-* > checksums.txt');
-  expect(releaseArtifacts.filter(artifact => artifact.startsWith('archon-'))).toEqual(
-    releaseArtifacts
-  );
-  expect(releaseArtifacts.filter(artifact => artifact === 'archon-web.tar.gz')).toHaveLength(1);
+  if (checksumCommand === undefined) throw new Error('release workflow has no checksum command');
+
+  const dist = trackTempRoot(mkdtempSync(join(tmpdir(), 'release-checksums-')));
+  for (const artifact of releaseArtifacts) writeFileSync(join(dist, artifact), artifact);
+
+  const result = Bun.spawnSync(['sh', '-c', checksumCommand], {
+    cwd: dist,
+    stderr: 'pipe',
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.stderr.toString()).toBe('');
+
+  const manifestFiles = readFileSync(join(dist, 'checksums.txt'), 'utf8')
+    .trim()
+    .split('\n')
+    .map(line => line.match(/^[a-f0-9]{64}  (.+)$/)?.[1]);
+  expect(manifestFiles.sort()).toEqual(releaseArtifacts.sort());
+  expect(manifestFiles.filter(artifact => artifact === 'archon-web.tar.gz')).toHaveLength(1);
 });

--- a/scripts/release-checksums.test.ts
+++ b/scripts/release-checksums.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+test('release checksums include each release artifact once', () => {
+  const workflow = readFileSync(
+    resolve(import.meta.dir, '../.github/workflows/release.yml'),
+    'utf8'
+  );
+  const checksumCommand = workflow.match(/^\s*(sha256sum .+ > checksums\.txt)$/m)?.[1];
+  const releaseArtifacts = [
+    'archon-darwin-arm64',
+    'archon-darwin-x64',
+    'archon-linux-arm64',
+    'archon-linux-x64',
+    'archon-windows-x64.exe',
+    'archon-web.tar.gz',
+  ];
+
+  expect(checksumCommand).toBe('sha256sum archon-* > checksums.txt');
+  expect(releaseArtifacts.filter(artifact => artifact.startsWith('archon-'))).toEqual(
+    releaseArtifacts
+  );
+  expect(releaseArtifacts.filter(artifact => artifact === 'archon-web.tar.gz')).toHaveLength(1);
+});


### PR DESCRIPTION
## Problem and outcome

The release checksum command named `archon-web.tar.gz` both through `archon-*` and as an explicit operand, producing two checksum rows for the same uploaded asset. Each release artifact now has exactly one checksum entry.

- **Outcome:** The checksum manifest contains one SHA-256 checksum for each of the six release artifacts.
- **Invariant:** `archon-web.tar.gz` remains included in the manifest because it matches `archon-*`.
- **Scope boundary:** The release assets, upload step, and checksum algorithm are unchanged.
- **Root cause:** The web tarball was passed twice to `sha256sum`.

## Review guidance

- **Feedback requested:** Confirm that the glob covers the complete release artifact set without a duplicate web-tarball operand.
- **Start here:** `.github/workflows/release.yml:280` — the release checksum command now passes each matching artifact once.
- **Review order:** Review the workflow change, then the focused regression test in `scripts/release-checksums.test.ts`.
- **Known risk or uncertainty:** None.

## Solution

Checksum generation now relies solely on `archon-*`. The glob already includes all five platform binaries and `archon-web.tar.gz`, so removing the redundant explicit filename preserves coverage while eliminating the duplicate checksum. The focused test locks that command and the six-artifact manifest expectation.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | `archon-web.tar.gz` appeared twice in `checksums.txt`. | Each release artifact appears once in `checksums.txt`. |
| **Failure behavior** | Consumers could receive an ambiguous duplicate checksum entry. | The manifest has one unambiguous checksum per artifact. |

## Validation

- `bun test ./scripts/release-checksums.test.ts` — passed — verifies the checksum command and six-artifact coverage.
- `bun test ./scripts/` — passed (148 tests).
- `bun run lint --max-warnings 0` — passed.
- `bun run validate` — passed, including generated-artifact checks, API and package type checks, lint, formatting, installer tests, and all package and script tests.
- `git diff --check f339df7a6..HEAD` — passed.
- **Not verified:** Nothing material; the focused regression test covers the corrected manifest input and the repository validation suite passed.

## Links

- Closes #2377


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release checksum files now include only binary artifacts, preventing the web archive from being included unintentionally.

* **Tests**
  * Added automated validation to ensure every released artifact is covered by exactly one checksum entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->