### PR TITLE
chore: copy .env into worktrees

### DIFF
--- a/.archon/config.yaml
+++ b/.archon/config.yaml
@@ -1,5 +1,12 @@
 worktree:
   baseBranch: dev
+  # `git worktree add` carries tracked files only, so every gitignored runtime file is
+  # absent from a fresh worktree. Agents work inside worktrees, so without this they
+  # cannot start the server, run integration tests, or reproduce anything that reads
+  # local credentials. A contributor with no `.env` is unaffected: a missing source is
+  # skipped silently (worktree-copy.ts).
+  copyFiles:
+    - .env
 
 docs:
   path: packages/docs-web/src/content/docs


### PR DESCRIPTION
## Problem and outcome

Agents do their work inside worktrees, and `git worktree add` carries **tracked** files only. Every gitignored runtime file is therefore absent from a fresh worktree — `.env` first among them. An agent cannot start the server, run an integration test, or reproduce anything that reads local credentials from the checkout it was handed.

Nothing failed loudly, which is why this went unnoticed. Measured before this change on a fully configured install: **ten live worktrees under `~/.archon/workspaces/`, none with a `.env`.**

- **Outcome:** a worktree created for this repo carries the contributor's own `.env`, so agent self-testing inside the worktree works.
- **Invariant:** the real gitignored file is copied. A tracked template is never materialised as `.env` — a placeholder `.env` is worse than none, because a server starts against fake credentials instead of failing.
- **Scope boundary:** one config entry. No engine change; `worktree.copyFiles` already works and is documented at `/reference/configuration/`.

## Review guidance

- **Feedback requested:** whether `.env` alone is the right set, or whether other gitignored paths in this repo deserve to travel too.
- **Start here:** `.archon/config.yaml:8-9`.
- **Known risk or uncertainty:** None for contributors without a `.env` — see below.

## Solution

```yaml
worktree:
  baseBranch: dev
  copyFiles:
    - .env
```

Deliberately just `.env`. `.env.local` is also gitignored here but does not exist in this repo, and listing paths nobody uses turns a short justified list into an allowlist nobody re-reads.

**Why this belongs in the committed project config rather than a personal one.** The path is identical for every contributor; only the contents differ, and the contents are never committed. It states a fact about the project — *this repo needs `.env` at runtime* — not a preference. It is also the only scope that works: `worktree` lives on `RepoConfig`, not `GlobalConfig`, and nothing in the codebase reads `global.worktree`.

**A contributor with no `.env` is unaffected.** `worktree-copy.ts:74` documents a missing source as "expected, silently skipped", and `:126-129` implements it — ENOENT is caught and logged at debug. Worktree creation is unchanged for them.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | A new worktree has no `.env`; a server started inside it runs unconfigured | The contributor's `.env` is copied in after creation |
| **Failure behavior** | Silent — the agent discovers it only when something reads an env var and gets nothing | Unchanged for a contributor with no `.env`: still silent, still no file, no error |

## Validation

- `ls ~/.archon/workspaces/coleam00/Archon/worktrees/*/.env` — none of the ten existing worktrees has one — establishes the problem.
- `worktree-copy.ts:74` and `:126-129` — ENOENT is caught and skipped at debug level — proves this is safe for contributors without a `.env`.
- `worktree.ts:1005-1010` reads `copyFiles` from the loaded repo config, so this entry is on the live path.
- **Not verified:** I have not created a fresh worktree to observe the copy end to end. The existing worktrees predate this change and adopting one deliberately skips copying (`does not copy files when adopting existing worktree`), so the next fresh run is the real check.

## Links

- Related #3024 — the CLI skill never mentions `worktree.copyFiles`, which is why this gap persisted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fresh worktrees now automatically copy the `.env` file when available.
  * Worktrees are created successfully even when no `.env` file exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->