### PR TITLE
docs(agents): name the hand-synced pair as a present defect

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,10 +38,10 @@ This file is the canonical project guidance for coding agents. Keep it short, du
 
 ### Let types carry invariants
 
-- Keep TypeScript strict. Avoid `any`, broad assertions, and parallel hand-written shapes when a sound type can express the state.
-- Derive types from the owning schema. Do not maintain a schema and a second equivalent interface by hand.
+- Keep TypeScript strict. Avoid `any` and broad assertions when a sound type can express the state.
+- Two declarations that must agree to stay correct, kept in agreement by discipline rather than by a mechanism, are a present defect and not a future risk. Treat a hand-synced pair as a bug the moment it exists, and as a live one once the sides already disagree. Derive from the owner instead: an import, a derived or mapped type, a generated artifact with an owning script, or an enforced conformance test. A "keep in sync" comment is none of those; it records the defect rather than clearing it.
+- Import external SDK types rather than restating them. Where a boundary genuinely cannot share one definition, the copy owes a conformance test.
 - Use discriminated unions and constructors to make invalid states hard to represent.
-- Import external SDK types instead of recreating them locally.
 - Keep interfaces narrow. Extend an existing interface only when the new method belongs to the same responsibility.
 
 ### Fail clearly


### PR DESCRIPTION
## Problem and outcome

`AGENTS.md` carried the hand-synced-pair idea in two places, both phrased as taste: "avoid parallel hand-written shapes when a sound type can express the state" and "do not maintain a schema and a second equivalent interface by hand." Phrased that way it reads as a preference a reviewer can weigh against other preferences, which is not how the class behaves — a pair kept in agreement by discipline is already broken, it just has not diverged yet.

The sdlc seams lens has treated it as a defect class since #3003 and it is that lens's best-performing rule. This states it the same way in the canonical guidance file.

- **Outcome:** the rule names the class, its severity, and the four mechanisms that actually clear a pair. A "keep in sync" comment is explicitly not one of them.
- **Invariant:** `AGENTS.md` stays short, durable, and about judgment. This adds one rule and removes the redundancy it supersedes, so the section is one line shorter than before.
- **Scope boundary:** prose only. No code, no lint rule, no pack change. The lens wording in `.archon/workflows/sdlc/review/commands/review-seams.md` is untouched.

## Review guidance

- **Feedback requested:** wording. The substance is settled; the phrasing is mine and is the part worth disagreeing with.
- **Start here:** `AGENTS.md:42` — the new rule.
- **Known risk or uncertainty:** the lens version carries an explicit Important/Critical severity ladder. I dropped it here as too review-specific for a file that is read by every agent on every task, not only by reviewers. If you want the ladder in both places, say so.

## Solution

One bullet replaces the two weaker statements and absorbs the SDK-type case, which was a third instance of the same class stated separately:

| Before | After |
|---|---|
| "Avoid `any`, broad assertions, and parallel hand-written shapes…" | "Avoid `any` and broad assertions…" (the pair case moves to its own rule) |
| "Derive types from the owning schema. Do not maintain a schema and a second equivalent interface by hand." | the hand-synced-pair rule |
| "Import external SDK types instead of recreating them locally." | "Import external SDK types rather than restating them. Where a boundary genuinely cannot share one definition, the copy owes a conformance test." |

The conformance-test clause matters: it is the honest answer for pairs that provably cannot share one definition, and without it the rule reads as absolute and gets ignored where it cannot be followed.

## Validation

- `bun x prettier --check AGENTS.md` — passes — proves formatting matches the repo style.
- `grep -rln "parallel hand-written shapes" packages/ scripts/` — no matches — proves `AGENTS.md` is not mirrored into any bundled or generated artifact, so no `generate:bundled` run is required.
- **Not verified:** nothing material. The change is prose in a file no code reads.

## Links

- Related #3014 — the rule is recorded there as review-owned rather than lintable, with the reasoning that detecting the class generically is the structural-similarity search that issue's scope boundary already refuses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development guidance to discourage manually synchronized duplicate type definitions.
  * Clarified preferred approaches for deriving types from an authoritative source.
  * Added guidance to use conformance tests when shared definitions aren’t possible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->