### PR TITLE
docs: fix drift on the path you touch

### DIFF
--- a/.archon/engineering.md
+++ b/.archon/engineering.md
@@ -32,6 +32,7 @@ These describe where the engineering is going. Do not reject a change for failin
 ## Taste
 
 - The smallest truthful system. Every validator, guard, state, and compatibility path protects a named requirement or a concrete failure mode. Before adding machinery, look for machinery to delete.
+- Fix drift on the path you touch. When a change reveals two sites that should agree and do not — one recording a field the other omits, one performing a cleanup the other skips — correct them rather than carry the disagreement forward. A pure-move diff is easier to review, and that is not enough: deferring buys a second change and a second review that usually never come, while the drift keeps producing the defect that exposed it. Code is cheap; a second run is not. The bound is relevance, not size — correct what the change already touches, not what it merely noticed.
 - Types carry invariants. Invalid states should be hard to represent; a sound type beats a runtime check beats a comment. Escape hatches carry a justification or they are findings.
 - Explicit control flow over meta-programming, shared mutable state, or hidden coupling. Duplicate small local logic until a pattern has repeated and stabilized.
 - Fail early and loudly on unsupported, ambiguous, or unsafe states. A fallback is intentional, documented at the branch, and observable, or it is a bug.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ This file is the canonical project guidance for coding agents. Keep it short, du
 
 - Apply KISS and YAGNI. Do not add configuration, interfaces, lifecycle states, compatibility paths, or guards without a current requirement or concrete failure mode.
 - Before adding machinery, look for dead, redundant, or superseded machinery on the same path that can disappear.
+- Fix drift on the path you touch rather than preserving it for a cleaner diff. Two sites that should agree and do not are a defect, not a diff-size decision.
 - Duplicate small local logic when it keeps ownership clear. Extract only after a pattern has repeated and stabilized.
 - Prefer explicit control flow and narrow typed interfaces over meta-programming, shared mutable state, or hidden coupling.
 - Keep policy, transport, persistence, and execution concerns separate.


### PR DESCRIPTION
## Problem and outcome

Settled while designing #2698. Its four terminal-failure blocks disagree on whether `node_failed` carries `duration_ms` — two record it, two do not — and the issue's own acceptance asked for *"the same events, the same payloads, the same order"*. Followed literally, that would have preserved a known defect in order to keep the diff a pure move.

The rule that resolves it was not written down anywhere. `engineering.md` says *"before adding machinery, look for machinery to delete"*, which is adjacent but different: that is about deletion, this is about **correction**.

- **Outcome:** a change that exposes drift on the path it is already touching corrects it, and nobody has to relitigate that against a "keep the diff clean" argument.
- **Invariant:** the bound is unchanged. Relevance, not size — what the change already touches, never what it merely noticed.
- **Scope boundary:** two prose lines. No code, no pack change.

## Review guidance

- **Feedback requested:** wording. Both lines were drafted with the operator; this is the last look before they become law.
- **Start here:** `.archon/engineering.md` under Taste — the fuller statement.
- **Known risk or uncertainty:** "fix drift" can be read as licence to widen scope. Mitigated by keeping the bound where it already lives rather than repeating it — see below.

## Solution

The two documents are layered by design (`AGENTS.md`: *"put aspirational engineering craft and review values in `.archon/engineering.md`"*), so they carry different halves rather than two copies of one rule.

**`engineering.md`** — the reasoning:

> Fix drift on the path you touch. When a change reveals two sites that should agree and do not — one recording a field the other omits, one performing a cleanup the other skips — correct them rather than carry the disagreement forward. A pure-move diff is easier to review, and that is not enough: deferring buys a second change and a second review that usually never come, while the drift keeps producing the defect that exposed it. Code is cheap; a second run is not. The bound is relevance, not size — correct what the change already touches, not what it merely noticed.

**`AGENTS.md`** — the operative line and nothing else:

> Fix drift on the path you touch rather than preserving it for a cleaner diff. Two sites that should agree and do not are a defect, not a diff-size decision.

**Neither restates the limit.** `AGENTS.md` already says it once, under Pull requests: *"Keep commits and pull requests focused. Do not mix unrelated cleanup into the requested outcome."* Repeating it beside the new licence would create exactly the hand-synced pair `AGENTS.md:42` now forbids. What these two documents share is the licence; the limit keeps its single owner.

## Validation

- `bun x prettier --check` on both files — clean.
- Neither file is a generated or mirrored artifact: `grep -rln` over `packages/` and `scripts/` finds no copy of either line, so no regeneration applies.
- **Not verified:** whether it changes review behaviour. Prose rules show up in reviews, not in checks.

## Links

- Related #2698 — the design that produced the ruling; its body now records the decision and the superseded acceptance line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated engineering guidance to recommend correcting relevant inconsistencies encountered in the area being changed.
  * Clarified that fixes should remain focused on directly affected code while avoiding unnecessary scope expansion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->