### PR TITLE
fix(ci): compare against the merge base so the docs filter actually fires

### DIFF
--- a/scripts/should-run-test-suite.test.ts
+++ b/scripts/should-run-test-suite.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from 'bun:test';
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
-import { shouldRunTestSuite } from './should-run-test-suite';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { trackTempRoots } from '@archon/paths/test-utils';
+import { changedFilesBetween, shouldRunTestSuite } from './should-run-test-suite';
 
 const EMPTY_GIT_SHA = '0000000000000000000000000000000000000000';
 
@@ -166,5 +168,89 @@ describe('test-suite change decision', () => {
     expect(fixtureJob).toContain('uses: astral-sh/setup-uv@v4');
     expect(fixtureJob).toContain('run: bun install --frozen-lockfile');
     expect(fixtureJob).toContain('run: bun run cli workflow test --json');
+  });
+});
+
+describe('diff mode', () => {
+  const trackTempRoot = trackTempRoots();
+
+  const git = (cwd: string, ...args: string[]): void => {
+    const r = Bun.spawnSync(['git', ...args], { cwd, stdout: 'pipe', stderr: 'pipe' });
+    if (r.exitCode !== 0) throw new Error(`git ${args.join(' ')}: ${r.stderr.toString()}`);
+  };
+
+  const commit = (repo: string, file: string, message: string): string => {
+    writeFileSync(join(repo, file), `${message}\n`);
+    git(repo, 'add', file);
+    git(repo, 'commit', '-m', message);
+    return Bun.spawnSync(['git', 'rev-parse', 'HEAD'], { cwd: repo, stdout: 'pipe' })
+      .stdout.toString()
+      .trim();
+  };
+
+  /**
+   * The shape that disabled this filter in production: a docs-only branch whose base moved on.
+   * A two-dot `git diff base head` also reports the base's own new commit and forces the suite;
+   * the merge-base diff reports only what the branch changed.
+   */
+  function docsBranchWithMovedBase(): { repo: string; base: string; head: string } {
+    const repo = trackTempRoot(mkdtempSync(join(tmpdir(), 'run-suite-diff-')));
+    git(repo, 'init', '-q', '-b', 'main');
+    git(repo, 'config', 'user.email', 'test@example.com');
+    git(repo, 'config', 'user.name', 'Test');
+    commit(repo, 'seed.ts', 'seed');
+
+    git(repo, 'checkout', '-q', '-b', 'docs-branch');
+    const head = commit(repo, 'GUIDE.md', 'docs only');
+
+    git(repo, 'checkout', '-q', 'main');
+    const base = commit(repo, 'unrelated.ts', 'landed on the base after the branch point');
+
+    return { repo, base, head };
+  }
+
+  test('a docs-only branch skips even when the base branch moved on', () => {
+    const { repo, base, head } = docsBranchWithMovedBase();
+    // Seen red against the previous two-dot call: it also reported `unrelated.ts`.
+    expect(changedFilesBetween(base, head, repo)).toEqual(['GUIDE.md']);
+    expect(shouldRunTestSuite(changedFilesBetween(base, head, repo))).toBe(false);
+  });
+
+  test('a code change on the branch still runs the suite', () => {
+    const repo = trackTempRoot(mkdtempSync(join(tmpdir(), 'run-suite-diff-')));
+    git(repo, 'init', '-q', '-b', 'main');
+    git(repo, 'config', 'user.email', 'test@example.com');
+    git(repo, 'config', 'user.name', 'Test');
+    const base = commit(repo, 'seed.ts', 'seed');
+    git(repo, 'checkout', '-q', '-b', 'code-branch');
+    const head = commit(repo, 'feature.ts', 'real code');
+
+    expect(shouldRunTestSuite(changedFilesBetween(base, head, repo))).toBe(true);
+  });
+});
+
+describe('inert paths', () => {
+  test.each([
+    '.gitignore',
+    '.gitattributes',
+    'LICENSE',
+    '.env.example',
+    'Caddyfile.example',
+    '.archon/config.example.yaml',
+    'assets/logo.png',
+  ])('skips %s, which no check reads', file => {
+    expect(shouldRunTestSuite([file])).toBe(false);
+  });
+
+  test.each([
+    ['Dockerfile', 'the docker-build job'],
+    ['.dockerignore', 'the docker-build job'],
+    ['.prettierrc', 'format:check'],
+    ['homebrew/archon.rb', 'build:checksums'],
+    ['scripts/install.ps1', 'test:install'],
+    ['.github/workflows/test.yml', 'the gate itself'],
+    ['packages/web/public/favicon.png', 'the web build'],
+  ])('runs for %s, which is read by %s', file => {
+    expect(shouldRunTestSuite([file])).toBe(true);
   });
 });

--- a/scripts/should-run-test-suite.ts
+++ b/scripts/should-run-test-suite.ts
@@ -25,23 +25,70 @@ const BUILD_INPUTS = [
   'packages/docs-web/package.json',
 ];
 
+/**
+ * Paths that are not documentation but that no check reads, so changing one cannot alter a test
+ * or build outcome. The bar for an entry is the mirror of `BUILD_INPUTS`: nothing in `validate`,
+ * no test, and no workflow consumes the file's CONTENTS. Verified per entry, and every match
+ * found when this list was written was prose in a comment or a fixture string literal.
+ *
+ * Deliberately absent, each because a named check reads it: `Dockerfile` and friends plus
+ * `.dockerignore` (the `docker-build` job), `.prettierrc`/`.prettierignore` (`format:check`),
+ * `homebrew/archon.rb` (`build:checksums`), `scripts/install.ps1` (`test:install`), the web
+ * assets that feed the Docker image, and anything under `.github/workflows/` — changing the
+ * gate must run the gate.
+ *
+ * An entry ending in `/` matches a directory, anything else matches one file.
+ */
+const INERT_PATHS = [
+  '.gitignore',
+  '.gitattributes',
+  'LICENSE',
+  '.env.example',
+  'Caddyfile.example',
+  '.archon/config.example.yaml',
+  'assets/',
+];
+
+const isInert = (file: string): boolean =>
+  INERT_PATHS.some(entry => (entry.endsWith('/') ? file.startsWith(entry) : file === entry));
+
 const isBuildInput = (file: string): boolean =>
   BUILD_INPUTS.some(input => (input.endsWith('/') ? file.startsWith(input) : file === input));
 
-export function shouldRunTestSuite(changedFiles: Iterable<string>): boolean {
-  for (const file of changedFiles) {
-    if (isBuildInput(file) || (!file.endsWith('.md') && !file.startsWith(DOCS_DIRECTORY))) {
-      return true;
-    }
+export function shouldRunTestSuite(files: Iterable<string>): boolean {
+  for (const file of files) {
+    if (isBuildInput(file)) return true;
+    if (isInert(file) || file.endsWith('.md') || file.startsWith(DOCS_DIRECTORY)) continue;
+    return true;
   }
   return false;
 }
 
-function changedFiles(base: string, head: string): string[] {
-  const result = Bun.spawnSync(['git', 'diff', '--name-only', '--no-renames', base, head], {
-    stdout: 'pipe',
-    stderr: 'pipe',
-  });
+/**
+ * Files this change introduces, via a MERGE-BASE (three-dot) diff.
+ *
+ * Two-dot `git diff A B` reports every difference between the commits, so on a `pull_request`
+ * it also reports commits that landed on the base branch after the branch point and attributes
+ * them to the PR. One stray `.ts` path is enough to force the suite, which silently disabled
+ * this filter for any PR opened against a moving branch. Three-dot compares against the merge
+ * base, so it reports only what the branch itself changed.
+ *
+ * Correct for `push` too: `before` is an ancestor of `after`, so it is its own merge base and
+ * the two forms agree. Exported so a test can exercise the diff mode rather than only the
+ * pure decision below — a correct decision behind a wrong diff is exactly what shipped here.
+ *
+ * `repo` defaults to the process working directory, which is what the workflow runs in. It is a
+ * parameter because this function's answer depends entirely on which repository it reads.
+ */
+export function changedFilesBetween(base: string, head: string, repo = process.cwd()): string[] {
+  const result = Bun.spawnSync(
+    ['git', 'diff', '--name-only', '--no-renames', `${base}...${head}`],
+    {
+      cwd: repo,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    }
+  );
   if (result.exitCode !== 0) {
     throw new Error(`Could not read changed files: ${result.stderr.toString().trim()}`);
   }
@@ -59,7 +106,7 @@ function changedFiles(base: string, head: string): string[] {
  */
 function decideFromDiff(base: string, head: string): boolean {
   try {
-    return shouldRunTestSuite(changedFiles(base, head));
+    return shouldRunTestSuite(changedFilesBetween(base, head));
   } catch (error) {
     const cause = error instanceof Error ? error.message : String(error);
     console.error(`Could not compare ${base}..${head}, so the test suite runs: ${cause}`);


### PR DESCRIPTION
## Problem and outcome

The docs path filter from #2897 has never skipped anything on a real pull request. Its decision function is correct and its tests pass; the **call site** compared the wrong two commits.

`git diff base head` reports every difference between two commits. On a `pull_request`, `base` is the base branch's current tip, so the diff also reports whatever landed on `dev` after the branch point and attributes it to the PR. `shouldRunTestSuite` returns `true` on the first non-`.md` path, so one stray `.ts` file forces the full matrix.

- **Outcome:** a documentation-only PR skips the test matrix, schema-upgrade, postgres-parity and docker-build, regardless of what has landed on the base branch since it was opened.
- **Invariant:** the fail-safe direction is unchanged. An unreadable diff or an unreachable force-push SHA still runs the suite — an unnecessary run costs minutes, a wrong skip merges unchecked code.
- **Scope boundary:** one call site plus the skip list. Job gating in `test.yml` is untouched and was already correct.
- **Root cause:** two-dot `git diff A B` where a `pull_request` needs the merge-base form `git diff A...B`.

## Review guidance

- **Feedback requested:** the `INERT_PATHS` entries. Each is claimed to have no reader; that claim is the thing worth checking.
- **Start here:** `scripts/should-run-test-suite.ts` — `changedFilesBetween`.
- **Review order:** the diff fix, then `INERT_PATHS`, then the `diff mode` tests.
- **Known risk or uncertainty:** `INERT_PATHS` is a curated list, and a future file that looks inert but gains a reader would be skipped wrongly. Mitigated by keeping it short, documenting the bar, and naming what is deliberately excluded — but it is judgement, not a proof.

## Solution

**The fix is the merge-base form.** Correct for `push` too: `before` is an ancestor of `after`, so it is its own merge base and both forms agree. The existing try/catch that runs the suite when the diff fails is untouched.

**The repository is now an explicit parameter** (`repo = process.cwd()`), because this function's answer depends entirely on which repository it reads. That is also what makes the diff mode testable — and a correct function behind a wrong call site is exactly what shipped here unnoticed.

**Skip list.** Paths no check reads, each verified: `.gitignore`, `.gitattributes`, `LICENSE`, `.env.example`, `Caddyfile.example`, `.archon/config.example.yaml`, `assets/`. Every match found when writing the list was prose in a comment or a fixture string literal, never a content read. The docblock names what is deliberately absent and why — Dockerfiles and `.dockerignore` (docker-build), `.prettierrc`/`.prettierignore` (`format:check`), `homebrew/archon.rb` (`build:checksums`), `scripts/install.ps1` (`test:install`), the web assets feeding the image, and anything under `.github/workflows/`, since changing the gate must run the gate.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | A docs-only PR ran the full matrix whenever the base had moved, which is nearly always | It skips |
| **Failure behavior** | Unchanged: an unreadable diff or unreachable SHA still runs the suite |

## Validation

- `bun test ./scripts/should-run-test-suite.test.ts` — **34 pass, 0 fail**.
- **Seen red.** Reverting only the diff form to two-dot and rerunning: `(fail) diff mode > a docs-only branch skips even when the base branch moved on`, 33 pass / 1 fail. Restored: 34 pass. The new coverage fails against the exact defect being fixed rather than only passing afterwards.
- **Verified against the real reproduction.** Running `changedFilesBetween` on #3021's actual SHAs (`d215ac54a`, `00b6f3d96`) now returns `['AGENTS.md']` and `shouldRunTestSuite` returns `false`. Before the fix it also returned `scripts/migrate-state-dir.test.ts`, from PR #3001 merged an hour earlier, and decided `true`.
- `bun x tsc --noEmit -p scripts/tsconfig.json` — clean.
- `bun x eslint 'scripts/**/*.ts' --max-warnings 0 --no-warn-ignored` — exit 0.
- `bun x prettier --check` on both files — clean.
- **Not verified:** the end-to-end GitHub Actions behaviour. This PR changes `.ts` files, so its own run will not skip; the proof is the merge-base test plus the #3021 SHA check. The next docs-only PR is the live confirmation.

## Links

- Closes #3023
- Related #2897 — delivered the filter whose call site this corrects.
- Related #3022 — added `.archon/config.example.yaml`, one skip-list entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic test-suite decisions by accurately detecting changes relative to the merge base.
  * Prevented tests from running for documentation and other non-functional files that do not affect application behavior.
  * Continued triggering the test suite for source-code, repository, and configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->