### PR TITLE
docs: the input to a run is the contract

### DIFF
--- a/.claude/skills/archon-cli/SKILL.md
+++ b/.claude/skills/archon-cli/SKILL.md
@@ -39,18 +39,27 @@ Most requests land here. The short version; details in the running reference:
 
 1. Discover what exists: `archon workflow list`. Map the user's intent to a workflow
    by reading descriptions — never assume names from memory.
-2. Invoke detached by default (workflows are long-running):
+2. **Check the input before spending anything.** The message (or the issue, or the
+   document the run reads) is the contract the whole run is measured against. Hold it
+   against the six in `running-workflows.md` — problem, why it matters, why now,
+   outcome, invariants, acceptance. If any is missing, say which, propose a corrected
+   input, and get the user's agreement before launching. Do not silently improve it,
+   and do not launch anyway.
+3. Invoke detached by default (workflows are long-running):
 
    ```bash
    archon workflow run <workflow> --branch <branch-name> "<the work, as a clear message>" --detach
    ```
 
-3. Find the run id and monitor: `archon workflow runs --json`, then
+4. Find the run id and monitor: `archon workflow runs --json`, then
    `archon workflow get <run-id> --json`.
-4. When a run pauses at a gate, resolve it deliberately:
+5. When a run pauses at a gate, resolve it deliberately:
    see `manage-run/manage-runs.md`.
 
-Three hard rules:
+Four hard rules:
+
+- Never launch against a thin brief. A weak input does not produce a weak result — it
+  produces a confident, well-formed answer to the wrong question, at full price.
 
 - A fresh launch of an interactive-class workflow refuses `--detach`. Run that
   launch in the foreground as a background *task* of your harness. Once the run

--- a/.claude/skills/archon-cli/running-workflows/running-workflows.md
+++ b/.claude/skills/archon-cli/running-workflows/running-workflows.md
@@ -19,6 +19,49 @@ Map intent to workflow by reading the listed descriptions — never from memory 
 names you have seen elsewhere. If two names plausibly match, say which you picked
 and why in one line.
 
+## The input is the contract
+
+Everything the run does is measured against its input — the message, the issue body, or the
+document it reads. Archon governs how the work happens; it cannot supply what the user
+actually wanted. This is the highest-leverage moment in the whole flow, and it is before any
+money is spent.
+
+Check the input names all six. Solution steering is a seventh, optional, and last:
+
+1. **Problem to solve** — what is wrong today, concretely.
+2. **Why it is worth solving** — the cost of leaving it.
+3. **Why now** — what makes this the moment.
+4. **Desired outcome** — what is observably different afterwards.
+5. **Invariants** — what must stay true across any acceptable implementation.
+6. **Acceptance** — how completion is checked.
+
+**When something is missing, do not fix it silently and do not launch anyway.** Tell the user
+which of the six is absent, propose concrete wording, and let them decide. They own the
+contract; your job is to notice it is thin before it costs them a run.
+
+A useful shape:
+
+> Before I launch: this brief states the problem and the outcome, but not the invariants or
+> acceptance. Without acceptance the run decides for itself when it is done. Suggest adding:
+> "Acceptance: X passes, Y is covered by a test, Z is unchanged." Want me to run it with that,
+> or would you rather word it yourself?
+
+Two failure modes worth naming, because they look like diligence:
+
+- **Naming a solution before the problem is settled.** It narrows the run to the first guess
+  and hides better answers. If the user supplied one, keep it, but make sure the problem is
+  stated too — a run that only knows the proposed fix cannot tell you it was the wrong fix.
+- **Dropping steering the user actually holds.** Optional does not mean unwanted. If they have
+  said anywhere in the conversation how they want this done — reuse a primitive, avoid a
+  dependency, migrate rather than rewrite — carry it into the input as explicit steering. An
+  unstated preference cannot be honoured, and the user discovers it only in the diff.
+- **Silence about uncertainty.** An assumption stated in the brief is something the run can
+  contradict. An assumption left out is one it will quietly inherit.
+
+If the input is a GitHub issue, read the actual body before launching rather than trusting the
+title. Recommend edits to the issue itself when it is thin — the issue is the durable contract,
+and the next run against it inherits whatever you leave there.
+
 ## Invocation
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,31 @@ The governing rule is: **YAML coordinates. Code computes. Agents judge.** Read [
 - When stopping a process, target the recorded PID or exact bound port. Never kill by a broad process-name match.
 - Keep commits and pull requests focused. Do not mix unrelated cleanup into the requested outcome.
 
+## Running Archon workflows
+
+The input is the contract. A run is only as accurate as the brief it starts from, and a
+workflow cannot recover from a premise that was never stated — it will produce a confident,
+well-formed answer to the wrong question. Treat writing the input as the work, not the
+preamble to it.
+
+Before launching a run, the input — an issue body, a message, a document, whatever the run
+reads — must state:
+
+- the problem to solve;
+- why it is worth solving;
+- why now;
+- the desired outcome;
+- the invariants that must hold;
+- what acceptance looks like.
+
+Solution steering is optional and belongs last, but omitting it is a decision: the run then
+chooses its own approach. State a constraint you actually hold — reuse this primitive, no new
+dependency, migrate rather than rewrite — because an unstated preference cannot be honoured.
+Naming an implementation *before* the problem is settled narrows the run to your first guess.
+
+Do not launch a run against an input missing any of the six. Fix the input first, and say
+what you changed — a thin brief is cheaper to correct before a run than after one.
+
 ## Tests and validation
 
 - Add tests for meaningful behavior and failure modes. Do not preserve deleted features through regression-test clutter.

--- a/packages/docs-web/src/content/docs/getting-started/quick-start.md
+++ b/packages/docs-web/src/content/docs/getting-started/quick-start.md
@@ -29,6 +29,71 @@ archon workflow run assist "What does this codebase do?"
 archon workflow run smart-pr-review
 ```
 
+## The input is the contract
+
+That quoted message is not a prompt — it is the specification the whole run is measured
+against, and it is yours to write. Archon governs *how* the work happens: isolation, gates,
+retries, the audit trail. It cannot supply *what* you actually wanted. A vague brief does not
+produce a vague result; it produces a confident, well-structured answer to a question you did
+not ask, and you pay full price for it.
+
+The same applies wherever the run reads its input — a GitHub issue body, a message, a
+document. Whichever it is, make it say:
+
+| | |
+|---|---|
+| **Problem to solve** | What is wrong today, concretely. |
+| **Why it is worth solving** | The cost of leaving it alone. |
+| **Why now** | What makes this the moment. |
+| **Desired outcome** | What is observably different afterwards. |
+| **Invariants** | What must stay true across any acceptable implementation. |
+| **Acceptance** | How you will know it is done. |
+
+**Solution steering is optional — but silence is a choice too.** Leave it out and the run
+picks its own approach, which is often the right call: it has read the code and you may not
+have. If you *do* have an opinion about how — reuse this helper, do not add a dependency,
+follow the pattern in that module, this must be a migration rather than a rewrite — then say
+so in the input. An unstated preference is one the run cannot honour, and you will only find
+out when you read the diff.
+
+Put steering last, after the problem is stated. Leading with an implementation narrows the run
+to your first guess and hides better answers; adding it at the end constrains *how* without
+replacing *what*.
+
+A brief worth running looks like this:
+
+```bash
+archon workflow run archon-ship --branch fix/upload-timeout "$(cat <<'BRIEF'
+Problem: uploads over ~8 MB fail with a 504 after 30s. The proxy read timeout is
+30s and the upload handler streams to disk before responding, so any file large
+enough to take longer than that is rejected after the bytes were already sent.
+
+Why it matters: this is the top support complaint this month, and every failure
+wastes the user's full upload time before telling them.
+
+Why now: the new export feature ships next week and its files are 20-50 MB, so
+this moves from an edge case to the default path.
+
+Outcome: a 50 MB upload completes, and a genuinely stuck upload still fails
+rather than hanging forever.
+
+Invariants: no change to the storage layout or the public upload API; memory use
+must not scale with file size.
+
+Acceptance: a 50 MB upload succeeds end to end; a test covers the timeout path;
+the 30s proxy timeout is either raised deliberately or no longer on the path.
+
+Steering (optional): prefer streaming straight to storage over raising the
+timeout, if that holds the memory invariant. Do not add a queue for this.
+BRIEF
+)" --detach
+```
+
+Compare that with `"fix the upload bug"`. Both start a run. Only one can be checked.
+
+Being wrong in the brief is fine and normal — being *silent* is what costs. State the
+assumption you are unsure about, and the run has something to contradict.
+
 ## What's Next?
 
 For the full getting started guide -- installation, authentication, Web UI setup, CLI setup, and troubleshooting -- see the [Overview](/getting-started/overview/).


### PR DESCRIPTION
## Problem and outcome

A run is measured entirely against the input it starts from — a message, an issue body, a document. Archon governs *how* work happens: isolation, gates, retries, the audit trail. It cannot supply *what* was actually wanted. A thin brief does not produce a thin result; it produces a confident, well-structured answer to a question nobody asked, and it costs the same as a good one.

Nothing said so on any of the three surfaces where it matters: the project guidance agents read, the quickstart users read, or the skill that drives the CLI.

- **Outcome:** each audience learns that the input is the contract and what it must contain, and the CLI skill checks it before spending anything.
- **Invariant:** the user owns the contract. The agent flags what is missing and proposes wording; it never silently rewrites the brief and never launches against a thin one anyway.
- **Scope boundary:** prose on three surfaces. No engine change, no CLI behaviour change, no schema change.

## Review guidance

- **Feedback requested:** the six required elements and the worked example. This is your contract standard written down — check it says what you mean.
- **Start here:** `AGENTS.md`, the new "Running Archon workflows" section.
- **Review order:** `AGENTS.md`, then `quick-start.md` (the worked brief), then the skill.
- **Known risk or uncertainty:** None; prose only.

## Solution

The same rule in three voices.

**`AGENTS.md`** — project law for agents dogfooding Archon here. Terse: the six, steering last, do not launch against an input missing any of them.

**`quick-start.md`** — for users, framed as *the quoted message is not a prompt, it is the specification*. Carries a table of the six and a worked brief for a real-shaped bug, placed beside `"fix the upload bug"` so the difference is visible rather than asserted. Both start a run; only one can be checked.

**`archon-cli` skill** — as behaviour, in two places. A new step 2 in the quick spine ("check the input before spending anything") and a new first hard rule; then a fuller section in `running-workflows.md` with a suggested phrasing for raising it, and two failure modes that look like diligence. It also says to read a GitHub issue's actual body rather than trusting the title, and to recommend edits to the issue itself when thin — the issue is the durable contract, and the next run inherits whatever is left there.

**Solution steering** is a seventh element, optional, and last — but omitting it is a decision, because the run then picks its own approach. A preference the user holds and does not write down cannot be honoured, and they discover that in the diff. Placing it last constrains *how* without replacing *what*; leading with it narrows the run to the first guess.

## Validation

- `bun run build` in `packages/docs-web` — **85 pages built, Complete** — proves the quickstart's heredoc-in-a-fence renders.
- `bun run check:bundled-skill` — "bundled-skill.ts is up to date (9 files across 1 skills), and bundled skill metadata is valid" — proves the skill edits keep the CLI bundle consistent.
- `bun x prettier --check` on all four files — clean.
- Quick-spine renumbering verified by inspection: steps 1–5, four hard rules with the input rule first.
- **Not verified:** whether the guidance changes agent behaviour in practice. That shows up in the next runs, not in a check.

## Links

- Related #3024 — the other skill gap found in the same pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for defining complete workflow inputs, including the problem, value, timing, desired outcome, constraints, and acceptance criteria.
  - Clarified that workflow inputs serve as the governing contract for a run.
  - Added instructions to review incomplete briefs with the requester before launching.
  - Added a Quick Start example showing a fully specified workflow brief.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->