### PR TITLE
fix(workflows): fail conditions on structured input references

### DIFF
--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -1546,7 +1546,8 @@ nodes:
 
 The condition resolves the name against the run's inputs at evaluation time; the value is
 never spliced into the expression, so an input containing a quote or an operator is
-compared as data and can never be re-read as syntax. An `$INPUTS.<name>` the run does not
+compared as data and can never be re-read as syntax. Present object and array inputs fail
+the node loudly rather than stringify-comparing. An `$INPUTS.<name>` the run does not
 carry **fails the node**, with the same message the prompt surface gives
 (`Unknown input '$INPUTS.mdoe'. Did you mean $INPUTS.mode?`) — it never resolves to an
 empty string, because a condition that quietly compares nothing is the silent-branch

--- a/packages/workflows/src/condition-evaluator.test.ts
+++ b/packages/workflows/src/condition-evaluator.test.ts
@@ -918,3 +918,60 @@ describe('typed $INPUTS values in when: (#2637)', () => {
     });
   });
 });
+
+// #2999 — structured $INPUTS values (objects/arrays) in when: expressions must fail loudly
+// with diagnostic metadata rather than silently stringify-comparing.
+describe('structured $INPUTS values in when: (#2999)', () => {
+  const noOutputs = new Map<string, NodeOutput>();
+
+  it('rejects object-valued inputs, failing false-skips loudly with safe diagnostic log', () => {
+    mockLogFn.mockClear();
+    expect(() =>
+      evaluateCondition("$INPUTS.route == 'true'", noOutputs, { route: { ready: true } })
+    ).toThrow(
+      "Condition reference '$INPUTS.route' resolved to an object. " +
+        "A 'when:' input must be a string, number, boolean, or null; emit a scalar routing field " +
+        'or inspect structured data in a script node.'
+    );
+    expect(mockLogFn).toHaveBeenCalledWith(
+      {
+        input: 'route',
+        actualType: 'object',
+        exprSnippet: "$INPUTS.route == 'true'",
+      },
+      'dag.condition_field_not_primitive'
+    );
+  });
+
+  it('rejects array-valued inputs, failing false-skips loudly with safe diagnostic log', () => {
+    mockLogFn.mockClear();
+    expect(() =>
+      evaluateCondition("$INPUTS.items == 'true'", noOutputs, { items: ['a', 'b'] })
+    ).toThrow(
+      "Condition reference '$INPUTS.items' resolved to an array. " +
+        "A 'when:' input must be a string, number, boolean, or null; emit a scalar routing field " +
+        'or inspect structured data in a script node.'
+    );
+    expect(mockLogFn).toHaveBeenCalledWith(
+      {
+        input: 'items',
+        actualType: 'array',
+        exprSnippet: "$INPUTS.items == 'true'",
+      },
+      'dag.condition_field_not_primitive'
+    );
+  });
+
+  it('rejects stringify-coincidence comparisons against hand-typed JSON literals', () => {
+    mockLogFn.mockClear();
+    expect(() =>
+      evaluateCondition('$INPUTS.tags == \'["a","b"]\'', noOutputs, { tags: ['a', 'b'] })
+    ).toThrow("Condition reference '$INPUTS.tags' resolved to an array");
+
+    expect(() =>
+      evaluateCondition('$INPUTS.config == \'{"timeout":30}\'', noOutputs, {
+        config: { timeout: 30 },
+      })
+    ).toThrow("Condition reference '$INPUTS.config' resolved to an object");
+  });
+});

--- a/packages/workflows/src/condition-evaluator.ts
+++ b/packages/workflows/src/condition-evaluator.ts
@@ -27,10 +27,11 @@
  *     no-silent-drop contract a referenced-but-missing value is a visible failure,
  *     not a silent skip. That covers `$node.output.field` (field not in the
  *     producer's declared schema, or a schemaless node whose output isn't JSON /
- *     lacks the key) via `OutputRefError`, and an undeclared `$INPUTS.<name>` via
- *     `InputRefError`. (A declared-optional-absent field still resolves to '' and
- *     never throws — but a FAILED producer always throws, fielded or whole-text,
- *     #2713 — see `resolveOutputRef` below.)
+ *     lacks the key) via `OutputRefError`, an undeclared `$INPUTS.<name>` via
+ *     `InputRefError`, and a present object/array compared as a scalar in either
+ *     `$node.output.field` or `$INPUTS.<name>`. (A declared-optional-absent field still
+ *     resolves to '' and never throws — but a FAILED producer always throws, fielded
+ *     or whole-text, #2713 — see `resolveOutputRef` below.)
  */
 import type { NodeOutput } from './schemas';
 import { createLogger } from '@archon/paths';
@@ -172,12 +173,30 @@ export class InputRefError extends Error {
  *
  * Inputs are supplied by a caller's `with:` on a `workflow:` node (or a direct run's
  * `--input`), reach the child as `metadata.inputs`, and are threaded here by the
- * executor. An undeclared name THROWS — see {@link InputRefError}.
+ * executor. An undeclared name THROWS — see {@link InputRefError}. A present object
+ * or array THROWS — under the no-silent-drop contract, comparing structured data
+ * as a scalar fails loudly with diagnostic evidence rather than silently stringify-comparing.
  */
-function resolveInputRef(name: string, inputs: Record<string, JsonValue> | undefined): string {
+function resolveInputRef(
+  name: string,
+  inputs: Record<string, JsonValue> | undefined,
+  exprSnippet: string
+): string {
   // Canonical text (#2637): a typed input compares as its deterministic text —
   // `$INPUTS.flag == true` matches a boolean `true` via the unquoted-RHS grammar.
-  if (inputs && Object.hasOwn(inputs, name)) return canonicalValueText(inputs[name]);
+  if (inputs && Object.hasOwn(inputs, name)) {
+    const value = inputs[name];
+    if (Array.isArray(value) || (value !== null && typeof value === 'object')) {
+      const actualType = Array.isArray(value) ? 'array' : 'object';
+      getLog().error({ input: name, actualType, exprSnippet }, 'dag.condition_field_not_primitive');
+      throw new Error(
+        `Condition reference '$INPUTS.${name}' resolved to an ${actualType}. ` +
+          "A 'when:' input must be a string, number, boolean, or null; emit a scalar routing field " +
+          'or inspect structured data in a script node.'
+      );
+    }
+    return canonicalValueText(value);
+  }
   throw new InputRefError(name, inputs ? Object.keys(inputs) : []);
 }
 
@@ -189,7 +208,7 @@ function resolveAtomRef(
   loopPrevOutputs: ReadonlyMap<string, NodeOutput> | undefined,
   exprSnippet: string
 ): string {
-  if (ref.kind === 'input') return resolveInputRef(ref.name, inputs);
+  if (ref.kind === 'input') return resolveInputRef(ref.name, inputs, exprSnippet);
   // No prior iteration is an ordinary first-iteration condition, not an unknown-node
   // authoring error. Once a prior body node exists, retain normal output-field checks.
   if (ref.kind === 'loop_prev' && !loopPrevOutputs?.has(ref.nodeId)) return '';

--- a/packages/workflows/src/dry-run.test.ts
+++ b/packages/workflows/src/dry-run.test.ts
@@ -583,6 +583,62 @@ describe('dryRunWorkflow', () => {
     });
   });
 
+  test('fails an object-valued condition input instead of recording a false skip (#2999)', async () => {
+    const workflow = makeTestWorkflow({
+      name: 'structured-input-condition',
+      inputs: {
+        route: { default: { ready: true } },
+      },
+      nodes: [
+        {
+          id: 'gated',
+          prompt: 'gated',
+          when: "$INPUTS.route == 'true'",
+        },
+      ],
+    });
+    const result = await dryRunWorkflow({
+      workflow,
+      userMessage: '',
+      cwd: process.cwd(),
+      stubs: { gated: 'unused' },
+    });
+
+    expect(result.outcome).toBe('failed');
+    expect(result.trace.find(entry => entry.nodeId === 'gated')).toMatchObject({
+      state: 'failed',
+      reason: expect.stringContaining("Condition reference '$INPUTS.route' resolved to an object"),
+    });
+  });
+
+  test('fails an array-valued condition input instead of recording a false skip (#2999)', async () => {
+    const workflow = makeTestWorkflow({
+      name: 'structured-array-input-condition',
+      inputs: {
+        tags: { default: ['a', 'b'] },
+      },
+      nodes: [
+        {
+          id: 'gated',
+          prompt: 'gated',
+          when: "$INPUTS.tags == 'true'",
+        },
+      ],
+    });
+    const result = await dryRunWorkflow({
+      workflow,
+      userMessage: '',
+      cwd: process.cwd(),
+      stubs: { gated: 'unused' },
+    });
+
+    expect(result.outcome).toBe('failed');
+    expect(result.trace.find(entry => entry.nodeId === 'gated')).toMatchObject({
+      state: 'failed',
+      reason: expect.stringContaining("Condition reference '$INPUTS.tags' resolved to an array"),
+    });
+  });
+
   test('applies all trigger rules after failed and skipped upstream nodes', async () => {
     const workflow = makeTestWorkflow({
       name: 'triggers',


### PR DESCRIPTION
## Problem and outcome

In `when:` conditions, `$INPUTS.<name>` references holding structured objects or arrays fell through to JSON stringification instead of being rejected as non-scalar condition values. This allowed accidental stringify-coincidence matches or silent false-skips instead of failing visibly at run time.

- **Outcome:** Evaluating a `when:` expression against an object or array `$INPUTS.<name>` reference now logs `dag.condition_field_not_primitive` with diagnostic metadata and throws an error immediately, failing the node loudly.
- **Invariant:** Scalar inputs (strings, numbers, booleans, and null) continue to compare normally, and undeclared input references continue to throw `InputRefError`.
- **Scope boundary:** Only `$INPUTS.<name>` resolution in condition evaluation is changed; node output field condition evaluation was already guarded in #2995.
- **Root cause:** `resolveAtomRef` for `'input'` kinds delegated to `resolveInputRef` without checking whether `inputs[name]` was an object or array before formatting it through `canonicalValueText`.

## Review guidance

- **Feedback requested:** Correctness of structured input guard, symmetry with `$node.output.field` diagnostics, and error messaging.
- **Start here:** `packages/workflows/src/condition-evaluator.ts:180` — guarded `resolveInputRef` implementation and error throwing.
- **Review order:**
  1. `packages/workflows/src/condition-evaluator.ts` — structured type guard and diagnostic logging in `resolveInputRef`.
  2. `packages/workflows/src/condition-evaluator.test.ts` — unit tests for object/array input rejections and diagnostic logs.
  3. `packages/workflows/src/dry-run.test.ts` — dry-run trace behavior asserting node failure instead of false skip.
  4. `packages/docs-web/src/content/docs/guides/authoring-workflows.md` — condition documentation update.
- **Lower-attention areas:** Documentation wording in `authoring-workflows.md`.
- **Known risk or uncertainty:** None. Bundled workflows were audited and do not compare structured `$INPUTS` in `when:` expressions.

## Solution

In `packages/workflows/src/condition-evaluator.ts`, `resolveInputRef` now takes `exprSnippet: string`. When `inputs[name]` is an array or non-null object, it logs a `dag.condition_field_not_primitive` error with structured diagnostics (`input`, `actualType`, `exprSnippet`) and throws an error instructing workflow authors to emit a scalar routing field or inspect structured data in a script node.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Structured `$INPUTS` (objects/arrays) in `when:` expressions were stringified into JSON strings and compared against expression literals. | Present object and array `$INPUTS` fail the condition evaluation with a clear error. |
| **Failure behavior** | Conditions either silently skipped (false-skip) or unexpectedly matched stringified JSON literals. | Node condition evaluation fails loudly with diagnostic log `dag.condition_field_not_primitive` and an actionable error message. |

## Changed seams

| Boundary or contract | Change | Evidence |
|---|---|---|
| `$INPUTS.<name> → condition evaluator` | Array and object inputs throw an Error instead of returning JSON-stringified values | `packages/workflows/src/condition-evaluator.ts:187`, `packages/workflows/src/condition-evaluator.test.ts:921` |

## Validation

- `bun run validate` — clean pass across all packages (typecheck, lint, prettier check, bundled schemas/defaults checks, test:install, full test suite).
- `bun test packages/workflows/src/condition-evaluator.test.ts packages/workflows/src/dry-run.test.ts` — verified false-skip rejection, stringify-coincidence rejection, structured log emission, and dry-run node failure traces.
- **Not verified:** Nothing material; bundled workflow audit and unit/dry-run test coverage cover all condition evaluation paths for structured inputs.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | Workflows comparing structured `$INPUTS` in `when:` will now fail instead of silently skipping or stringify-matching. Bundled workflows were audited and none use structured inputs in conditions. | `.archon/workflows` audit; `packages/docs-web/src/content/docs/guides/authoring-workflows.md` |
| Observability | Emits `dag.condition_field_not_primitive` log with `input`, `actualType`, and `exprSnippet` fields on failure. | Unit tests in `packages/workflows/src/condition-evaluator.test.ts` |
| Documentation / communication | Authoring guide updated to document that present object and array `$INPUTS` fail loudly. | `packages/docs-web/src/content/docs/guides/authoring-workflows.md:1549` |

## Links

- Closes #2999


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Conditions comparing object- or array-valued workflow inputs now fail explicitly with a clear diagnostic instead of silently comparing stringified values.
  * Dry-run evaluations now report these invalid comparisons as failures rather than incorrectly recording them as skipped conditions.
  * Structured values referenced in node outputs receive the same consistent handling.

* **Documentation**
  * Updated guidance explains how structured inputs behave in `when:` conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->