### PR TITLE
Enforce bundled skill description limits

### DIFF
--- a/scripts/check-bundled-skill.test.ts
+++ b/scripts/check-bundled-skill.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { MAX_SKILL_DESCRIPTION_LENGTH, validateSkillDescription } from './check-bundled-skill';
+
+describe('bundled skill metadata', () => {
+  test('accepts the bundled archon-cli skill description', () => {
+    const skill = readFileSync(
+      join(import.meta.dir, '..', '.claude', 'skills', 'archon-cli', 'SKILL.md'),
+      'utf8'
+    );
+
+    expect(validateSkillDescription('archon-cli', skill)).toBeUndefined();
+  });
+
+  test('rejects an empty description', () => {
+    expect(validateSkillDescription('fixture', '---\ndescription: ""\n---\n')).toContain(
+      'non-empty'
+    );
+  });
+
+  test('rejects a description longer than the Agent Skills limit', () => {
+    const skill = `---\ndescription: ${'a'.repeat(MAX_SKILL_DESCRIPTION_LENGTH + 1)}\n---\n`;
+
+    expect(validateSkillDescription('fixture', skill)).toContain(
+      `${MAX_SKILL_DESCRIPTION_LENGTH + 1}-character`
+    );
+  });
+});

--- a/scripts/check-bundled-skill.ts
+++ b/scripts/check-bundled-skill.ts
@@ -15,9 +15,9 @@
  *   bun run scripts/check-bundled-skill.ts --check  # exit 2 if missing (CI)
  *
  * Exit codes:
- *   0  bundled-skill.ts covers every file of the bundled skills
- *   1  missing files (default mode)
- *   2  missing files (--check mode, used by `bun run validate`)
+ *   0  bundled-skill.ts covers every file and each bundled skill has valid metadata
+ *   1  validation failure (default mode)
+ *   2  validation failure (--check mode, used by `bun run validate`)
  */
 import { readdirSync, readFileSync, statSync } from 'fs';
 import { join, relative, resolve } from 'path';
@@ -27,6 +27,7 @@ const SKILLS_DIR = join(REPO_ROOT, '.claude', 'skills');
 /** Skills bundled into the binary and installed by `archon skill install`. */
 const BUNDLED_SKILLS = ['archon-cli'];
 const BUNDLED_SKILL_PATH = join(REPO_ROOT, 'packages', 'cli', 'src', 'bundled-skill.ts');
+export const MAX_SKILL_DESCRIPTION_LENGTH = 1024;
 
 const CHECK_ONLY = process.argv.includes('--check');
 
@@ -37,31 +38,77 @@ function listSkillFiles(dir: string, base: string): string[] {
   });
 }
 
-// Paths are relative to .claude/skills/ so they keep the skill dir name
-// (e.g. `archon/SKILL.md`, `manage-run/references/commands.md`). That makes the
-// substring check distinguish the two skills' identically-named files (both have
-// a SKILL.md) and matches the literal import paths in bundled-skill.ts.
-// Normalize to forward slashes so the substring check works on Windows.
-const skillFiles = BUNDLED_SKILLS.flatMap(skill =>
-  listSkillFiles(join(SKILLS_DIR, skill), SKILLS_DIR)
-)
-  .map(f => f.replace(/\\/g, '/'))
-  .sort();
-
-const bundledSrc = readFileSync(BUNDLED_SKILL_PATH, 'utf-8');
-// NOTE: This is a substring check — a filename that appears in a comment or
-// stale string literal will also pass. It's a safety net against missing imports,
-// not a structural verification of the export map.
-const missing = skillFiles.filter(f => !bundledSrc.includes(f));
-
-if (missing.length > 0) {
-  console.error(
-    `bundled-skill.ts is missing these files:\n${missing.map(f => `  - ${f}`).join('\n')}\n\n` +
-      `Add a corresponding import + bundled map entry to\n  ${relative(REPO_ROOT, BUNDLED_SKILL_PATH)}`
+function hasDescription(metadata: unknown): metadata is { description: string } {
+  return (
+    typeof metadata === 'object' &&
+    metadata !== null &&
+    'description' in metadata &&
+    typeof metadata.description === 'string'
   );
-  process.exit(CHECK_ONLY ? 2 : 1);
 }
 
-console.log(
-  `bundled-skill.ts is up to date (${skillFiles.length} files across ${BUNDLED_SKILLS.length} skills).`
-);
+export function validateSkillDescription(skillName: string, content: string): string | undefined {
+  const frontmatter = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/.exec(content);
+  if (!frontmatter) {
+    return `Bundled skill \`${skillName}\` must start with YAML frontmatter.`;
+  }
+
+  let metadata: unknown;
+  try {
+    metadata = Bun.YAML.parse(frontmatter[1]);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return `Bundled skill \`${skillName}\` has invalid YAML frontmatter: ${message}`;
+  }
+
+  if (!hasDescription(metadata) || metadata.description.trim() === '') {
+    return `Bundled skill \`${skillName}\` must have a non-empty frontmatter \`description\`.`;
+  }
+
+  if (metadata.description.length > MAX_SKILL_DESCRIPTION_LENGTH) {
+    return `Bundled skill \`${skillName}\` has a ${metadata.description.length}-character frontmatter \`description\`; the limit is ${MAX_SKILL_DESCRIPTION_LENGTH}.`;
+  }
+
+  return undefined;
+}
+
+function checkBundledSkills(): void {
+  // Paths are relative to .claude/skills/ so they keep the skill dir name
+  // (e.g. `archon-cli/SKILL.md`). That makes the substring check match the
+  // literal import paths in bundled-skill.ts. Normalize separators for Windows.
+  const skillFiles = BUNDLED_SKILLS.flatMap(skill =>
+    listSkillFiles(join(SKILLS_DIR, skill), SKILLS_DIR)
+  )
+    .map(f => f.replace(/\\/g, '/'))
+    .sort();
+
+  const bundledSrc = readFileSync(BUNDLED_SKILL_PATH, 'utf-8');
+  // This is a substring check, so a stale string literal can satisfy it. It is a
+  // safety net for missing bundled files, not structural verification of the map.
+  const missing = skillFiles.filter(f => !bundledSrc.includes(f));
+  const metadataErrors = BUNDLED_SKILLS.flatMap(skill => {
+    const error = validateSkillDescription(
+      skill,
+      readFileSync(join(SKILLS_DIR, skill, 'SKILL.md'), 'utf-8')
+    );
+    return error ? [error] : [];
+  });
+
+  if (missing.length > 0 || metadataErrors.length > 0) {
+    const errors = [
+      missing.length > 0
+        ? `bundled-skill.ts is missing these files:\n${missing.map(f => `  - ${f}`).join('\n')}\n\n` +
+          `Add a corresponding import + bundled map entry to\n  ${relative(REPO_ROOT, BUNDLED_SKILL_PATH)}`
+        : undefined,
+      ...metadataErrors,
+    ].filter((error): error is string => error !== undefined);
+    console.error(errors.join('\n\n'));
+    process.exit(CHECK_ONLY ? 2 : 1);
+  }
+
+  console.log(
+    `bundled-skill.ts is up to date (${skillFiles.length} files across ${BUNDLED_SKILLS.length} skills), and bundled skill metadata is valid.`
+  );
+}
+
+if (import.meta.main) checkBundledSkills();


### PR DESCRIPTION
## Problem and outcome

Bundled skill descriptions could exceed the Agent Skills 1024-character limit without CI detecting it, risking rejection or truncation by skill loaders. This adds validation for the bundled `archon-cli` skill and protects the limit with focused tests.

- **Outcome:** `check-bundled-skill` now rejects missing, empty, non-string, malformed, or over-limit YAML frontmatter descriptions for every allowlisted bundled skill.
- **Invariant:** The existing check still verifies that every bundled skill file is represented in the CLI bundle.
- **Scope boundary:** This PR does not rewrite `.claude/skills/archon/SKILL.md`; issue #2247 identifies that wording as a separate maintainer-owned decision.

## Review guidance

- **Feedback requested:** Confirm that the metadata validation and its failure messages enforce the intended bundled-skill contract.
- **Start here:** `scripts/check-bundled-skill.ts:50` — parses frontmatter and validates the description before the check reports success.
- **Review order:** Read the validator, then the integration in `checkBundledSkills`, then the three focused tests.
- **Lower-attention areas:** The comment and success-message edits reflect the checker's expanded behavior.
- **Known risk or uncertainty:** None.

## Solution

The existing bundled-skill checker now reads each allowlisted skill's `SKILL.md`, parses its YAML frontmatter with `Bun.YAML`, and reports an error unless `description` is a non-empty string of at most 1024 characters. File-coverage validation remains in the same command, so CI verifies both the bundle contents and required skill metadata in one place.

The exported validator is covered with the real bundled `archon-cli` skill plus empty and 1025-character fixtures. The checker only executes when it is the entry module, allowing the tests to import its validation logic without running the repository check as a side effect.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | The bundled-skill check only verified that files were imported into the CLI bundle. | It also verifies valid, non-empty descriptions within the 1024-character Agent Skills limit. |
| **Failure behavior** | Invalid or oversized bundled-skill descriptions passed the checker. | The checker emits the relevant metadata error and exits nonzero (`2` in `--check` mode). |

## Validation

- `bun test ./scripts/check-bundled-skill.test.ts` — passed (3 tests) — verifies valid, empty, and over-limit descriptions.
- `bun run check:bundled-skill` — passed — verifies the bundled skill and file coverage through the production command.
- `bun x prettier --check scripts/check-bundled-skill.ts scripts/check-bundled-skill.test.ts` — passed.
- `bun x tsc --noEmit -p scripts/tsconfig.json` — passed.
- `bun run lint --max-warnings 0` — passed.
- `bun run validate` — passed — covers generated-file checks, type checks, lint, format, installer tests, and test suites.
- **Not verified:** Nothing material; the focused tests and full validation suite cover the changed checker behavior.

## Links

- Closes #2247


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bundled skills are now checked for valid YAML frontmatter descriptions.
  * Empty or overly long descriptions are rejected with clear validation errors.
  * Validation failures now return the appropriate failure status.

* **Tests**
  * Added coverage for valid descriptions, missing descriptions, and descriptions exceeding the 1,024-character limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
