### PR TITLE
fix(ci): deduplicate publish workflow on release tag pushes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,14 @@
 name: Publish
 
 on:
-  release:
-    types: [published]
   push:
     tags:
       - 'v*'
   workflow_dispatch:
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
 
 env:
   REGISTRY: ghcr.io

--- a/scripts/publish-triggers.test.ts
+++ b/scripts/publish-triggers.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// `* text=auto` checks this workflow out with CRLF on Windows CI. Normalizing here lets every
+// pattern below anchor on LF, so a stray `\r` can never reach a capture.
+const workflow = readFileSync(
+  resolve(import.meta.dir, '../.github/workflows/publish.yml'),
+  'utf8'
+).replace(/\r\n/g, '\n');
+
+test('publish workflow triggers only on tag pushes and manual dispatch', () => {
+  // Must trigger on tag push matching v* so Docker images build alongside release binaries.
+  expect(workflow).toMatch(/^ {2}push:\n {4}tags:\n {6}- ['"]v\*['"]/m);
+  // Must support manual re-publishing.
+  expect(workflow).toMatch(/^ {2}workflow_dispatch:/m);
+  // Must NOT trigger on release: [published] to prevent duplicate execution (#3012).
+  expect(workflow).not.toMatch(/^ {2}release:/m);
+  expect(workflow).not.toMatch(/types:\s*\[published\]/);
+});
+
+test('publish workflow configures concurrency with cancel-in-progress false', () => {
+  // Concurrency group prevents overlapping runs for the same ref without aborting
+  // in-flight multi-platform builds.
+  expect(workflow).toMatch(
+    /^concurrency:\n {2}group: publish-\${{\s*github\.ref\s*}}\n {2}cancel-in-progress: false/m
+  );
+});
+
+test('publish workflow preserves docker metadata tag definitions and flavor', () => {
+  expect(workflow).toContain('type=semver,pattern={{version}}');
+  expect(workflow).toContain('type=semver,pattern={{major}}.{{minor}}');
+  expect(workflow).toContain('type=semver,pattern={{major}}');
+  expect(workflow).toContain('type=sha');
+  expect(workflow).toContain(
+    "type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}"
+  );
+  expect(workflow).toContain('latest=auto');
+});
+
+test('publish workflow targets multi-platform build on ubuntu-latest', () => {
+  expect(workflow).toMatch(/runs-on:\s*ubuntu-latest/);
+  expect(workflow).toContain('platforms: linux/amd64,linux/arm64');
+  expect(workflow).toContain('push: true');
+});


### PR DESCRIPTION
## Problem and outcome

The Publish workflow currently triggers twice on every release: once when the release tag (`v*`) is pushed, and a second time when the GitHub Release is published. Because both runs perform expensive multi-platform Docker builds (`linux/amd64` and emulated `linux/arm64`) concurrently without concurrency controls, they waste runner minutes, contend on GitHub Actions layer cache, and can race during registry authentication to cause false-positive release failures.

- **Outcome:** Every release tag push triggers exactly one Publish workflow run, eliminating duplicate multi-architecture builds, GHA cache contention, and registry login races.
- **Invariant:** Docker image tagging, semver extraction via `docker/metadata-action`, and multi-platform build outputs remain completely identical.
- **Scope boundary:** Arm64 native runner migration is out of scope; Dockerfile and release build targets remain unchanged.
- **Root cause:** `.github/workflows/publish.yml` subscribed to both `push.tags: ['v*']` and `release.types: [published]`, which are both fired in sequence during normal release procedures.

## Review guidance

- **Feedback requested:** Correctness of trigger configuration and concurrency behavior.
- **Start here:** `.github/workflows/publish.yml:3` — Removal of the redundant `release:` trigger block and addition of the non-cancelling `concurrency` group.
- **Review order:** `.github/workflows/publish.yml`, then `scripts/publish-triggers.test.ts`.
- **Lower-attention areas:** None; this is a compact 2-file change.
- **Known risk or uncertainty:** None.

## Solution

1. Removed the `release: types: [published]` trigger from `.github/workflows/publish.yml`, retaining `push: tags: ['v*']` and `workflow_dispatch:`. Both `release.yml` and `publish.yml` now trigger consistently on release tag pushes.
2. Added `concurrency: group: publish-${{ github.ref }}` with `cancel-in-progress: false` matching `release.yml`, ensuring any successive dispatch on the same ref queues cleanly without cancelling or orphaning in-flight builds.
3. Added `scripts/publish-triggers.test.ts` to statically enforce workflow trigger invariants and preserve Docker metadata tagging rules.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Pushing a release tag and creating a GitHub Release triggered two parallel ~20m Publish workflow runs. | Pushing a release tag triggers exactly one Publish workflow run. |
| **Failure behavior** | Concurrent registry login and layer pushes could race and fail with HTTP 403 / denied on GHCR. | Publish runs execute isolated without concurrent authentication races. |

## Validation

- `bun test ./scripts/publish-triggers.test.ts` — 4 passed — verifies workflow triggers, concurrency configuration, metadata tags, and target platforms.
- `bun test ./scripts/` — 172 passed across 12 files — confirms all script invariants pass.
- `bun run type-check` — 0 errors — TypeScript compilation succeeds.
- `bun run lint` — 0 errors, 0 warnings — ESLint passes.
- `bun run format:check` — 0 errors — formatting verified.
- `bun run validate` — clean pass across the full repository test suite.
- **Not verified:** Live GHCR Docker push on an actual release tag in GitHub Actions; verified via static workflow assertions and existing release triggers test pattern.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Rollout / rollback | Reverting `.github/workflows/publish.yml` restores previous trigger configuration immediately. | Git history on `dev` |
| Observability | Publish workflow runs in GitHub Actions Actions tab. | Workflow run logs |

## Links

- Closes #3012


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container publishing reliability by preventing duplicate or overlapping publish runs.
  * Publishing now starts consistently from version tags or manual requests, avoiding unintended release-event triggers.
  * Preserved automatic latest-tag handling and multi-platform image builds.
* **Tests**
  * Added automated checks to verify publishing triggers, concurrency behavior, image tagging, and build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->