### PR TITLE
docs: teach worktree.copyFiles in the CLI skill and reference

### DIFF
--- a/.claude/skills/archon-cli/setup-and-config/setup-and-config.md
+++ b/.claude/skills/archon-cli/setup-and-config/setup-and-config.md
@@ -89,7 +89,47 @@ defaults:
 docs:
   path: docs/                  # where $DOCS_DIR points
 env:                           # per-project env vars injected into execution
+worktree:                      # repo scope only — see "Files agents need in worktrees"
+  baseBranch: main
+  copyFiles:
+    - .env
 ```
+
+### Files agents need in worktrees
+
+`git worktree add` carries **tracked** files only. Everything gitignored is absent
+from a fresh worktree — `.env` above all — so an agent cannot start the project's
+server, run integration tests, or reproduce anything reading local credentials
+from the checkout it was handed. Nothing errors; the agent just finds no config.
+
+If a user asks why something works in their checkout but not in a run, check this
+first. The fix is one entry:
+
+```yaml
+# <repo>/.archon/config.yaml
+worktree:
+  copyFiles:
+    - .env
+```
+
+Rules worth knowing before suggesting entries:
+
+- **Repo scope only.** `worktree` is read from `<repo>/.archon/config.yaml`.
+  Putting it in `~/.archon/config.yaml` parses and does nothing.
+- **Copy the real gitignored file, never a tracked template.** Suggesting
+  `.env.example` is wrong twice: a worktree already has it, and materialising a
+  placeholder `.env` makes a server start against fake credentials instead of
+  failing.
+- **Entries are plain paths.** Source and destination are always identical; there
+  is no rename syntax.
+- **Missing entries are skipped silently**, so listing an optional path is safe
+  and a contributor without the file is unaffected.
+- Nothing is copied unless listed. Workflows, commands, and scripts do **not**
+  need an entry — a run freezes its own source.
+
+Other common entries: `.vscode/`, `.claude/`, and local-only fixture or plans
+directories. Full semantics, including path-traversal rejection and the
+`worktree.path` interaction, are in `/reference/configuration/`.
 
 Prefer the typed commands over hand-editing when they exist — they validate:
 
@@ -114,7 +154,8 @@ premium one — does not need to edit their main config. Create a **sparse YAML
 layer** holding only the keys it overrides, and load it per run with `--config`:
 
 ```yaml
-# e.g. .config.free.yaml at the repo root (operator-local; keep untracked)
+# e.g. .archon/config.free.yaml (operator-local; `.archon/config.*.yaml` is gitignored,
+# and `.archon/config.example.yaml` is the committed template to copy)
 tiers:
   small:
     provider: pi

--- a/packages/docs-web/src/content/docs/reference/configuration.md
+++ b/packages/docs-web/src/content/docs/reference/configuration.md
@@ -272,6 +272,12 @@ Set in `~/.archon/config.yaml` (global) or `.archon/config.yaml` (repo-specific)
 
 `git worktree add` only copies **tracked** files into a new worktree. Anything gitignored — secrets, local planning docs, agent reports, IDE settings, data fixtures — is absent by default. Archon's `worktree.copyFiles` closes that gap: after the worktree is created, each listed path is copied from the canonical repo into the worktree via raw filesystem copy (not git), so gitignored content comes along for the ride.
 
+**Why this matters for agent runs.** A run does its work inside the worktree, so anything the agent needs at runtime has to be there. `.env` is the common case: without it an agent cannot start the project's server, run an integration test, or reproduce a bug that reads local credentials — and nothing errors, it simply finds no configuration. If you want agents to verify their own work by running the thing they changed, list `.env` here.
+
+Copy the **real** gitignored file, never a tracked template. Listing `.env.example` is wrong twice over: the worktree already has it, because it is tracked; and materialising it as `.env` produces placeholder credentials, so a server starts misconfigured instead of failing loudly.
+
+`worktree.copyFiles` is read from the repo's own `.archon/config.yaml`. It is not a global setting — placing it in `~/.archon/config.yaml` parses without error and has no effect.
+
 **Nothing is copied unless you list it.** Archon used to copy `.archon/` into every worktree automatically, because that was the only way a workflow's own commands and scripts could be found from inside the worktree it was running against. Runs now carry their own source (see below), so the implicit copy is gone.
 
 If you relied on it — most often for a gitignored `.archon/config.yaml` holding local settings — add it explicitly:

--- a/packages/isolation/src/providers/worktree.test.ts
+++ b/packages/isolation/src/providers/worktree.test.ts
@@ -2012,12 +2012,12 @@ describe('WorktreeProvider', () => {
     test('copies configured files after worktree creation', async () => {
       const configLoader: RepoConfigLoader = async () => ({
         baseBranch: git.toBranchName('main'),
-        copyFiles: ['.env.example -> .env', '.vscode/settings.json'],
+        copyFiles: ['.env', '.vscode/settings.json'],
       });
       provider = new WorktreeProvider(configLoader);
 
       copyWorktreeFilesSpy.mockResolvedValue([
-        { source: '.env.example', destination: '.env' },
+        { source: '.env', destination: '.env' },
         { source: '.vscode/settings.json', destination: '.vscode/settings.json' },
       ]);
 
@@ -2027,7 +2027,7 @@ describe('WorktreeProvider', () => {
       expect(copyWorktreeFilesSpy).toHaveBeenCalledWith(
         '/.archon/workspaces/owner/repo',
         expect.stringContaining('issue-42'),
-        ['.env.example -> .env', '.vscode/settings.json']
+        ['.env', '.vscode/settings.json']
       );
     });
 
@@ -2092,7 +2092,7 @@ describe('WorktreeProvider', () => {
         'gitdir: /.archon/workspaces/owner/repo/.git/worktrees/archon/issue-42\n'
       );
       const configLoader: RepoConfigLoader = async () => ({
-        copyFiles: ['.env.example -> .env'],
+        copyFiles: ['.env'],
       });
       provider = new WorktreeProvider(configLoader);
 


### PR DESCRIPTION
## Problem and outcome

A worktree is where an agent works, and `git worktree add` carries **tracked** files only. Every gitignored runtime file is absent from a fresh worktree — `.env` first among them — so an agent cannot start the project's server, run an integration test, or reproduce anything reading local credentials. Nothing errors; it simply finds no configuration.

`worktree.copyFiles` closes that gap and the configuration reference documents its mechanics well. The `archon-cli` skill — the thing that actually walks a user through setup — had **zero** occurrences of `worktree` or `copyFiles`. So the one setting that decides whether an agent can run the project it is changing was undiscoverable at the point of setup, which is why this install had ten worktrees and no `.env` in any of them.

- **Outcome:** the skill teaches which gitignored paths an agent needs and how to configure them, so an agent can help a user set this up; the reference states the agent-self-testing motivation and the scope limit.
- **Invariant:** both surfaces say to copy the **real** gitignored file and never a tracked template. Materialising `.env` from `.env.example` starts a server on placeholder credentials instead of failing loudly.
- **Scope boundary:** prose and test fixtures. No engine change, no config-schema change, no behaviour change. `worktree.copyFiles` already works.

## Review guidance

- **Feedback requested:** skill wording. It is model-visible instruction, so it is scoped to the decision a user faces rather than restating the reference — check that trade is right.
- **Start here:** `.claude/skills/archon-cli/setup-and-config/setup-and-config.md` — the new "Files agents need in worktrees" section.
- **Review order:** skill, then `configuration.md`, then the test fixtures.
- **Known risk or uncertainty:** None.

## Solution

**Skill.** Adds `worktree:` to the config block and a short section covering: why the gap exists, the one-entry fix, and four rules worth knowing before suggesting entries — repo scope only, copy the real file never a template, plain paths with no rename syntax, missing entries skipped silently. Points at `/reference/configuration/` for full semantics instead of duplicating them, so the two cannot drift.

**Reference.** Adds the agent-self-testing motivation, the never-a-template rule, and one fact that was not stated anywhere: `worktree.copyFiles` is repo scope only. `worktree` lives on `RepoConfig`, not `GlobalConfig`, and nothing reads `global.worktree` — so placing it in `~/.archon/config.yaml` parses without error and does nothing.

**Test fixtures.** Three sites configured `copyFiles: ['.env.example -> .env']`. There is no rename syntax; `configuration.md:308` says source and destination are always identical, and `worktree-copy.ts`'s own docstring repeats it. That string is a literal path to a file no repo has, so the fixtures pinned a feature that does not exist. They passed because `copyWorktreeFiles` is spied and its result hand-written by the test — the assertion compared the config value against a literal the same test wrote, and would have passed with `'banana'`. The mocked return also fabricated `{ source: '.env.example', destination: '.env' }`, a distinct-destination shape the implementation cannot emit.

Replaced with realistic entries (`.env`, `.vscode/settings.json`) and a mock result whose source and destination match, as the real code produces.

## Validation

- `bun test src/providers/worktree.test.ts` in `packages/isolation` — **164 pass, 0 fail**.
- `bun run check:bundled-skill` — "bundled-skill.ts is up to date (9 files across 1 skills), and bundled skill metadata is valid" — proves the skill edit keeps the CLI bundle consistent.
- `bun x prettier --check` on all three files — clean.
- `grep -rn 'env\.example' packages/isolation/src/providers/worktree.test.ts` — no matches.
- **Not verified:** the fixture change does not make those tests stronger, only honest. They still assert a config value round-trips through a spy. Giving `copyFiles` coverage that could fail against a real filesystem is a larger change and belongs with #2982's audit, not here.

## Links

- Closes #3024
- Related #3025 — sets `copyFiles: [.env]` in this repo's own config, the change this documents.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for copying selected runtime files, such as `.env`, into worktree checkouts.
  * File entries now use plain paths, with destinations inferred automatically.
  * Missing files are skipped without interrupting setup.

* **Documentation**
  * Clarified that only tracked files are included by default in worktrees.
  * Documented repository-level configuration requirements and guidance for safely copying ignored runtime files.
  * Updated configuration examples for alternate local settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->