### PR TITLE
feat(core): core runtime and chat reliability improvements

### DIFF
--- a/packages/core/src/db/messages.test.ts
+++ b/packages/core/src/db/messages.test.ts
@@ -91,6 +91,19 @@ describe('messages', () => {
       ]);
     });
 
+    test('persists custom message id when provided', async () => {
+      mockQuery.mockResolvedValueOnce(createQueryResult([mockMessage]));
+
+      await addMessage('conv-456', 'user', 'Hello', undefined, undefined, 'custom-uuid-123');
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        `INSERT INTO remote_agent_messages (id, conversation_id, role, content, metadata, user_id, created_at)
+     VALUES ($1, $2, $3, $4, $5, $6, NOW())
+     RETURNING *`,
+        ['custom-uuid-123', 'conv-456', 'user', 'Hello', '{}', null]
+      );
+    });
+
     test('defaults metadata to empty object when not provided', async () => {
       mockQuery.mockResolvedValueOnce(createQueryResult([mockMessage]));
 

--- a/packages/core/src/db/messages.ts
+++ b/packages/core/src/db/messages.ts
@@ -25,15 +25,23 @@ export async function addMessage(
   role: 'user' | 'assistant',
   content: string,
   metadata?: Record<string, unknown>,
-  userId?: string
+  userId?: string,
+  id?: string
 ): Promise<MessageRow> {
   const dialect = getDialect();
-  const result = await pool.query<MessageRow>(
-    `INSERT INTO remote_agent_messages (conversation_id, role, content, metadata, user_id, created_at)
+  const result = id
+    ? await pool.query<MessageRow>(
+        `INSERT INTO remote_agent_messages (id, conversation_id, role, content, metadata, user_id, created_at)
+     VALUES ($1, $2, $3, $4, $5, $6, ${dialect.now()})
+     RETURNING *`,
+        [id, conversationId, role, content, JSON.stringify(metadata ?? {}), userId ?? null]
+      )
+    : await pool.query<MessageRow>(
+        `INSERT INTO remote_agent_messages (conversation_id, role, content, metadata, user_id, created_at)
      VALUES ($1, $2, $3, $4, $5, ${dialect.now()})
      RETURNING *`,
-    [conversationId, role, content, JSON.stringify(metadata ?? {}), userId ?? null]
-  );
+        [conversationId, role, content, JSON.stringify(metadata ?? {}), userId ?? null]
+      );
   const row = result.rows[0];
   if (!row) {
     throw new Error(

--- a/packages/core/src/db/workflows.test.ts
+++ b/packages/core/src/db/workflows.test.ts
@@ -22,6 +22,7 @@ mock.module('./connection', () => ({
 import {
   createWorkflowRun,
   getWorkflowRun,
+  findWorkflowRunsByIdPrefix,
   getWorkflowRunStatus,
   getActiveWorkflowRun,
   getActiveWorkflowRunByPath,
@@ -182,6 +183,42 @@ describe('workflows database', () => {
       const result = await getWorkflowRun('non-existent');
 
       expect(result).toBeNull();
+    });
+  });
+
+  describe('findWorkflowRunsByIdPrefix', () => {
+    test('finds workflow runs by id prefix with uuid text cast', async () => {
+      mockQuery.mockResolvedValueOnce(createQueryResult([mockWorkflowRun]));
+
+      const results = await findWorkflowRunsByIdPrefix('791ea29d', 'codebase-789');
+
+      expect(results).toEqual([mockWorkflowRun]);
+      expect(mockQuery).toHaveBeenCalledWith(
+        'SELECT * FROM remote_agent_workflow_runs WHERE codebase_id = $1 AND id::text LIKE $2 LIMIT 2',
+        ['codebase-789', '791ea29d%']
+      );
+    });
+
+    test('returns empty array for invalid prefix charset', async () => {
+      const results = await findWorkflowRunsByIdPrefix('invalid;drop', 'codebase-789');
+
+      expect(results).toEqual([]);
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+
+    test('returns empty array for empty prefix', async () => {
+      const results = await findWorkflowRunsByIdPrefix('', 'codebase-789');
+
+      expect(results).toEqual([]);
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+
+    test('throws on database error', async () => {
+      mockQuery.mockRejectedValueOnce(new Error('Connection refused'));
+
+      await expect(findWorkflowRunsByIdPrefix('791ea29d', 'codebase-789')).rejects.toThrow(
+        'Failed to find workflow runs by id prefix: Connection refused'
+      );
     });
   });
 

--- a/packages/core/src/db/workflows.ts
+++ b/packages/core/src/db/workflows.ts
@@ -497,8 +497,9 @@ export async function findWorkflowRunsByIdPrefix(
 ): Promise<WorkflowRun[]> {
   if (idPrefix.length === 0 || !/^[0-9a-fA-F-]+$/.test(idPrefix)) return [];
   try {
+    const idCondition = getDatabaseType() === 'postgresql' ? 'id::text LIKE $2' : 'id LIKE $2';
     const result = await pool.query<WorkflowRun>(
-      'SELECT * FROM remote_agent_workflow_runs WHERE codebase_id = $1 AND id LIKE $2 LIMIT 2',
+      `SELECT * FROM remote_agent_workflow_runs WHERE codebase_id = $1 AND ${idCondition} LIMIT 2`,
       [codebaseId, `${idPrefix}%`]
     );
     return result.rows.map(normalizeWorkflowRun);

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -1944,6 +1944,7 @@ export async function handleMessage(
     parentConversationId,
     isolationHints,
     attachedFiles,
+    abortSignal,
     userId,
   } = context ?? {};
   // Anchor "is this a slash command" at the true start of the message —
@@ -2501,6 +2502,7 @@ export async function handleMessage(
       protectedEnvKeys: protectedEnvKeys.length > 0 ? protectedEnvKeys : undefined,
       model: chatRequest.model,
       systemPrompt,
+      abortSignal,
     };
     if (chatRequest.preset) {
       applyPresetToRequestOptions(providerKey, chatRequest.preset, requestOptions);
@@ -2683,6 +2685,14 @@ export async function handleMessage(
     getLog().debug({ conversationId }, 'orchestrator_message_completed');
   } catch (error) {
     const err = toError(error);
+    if (
+      abortSignal?.aborted ||
+      err.name === 'AbortError' ||
+      err.message.toLowerCase().includes('abort')
+    ) {
+      getLog().info({ conversationId }, 'orchestrator_message_aborted');
+      return;
+    }
     getLog().error({ err, conversationId }, 'orchestrator_message_failed');
     const userMessage = classifyAndFormatError(err);
     try {
@@ -2801,6 +2811,10 @@ async function handleStreamMode(
       // pair raw — without it, direct chat would surface a spurious error to
       // the user and drop the actual conversation output.
       if (msg.isError && msg.errorSubtype !== 'success') {
+        if (requestOptions?.abortSignal?.aborted) {
+          getLog().info({ conversationId }, 'orchestrator_stream_turn_aborted');
+          return;
+        }
         getLog().warn(
           {
             conversationId,
@@ -3035,6 +3049,10 @@ async function handleBatchMode(
       // pair raw — without it, direct chat would surface a spurious error to
       // the user and drop the actual conversation output.
       if (msg.isError && msg.errorSubtype !== 'success') {
+        if (requestOptions?.abortSignal?.aborted) {
+          getLog().info({ conversationId }, 'orchestrator_batch_turn_aborted');
+          return;
+        }
         getLog().warn(
           {
             conversationId,

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -50,6 +50,10 @@ export interface HandleMessageContext {
   readonly isolationHints?: IsolationHints;
   readonly attachedFiles?: AttachedFile[];
   /**
+   * Optional AbortSignal to cancel/interrupt an in-flight orchestrator query.
+   */
+  readonly abortSignal?: AbortSignal;
+  /**
    * Archon user UUID resolved from the inbound platform user identifier.
    * Chat/forge adapters resolve this via findOrCreateUserByPlatformIdentity
    * before calling handleMessage. Undefined for web/CLI surfaces until their

--- a/packages/core/src/utils/error-formatter.ts
+++ b/packages/core/src/utils/error-formatter.ts
@@ -150,6 +150,18 @@ export function classifyAndFormatError(error: Error): string {
     return '⚠️ AI service authentication error. Please check your API key or credentials.';
   }
 
+  // AI Service Provider Outage / 503 Service Unavailable
+  if (
+    lower.includes('503') ||
+    lower.includes('service unavailable') ||
+    lower.includes('service_unavailable') ||
+    lower.includes('temporarily unavailable') ||
+    lower.includes('provider unavailable') ||
+    (lower.includes('overloaded') && !message.startsWith('Codex query failed:'))
+  ) {
+    return '⚠️ 503: Archon is fine, the AI service provider is currently DOWN.';
+  }
+
   // Network errors - timeout
   if (message.includes('timeout') || message.includes('ETIMEDOUT')) {
     return '⚠️ Request timed out. The AI service may be slow. Try again or use /reset.';

--- a/packages/server/src/routes/api.messages.test.ts
+++ b/packages/server/src/routes/api.messages.test.ts
@@ -38,6 +38,14 @@ const mockAddMessage = mock(
 const mockListMessages = mock(async (_conversationId: string, _limit?: number) => []);
 const mockHandleMessage = mock(async () => {});
 
+const mockPoolQuery = mock(() => Promise.resolve({ rows: [] }));
+
+mock.module('@archon/core/db/connection', () => ({
+  pool: {
+    query: mockPoolQuery,
+  },
+}));
+
 mock.module('@archon/core', () => ({
   handleMessage: mockHandleMessage,
   getDatabaseType: () => 'sqlite',
@@ -218,6 +226,8 @@ describe('POST /api/conversations/:id/message', () => {
     mockFindConversationByPlatformId.mockReset();
     mockHandleMessage.mockReset();
     mockAddMessage.mockReset();
+    mockPoolQuery.mockReset();
+    mockPoolQuery.mockResolvedValue({ rows: [] });
   });
 
   test('accepts a valid message and dispatches to orchestrator', async () => {
@@ -269,8 +279,58 @@ describe('POST /api/conversations/:id/message', () => {
       'user',
       'Test message',
       undefined,
+      undefined,
       undefined
     );
+  });
+
+  test('persists user message to DB with client-provided message id when valid', async () => {
+    const validUuid = '123e4567-e89b-12d3-a456-426614174000';
+    mockFindConversationByPlatformId.mockImplementationOnce(async () => MOCK_CONV);
+    mockPoolQuery.mockResolvedValueOnce({ rows: [] }); // unique check
+    mockAddMessage.mockImplementationOnce(async () => ({
+      id: validUuid,
+      conversation_id: MOCK_CONV.id,
+      role: 'user' as const,
+      content: 'Hello UUID',
+      metadata: '{}',
+      created_at: new Date().toISOString(),
+    }));
+    mockHandleMessage.mockImplementationOnce(async () => {});
+
+    const { app } = makeApp();
+    const response = await app.request('/api/conversations/web-test-abc/message', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: 'Hello UUID', id: validUuid }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mockAddMessage).toHaveBeenCalledWith(
+      MOCK_CONV.id,
+      'user',
+      'Hello UUID',
+      undefined,
+      undefined,
+      validUuid
+    );
+  });
+
+  test('rejects an invalid message ID format', async () => {
+    const invalidUuid = 'not-a-uuid';
+    mockFindConversationByPlatformId.mockImplementationOnce(async () => MOCK_CONV);
+
+    const { app } = makeApp();
+    const response = await app.request('/api/conversations/web-test-abc/message', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: 'Hello UUID', id: invalidUuid }),
+    });
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe('Invalid message ID format');
+    expect(mockAddMessage).not.toHaveBeenCalled();
   });
 
   test('still dispatches when conversation lookup fails (no message persistence)', async () => {

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -265,6 +265,7 @@ import * as isolationEnvDb from '@archon/core/db/isolation-environments';
 import * as workflowDb from '@archon/core/db/workflows';
 import * as workflowEventDb from '@archon/core/db/workflow-events';
 import * as messageDb from '@archon/core/db/messages';
+import { pool } from '@archon/core/db/connection';
 import * as userDb from '@archon/core/db/users';
 import {
   abandonWorkflow,
@@ -708,6 +709,24 @@ const sendMessageRoute = createRoute({
       description: 'Accepted',
     },
     400: jsonError('Bad request'),
+    500: jsonError('Server error'),
+  },
+});
+
+const stopConversationRoute = createRoute({
+  method: 'post',
+  path: '/api/conversations/{id}/stop',
+  tags: ['Conversations'],
+  summary: 'Stop an in-progress conversation orchestrator run',
+  request: {
+    params: conversationIdParamsSchema,
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: successResponseSchema } },
+      description: 'Stopped',
+    },
+    404: jsonError('Not found'),
     500: jsonError('Server error'),
   },
 });
@@ -2393,12 +2412,17 @@ export function registerApiRoutes(
     return { ok: true, savedFiles, uploadDir };
   }
 
+  const conversationAbortControllers = new Map<string, AbortController>();
+
   async function dispatchToOrchestrator(
     conversationId: string,
     message: string,
     extraContext?: Omit<HandleMessageContext, 'isolationHints'>,
     filesToCleanup?: { files: AttachedFile[]; uploadDir: string }
   ): Promise<{ accepted: boolean; status: string }> {
+    const abortController = new AbortController();
+    conversationAbortControllers.set(conversationId, abortController);
+
     const result = await lockManager.acquireLock(conversationId, async () => {
       // Emit lock:true at handler start so the UI knows processing has begun.
       // Fire-and-forget — if no SSE stream is connected yet, the event is buffered.
@@ -2406,9 +2430,14 @@ export function registerApiRoutes(
       try {
         await handleMessage(webAdapter, conversationId, message, {
           isolationHints: { workflowType: 'thread', workflowId: conversationId },
+          abortSignal: abortController.signal,
           ...extraContext,
         });
       } catch (error) {
+        if (abortController.signal.aborted) {
+          getLog().info({ conversationId }, 'dispatch_to_orchestrator_aborted');
+          return;
+        }
         getLog().error({ err: error, conversationId }, 'handle_message_failed');
         try {
           await webAdapter.emitSSE(
@@ -2424,6 +2453,9 @@ export function registerApiRoutes(
           getLog().error({ err: sseError, conversationId }, 'sse_error_emit_failed');
         }
       } finally {
+        if (conversationAbortControllers.get(conversationId) === abortController) {
+          conversationAbortControllers.delete(conversationId);
+        }
         await webAdapter.emitLockEvent(conversationId, false);
         // Clean up uploaded files AFTER handleMessage completes so the AI subprocess
         // has had a chance to read them. Doing this in the HTTP handler's finally block
@@ -2733,7 +2765,7 @@ export function registerApiRoutes(
   // Accepts optional `message` field for atomic create+send (avoids ghost "Untitled" entries)
   registerOpenApiRoute(createConversationRoute, async c => {
     try {
-      const { codebaseId, message } = getValidatedBody(c, createConversationBodySchema);
+      const { codebaseId, message, messageId } = getValidatedBody(c, createConversationBodySchema);
       const userId = await resolveWebUserId(c);
 
       // Validate codebase exists if provided
@@ -2742,6 +2774,38 @@ export function registerApiRoutes(
         if (!codebase) {
           return apiError(c, 400, 'Codebase not found', `No codebase with id "${codebaseId}"`);
         }
+      }
+
+      let providedMessageId: string | undefined;
+      if (messageId) {
+        // Validate uuid shape
+        const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+        if (!uuidRegex.test(messageId)) {
+          return apiError(
+            c,
+            400,
+            'Invalid message ID format',
+            'Provided message ID must be a valid UUID'
+          );
+        }
+        // Validate uniqueness
+        try {
+          const existing = await pool.query('SELECT 1 FROM remote_agent_messages WHERE id = $1', [
+            messageId,
+          ]);
+          if (existing.rows.length > 0) {
+            return apiError(
+              c,
+              400,
+              'Message ID already exists',
+              'Provided message ID must be unique'
+            );
+          }
+        } catch (dbErr: unknown) {
+          getLog().error({ err: dbErr, messageId }, 'message_id_uniqueness_check_failed');
+          return apiError(c, 500, 'Database check failed');
+        }
+        providedMessageId = messageId;
       }
 
       const conversationId = `web-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -2758,7 +2822,14 @@ export function registerApiRoutes(
       // If message provided, dispatch it atomically (avoids ghost "Untitled" conversations)
       if (message) {
         try {
-          await messageDb.addMessage(conversation.id, 'user', message, undefined, userId);
+          await messageDb.addMessage(
+            conversation.id,
+            'user',
+            message,
+            undefined,
+            userId,
+            providedMessageId
+          );
         } catch (e: unknown) {
           // Log only (no SSE warning) — the SSE stream isn't connected yet for new conversations.
           // The existing /message endpoint emits a warning because the stream is guaranteed to be active.
@@ -2881,6 +2952,7 @@ export function registerApiRoutes(
     let message: string;
     let savedFiles: AttachedFile[] = [];
     let uploadDir = '';
+    let providedMessageId: string | undefined;
 
     const contentType = c.req.header('content-type') ?? '';
 
@@ -2898,6 +2970,11 @@ export function registerApiRoutes(
         return c.json({ error: 'message must be a non-empty string' }, 400);
       }
       message = rawMessage;
+
+      const rawId = body.id;
+      if (typeof rawId === 'string' && rawId) {
+        providedMessageId = rawId;
+      }
 
       const rawFiles = body.files;
       let fileList: (string | File)[];
@@ -2920,7 +2997,7 @@ export function registerApiRoutes(
         getLog().info({ conversationId, fileCount: savedFiles.length }, 'message.files_uploaded');
       }
     } else {
-      let body: { message?: unknown };
+      let body: { message?: unknown; id?: unknown };
       try {
         body = await c.req.json();
       } catch (parseErr: unknown) {
@@ -2932,6 +3009,33 @@ export function registerApiRoutes(
         return c.json({ error: 'message must be a non-empty string' }, 400);
       }
       message = body.message;
+
+      if (typeof body.id === 'string' && body.id) {
+        providedMessageId = body.id;
+      }
+    }
+
+    if (providedMessageId) {
+      // Validate uuid shape
+      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+      if (!uuidRegex.test(providedMessageId)) {
+        return c.json({ error: 'Invalid message ID format' }, 400);
+      }
+      // Validate uniqueness
+      try {
+        const existing = await pool.query('SELECT 1 FROM remote_agent_messages WHERE id = $1', [
+          providedMessageId,
+        ]);
+        if (existing.rows.length > 0) {
+          return c.json({ error: 'Message ID already exists' }, 400);
+        }
+      } catch (dbErr: unknown) {
+        getLog().error(
+          { err: dbErr, messageId: providedMessageId },
+          'message_id_uniqueness_check_failed'
+        );
+        return c.json({ error: 'Database check failed' }, 500);
+      }
     }
 
     // Look up conversation for message persistence
@@ -2951,7 +3055,7 @@ export function registerApiRoutes(
           ? { files: savedFiles.map(f => ({ name: f.name, mimeType: f.mimeType, size: f.size })) }
           : undefined;
       try {
-        await messageDb.addMessage(conv.id, 'user', message, meta, userId);
+        await messageDb.addMessage(conv.id, 'user', message, meta, userId, providedMessageId);
       } catch (e: unknown) {
         getLog().error({ err: e, conversationId: conv.id }, 'message_persistence_failed');
         try {
@@ -2986,6 +3090,27 @@ export function registerApiRoutes(
       filesToCleanup
     );
     return c.json(result);
+  });
+
+  // POST /api/conversations/:id/stop - Interrupt active orchestrator run
+  registerOpenApiRoute(stopConversationRoute, async c => {
+    const platformConversationId = c.req.param('id') ?? '';
+    try {
+      const conv = await conversationDb.findConversationByPlatformId(platformConversationId);
+      if (!conv) {
+        return apiError(c, 404, 'Conversation not found');
+      }
+      const controller = conversationAbortControllers.get(platformConversationId);
+      if (controller) {
+        controller.abort();
+        conversationAbortControllers.delete(platformConversationId);
+      }
+      webAdapter.emitLockEvent(platformConversationId, false);
+      return c.json({ success: true });
+    } catch (error) {
+      getLog().error({ err: error }, 'stop_conversation_failed');
+      return apiError(c, 500, 'Failed to stop conversation run');
+    }
   });
 
   // GET /api/stream/__dashboard__ — multiplexed dashboard SSE (all workflow events)

--- a/packages/server/src/routes/schemas/conversation.schemas.ts
+++ b/packages/server/src/routes/schemas/conversation.schemas.ts
@@ -38,6 +38,7 @@ export const createConversationBodySchema = z
   .object({
     codebaseId: z.string().optional(),
     message: z.string().optional(),
+    messageId: z.string().optional(),
   })
   .strict()
   .openapi('CreateConversationBody');
@@ -76,13 +77,17 @@ export const messageListResponseSchema = z.array(messageSchema).openapi('Message
 
 /** POST /api/conversations/:id/message JSON request body. */
 export const sendMessageBodySchema = z
-  .object({ message: z.string().min(1) })
+  .object({
+    message: z.string().min(1),
+    id: z.string().optional(),
+  })
   .openapi('SendMessageBody');
 
 /** POST /api/conversations/:id/message multipart request body (file uploads). */
 export const sendMessageMultipartSchema = z
   .object({
     message: z.string().min(1),
+    id: z.string().optional(),
     files: z
       .array(z.string().openapi({ format: 'binary' }))
       .max(5)

--- a/packages/web/src/components/chat/ChatInterface.tsx
+++ b/packages/web/src/components/chat/ChatInterface.tsx
@@ -19,6 +19,7 @@ import {
   createConversation,
   getWorkflowRunByWorker,
   getHealth,
+  stopConversationRun,
 } from '@/lib/api';
 import type { ConversationResponse, CodebaseResponse, MessageResponse } from '@/lib/api';
 import type {
@@ -97,6 +98,21 @@ function mapMessageRow(row: MessageResponse): ChatMessage {
     timestamp: new Date(ensureUtc(row.created_at)).getTime(),
     isStreaming: false,
   };
+}
+
+function safeRandomUUID(): string {
+  if (typeof window !== 'undefined' && window.crypto?.randomUUID) {
+    try {
+      return window.crypto.randomUUID();
+    } catch {
+      // fall through to the manual UUID fallback below
+    }
+  }
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
 }
 
 interface ChatInterfaceProps {
@@ -181,19 +197,39 @@ export function ChatInterface({
           // survive hydration regardless of isStreaming state.
           // Note: dedup below relies on SSE messages using 'msg-{timestamp}' IDs that
           // never match DB-assigned IDs. Keep SSE IDs synthetic to preserve this invariant.
-          const activeSSE = prev.filter(
-            m =>
-              m.role === 'system' ||
-              (m.isStreaming && (m.content || sendActive)) ||
-              (m.toolCalls && m.toolCalls.length > 0)
-          );
-          if (activeSSE.length === 0) return hydrated;
-          // Merge: DB is canonical, append SSE-only messages that aren't yet in DB.
-          // Identify which SSE messages are already covered by hydrated DB data to avoid dupes.
           const hydratedIds = new Set(hydrated.map(m => m.id));
-          const sseOnly = activeSSE.filter(m => !hydratedIds.has(m.id));
-          if (sseOnly.length === 0) return hydrated;
-          const merged = [...hydrated, ...sseOnly];
+          const systemMessages = prev.filter(m => m.role === 'system' && !hydratedIds.has(m.id));
+          const errorMessages = prev.filter(
+            m => Boolean(m.error) && !hydratedIds.has(m.id) && !m.content && !m.toolCalls?.length
+          );
+          const unpersistedUserMessages = prev.filter(
+            m => m.role === 'user' && !hydratedIds.has(m.id)
+          );
+          const lastHydrated = hydrated[hydrated.length - 1];
+          const hasCompletedAssistantTurn = lastHydrated?.role === 'assistant';
+          const streamingMessages = prev.filter(m => {
+            if (!m.isStreaming) return false;
+            if (hydratedIds.has(m.id)) return false;
+            if (!m.content && (!m.toolCalls || m.toolCalls.length === 0)) {
+              return sendActive && !hasCompletedAssistantTurn;
+            }
+            return !hasCompletedAssistantTurn;
+          });
+          if (
+            systemMessages.length === 0 &&
+            errorMessages.length === 0 &&
+            unpersistedUserMessages.length === 0 &&
+            streamingMessages.length === 0
+          ) {
+            return hydrated;
+          }
+          const merged = [
+            ...hydrated,
+            ...systemMessages,
+            ...errorMessages,
+            ...unpersistedUserMessages,
+            ...streamingMessages,
+          ];
           merged.sort((a, b) => a.timestamp - b.timestamp);
           return merged;
         });
@@ -457,18 +493,14 @@ export function ChatInterface({
             setMessages(prev => {
               const hydratedIds = new Set(hydrated.map(m => m.id));
               // Keep only meaningful client-only messages not present in hydrated set.
-              // Exclude optimistic user rows and empty thinking placeholders.
+              // Keep only client system messages and transient error cards not in DB.
+              // Persisted DB messages (hydrated) are canonical for assistant responses.
               const clientOnly = prev.filter(m => {
                 if (hydratedIds.has(m.id)) return false;
                 if (m.role === 'system') return true;
-                if (m.role !== 'assistant') return false;
-                return (
-                  Boolean(m.content) ||
-                  Boolean(m.error) ||
-                  Boolean(m.workflowDispatch) ||
-                  Boolean(m.workflowResult) ||
-                  Boolean(m.toolCalls?.length)
-                );
+                if (m.error && !m.content && (!m.toolCalls || m.toolCalls.length === 0))
+                  return true;
+                return false;
               });
               if (clientOnly.length === 0) return hydrated;
               // Interleave client-only messages at their original positions by timestamp
@@ -586,22 +618,34 @@ export function ChatInterface({
     ...workflowSSEHandlers,
   });
 
+  const handleStop = useCallback(async () => {
+    try {
+      await stopConversationRun(conversationId);
+      setSending(false);
+      setLocked(false);
+    } catch (err) {
+      console.error('Failed to stop run:', err);
+    }
+  }, [conversationId]);
+
   const handleSend = useCallback(
     async (message: string, uploadedFiles?: File[]): Promise<void> => {
       // Build lightweight attachment metadata for optimistic UI display
       const fileAttachments: FileAttachment[] | undefined =
         uploadedFiles && uploadedFiles.length > 0
           ? uploadedFiles.map(f => ({
-              id: crypto.randomUUID(),
+              id: safeRandomUUID(),
               name: f.name,
               mimeType: f.type,
               size: f.size,
             }))
           : undefined;
 
+      const messageId = safeRandomUUID();
+
       // Add user message + thinking indicator to UI immediately
       const userMsg: ChatMessage = {
-        id: nextId(),
+        id: messageId,
         role: 'user',
         content: message,
         timestamp: Date.now(),
@@ -627,7 +671,8 @@ export function ChatInterface({
         try {
           const { conversationId: newId } = await createConversation(
             selectedProjectId ?? undefined,
-            message
+            message,
+            messageId
           );
           targetConversationId = newId;
           // Cache messages under the new ID so the remounted ChatInterface picks them up
@@ -659,7 +704,7 @@ export function ChatInterface({
       }
 
       try {
-        await apiSendMessage(targetConversationId, message, uploadedFiles);
+        await apiSendMessage(targetConversationId, message, uploadedFiles, messageId);
         // Invalidate conversations cache once after first non-command message
         // so the auto-generated title appears in the sidebar immediately
         if (!hasTriggeredTitleRefresh.current && !message.startsWith('/')) {
@@ -742,6 +787,8 @@ export function ChatInterface({
           isStreaming ||
           (currentConv != null && currentConv.platform_type !== 'web')
         }
+        isRunning={sending || locked || isStreaming}
+        onStop={handleStop}
         disabledReason={
           currentConv != null && currentConv.platform_type !== 'web'
             ? 'Continuing chats from other platforms in the Web UI is coming soon'

--- a/packages/web/src/components/chat/MessageInput.tsx
+++ b/packages/web/src/components/chat/MessageInput.tsx
@@ -8,7 +8,7 @@ import {
   type DragEvent,
   type ClipboardEvent,
 } from 'react';
-import { ArrowUp, Loader2, Paperclip, X } from 'lucide-react';
+import { ArrowUp, Loader2, Paperclip, X, Square } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
 /** Binary (non-text) MIME types explicitly accepted */
@@ -109,6 +109,8 @@ interface MessageInputProps {
   onSend: (message: string, files?: File[]) => void;
   disabled: boolean;
   disabledReason?: string;
+  isRunning?: boolean;
+  onStop?: () => void;
 }
 
 export interface MessageInputHandle {
@@ -122,7 +124,7 @@ function formatBytes(bytes: number): string {
 }
 
 const messageInput = forwardRef<MessageInputHandle, MessageInputProps>(function MessageInputInner(
-  { onSend, disabled, disabledReason }: MessageInputProps,
+  { onSend, disabled, disabledReason, isRunning = false, onStop }: MessageInputProps,
   ref
 ): React.ReactElement {
   const [value, setValue] = useState('');
@@ -317,18 +319,31 @@ const messageInput = forwardRef<MessageInputHandle, MessageInputProps>(function 
             className="flex-1 resize-none overflow-hidden rounded-lg border border-border bg-background px-4 py-2 text-sm leading-6 text-text-primary placeholder:text-text-tertiary focus:border-primary focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
             style={{ minHeight: '40px', maxHeight: '200px' }}
           />
-          <Button
-            onClick={handleSend}
-            disabled={disabled || !value.trim()}
-            size="icon"
-            className="h-10 w-10 shrink-0 rounded-lg bg-primary text-primary-foreground hover:bg-accent-hover disabled:opacity-50"
-          >
-            {disabled && !disabledReason ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : (
-              <ArrowUp className="h-4 w-4" />
-            )}
-          </Button>
+          {isRunning ? (
+            <Button
+              type="button"
+              onClick={onStop}
+              size="icon"
+              className="h-10 w-10 shrink-0 rounded-lg bg-destructive text-destructive-foreground hover:bg-destructive/90 transition-colors"
+              aria-label="Stop run"
+              title="Stop run"
+            >
+              <Square className="h-4 w-4 fill-current" />
+            </Button>
+          ) : (
+            <Button
+              onClick={handleSend}
+              disabled={disabled || !value.trim()}
+              size="icon"
+              className="h-10 w-10 shrink-0 rounded-lg bg-primary text-primary-foreground hover:bg-accent-hover disabled:opacity-50"
+            >
+              {disabled && !disabledReason ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <ArrowUp className="h-4 w-4" />
+              )}
+            </Button>
+          )}
         </div>
       </div>
     </div>

--- a/packages/web/src/experiments/console/skills/conversations.ts
+++ b/packages/web/src/experiments/console/skills/conversations.ts
@@ -28,13 +28,15 @@ interface CreateConversationResponse {
 
 export async function createConversation(
   projectId: string,
-  message?: string
+  message?: string,
+  messageId?: string
 ): Promise<CreateConversationResponse> {
+  const body: Record<string, string> = { codebaseId: projectId };
+  if (message !== undefined) body.message = message;
+  if (messageId !== undefined) body.messageId = messageId;
   return requestJson<CreateConversationResponse>('/api/conversations', {
     method: 'POST',
-    body: JSON.stringify(
-      message !== undefined ? { codebaseId: projectId, message } : { codebaseId: projectId }
-    ),
+    body: JSON.stringify(body),
   });
 }
 
@@ -48,14 +50,15 @@ export async function listConversations(projectId: string): Promise<Conversation
 export async function sendMessage(
   conversationPlatformId: string,
   message: string,
-  files?: File[]
+  files?: File[],
+  messageId?: string
 ): Promise<void> {
   const url = `/api/conversations/${encodeURIComponent(conversationPlatformId)}/message`;
 
   if (files === undefined || files.length === 0) {
     await requestJson<{ accepted: boolean; status: string }>(url, {
       method: 'POST',
-      body: JSON.stringify({ message }),
+      body: JSON.stringify({ message, id: messageId }),
     });
     return;
   }
@@ -63,6 +66,9 @@ export async function sendMessage(
   // Multipart path: don't set Content-Type — the browser adds the boundary.
   const form = new FormData();
   form.append('message', message);
+  if (messageId) {
+    form.append('id', messageId);
+  }
   for (const file of files) {
     form.append('files', file, file.name);
   }

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -141,11 +141,13 @@ export async function listConversations(codebaseId?: string): Promise<Conversati
 
 export async function createConversation(
   codebaseId?: string,
-  message?: string
+  message?: string,
+  messageId?: string
 ): Promise<{ conversationId: string; id: string; dispatched?: boolean }> {
   const body: Record<string, string> = {};
   if (codebaseId) body.codebaseId = codebaseId;
   if (message) body.message = message;
+  if (messageId) body.messageId = messageId;
 
   return fetchJSON('/api/conversations', {
     method: 'POST',
@@ -169,10 +171,18 @@ export async function deleteConversation(id: string): Promise<{ success: boolean
   return fetchJSON(`/api/conversations/${encodeURIComponent(id)}`, { method: 'DELETE' });
 }
 
+export async function stopConversationRun(conversationId: string): Promise<{ success: boolean }> {
+  const url = `/api/conversations/${encodeURIComponent(conversationId)}/stop`;
+  return fetchJSON(url, {
+    method: 'POST',
+  });
+}
+
 export async function sendMessage(
   conversationId: string,
   message: string,
-  files?: File[]
+  files?: File[],
+  messageId?: string
 ): Promise<{ accepted: boolean; status: string }> {
   const url = `/api/conversations/${encodeURIComponent(conversationId)}/message`;
 
@@ -180,12 +190,15 @@ export async function sendMessage(
     return fetchJSON(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ message }),
+      body: JSON.stringify({ message, id: messageId }),
     });
   }
 
   const form = new FormData();
   form.append('message', message);
+  if (messageId) {
+    form.append('id', messageId);
+  }
   for (const file of files) {
     form.append('files', file, file.name);
   }


### PR DESCRIPTION
## Problem and outcome

Enhances core runtime and chat streaming reliability across message persistence, run interruption, PostgreSQL UUID queries, and upstream outage classification.

- **Outcome:** 
  1. Messages can be persisted with client-supplied UUIDs, eliminating duplicate messages during SSE stream-to-persisted hydration reconciliation.
  2. Running conversation turns and workflows can be stopped cleanly via an AbortSignal mechanism wired from `POST /api/conversations/:id/stop` and a UI stop button.
  3. Prefix run searches in PostgreSQL handle UUID columns with dialect-appropriate casts (`id::text LIKE $2` for Postgres, `id LIKE $2` for SQLite).
  4. Upstream 503 and service provider outage errors are explicitly classified and surfaced with clear provider-down attribution.
- **Invariant:** Existing SQLite and PostgreSQL database operations continue to operate identically without breaking schema changes.
- **Scope boundary:** Does not modify external CLI or background worker execution architectures.

## Review guidance

- **Feedback requested:** Correctness of message reconciliation, AbortSignal propagation through orchestrator agent, and PostgreSQL UUID prefix query compatibility.
- **Start here:** `packages/server/src/routes/api.ts:2412` — Stop endpoint handling and client-side message ID persistence.
- **Review order:**
  1. `packages/core/src/db/messages.ts` and `packages/core/src/db/workflows.ts` (DB persistence and dialect branching)
  2. `packages/server/src/routes/api.ts` (Stop route and message ID validation)
  3. `packages/core/src/orchestrator/orchestrator-agent.ts` (AbortSignal wiring)
  4. `packages/web/src/components/chat/ChatInterface.tsx` and `packages/web/src/components/chat/MessageInput.tsx` (UI stop button and client UUID hydration reconciliation)
- **Lower-attention areas:** `packages/web/src/experiments/console/skills/conversations.ts` and `packages/web/src/lib/api.ts` (type signature updates).
- **Known risk or uncertainty:** None.

## Solution

1. **Client Message ID Persistence**: Updates `addMessage` in `packages/core/src/db/messages.ts` and `/api/conversations/:id/message` route to accept optional client UUIDs. `ChatInterface.tsx` uses deterministic client-generated UUIDs so that SSE streaming chunks match persisted history items during post-stream database hydration without duplicate renders.
2. **In-Flight Run Cancellation via AbortSignal**: Introduces `abortSignal` on `HandleMessageContext` and `SendQueryOptions`. `packages/server/src/routes/api.ts` tracks active conversation `AbortController`s and provides `POST /api/conversations/:id/stop` to trigger immediate aborts. The web UI toggles the send button into a stop button when a query is running.
3. **Dialect-Aware Workflow Run Prefix Query**: Updates `findWorkflowRunsByIdPrefix` in `packages/core/src/db/workflows.ts` to branch dynamically between `id::text LIKE $2` on PostgreSQL and `id LIKE $2` on SQLite.
4. **503 Outage Error Classification**: Adds 503 HTTP status and service downtime patterns to `classifyAndFormatError` in `packages/core/src/utils/error-formatter.ts`.

## Behavior change

| | Before | After |
|---|---|---|
| **Message hydration** | Server generates random UUID on insert; streaming-to-persisted transition could produce temporary message flicker/duplicates | Client supplies message UUID; persisted row matches client state immediately |
| **Running turn control** | User cannot stop a long-running response or tool execution in the web UI | Stop button cancels running turn via `POST /api/conversations/:id/stop` and AbortSignal |
| **PostgreSQL run lookup** | Prefix search fails on PostgreSQL when querying UUID column with string LIKE | Prefix search casts `id::text` dynamically on PostgreSQL |
| **Provider 503 errors** | Generic error messages shown to user | Explicit notification that the upstream AI service provider is experiencing an outage |

## Validation

- `bun run type-check` — passes with 0 errors across all packages.
- `bun run lint` — passes with 0 warnings/errors.
- `bun test packages/core/src/db/messages.test.ts` — passes (persists custom message id when provided).
- `bun test packages/core/src/db/workflows.test.ts` — passes (finds workflow runs by id prefix with uuid text cast).
- `bun test packages/server/src/routes/api.messages.test.ts` — passes (persists user message to DB with client-provided message id when valid, rejects invalid message ID format).
- **Not verified:** Live production multi-tenant database clusters; covered via comprehensive SQLite and PostgreSQL mocked dialect unit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Stop button to cancel in-progress conversation runs.
  * Added support for preserving client-generated message IDs.
  * Improved message display during streaming, errors, and reconnections.
* **Bug Fixes**
  * AI provider outages now show a clear, dedicated availability message.
  * Improved workflow run lookup across supported database platforms.
  * Cancelled requests no longer surface unnecessary errors to the user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->