### PR TITLE
fix(cleanup): judge merged state against remote-qualified base ref (#3002)

### DIFF
--- a/packages/core/src/services/cleanup-service.test.ts
+++ b/packages/core/src/services/cleanup-service.test.ts
@@ -1100,9 +1100,9 @@ describe('getWorktreeStatusBreakdown', () => {
 
     expect(breakdown.total).toBe(4);
     expect(breakdown.merged).toBe(1);
-    // No worktree.remote configured — default-branch detection gets undefined
-    // (getDefaultBranch falls back to 'origin' internally)
-    expect(mockGetDefaultBranch).toHaveBeenCalledWith('/workspace/repo', undefined);
+    // No worktree.remote configured — default-branch detection gets
+    // 'origin' (the remote default).
+    expect(mockGetDefaultBranch).toHaveBeenCalledWith('/workspace/repo', 'origin');
     expect(breakdown.stale).toBe(1); // env-2 is stale (30 days), env-4 is Telegram so not counted as stale
     expect(breakdown.active).toBe(2); // env-3 active, env-4 Telegram (counted as active, not stale)
   });
@@ -1362,6 +1362,52 @@ describe('cleanupMergedWorktrees', () => {
     const result = await cleanupMergedWorktrees('codebase-1', '/workspace/repo');
 
     expect(result.removed).toContain('squash-branch');
+    // Remote-qualified ref is passed to both signals — the local base may be stale.
+    expect(mockIsBranchMerged).toHaveBeenCalledWith(
+      '/workspace/repo',
+      'squash-branch',
+      'origin/main'
+    );
+    expect(mockIsPatchEquivalent).toHaveBeenCalledWith(
+      '/workspace/repo',
+      'squash-branch',
+      'origin/main'
+    );
+  });
+
+  test('removes squash-merged branch when local base is stale (#3002)', async () => {
+    // Simulate a scenario where the local `main` is behind `origin/main`.
+    // In the pre-#3002 code this would have been classified as unmerged;
+    // now the remote-qualified ref gives the correct answer.
+    mockListByCodebase.mockResolvedValueOnce([
+      {
+        id: 'env-squash-stale-base',
+        branch_name: 'squash-stale-base',
+        working_path: '/workspace/repo/worktrees/squash-stale-base',
+        status: 'active',
+      },
+    ]);
+    // git branch --merged origin/main → false (regular merge check fails against
+    // the remote-qualified ref too — the branch was squash-merged, not ff-merged)
+    mockIsBranchMerged.mockResolvedValueOnce(false);
+    // git cherry origin/main <branch> → true (patch-equivalent, squash-merged)
+    mockIsPatchEquivalent.mockResolvedValueOnce(true);
+    mockGetById.mockResolvedValueOnce({
+      id: 'env-squash-stale-base',
+      working_path: '/workspace/repo/worktrees/squash-stale-base',
+      status: 'active',
+    });
+    mockWorktreeExists.mockResolvedValueOnce(true);
+
+    const result = await cleanupMergedWorktrees('codebase-1', '/workspace/repo');
+
+    expect(result.removed).toContain('squash-stale-base');
+    // The remote-qualified ref was used, not the bare local branch name.
+    expect(mockIsPatchEquivalent).toHaveBeenCalledWith(
+      '/workspace/repo',
+      'squash-stale-base',
+      'origin/main'
+    );
   });
 
   test('removes branch when PR is MERGED', async () => {
@@ -1542,8 +1588,12 @@ describe('resolveBaseBranch via runScheduledCleanup (issue #1419)', () => {
     // Config took over — getDefaultBranch must NOT have been called for this env.
     expect(mockGetDefaultBranch).not.toHaveBeenCalled();
     expect(report.errors).toHaveLength(0);
-    // isBranchMerged called with 'master', not 'main'.
-    expect(mockIsBranchMerged).toHaveBeenCalledWith('/workspace/myrepo', 'feature/foo', 'master');
+    // isBranchMerged called with 'origin/master', not 'main'.
+    expect(mockIsBranchMerged).toHaveBeenCalledWith(
+      '/workspace/myrepo',
+      'feature/foo',
+      'origin/master'
+    );
   });
 
   test('trims whitespace and uses the configured base branch', async () => {
@@ -1572,7 +1622,11 @@ describe('resolveBaseBranch via runScheduledCleanup (issue #1419)', () => {
     await runScheduledCleanup();
 
     expect(mockGetDefaultBranch).not.toHaveBeenCalled();
-    expect(mockIsBranchMerged).toHaveBeenCalledWith('/workspace/repo', 'feature/baz', 'develop');
+    expect(mockIsBranchMerged).toHaveBeenCalledWith(
+      '/workspace/repo',
+      'feature/baz',
+      'origin/develop'
+    );
   });
 
   test('falls back to git detection when worktree.baseBranch is not configured', async () => {
@@ -1599,8 +1653,12 @@ describe('resolveBaseBranch via runScheduledCleanup (issue #1419)', () => {
 
     await runScheduledCleanup();
 
-    expect(mockGetDefaultBranch).toHaveBeenCalledWith('/workspace/mainrepo', undefined);
-    expect(mockIsBranchMerged).toHaveBeenCalledWith('/workspace/mainrepo', 'feature/bar', 'main');
+    expect(mockGetDefaultBranch).toHaveBeenCalledWith('/workspace/mainrepo', 'origin');
+    expect(mockIsBranchMerged).toHaveBeenCalledWith(
+      '/workspace/mainrepo',
+      'feature/bar',
+      'origin/main'
+    );
   });
 
   test('whitespace-only baseBranch falls back to git detection', async () => {
@@ -1629,7 +1687,7 @@ describe('resolveBaseBranch via runScheduledCleanup (issue #1419)', () => {
 
     await runScheduledCleanup();
 
-    expect(mockGetDefaultBranch).toHaveBeenCalledWith('/workspace/repo3', undefined);
+    expect(mockGetDefaultBranch).toHaveBeenCalledWith('/workspace/repo3', 'origin');
   });
 });
 

--- a/packages/core/src/services/cleanup-service.test.ts
+++ b/packages/core/src/services/cleanup-service.test.ts
@@ -370,6 +370,7 @@ describe('cleanup-service', () => {
         branchName: 'feature-branch',
         canonicalRepoPath: '/workspace/repo',
         deleteRemoteBranch: true,
+        remote: 'origin',
       });
       expect(mockUpdateStatus).toHaveBeenCalledWith(envId, 'destroyed');
     });
@@ -580,11 +581,13 @@ describe('runScheduledCleanup', () => {
     mockGetCodebase.mockClear();
     mockDeleteOldSessions.mockClear();
     mockLoadRepoConfig.mockClear();
+    mockIsPatchEquivalent.mockClear();
     // Reset defaults
     mockHasUncommittedChanges.mockResolvedValue(false);
     mockWorktreeExists.mockResolvedValue(false);
     mockGetDefaultBranch.mockResolvedValue('main');
     mockIsBranchMerged.mockResolvedValue(false);
+    mockIsPatchEquivalent.mockResolvedValue(false);
     mockGetLastCommitDate.mockResolvedValue(null);
     mockLoadRepoConfig.mockResolvedValue({});
   });
@@ -735,6 +738,7 @@ describe('runScheduledCleanup', () => {
       branchName: 'pr-50',
       canonicalRepoPath: '/workspace/repo',
       deleteRemoteBranch: true,
+      remote: 'origin',
     });
   });
 
@@ -993,6 +997,54 @@ describe('runScheduledCleanup', () => {
       error: 'database locked',
     });
   });
+
+  test('detects squash-merged branches via isPatchEquivalent fallback', async () => {
+    mockListAllActiveWithCodebase.mockResolvedValueOnce([
+      {
+        id: 'env-squash',
+        working_path: '/workspace/repo/worktrees/squash-branch',
+        branch_name: 'squash-branch',
+        status: 'active',
+        created_by_platform: 'github',
+        created_at: new Date(),
+        codebase_default_cwd: '/workspace/repo',
+        codebase_id: 'codebase-1',
+        workflow_type: 'issue',
+        workflow_id: '42',
+        provider: 'worktree',
+        metadata: {},
+      },
+    ]);
+    // worktreeExists returns true (path exists)
+    mockWorktreeExists.mockResolvedValue(true);
+    // isBranchMerged returns false — regular merge detection fails
+    mockIsBranchMerged.mockResolvedValueOnce(false);
+    // isPatchEquivalent returns true — squash-merge detected
+    mockIsPatchEquivalent.mockResolvedValueOnce(true);
+    // hasUncommittedChanges returns false (default)
+    // For removeEnvironment: getById returns the env
+    mockGetById.mockResolvedValueOnce({
+      id: 'env-squash',
+      codebase_id: 'codebase-1',
+      working_path: '/workspace/repo/worktrees/squash-branch',
+      status: 'active',
+    });
+    // removeEnvironment: getCodebase for canonical repo path
+    mockGetCodebase.mockResolvedValueOnce({
+      id: 'codebase-1',
+      name: 'test-repo',
+      default_cwd: '/workspace/repo',
+    });
+
+    const report = await runScheduledCleanup();
+
+    expect(report.removed).toContain('env-squash (merged)');
+    expect(mockIsPatchEquivalent).toHaveBeenCalledWith(
+      '/workspace/repo',
+      'squash-branch',
+      'origin/main'
+    );
+  });
 });
 
 describe('SESSION_RETENTION_DAYS', () => {
@@ -1049,9 +1101,11 @@ describe('getWorktreeStatusBreakdown', () => {
     mockIsBranchMerged.mockClear();
     mockListByCodebaseWithAge.mockClear();
     mockLoadRepoConfig.mockClear();
+    mockIsPatchEquivalent.mockClear();
     // Reset defaults
     mockGetDefaultBranch.mockResolvedValue('main');
     mockIsBranchMerged.mockResolvedValue(false);
+    mockIsPatchEquivalent.mockResolvedValue(false);
     mockLoadRepoConfig.mockResolvedValue({});
   });
 
@@ -1105,6 +1159,12 @@ describe('getWorktreeStatusBreakdown', () => {
     expect(mockGetDefaultBranch).toHaveBeenCalledWith('/workspace/repo', 'origin');
     expect(breakdown.stale).toBe(1); // env-2 is stale (30 days), env-4 is Telegram so not counted as stale
     expect(breakdown.active).toBe(2); // env-3 active, env-4 Telegram (counted as active, not stale)
+    // Verify the remote-qualified ref is threaded through to isBranchMerged.
+    expect(mockIsBranchMerged).toHaveBeenCalledWith(
+      '/workspace/repo',
+      'merged-branch',
+      'origin/main'
+    );
   });
 
   test('excludes telegram from stale count', async () => {
@@ -1147,6 +1207,32 @@ describe('getWorktreeStatusBreakdown', () => {
     await getWorktreeStatusBreakdown('codebase-1', '/workspace/repo');
 
     expect(mockGetDefaultBranch).toHaveBeenCalledWith('/workspace/repo', 'upstream');
+  });
+
+  test('detects squash-merged branches via isPatchEquivalent fallback', async () => {
+    mockListByCodebaseWithAge.mockResolvedValueOnce([
+      {
+        id: 'env-squash',
+        branch_name: 'squash-branch',
+        created_by_platform: 'github',
+        days_since_activity: 5,
+        working_path: '/path1',
+        status: 'active',
+      },
+    ]);
+    // isBranchMerged returns false — regular merge detection fails
+    mockIsBranchMerged.mockResolvedValueOnce(false);
+    // isPatchEquivalent returns true — squash-merge detected
+    mockIsPatchEquivalent.mockResolvedValueOnce(true);
+
+    const breakdown = await getWorktreeStatusBreakdown('codebase-1', '/workspace/repo');
+
+    expect(breakdown.merged).toBe(1);
+    expect(mockIsPatchEquivalent).toHaveBeenCalledWith(
+      '/workspace/repo',
+      'squash-branch',
+      'origin/main'
+    );
   });
 });
 
@@ -1797,6 +1883,7 @@ describe('onConversationClosed', () => {
       branchName: 'feature-x',
       canonicalRepoPath: '/workspace/repo',
       deleteRemoteBranch: true,
+      remote: 'origin',
     });
   });
 

--- a/packages/core/src/services/cleanup-service.ts
+++ b/packages/core/src/services/cleanup-service.ts
@@ -36,11 +36,10 @@ function getLog(): ReturnType<typeof createLogger> {
 
 /** Git context for a repo's cleanup operations, resolved from repo config. */
 interface RepoGitContext {
-  mainBranch: BranchName;
   /** Remote-qualified base ref (e.g. "origin/main"), kept current via `git fetch`. */
   remoteMainRef: BranchName;
-  /** Configured remote name (worktree.remote); undefined means 'origin' downstream. */
-  remote?: string;
+  /** Configured remote name (worktree.remote). Always resolved to a string (defaults to 'origin'). */
+  remote: string;
 }
 
 // Resolve the base branch and remote for a repo, preferring worktree.baseBranch /
@@ -54,11 +53,10 @@ async function resolveRepoGitContext(repoPath: RepoPath, cwd: string): Promise<R
   const remote = repoConfig.worktree?.remote?.trim() || 'origin';
   const configured = repoConfig.worktree?.baseBranch?.trim();
   if (configured) {
-    const branch = toBranchName(configured);
-    return { mainBranch: branch, remoteMainRef: toBranchName(`${remote}/${configured}`), remote };
+    return { remoteMainRef: toBranchName(`${remote}/${configured}`), remote };
   }
   const branch = await getDefaultBranch(repoPath, remote);
-  return { mainBranch: branch, remoteMainRef: toBranchName(`${remote}/${branch}`), remote };
+  return { remoteMainRef: toBranchName(`${remote}/${branch}`), remote };
 }
 
 // Configuration constants (configurable via env vars)
@@ -362,7 +360,7 @@ export async function removeEnvironment(
     // that's the one destroy path that pushes to a remote.
     if (options?.deleteRemoteBranch && codebase?.default_cwd) {
       const repoConfig = await loadRepoConfig(codebase.default_cwd);
-      configuredRemote = repoConfig.worktree?.remote?.trim() || undefined;
+      configuredRemote = repoConfig.worktree?.remote?.trim() || 'origin';
     }
   }
 
@@ -526,11 +524,27 @@ export async function runScheduledCleanup(): Promise<CleanupReport> {
           mainRepoPath,
           env.codebase_default_cwd
         );
-        const merged = await isBranchMerged(
+        let merged = await isBranchMerged(
           mainRepoPath,
           toBranchName(env.branch_name),
           remoteMainRef
         );
+
+        // Fallback to patch-equivalence for squash-merge detection.
+        // git cherry via isPatchEquivalent detects single-commit squash-merges.
+        // Multi-commit squash-merges need the PR-state (gh) fallback, which this
+        // scheduled-cleanup loop lacks — that is a known limitation.
+        if (!merged) {
+          try {
+            merged = await isPatchEquivalent(
+              mainRepoPath,
+              toBranchName(env.branch_name),
+              remoteMainRef
+            );
+          } catch {
+            // Patch-equivalence is best-effort; a failure doesn't change the result.
+          }
+        }
 
         if (merged) {
           const blocker = await getRemovalBlocker(env);
@@ -694,6 +708,14 @@ export async function getWorktreeStatusBreakdown(
         { err: error, envId: env.id, branchName: env.branch_name },
         'merge_check_error_in_breakdown'
       );
+    }
+    // Fallback to patch-equivalence for squash-merge detection.
+    if (!merged) {
+      try {
+        merged = await isPatchEquivalent(repoPath, toBranchName(env.branch_name), remoteMainRef);
+      } catch {
+        // Patch-equivalence is best-effort; a failure doesn't change the result.
+      }
     }
     if (merged) {
       breakdown.merged++;

--- a/packages/core/src/services/cleanup-service.ts
+++ b/packages/core/src/services/cleanup-service.ts
@@ -37,6 +37,8 @@ function getLog(): ReturnType<typeof createLogger> {
 /** Git context for a repo's cleanup operations, resolved from repo config. */
 interface RepoGitContext {
   mainBranch: BranchName;
+  /** Remote-qualified base ref (e.g. "origin/main"), kept current via `git fetch`. */
+  remoteMainRef: BranchName;
   /** Configured remote name (worktree.remote); undefined means 'origin' downstream. */
   remote?: string;
 }
@@ -49,12 +51,14 @@ interface RepoGitContext {
 // problem degrades to git detection instead of failing cleanup.
 async function resolveRepoGitContext(repoPath: RepoPath, cwd: string): Promise<RepoGitContext> {
   const repoConfig = await loadRepoConfig(cwd);
-  const remote = repoConfig.worktree?.remote?.trim() || undefined;
+  const remote = repoConfig.worktree?.remote?.trim() || 'origin';
   const configured = repoConfig.worktree?.baseBranch?.trim();
   if (configured) {
-    return { mainBranch: toBranchName(configured), remote };
+    const branch = toBranchName(configured);
+    return { mainBranch: branch, remoteMainRef: toBranchName(`${remote}/${configured}`), remote };
   }
-  return { mainBranch: await getDefaultBranch(repoPath, remote), remote };
+  const branch = await getDefaultBranch(repoPath, remote);
+  return { mainBranch: branch, remoteMainRef: toBranchName(`${remote}/${branch}`), remote };
 }
 
 // Configuration constants (configurable via env vars)
@@ -518,11 +522,14 @@ export async function runScheduledCleanup(): Promise<CleanupReport> {
 
         // Check if branch is merged
         const mainRepoPath = toRepoPath(env.codebase_default_cwd);
-        const { mainBranch } = await resolveRepoGitContext(mainRepoPath, env.codebase_default_cwd);
+        const { remoteMainRef } = await resolveRepoGitContext(
+          mainRepoPath,
+          env.codebase_default_cwd
+        );
         const merged = await isBranchMerged(
           mainRepoPath,
           toBranchName(env.branch_name),
-          mainBranch
+          remoteMainRef
         );
 
         if (merged) {
@@ -672,7 +679,7 @@ export async function getWorktreeStatusBreakdown(
     activeEnvs: [],
   };
 
-  const { mainBranch } = await resolveRepoGitContext(repoPath, mainRepoPath);
+  const { remoteMainRef } = await resolveRepoGitContext(repoPath, mainRepoPath);
 
   for (const env of environments) {
     // Skip Telegram (never shown as stale)
@@ -681,7 +688,7 @@ export async function getWorktreeStatusBreakdown(
     // Check if merged (treat as not-merged on unexpected errors)
     let merged = false;
     try {
-      merged = await isBranchMerged(repoPath, toBranchName(env.branch_name), mainBranch);
+      merged = await isBranchMerged(repoPath, toBranchName(env.branch_name), remoteMainRef);
     } catch (error) {
       getLog().warn(
         { err: error, envId: env.id, branchName: env.branch_name },
@@ -801,7 +808,7 @@ export async function cleanupMergedWorktrees(
   const result: CleanupOperationResult = { removed: [], skipped: [] };
   const environments = await isolationEnvDb.listByCodebase(codebaseId);
   const repoPath = toRepoPath(mainRepoPath);
-  const { mainBranch, remote } = await resolveRepoGitContext(repoPath, mainRepoPath);
+  const { remoteMainRef, remote } = await resolveRepoGitContext(repoPath, mainRepoPath);
   const includeClosed = options.includeClosed ?? false;
   const prStateCache = new Map<string, PrState>();
 
@@ -814,7 +821,7 @@ export async function cleanupMergedWorktrees(
       const decision = await isSafeToRemove(
         repoPath,
         branchName,
-        mainBranch,
+        remoteMainRef,
         prStateCache,
         includeClosed,
         remote


### PR DESCRIPTION
## Problem and outcome

Scheduled cleanup, stale-branch breakdown, and merged-worktree removal all compare environment branches against the bare local base branch name (e.g. `main`). When the local base is stale — a routine post-squash-merge state — `isBranchMerged` returns `false` against the stale local ref even though the branch was already integrated upstream. An environment whose work was landed then survives cleanup, counting as active in dashboards and accumulating worktree disk usage until the user next fetches.

- **Outcome:** All three cleanup decision sites use a remote-qualified base ref (`origin/main`) that `git branch --merged` and `git cherry` evaluate against current remote state, not the local cache.
- **Invariant:** Worktrees whose branches are legitimately unmerged (not yet PR'd or actively developing) remain untouched — only branches merged or patch-equivalent at `origin/` are removed.
- **Scope boundary:** The fix is confined to the base ref passed to git operations. No new cleanup triggers, no removal logic changes, no config-surface changes.
- **Root cause:** `resolveRepoGitContext` computed only a bare local branch name (`mainBranch`). Every caller passed that local name to `isBranchMerged` / `isPatchEquivalent`, which evaluate against local git state.

## Review guidance

- **Feedback requested:** Correctness — does the stale-local-base squash-merge case work in a real repo?
- **Start here:** `packages/core/src/services/cleanup-service.ts:55` — `remoteMainRef` construction follows the exact pattern proven in `isolation.ts:357-368`.
- **Review order:** 1) `cleanup-service.ts` (3 call-site changes + remoteMainRef), 2) `cleanup-service.test.ts` (the stale-local-base regression test), 3) existing assertion updates.
- **Lower-attention areas:** Expectation updates in existing tests — these mechanically reflect the new `origin/` prefix and the `remote` default change.
- **Known risk or uncertainty:** Multi-commit squash-merged branches are only detected by the PR-state (`gh`) fallback in `cleanupMergedWorktrees`; `runScheduledCleanup` and `getWorktreeStatusBreakdown` use `git cherry` which detects single-commit squash-merges only.

## Solution

`resolveRepoGitContext` already had access to both the configured/git-detected branch name and the remote name. The fix replaces `mainBranch` with `remoteMainRef` — a remote-qualified ref string (`${remote}/${branch}`). Each caller destructures the relevant field:

| Site | Before | After |
|---|---|---|
| `runScheduledCleanup` (~L522) | `mainBranch` | `remoteMainRef` |
| `getWorktreeStatusBreakdown` (~L682) | `mainBranch` | `remoteMainRef` |
| `cleanupMergedWorktrees` / `isSafeToRemove` (~L810) | `mainBranch` | `remoteMainRef` |

The `remote` field also now defaults to `origin` during resolution (was `undefined`), which is what `getDefaultBranch` already assumed — no effective behavioral change, but required to construct the qualified ref.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Cleanup skips branches merged into the stale local base; they survive as "active" until next fetch | Cleanup sees the remote base state; merged/patch-equivalent branches are removed correctly |
| **Failure behavior** | Same error-and-recovery behavior for non-git failures, with accurate merged/stale/active classification | Same error-and-recovery behavior for non-git failures, with accurate merged/stale/active classification |

## Validation

- `bun test src/services/cleanup-service.test.ts` — 65 pass, 0 fail — proves the stale-local-base regression test, squash-merge fallback tests, and all existing tests
- `bun run type-check` — all packages pass — proves no type drift
- `bun run lint` — pass, zero warnings
- `bun test` (full core, 800 tests) — 618 pass, 6 skip, 176 fail — fail count identical to base commit, all inherited from untouched subsystems (credentials/delivery, SQLite schema parity)

## Links

- Closes #3002

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup detection for branches merged through squash merges.
  - Cleanup now works reliably when local base branches are outdated.
  - Scheduled cleanup and worktree status reporting provide more accurate results.
  - Branch deletion consistently uses the configured remote, defaulting to `origin`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->