### PR TITLE
chore: ignore personal run configs, and document the layer with an example

### DIFF
--- a/.archon/config.example.yaml
+++ b/.archon/config.example.yaml
@@ -1,0 +1,91 @@
+# Example per-run config for `archon workflow run --config <path>`.
+#
+# Archon never loads THIS file. Copy it to `.archon/config.<name>.yaml`, edit it,
+# and pass it with `--config`. That naming is gitignored, so your copy stays local
+# and other contributors keep their own.
+#
+#   archon workflow run <workflow> --branch <branch> "<message>" \
+#     --config .archon/config.mysetup.yaml --detach
+#
+# ---------------------------------------------------------------------------
+# The three config layers, and which one you probably want
+# ---------------------------------------------------------------------------
+#
+#   ~/.archon/config.yaml       Yours, machine-wide. Default provider, per-provider
+#                               defaults, tiers, concurrency. Archon writes a fully
+#                               commented template here on first run — read that file
+#                               for the global-only keys (botName, concurrency, ...).
+#
+#   .archon/config.yaml         The PROJECT's, committed. Only facts true for every
+#                               contributor: the worktree base branch, the docs path,
+#                               and aliases the repo's own workflows reference. Do not
+#                               put personal model choices here; they would ship to
+#                               everyone.
+#
+#   .archon/config.<name>.yaml  Yours, per run, via `--config`. Gitignored. This file
+#                               is the example for that layer.
+#
+# A run config is SPARSE and STRICT: set only what you want to override, and an
+# unknown key is a hard error rather than a silent drop. Values here beat persistent
+# config and user AI preferences; an explicit `--model` flag then replaces only the
+# binding it names. Sealed at launch, so editing the file mid-run changes nothing.
+# `--config` is rejected with `--resume`, which restores the layer the run started with.
+#
+# ---------------------------------------------------------------------------
+# Every supported key
+# ---------------------------------------------------------------------------
+#
+# assistant:  <provider>                 default provider for nodes that name none
+# assistants: { <provider>: { ... } }    per-provider defaults for this run
+# tiers:      { small|medium|large: { provider, model, effort?, thinking? } }
+# aliases:    { '@name': { provider, model, effort?, thinking? } }
+# docsPath:   <path>                     overrides the project docs path
+# envVars:    { KEY: value }             extra env for this run's nodes
+# workflows:  { autoResumeOnQuotaReset, quotaFallbackDelayMs,
+#               quotaMaxAttempts, quotaDeadlineMs }
+#
+# Alias names must start with `@`. Tier names are exactly small / medium / large.
+#
+# ---------------------------------------------------------------------------
+# Example: pin one provider across every tier
+# ---------------------------------------------------------------------------
+# Useful for cross-provider testing — prove a workflow's structured output survives
+# on a provider it does not normally run on.
+#
+# tiers:
+#   small:  { provider: claude, model: claude-sonnet-5 }
+#   medium: { provider: claude, model: claude-sonnet-5 }
+#   large:  { provider: claude, model: claude-sonnet-5 }
+#
+# ---------------------------------------------------------------------------
+# Example: cheap models for a high-volume dogfood batch
+# ---------------------------------------------------------------------------
+# Reasoning work on the large/medium tiers, a cheaper model on small. Model ids are
+# passed to the provider as written; for Pi the form is `<vendor>/<slug>`, and an
+# OpenRouter slug is `openrouter/<org>/<model>`.
+#
+# tiers:
+#   small:  { provider: pi, model: openrouter/z-ai/glm-5.3-flash }
+#   medium: { provider: pi, model: openrouter/google/gemini-3.7-flash }
+#   large:  { provider: pi, model: openrouter/google/gemini-3.7-flash }
+#
+# Check current prices before a large batch. Provider catalogues move, and Pi ships a
+# static snapshot of its model data that can lag the vendor's live pricing.
+#
+# ---------------------------------------------------------------------------
+# Example: retarget an alias without touching the workflows that use it
+# ---------------------------------------------------------------------------
+# A workflow referencing `model: '@mini'` follows this binding for this run only.
+#
+# aliases:
+#   '@mini': { provider: pi, model: minimax/MiniMax-M3 }
+#
+# ---------------------------------------------------------------------------
+# Example: keep a long batch alive across a quota reset
+# ---------------------------------------------------------------------------
+# workflows:
+#   autoResumeOnQuotaReset: true
+#   quotaMaxAttempts: 3
+
+# The file you copy needs at least one real key. This one is deliberately inert.
+tiers: {}

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ e2e-screenshots/
 # Personal per-run steering configs (#2482 sparse run config).
 # The shared .archon/config.yaml stays committed; only config.<name>.yaml variants are local.
 .archon/config.*.yaml
+!.archon/config.example.yaml
 
 # Maintainer standup — per-maintainer state and briefs (direction.md is committed)
 .archon/maintainer-standup/profile.md

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,10 @@ e2e-screenshots/
 # Cross-run workflow state (e.g. issue-triage memory)
 .archon/state/
 
+# Personal per-run steering configs (#2482 sparse run config).
+# The shared .archon/config.yaml stays committed; only config.<name>.yaml variants are local.
+.archon/config.*.yaml
+
 # Maintainer standup — per-maintainer state and briefs (direction.md is committed)
 .archon/maintainer-standup/profile.md
 .archon/maintainer-standup/state.json


### PR DESCRIPTION
## Problem and outcome

Two gaps in the same surface, the per-run `--config` layer.

**Local run configs were untracked but not ignored.** The #2482 sparse run configs are per-maintainer files pinning a provider and model tiers for one run and its children. Each declares "locally excluded, never tracked" in its own header, but nothing enforced it — they appeared as untracked in every `git status` and sat one broad `git add` away from being committed onto everyone.

**The layer had no worked example.** `--config <path>` is documented in the CLI reference, but there was no example file, so learning the shape meant reading the Zod schema or copying someone's local file. Nothing showed a contributor where their personal settings belong versus the project's.

- **Outcome:** `config.<name>.yaml` under `.archon/` is ignored, and `.archon/config.example.yaml` is committed as the template to copy.
- **Invariant:** the shared `.archon/config.yaml` stays committed and unignored. It holds project facts every contributor needs — the worktree base branch, the docs path, and the `@mini` alias that seven `rasmus-tests` workflows resolve through.
- **Scope boundary:** ignore rules and one new documentation file. No existing file is added, removed, or untracked, and no code changes.

## Review guidance

- **Feedback requested:** whether the example's framing of the three layers matches how you want contributors to set up.
- **Start here:** `.gitignore:58-59` — the pattern and its one negation.
- **Review order:** `.gitignore`, then `.archon/config.example.yaml`.
- **Known risk or uncertainty:** None. The pattern cannot match the committed files, proven below.

## Solution

One pattern plus one negation, beside the other `.archon/` runtime entries:

```
.archon/config.*.yaml
!.archon/config.example.yaml
```

`config.*.yaml` requires a middle segment, so `.archon/config.yaml` cannot match it — that is what keeps the shared project config committed while excluding personal variants, and why the pattern is not `config*.yaml`. The negation is needed because the example's own name matches the pattern it documents.

The example names every supported key (`assistant`, `assistants`, `tiers`, `aliases`, `docsPath`, `envVars`, `workflows`), explains how the global, project, and per-run layers differ and which one a personal setting belongs in, and carries four realistic setups: pinning one provider across all tiers, cheap models for a dogfood batch, retargeting an alias, and surviving a quota reset.

## Validation

- `git check-ignore -v` on `config.fast.yaml`, `config.claude-sonnet.yaml`, `config.deepseek.yaml`, `config.gemini-glm.yaml`, `config.glm-flash.yaml` — all matched — proves personal variants are excluded.
- `git check-ignore .archon/config.yaml` — no match, exit 1 — proves the shared project config is unaffected.
- `git check-ignore .archon/config.example.yaml` — no match — proves the negation works.
- `git ls-files .archon/` — lists `config.yaml` and `config.example.yaml`, and nothing else — proves no file was untracked by this change.
- The example parses through `loadWorkflowRunConfigFile` with providers registered, yielding `{"tiers":{}}` — proves the committed template is a valid run config rather than prose that would fail if copied and passed to `--config` unedited.
- **Not verified:** nothing material.

## Links

- Related #2482 — the sparse run-config feature this documents.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ignore rules to exclude local `.archon` configuration variants while keeping the shared configuration tracked.

* **Documentation**
  * Added an example Archon configuration file documenting available settings, configuration layers, per-run usage, validation rules, and practical configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->