### PR TITLE
Make binary pin errors actionable

### DIFF
--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -272,6 +272,23 @@ describe('checkCodexBinary', () => {
     expect(execSpy).not.toHaveBeenCalled();
   });
 
+  it('surfaces a stale-pin candidate hint verbatim', async () => {
+    const diagnostic =
+      'assistants.codex.codexBinaryPath is set to "/stale/codex" but the file does not exist.\n\n' +
+      'A Codex binary was found at /opt/codex.\n' +
+      'Update assistants.codex.codexBinaryPath to that path, or remove codexBinaryPath to let Archon detect it.';
+    const result = await checkCodexBinary(
+      { DEFAULT_AI_ASSISTANT: 'codex' },
+      loadDeps(notConfigured),
+      async () => {
+        throw new Error(diagnostic);
+      }
+    );
+
+    expect(result).toEqual({ label: 'Codex binary', status: 'fail', message: diagnostic });
+    expect(execSpy).not.toHaveBeenCalled();
+  });
+
   it('fails when the resolved binary does not spawn', async () => {
     execSpy.mockRejectedValue(new Error('ENOENT'));
     const result = await checkCodexBinary(

--- a/packages/providers/src/claude/binary-resolver.test.ts
+++ b/packages/providers/src/claude/binary-resolver.test.ts
@@ -20,6 +20,15 @@ mock.module('@archon/paths', () => ({
 import * as resolver from './binary-resolver';
 import { CLAUDE_BINARY_NAME } from './binary-resolver';
 
+async function rejectionMessage(promise: Promise<unknown>): Promise<string> {
+  try {
+    await promise;
+  } catch (error) {
+    return (error as Error).message;
+  }
+  throw new Error('Expected promise to reject');
+}
+
 describe('resolveClaudeBinaryPath (binary mode)', () => {
   const originalEnv = process.env.CLAUDE_BIN_PATH;
   let pathKindSpy: ReturnType<typeof spyOn> | undefined;
@@ -52,8 +61,32 @@ describe('resolveClaudeBinaryPath (binary mode)', () => {
     process.env.CLAUDE_BIN_PATH = '/nonexistent/cli.js';
     pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('missing');
 
-    await expect(resolver.resolveClaudeBinaryPath()).rejects.toThrow(
-      'CLAUDE_BIN_PATH is set to "/nonexistent/cli.js" but the file does not exist'
+    expect(await rejectionMessage(resolver.resolveClaudeBinaryPath())).toBe(
+      'CLAUDE_BIN_PATH is set to "/nonexistent/cli.js" but the file does not exist.\n' +
+        'Please verify the path points to the Claude Code executable (native binary\n' +
+        'from the curl/PowerShell installer, or cli.js from an npm global install).'
+    );
+  });
+
+  test('names the autodetected binary when CLAUDE_BIN_PATH is stale without using it', async () => {
+    const candidate = join(homedir(), '.local', 'bin', CLAUDE_BINARY_NAME);
+    process.env.CLAUDE_BIN_PATH = '/stale/claude';
+    pathKindSpy = spyOn(resolver, 'pathKind').mockImplementation((path: string) =>
+      path === candidate ? 'file' : 'missing'
+    );
+
+    expect(await rejectionMessage(resolver.resolveClaudeBinaryPath())).toBe(
+      'CLAUDE_BIN_PATH is set to "/stale/claude" but the file does not exist.\n' +
+        'Please verify the path points to the Claude Code executable (native binary\n' +
+        'from the curl/PowerShell installer, or cli.js from an npm global install).\n\n' +
+        'A Claude Code binary was found at ' +
+        candidate +
+        '.\n' +
+        'Update CLAUDE_BIN_PATH to that path, or remove CLAUDE_BIN_PATH to let Archon detect it.'
+    );
+    expect(mockLogger.info).not.toHaveBeenCalledWith(
+      expect.objectContaining({ binaryPath: candidate }),
+      'claude.binary_resolved'
     );
   });
 
@@ -73,8 +106,31 @@ describe('resolveClaudeBinaryPath (binary mode)', () => {
   test('throws when config claudeBinaryPath file does not exist', async () => {
     pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('missing');
 
-    await expect(resolver.resolveClaudeBinaryPath('/nonexistent/cli.js')).rejects.toThrow(
-      'assistants.claude.claudeBinaryPath is set to "/nonexistent/cli.js" but the file does not exist'
+    expect(await rejectionMessage(resolver.resolveClaudeBinaryPath('/nonexistent/cli.js'))).toBe(
+      'assistants.claude.claudeBinaryPath is set to "/nonexistent/cli.js" but the file does not exist.\n' +
+        'Please verify the path points to the Claude Code executable (native binary\n' +
+        'from the curl/PowerShell installer, or cli.js from an npm global install).'
+    );
+  });
+
+  test('names the autodetected binary when claudeBinaryPath is stale without using it', async () => {
+    const candidate = join(homedir(), '.local', 'bin', CLAUDE_BINARY_NAME);
+    pathKindSpy = spyOn(resolver, 'pathKind').mockImplementation((path: string) =>
+      path === candidate ? 'file' : 'missing'
+    );
+
+    expect(await rejectionMessage(resolver.resolveClaudeBinaryPath('/stale/config/claude'))).toBe(
+      'assistants.claude.claudeBinaryPath is set to "/stale/config/claude" but the file does not exist.\n' +
+        'Please verify the path points to the Claude Code executable (native binary\n' +
+        'from the curl/PowerShell installer, or cli.js from an npm global install).\n\n' +
+        'A Claude Code binary was found at ' +
+        candidate +
+        '.\n' +
+        'Update assistants.claude.claudeBinaryPath to that path, or remove claudeBinaryPath to let Archon detect it.'
+    );
+    expect(mockLogger.info).not.toHaveBeenCalledWith(
+      expect.objectContaining({ binaryPath: candidate }),
+      'claude.binary_resolved'
     );
   });
 
@@ -201,6 +257,30 @@ describe('resolveClaudeBinaryPath (binary mode)', () => {
     await expect(promise).rejects.toThrow('assistants.claude.claudeBinaryPath');
     await expect(promise).rejects.toThrow('which is a directory');
     await expect(promise).rejects.toThrow(`does not contain ${CLAUDE_BINARY_NAME}`);
+  });
+
+  test('adds the autodetected binary to a configured-directory error without using it', async () => {
+    const dir = '/some/empty/dir';
+    const candidate = join(homedir(), '.local', 'bin', CLAUDE_BINARY_NAME);
+    pathKindSpy = spyOn(resolver, 'pathKind').mockImplementation((path: string) => {
+      if (path === dir) return 'directory';
+      if (path === candidate) return 'file';
+      return 'missing';
+    });
+
+    expect(await rejectionMessage(resolver.resolveClaudeBinaryPath(dir))).toBe(
+      `assistants.claude.claudeBinaryPath is set to "${dir}", which is a directory, but it does not contain ${CLAUDE_BINARY_NAME}.\n` +
+        'Please point this setting at the Claude Code executable itself (native binary\n' +
+        'from the curl/PowerShell installer, or cli.js from an npm global install).\n\n' +
+        'A Claude Code binary was found at ' +
+        candidate +
+        '.\n' +
+        'Update assistants.claude.claudeBinaryPath to that path, or remove claudeBinaryPath to let Archon detect it.'
+    );
+    expect(mockLogger.info).not.toHaveBeenCalledWith(
+      expect.objectContaining({ binaryPath: candidate }),
+      'claude.binary_resolved'
+    );
   });
 
   test('throws a directory-specific error when CLAUDE_BIN_PATH is a directory missing the expected executable', async () => {

--- a/packages/providers/src/claude/binary-resolver.ts
+++ b/packages/providers/src/claude/binary-resolver.ts
@@ -18,10 +18,15 @@
  * undefined so the caller omits `pathToClaudeCodeExecutable` entirely and
  * the SDK resolves via its normal node_modules lookup.
  */
-import { existsSync as _existsSync, statSync as _statSync } from 'node:fs';
+import { existsSync as _existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { BUNDLED_IS_BINARY, createLogger } from '@archon/paths';
+import {
+  appendBinaryCandidateHint,
+  classifyBinaryPath,
+  type BinaryPathKind,
+} from '../shared/binary-resolution';
 
 /** Wrapper for existsSync — enables spyOn in tests (direct imports can't be spied on). */
 export function fileExists(path: string): boolean {
@@ -31,7 +36,7 @@ export function fileExists(path: string): boolean {
 /** Platform-specific Claude Code binary filename: `claude.exe` on Windows, `claude` elsewhere. */
 export const CLAUDE_BINARY_NAME = process.platform === 'win32' ? 'claude.exe' : 'claude';
 
-export type PathKind = 'file' | 'directory' | 'missing';
+export type PathKind = BinaryPathKind;
 
 /**
  * Classify a configured path. The Claude Agent SDK requires a spawnable file:
@@ -46,18 +51,9 @@ export type PathKind = 'file' | 'directory' | 'missing';
  * would otherwise surface as a misleading "file does not exist".
  */
 export function pathKind(path: string): PathKind {
-  try {
-    const stat = _statSync(path);
-    if (stat.isFile()) return 'file';
-    if (stat.isDirectory()) return 'directory';
-    return 'missing';
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code !== 'ENOENT' && code !== 'ENOTDIR') {
-      getLog().warn({ err, path, code }, 'claude.path_stat_failed');
-    }
-    return 'missing';
-  }
+  return classifyBinaryPath(path, error => {
+    getLog().warn({ err: error, path, code: error.code }, 'claude.path_stat_failed');
+  });
 }
 
 /**
@@ -67,23 +63,41 @@ export function pathKind(path: string): PathKind {
  * which contains the binary inside — expand to the contained executable
  * transparently in that case.
  */
-function validateAndExpand(rawPath: string, sourceLabel: string): string {
+function validateAndExpand(
+  rawPath: string,
+  pin: { sourceLabel: string; removableSetting: string },
+  findCandidate?: () => string | undefined
+): string {
   const kind = pathKind(rawPath);
   if (kind === 'file') return rawPath;
+  let message: string;
   if (kind === 'directory') {
     const candidate = join(rawPath, CLAUDE_BINARY_NAME);
     if (pathKind(candidate) === 'file') return candidate;
-    throw new Error(
-      `${sourceLabel} is set to "${rawPath}", which is a directory, but it does not contain ${CLAUDE_BINARY_NAME}.\n` +
-        'Please point this setting at the Claude Code executable itself (native binary\n' +
-        'from the curl/PowerShell installer, or cli.js from an npm global install).'
-    );
-  }
-  throw new Error(
-    `${sourceLabel} is set to "${rawPath}" but the file does not exist.\n` +
+    message =
+      `${pin.sourceLabel} is set to "${rawPath}", which is a directory, but it does not contain ${CLAUDE_BINARY_NAME}.\n` +
+      'Please point this setting at the Claude Code executable itself (native binary\n' +
+      'from the curl/PowerShell installer, or cli.js from an npm global install).';
+  } else {
+    message =
+      `${pin.sourceLabel} is set to "${rawPath}" but the file does not exist.\n` +
       'Please verify the path points to the Claude Code executable (native binary\n' +
-      'from the curl/PowerShell installer, or cli.js from an npm global install).'
+      'from the curl/PowerShell installer, or cli.js from an npm global install).';
+  }
+
+  throw new Error(
+    appendBinaryCandidateHint(message, {
+      candidatePath: findCandidate?.(),
+      binaryLabel: 'Claude Code',
+      sourceLabel: pin.sourceLabel,
+      removableSetting: pin.removableSetting,
+    })
   );
+}
+
+function findAutodetectedBinary(): string | undefined {
+  const nativeInstallerPath = join(homedir(), '.local', 'bin', CLAUDE_BINARY_NAME);
+  return pathKind(nativeInstallerPath) === 'file' ? nativeInstallerPath : undefined;
 }
 
 /** Lazy-initialized logger */
@@ -155,7 +169,11 @@ export async function resolveClaudeBinaryWithSource(
   // its resolution order) can pin a known-good binary without a compiled build.
   const envPath = process.env.CLAUDE_BIN_PATH;
   if (envPath) {
-    const resolvedEnv = validateAndExpand(envPath, 'CLAUDE_BIN_PATH');
+    const resolvedEnv = validateAndExpand(
+      envPath,
+      { sourceLabel: 'CLAUDE_BIN_PATH', removableSetting: 'CLAUDE_BIN_PATH' },
+      BUNDLED_IS_BINARY ? findAutodetectedBinary : undefined
+    );
     getLog().info({ binaryPath: resolvedEnv, source: 'env' }, 'claude.binary_resolved');
     return { path: resolvedEnv, source: 'env' };
   }
@@ -166,7 +184,11 @@ export async function resolveClaudeBinaryWithSource(
   if (configClaudeBinaryPath) {
     const resolvedConfig = validateAndExpand(
       configClaudeBinaryPath,
-      'assistants.claude.claudeBinaryPath'
+      {
+        sourceLabel: 'assistants.claude.claudeBinaryPath',
+        removableSetting: 'claudeBinaryPath',
+      },
+      findAutodetectedBinary
     );
     getLog().info({ binaryPath: resolvedConfig, source: 'config' }, 'claude.binary_resolved');
     return { path: resolvedConfig, source: 'config' };
@@ -179,8 +201,8 @@ export async function resolveClaudeBinaryWithSource(
   // the recommended install path don't need any env var or config entry;
   // users who deviate (npm global, custom path, etc.) still set one of
   // the higher-priority sources above.
-  const nativeInstallerPath = join(homedir(), '.local', 'bin', CLAUDE_BINARY_NAME);
-  if (pathKind(nativeInstallerPath) === 'file') {
+  const nativeInstallerPath = findAutodetectedBinary();
+  if (nativeInstallerPath) {
     getLog().info(
       { binaryPath: nativeInstallerPath, source: 'autodetect' },
       'claude.binary_resolved'

--- a/packages/providers/src/codex/binary-resolver.test.ts
+++ b/packages/providers/src/codex/binary-resolver.test.ts
@@ -5,6 +5,7 @@
  * with BUNDLED_IS_BINARY=true, which conflicts with other test files.
  */
 import { homedir } from 'node:os';
+import { join } from 'node:path';
 
 import { describe, test, expect, mock, beforeEach, afterAll, spyOn } from 'bun:test';
 import { createMockLogger } from '../test/mocks/logger';
@@ -20,13 +21,28 @@ mock.module('@archon/paths', () => ({
 
 import * as resolver from './binary-resolver';
 
+const CODEX_BINARY_NAME = process.platform === 'win32' ? 'codex.exe' : 'codex';
+
+async function rejectionMessage(promise: Promise<unknown>): Promise<string> {
+  try {
+    await promise;
+  } catch (error) {
+    return (error as Error).message;
+  }
+  throw new Error('Expected promise to reject');
+}
+
 describe('resolveCodexBinaryPath (binary mode)', () => {
   const originalEnv = process.env.CODEX_BIN_PATH;
-  let fileExistsSpy: ReturnType<typeof spyOn>;
+  let fileExistsSpy: ReturnType<typeof spyOn> | undefined;
+  let pathKindSpy: ReturnType<typeof spyOn> | undefined;
 
   beforeEach(() => {
     delete process.env.CODEX_BIN_PATH;
     fileExistsSpy?.mockRestore();
+    pathKindSpy?.mockRestore();
+    fileExistsSpy = undefined;
+    pathKindSpy = undefined;
     mockLogger.info.mockClear();
   });
 
@@ -37,11 +53,12 @@ describe('resolveCodexBinaryPath (binary mode)', () => {
       delete process.env.CODEX_BIN_PATH;
     }
     fileExistsSpy?.mockRestore();
+    pathKindSpy?.mockRestore();
   });
 
   test('uses CODEX_BIN_PATH env var when set and file exists', async () => {
     process.env.CODEX_BIN_PATH = '/usr/local/bin/codex';
-    fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(true);
+    pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('file');
 
     const result = await resolver.resolveCodexBinaryPath();
     expect(result).toBe('/usr/local/bin/codex');
@@ -49,29 +66,135 @@ describe('resolveCodexBinaryPath (binary mode)', () => {
 
   test('throws when CODEX_BIN_PATH is set but file does not exist', async () => {
     process.env.CODEX_BIN_PATH = '/nonexistent/codex';
+    pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('missing');
     fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(false);
 
-    await expect(resolver.resolveCodexBinaryPath()).rejects.toThrow('does not exist');
+    expect(await rejectionMessage(resolver.resolveCodexBinaryPath())).toBe(
+      'CODEX_BIN_PATH is set to "/nonexistent/codex" but the file does not exist.\n' +
+        'Please verify the path points to the Codex CLI binary.'
+    );
+  });
+
+  test('names the vendor binary when CODEX_BIN_PATH is stale without using it', async () => {
+    process.env.CODEX_BIN_PATH = '/stale/codex';
+    const candidate = join('/tmp/test-archon-home', 'vendor', 'codex', CODEX_BINARY_NAME);
+    pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('missing');
+    fileExistsSpy = spyOn(resolver, 'fileExists').mockImplementation(
+      (path: string) => path === candidate
+    );
+
+    expect(await rejectionMessage(resolver.resolveCodexBinaryPath())).toBe(
+      'CODEX_BIN_PATH is set to "/stale/codex" but the file does not exist.\n' +
+        'Please verify the path points to the Codex CLI binary.\n\n' +
+        'A Codex binary was found at ' +
+        candidate +
+        '.\n' +
+        'Update CODEX_BIN_PATH to that path, or remove CODEX_BIN_PATH to let Archon detect it.'
+    );
+    expect(mockLogger.info).not.toHaveBeenCalledWith(
+      expect.objectContaining({ binaryPath: candidate }),
+      'codex.binary_resolved'
+    );
   });
 
   test('uses config codexBinaryPath when file exists', async () => {
-    fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(true);
+    pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('file');
 
     const result = await resolver.resolveCodexBinaryPath('/custom/codex/path');
     expect(result).toBe('/custom/codex/path');
   });
 
   test('throws when config codexBinaryPath file does not exist', async () => {
+    pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('missing');
     fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(false);
 
-    await expect(resolver.resolveCodexBinaryPath('/nonexistent/codex')).rejects.toThrow(
-      'does not exist'
+    expect(await rejectionMessage(resolver.resolveCodexBinaryPath('/nonexistent/codex'))).toBe(
+      'assistants.codex.codexBinaryPath is set to "/nonexistent/codex" but the file does not exist.\n' +
+        'Please verify the path in .archon/config.yaml points to the Codex CLI binary.'
+    );
+  });
+
+  test('names an autodetected binary when codexBinaryPath is stale without using it', async () => {
+    const candidate =
+      process.platform === 'win32'
+        ? join(homedir(), '.npm-global', 'codex.cmd')
+        : join(homedir(), '.npm-global', 'bin', 'codex');
+    pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('missing');
+    fileExistsSpy = spyOn(resolver, 'fileExists').mockImplementation(
+      (path: string) => path === candidate
+    );
+
+    expect(await rejectionMessage(resolver.resolveCodexBinaryPath('/stale/config/codex'))).toBe(
+      'assistants.codex.codexBinaryPath is set to "/stale/config/codex" but the file does not exist.\n' +
+        'Please verify the path in .archon/config.yaml points to the Codex CLI binary.\n\n' +
+        'A Codex binary was found at ' +
+        candidate +
+        '.\n' +
+        'Update assistants.codex.codexBinaryPath to that path, or remove codexBinaryPath to let Archon detect it.'
+    );
+    expect(mockLogger.info).not.toHaveBeenCalledWith(
+      expect.objectContaining({ binaryPath: candidate }),
+      'codex.binary_resolved'
+    );
+  });
+
+  test('expands a CODEX_BIN_PATH directory to its contained executable', async () => {
+    const directory = '/opt/codex-package';
+    const expected = join(directory, CODEX_BINARY_NAME);
+    process.env.CODEX_BIN_PATH = directory;
+    pathKindSpy = spyOn(resolver, 'pathKind').mockImplementation((path: string) => {
+      if (path === directory) return 'directory';
+      if (path === expected) return 'file';
+      return 'missing';
+    });
+
+    const result = await resolver.resolveCodexBinaryPath();
+    expect(result).toBe(expected);
+  });
+
+  test('expands a config codexBinaryPath directory to its contained executable', async () => {
+    const directory = '/opt/codex-package';
+    const expected = join(directory, CODEX_BINARY_NAME);
+    pathKindSpy = spyOn(resolver, 'pathKind').mockImplementation((path: string) => {
+      if (path === directory) return 'directory';
+      if (path === expected) return 'file';
+      return 'missing';
+    });
+
+    const result = await resolver.resolveCodexBinaryPath(directory);
+    expect(result).toBe(expected);
+  });
+
+  test('rejects a CODEX_BIN_PATH directory without the executable', async () => {
+    const directory = '/opt/empty-codex-package';
+    process.env.CODEX_BIN_PATH = directory;
+    pathKindSpy = spyOn(resolver, 'pathKind').mockImplementation((path: string) =>
+      path === directory ? 'directory' : 'missing'
+    );
+    fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(false);
+
+    expect(await rejectionMessage(resolver.resolveCodexBinaryPath())).toBe(
+      `CODEX_BIN_PATH is set to "${directory}", which is a directory, but it does not contain ${CODEX_BINARY_NAME}.\n` +
+        'Please point this setting at the Codex CLI binary itself.'
+    );
+  });
+
+  test('rejects a config codexBinaryPath directory without the executable', async () => {
+    const directory = '/opt/empty-codex-package';
+    pathKindSpy = spyOn(resolver, 'pathKind').mockImplementation((path: string) =>
+      path === directory ? 'directory' : 'missing'
+    );
+    fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(false);
+
+    expect(await rejectionMessage(resolver.resolveCodexBinaryPath(directory))).toBe(
+      `assistants.codex.codexBinaryPath is set to "${directory}", which is a directory, but it does not contain ${CODEX_BINARY_NAME}.\n` +
+        'Please point this setting at the Codex CLI binary itself.'
     );
   });
 
   test('env var takes precedence over config path', async () => {
     process.env.CODEX_BIN_PATH = '/env/codex';
-    fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(true);
+    pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('file');
 
     const result = await resolver.resolveCodexBinaryPath('/config/codex');
     expect(result).toBe('/env/codex');
@@ -125,6 +248,7 @@ describe('resolveCodexBinaryPath (binary mode)', () => {
     // present on disk; config must win. Mirrors the env-over-config and
     // env-over-autodetect tests above so the four-tier precedence
     // (env → config → vendor → autodetect) is fully covered.
+    pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('file');
     fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(true);
 
     const result = await resolver.resolveCodexBinaryPath('/explicit/config/codex');

--- a/packages/providers/src/codex/binary-resolver.test.ts
+++ b/packages/providers/src/codex/binary-resolver.test.ts
@@ -22,6 +22,13 @@ mock.module('@archon/paths', () => ({
 import * as resolver from './binary-resolver';
 
 const CODEX_BINARY_NAME = process.platform === 'win32' ? 'codex.exe' : 'codex';
+const VENDOR_BINARY_PATH = join('/tmp/test-archon-home', 'vendor', 'codex', CODEX_BINARY_NAME);
+const FIRST_AUTODETECT_PATH =
+  process.platform === 'win32'
+    ? process.env.APPDATA
+      ? join(process.env.APPDATA, 'npm', 'codex.cmd')
+      : join(homedir(), '.npm-global', 'codex.cmd')
+    : join(homedir(), '.npm-global', 'bin', 'codex');
 
 async function rejectionMessage(promise: Promise<unknown>): Promise<string> {
   try {
@@ -34,14 +41,11 @@ async function rejectionMessage(promise: Promise<unknown>): Promise<string> {
 
 describe('resolveCodexBinaryPath (binary mode)', () => {
   const originalEnv = process.env.CODEX_BIN_PATH;
-  let fileExistsSpy: ReturnType<typeof spyOn> | undefined;
   let pathKindSpy: ReturnType<typeof spyOn> | undefined;
 
   beforeEach(() => {
     delete process.env.CODEX_BIN_PATH;
-    fileExistsSpy?.mockRestore();
     pathKindSpy?.mockRestore();
-    fileExistsSpy = undefined;
     pathKindSpy = undefined;
     mockLogger.info.mockClear();
   });
@@ -52,7 +56,6 @@ describe('resolveCodexBinaryPath (binary mode)', () => {
     } else {
       delete process.env.CODEX_BIN_PATH;
     }
-    fileExistsSpy?.mockRestore();
     pathKindSpy?.mockRestore();
   });
 
@@ -67,7 +70,6 @@ describe('resolveCodexBinaryPath (binary mode)', () => {
   test('throws when CODEX_BIN_PATH is set but file does not exist', async () => {
     process.env.CODEX_BIN_PATH = '/nonexistent/codex';
     pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('missing');
-    fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(false);
 
     expect(await rejectionMessage(resolver.resolveCodexBinaryPath())).toBe(
       'CODEX_BIN_PATH is set to "/nonexistent/codex" but the file does not exist.\n' +
@@ -75,27 +77,42 @@ describe('resolveCodexBinaryPath (binary mode)', () => {
     );
   });
 
-  test('names the vendor binary when CODEX_BIN_PATH is stale without using it', async () => {
-    process.env.CODEX_BIN_PATH = '/stale/codex';
-    const candidate = join('/tmp/test-archon-home', 'vendor', 'codex', CODEX_BINARY_NAME);
-    pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('missing');
-    fileExistsSpy = spyOn(resolver, 'fileExists').mockImplementation(
-      (path: string) => path === candidate
-    );
+  test.each([
+    [
+      'CODEX_BIN_PATH',
+      'CODEX_BIN_PATH',
+      'Please verify the path points to the Codex CLI binary.',
+      true,
+    ],
+    [
+      'assistants.codex.codexBinaryPath',
+      'codexBinaryPath',
+      'Please verify the path in .archon/config.yaml points to the Codex CLI binary.',
+      false,
+    ],
+  ] as const)(
+    'names the vendor binary before autodetect when %s is stale without using it',
+    async (sourceLabel, removableSetting, instruction, usesEnv) => {
+      const stalePath = '/stale/codex';
+      if (usesEnv) process.env.CODEX_BIN_PATH = stalePath;
+      pathKindSpy = spyOn(resolver, 'pathKind').mockImplementation((path: string) =>
+        path === VENDOR_BINARY_PATH || path === FIRST_AUTODETECT_PATH ? 'file' : 'missing'
+      );
 
-    expect(await rejectionMessage(resolver.resolveCodexBinaryPath())).toBe(
-      'CODEX_BIN_PATH is set to "/stale/codex" but the file does not exist.\n' +
-        'Please verify the path points to the Codex CLI binary.\n\n' +
-        'A Codex binary was found at ' +
-        candidate +
-        '.\n' +
-        'Update CODEX_BIN_PATH to that path, or remove CODEX_BIN_PATH to let Archon detect it.'
-    );
-    expect(mockLogger.info).not.toHaveBeenCalledWith(
-      expect.objectContaining({ binaryPath: candidate }),
-      'codex.binary_resolved'
-    );
-  });
+      const configuredPath = usesEnv ? undefined : stalePath;
+      expect(await rejectionMessage(resolver.resolveCodexBinaryPath(configuredPath))).toBe(
+        `${sourceLabel} is set to "${stalePath}" but the file does not exist.\n` +
+          `${instruction}\n\n` +
+          `A Codex binary was found at ${VENDOR_BINARY_PATH}.\n` +
+          `Update ${sourceLabel} to that path, or remove ${removableSetting} to let Archon detect it.`
+      );
+      expect(pathKindSpy).toHaveBeenCalledWith(VENDOR_BINARY_PATH);
+      expect(mockLogger.info).not.toHaveBeenCalledWith(
+        expect.objectContaining({ binaryPath: VENDOR_BINARY_PATH }),
+        'codex.binary_resolved'
+      );
+    }
+  );
 
   test('uses config codexBinaryPath when file exists', async () => {
     pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('file');
@@ -106,7 +123,6 @@ describe('resolveCodexBinaryPath (binary mode)', () => {
 
   test('throws when config codexBinaryPath file does not exist', async () => {
     pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('missing');
-    fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(false);
 
     expect(await rejectionMessage(resolver.resolveCodexBinaryPath('/nonexistent/codex'))).toBe(
       'assistants.codex.codexBinaryPath is set to "/nonexistent/codex" but the file does not exist.\n' +
@@ -114,27 +130,16 @@ describe('resolveCodexBinaryPath (binary mode)', () => {
     );
   });
 
-  test('names an autodetected binary when codexBinaryPath is stale without using it', async () => {
-    const candidate =
-      process.platform === 'win32'
-        ? join(homedir(), '.npm-global', 'codex.cmd')
-        : join(homedir(), '.npm-global', 'bin', 'codex');
-    pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('missing');
-    fileExistsSpy = spyOn(resolver, 'fileExists').mockImplementation(
-      (path: string) => path === candidate
-    );
+  test('skips directory candidates when diagnosing a stale pin', async () => {
+    const stalePath = '/stale/config/codex';
+    pathKindSpy = spyOn(resolver, 'pathKind').mockImplementation((path: string) => {
+      if (path === VENDOR_BINARY_PATH) return 'directory';
+      if (path === FIRST_AUTODETECT_PATH) return 'file';
+      return 'missing';
+    });
 
-    expect(await rejectionMessage(resolver.resolveCodexBinaryPath('/stale/config/codex'))).toBe(
-      'assistants.codex.codexBinaryPath is set to "/stale/config/codex" but the file does not exist.\n' +
-        'Please verify the path in .archon/config.yaml points to the Codex CLI binary.\n\n' +
-        'A Codex binary was found at ' +
-        candidate +
-        '.\n' +
-        'Update assistants.codex.codexBinaryPath to that path, or remove codexBinaryPath to let Archon detect it.'
-    );
-    expect(mockLogger.info).not.toHaveBeenCalledWith(
-      expect.objectContaining({ binaryPath: candidate }),
-      'codex.binary_resolved'
+    expect(await rejectionMessage(resolver.resolveCodexBinaryPath(stalePath))).toContain(
+      `A Codex binary was found at ${FIRST_AUTODETECT_PATH}.`
     );
   });
 
@@ -171,7 +176,6 @@ describe('resolveCodexBinaryPath (binary mode)', () => {
     pathKindSpy = spyOn(resolver, 'pathKind').mockImplementation((path: string) =>
       path === directory ? 'directory' : 'missing'
     );
-    fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(false);
 
     expect(await rejectionMessage(resolver.resolveCodexBinaryPath())).toBe(
       `CODEX_BIN_PATH is set to "${directory}", which is a directory, but it does not contain ${CODEX_BINARY_NAME}.\n` +
@@ -184,7 +188,6 @@ describe('resolveCodexBinaryPath (binary mode)', () => {
     pathKindSpy = spyOn(resolver, 'pathKind').mockImplementation((path: string) =>
       path === directory ? 'directory' : 'missing'
     );
-    fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(false);
 
     expect(await rejectionMessage(resolver.resolveCodexBinaryPath(directory))).toBe(
       `assistants.codex.codexBinaryPath is set to "${directory}", which is a directory, but it does not contain ${CODEX_BINARY_NAME}.\n` +
@@ -201,9 +204,9 @@ describe('resolveCodexBinaryPath (binary mode)', () => {
   });
 
   test('checks vendor directory when no env or config path', async () => {
-    fileExistsSpy = spyOn(resolver, 'fileExists').mockImplementation((path: string) => {
+    pathKindSpy = spyOn(resolver, 'pathKind').mockImplementation((path: string) => {
       const normalized = path.replace(/\\/g, '/');
-      return normalized.includes('vendor/codex');
+      return normalized.includes('vendor/codex') ? 'file' : 'missing';
     });
 
     const result = await resolver.resolveCodexBinaryPath();
@@ -215,8 +218,8 @@ describe('resolveCodexBinaryPath (binary mode)', () => {
   test('autodetects npm global install at ~/.npm-global/bin/codex (POSIX)', async () => {
     if (process.platform === 'win32') return; // POSIX-only probe
     const expected = `${homedir()}/.npm-global/bin/codex`;
-    fileExistsSpy = spyOn(resolver, 'fileExists').mockImplementation(
-      (path: string) => path === expected
+    pathKindSpy = spyOn(resolver, 'pathKind').mockImplementation((path: string) =>
+      path === expected ? 'file' : 'missing'
     );
 
     const result = await resolver.resolveCodexBinaryPath();
@@ -231,8 +234,8 @@ describe('resolveCodexBinaryPath (binary mode)', () => {
     if (process.platform !== 'win32') return; // Windows-only probe
     const appData = process.env.APPDATA ?? 'C:\\Users\\test\\AppData\\Roaming';
     const expected = `${appData}\\npm\\codex.cmd`;
-    fileExistsSpy = spyOn(resolver, 'fileExists').mockImplementation(
-      (path: string) => path === expected
+    pathKindSpy = spyOn(resolver, 'pathKind').mockImplementation((path: string) =>
+      path === expected ? 'file' : 'missing'
     );
 
     const result = await resolver.resolveCodexBinaryPath();
@@ -249,7 +252,6 @@ describe('resolveCodexBinaryPath (binary mode)', () => {
     // env-over-autodetect tests above so the four-tier precedence
     // (env → config → vendor → autodetect) is fully covered.
     pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('file');
-    fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(true);
 
     const result = await resolver.resolveCodexBinaryPath('/explicit/config/codex');
     expect(result).toBe('/explicit/config/codex');
@@ -261,8 +263,8 @@ describe('resolveCodexBinaryPath (binary mode)', () => {
       // hosts this test has nothing to assert (the probe list excludes it).
       return;
     }
-    fileExistsSpy = spyOn(resolver, 'fileExists').mockImplementation(
-      (path: string) => path === '/opt/homebrew/bin/codex'
+    pathKindSpy = spyOn(resolver, 'pathKind').mockImplementation((path: string) =>
+      path === '/opt/homebrew/bin/codex' ? 'file' : 'missing'
     );
 
     const result = await resolver.resolveCodexBinaryPath();
@@ -278,8 +280,8 @@ describe('resolveCodexBinaryPath (binary mode)', () => {
       // /usr/local/bin is not probed on Windows.
       return;
     }
-    fileExistsSpy = spyOn(resolver, 'fileExists').mockImplementation(
-      (path: string) => path === '/usr/local/bin/codex'
+    pathKindSpy = spyOn(resolver, 'pathKind').mockImplementation((path: string) =>
+      path === '/usr/local/bin/codex' ? 'file' : 'missing'
     );
 
     const result = await resolver.resolveCodexBinaryPath();
@@ -288,9 +290,11 @@ describe('resolveCodexBinaryPath (binary mode)', () => {
 
   test('vendor directory takes precedence over autodetect', async () => {
     // Both vendor and npm-global would match; vendor must win (lower tier #).
-    fileExistsSpy = spyOn(resolver, 'fileExists').mockImplementation((path: string) => {
+    pathKindSpy = spyOn(resolver, 'pathKind').mockImplementation((path: string) => {
       const normalized = path.replace(/\\/g, '/');
-      return normalized.includes('vendor/codex') || normalized.includes('.npm-global');
+      return normalized.includes('vendor/codex') || normalized.includes('.npm-global')
+        ? 'file'
+        : 'missing';
     });
 
     const result = await resolver.resolveCodexBinaryPath();
@@ -303,7 +307,13 @@ describe('resolveCodexBinaryPath (binary mode)', () => {
 
   test('throws with install instructions when binary not found anywhere', async () => {
     // Env unset, config unset, vendor dir empty, every autodetect path missing.
-    fileExistsSpy = spyOn(resolver, 'fileExists').mockReturnValue(false);
+    pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('missing');
+
+    await expect(resolver.resolveCodexBinaryPath()).rejects.toThrow('Codex CLI binary not found');
+  });
+
+  test('does not resolve lower-tier directories as binaries', async () => {
+    pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('directory');
 
     await expect(resolver.resolveCodexBinaryPath()).rejects.toThrow('Codex CLI binary not found');
   });

--- a/packages/providers/src/codex/binary-resolver.ts
+++ b/packages/providers/src/codex/binary-resolver.ts
@@ -19,19 +19,22 @@ import { existsSync as _existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { BUNDLED_IS_BINARY, getArchonHome, createLogger } from '@archon/paths';
+import {
+  appendBinaryCandidateHint,
+  classifyBinaryPath,
+  type BinaryPathKind,
+} from '../shared/binary-resolution';
 
 /** Wrapper for existsSync — enables spyOn in tests (direct imports can't be spied on). */
 export function fileExists(path: string): boolean {
   return _existsSync(path);
 }
 
-// TODO(#1723): existsSync returns true for directories, so an env or config
-// path pointing at the platform-package *directory* (e.g. an npm-distributed
-// `@openai/codex-<platform>` folder containing `codex{.exe}`) currently slips
-// past validation and crashes inside the SDK's child_process.spawn as ENOENT.
-// The Claude resolver applies a pathKind() / expandDirectoryToExecutable()
-// fix; mirror the same pattern here when a Codex bug report lands or as part
-// of a deliberate parity pass.
+export function pathKind(path: string): BinaryPathKind {
+  return classifyBinaryPath(path, error => {
+    getLog().warn({ err: error, path, code: error.code }, 'codex.path_stat_failed');
+  });
+}
 
 /** Lazy-initialized logger */
 let cachedLog: ReturnType<typeof createLogger> | undefined;
@@ -44,14 +47,86 @@ const CODEX_VENDOR_DIR = 'vendor/codex';
 
 const SUPPORTED_PLATFORMS = ['darwin', 'linux', 'win32'];
 
+const CODEX_BINARY_NAME = process.platform === 'win32' ? 'codex.exe' : 'codex';
+
 /** Which resolution tier produced the Codex binary path. */
 export type CodexBinarySource = 'env' | 'config' | 'vendor' | 'autodetect';
+
+interface CodexBinaryResolution {
+  path: string;
+  source: CodexBinarySource;
+}
+
+interface CodexBinaryPin {
+  sourceLabel: string;
+  removableSetting: string;
+  missingInstruction: string;
+}
+
+const CODEX_ENV_PIN: CodexBinaryPin = {
+  sourceLabel: 'CODEX_BIN_PATH',
+  removableSetting: 'CODEX_BIN_PATH',
+  missingInstruction: 'Please verify the path points to the Codex CLI binary.',
+};
+
+const CODEX_CONFIG_PIN: CodexBinaryPin = {
+  sourceLabel: 'assistants.codex.codexBinaryPath',
+  removableSetting: 'codexBinaryPath',
+  missingInstruction:
+    'Please verify the path in .archon/config.yaml points to the Codex CLI binary.',
+};
 
 /** Returns the vendor binary filename for the current platform, or undefined if unsupported. */
 function getVendorBinaryName(): string | undefined {
   if (!SUPPORTED_PLATFORMS.includes(process.platform)) return undefined;
   if (process.arch !== 'x64' && process.arch !== 'arm64') return undefined;
-  return process.platform === 'win32' ? 'codex.exe' : 'codex';
+  return CODEX_BINARY_NAME;
+}
+
+function findLowerTierBinary(): CodexBinaryResolution | undefined {
+  const binaryName = getVendorBinaryName();
+  if (binaryName) {
+    const vendorBinaryPath = join(getArchonHome(), CODEX_VENDOR_DIR, binaryName);
+    if (fileExists(vendorBinaryPath)) {
+      return { path: vendorBinaryPath, source: 'vendor' };
+    }
+  }
+
+  for (const probePath of getAutodetectPaths()) {
+    if (fileExists(probePath)) {
+      return { path: probePath, source: 'autodetect' };
+    }
+  }
+
+  return undefined;
+}
+
+function validateAndExpand(rawPath: string, pin: CodexBinaryPin): string {
+  const kind = pathKind(rawPath);
+  if (kind === 'file') return rawPath;
+
+  let message: string;
+  if (kind === 'directory') {
+    const executablePath = join(rawPath, CODEX_BINARY_NAME);
+    if (pathKind(executablePath) === 'file') return executablePath;
+    message =
+      `${pin.sourceLabel} is set to "${rawPath}", which is a directory, but it does not contain ${CODEX_BINARY_NAME}.\n` +
+      'Please point this setting at the Codex CLI binary itself.';
+  } else {
+    message =
+      `${pin.sourceLabel} is set to "${rawPath}" but the file does not exist.\n` +
+      pin.missingInstruction;
+  }
+
+  const candidate = findLowerTierBinary();
+  throw new Error(
+    appendBinaryCandidateHint(message, {
+      candidatePath: candidate?.path,
+      binaryLabel: 'Codex',
+      sourceLabel: pin.sourceLabel,
+      removableSetting: pin.removableSetting,
+    })
+  );
 }
 
 /**
@@ -75,56 +150,33 @@ export async function resolveCodexBinaryPath(
  */
 export async function resolveCodexBinaryWithSource(
   configCodexBinaryPath?: string
-): Promise<{ path: string; source: CodexBinarySource } | undefined> {
+): Promise<CodexBinaryResolution | undefined> {
   if (!BUNDLED_IS_BINARY) return undefined;
 
   // 1. Environment variable override
   const envPath = process.env.CODEX_BIN_PATH;
   if (envPath) {
-    if (!fileExists(envPath)) {
-      throw new Error(
-        `CODEX_BIN_PATH is set to "${envPath}" but the file does not exist.\n` +
-          'Please verify the path points to the Codex CLI binary.'
-      );
-    }
-    getLog().info({ binaryPath: envPath, source: 'env' }, 'codex.binary_resolved');
-    return { path: envPath, source: 'env' };
+    const resolvedEnv = validateAndExpand(envPath, CODEX_ENV_PIN);
+    getLog().info({ binaryPath: resolvedEnv, source: 'env' }, 'codex.binary_resolved');
+    return { path: resolvedEnv, source: 'env' };
   }
 
   // 2. Config file override
   if (configCodexBinaryPath) {
-    if (!fileExists(configCodexBinaryPath)) {
-      throw new Error(
-        `assistants.codex.codexBinaryPath is set to "${configCodexBinaryPath}" but the file does not exist.\n` +
-          'Please verify the path in .archon/config.yaml points to the Codex CLI binary.'
-      );
-    }
-    getLog().info({ binaryPath: configCodexBinaryPath, source: 'config' }, 'codex.binary_resolved');
-    return { path: configCodexBinaryPath, source: 'config' };
+    const resolvedConfig = validateAndExpand(configCodexBinaryPath, CODEX_CONFIG_PIN);
+    getLog().info({ binaryPath: resolvedConfig, source: 'config' }, 'codex.binary_resolved');
+    return { path: resolvedConfig, source: 'config' };
   }
 
-  // 3. Check vendor directory (user-placed binary)
-  const binaryName = getVendorBinaryName();
-  if (binaryName) {
-    const archonHome = getArchonHome();
-    const vendorBinaryPath = join(archonHome, CODEX_VENDOR_DIR, binaryName);
-
-    if (fileExists(vendorBinaryPath)) {
-      getLog().info({ binaryPath: vendorBinaryPath, source: 'vendor' }, 'codex.binary_resolved');
-      return { path: vendorBinaryPath, source: 'vendor' };
-    }
-  }
-
-  // 4. Autodetect — probe the handful of paths Codex typically lands at
-  // when installed via the documented package managers. Users who install
-  // somewhere else (custom npm prefix, etc.) still set one of the higher-
-  // priority sources above. Order: most specific → least specific.
-  const autodetectPaths = getAutodetectPaths();
-  for (const probePath of autodetectPaths) {
-    if (fileExists(probePath)) {
-      getLog().info({ binaryPath: probePath, source: 'autodetect' }, 'codex.binary_resolved');
-      return { path: probePath, source: 'autodetect' };
-    }
+  // 3-4. Vendor then autodetect. The same search supplies diagnostics for an
+  // invalid explicit pin, but a candidate is returned only when no pin exists.
+  const lowerTierBinary = findLowerTierBinary();
+  if (lowerTierBinary) {
+    getLog().info(
+      { binaryPath: lowerTierBinary.path, source: lowerTierBinary.source },
+      'codex.binary_resolved'
+    );
+    return lowerTierBinary;
   }
 
   // 5. Not found — throw with install instructions

--- a/packages/providers/src/codex/binary-resolver.ts
+++ b/packages/providers/src/codex/binary-resolver.ts
@@ -87,13 +87,13 @@ function findLowerTierBinary(): CodexBinaryResolution | undefined {
   const binaryName = getVendorBinaryName();
   if (binaryName) {
     const vendorBinaryPath = join(getArchonHome(), CODEX_VENDOR_DIR, binaryName);
-    if (fileExists(vendorBinaryPath)) {
+    if (pathKind(vendorBinaryPath) === 'file') {
       return { path: vendorBinaryPath, source: 'vendor' };
     }
   }
 
   for (const probePath of getAutodetectPaths()) {
-    if (fileExists(probePath)) {
+    if (pathKind(probePath) === 'file') {
       return { path: probePath, source: 'autodetect' };
     }
   }

--- a/packages/providers/src/shared/binary-resolution.ts
+++ b/packages/providers/src/shared/binary-resolution.ts
@@ -1,0 +1,37 @@
+import { statSync } from 'node:fs';
+
+export type BinaryPathKind = 'file' | 'directory' | 'missing';
+
+export function classifyBinaryPath(
+  path: string,
+  onUnexpectedStatError: (error: NodeJS.ErrnoException) => void
+): BinaryPathKind {
+  try {
+    const stat = statSync(path);
+    if (stat.isFile()) return 'file';
+    if (stat.isDirectory()) return 'directory';
+    return 'missing';
+  } catch (error) {
+    const statError = error as NodeJS.ErrnoException;
+    if (statError.code !== 'ENOENT' && statError.code !== 'ENOTDIR') {
+      onUnexpectedStatError(statError);
+    }
+    return 'missing';
+  }
+}
+
+export function appendBinaryCandidateHint(
+  message: string,
+  options: {
+    candidatePath: string | undefined;
+    binaryLabel: string;
+    sourceLabel: string;
+    removableSetting: string;
+  }
+): string {
+  if (!options.candidatePath) return message;
+  return (
+    `${message}\n\nA ${options.binaryLabel} binary was found at ${options.candidatePath}.\n` +
+    `Update ${options.sourceLabel} to that path, or remove ${options.removableSetting} to let Archon detect it.`
+  );
+}


### PR DESCRIPTION
## Problem and outcome

An invalid explicit Codex binary pin failed without identifying an already-discoverable replacement, and a directory pin could reach the SDK as an unspawnable path. Claude had the same missing actionable diagnostic for stale pins, leaving maintained-provider behavior out of parity.

- **Outcome:** Invalid Codex and Claude pins fail closed with a candidate/removal hint when their existing lower-tier discovery finds a binary; Codex directory pins resolve only to their contained executable.
- **Invariant:** Explicit pins retain precedence and never silently fall through to a lower-tier binary; vendor-before-autodetect ordering and no-candidate errors are unchanged.
- **Scope boundary:** Resolution tiers, supported locations, and provider installation behavior are unchanged.
- **Root cause:** Codex validated pins with `existsSync`, which accepted directories and threw before inspecting lower tiers; Claude likewise threw before its native-installer discovery could inform the error.

## Review guidance

- **Feedback requested:** Verify fail-closed behavior and Codex/Claude diagnostic parity across both explicit pin tiers.
- **Start here:** `packages/providers/src/codex/binary-resolver.ts:86` — the existing vendor/autodetect order is reused for diagnostics without returning a candidate for an invalid pin.
- **Review order:** Review the shared path and hint helpers, then the Codex resolver and tests, then the Claude parity change and the doctor regression test.
- **Lower-attention areas:** Test expectation updates directly cover the changed messages and paths.
- **Known risk or uncertainty:** None.

## Solution

The resolvers now classify explicit paths as files, directories, or missing. A directory is expanded only when it contains the platform-specific executable; otherwise the resolver remains fail closed. For an invalid pin, it inspects the same lower-tier candidate search used by normal resolution solely to add a repoint-or-remove hint. The candidate is never returned from that failure path.

Claude uses the same path classification and hint formatting helper, while retaining its native-installer discovery boundary. `archon doctor` continues to surface resolver failures verbatim, covered by a focused regression test.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Stale Codex/Claude pins reported only the invalid path; a Codex directory could be returned as the executable. | Errors name a discoverable candidate and how to repoint or remove the pin; valid binary directories expand to their executable. |
| **Failure behavior** | An invalid pin lacked recovery guidance, or a Codex directory failed later during SDK spawn. | Invalid pins fail at resolution with a precise error; lower-tier binaries remain diagnostic-only. |

## Validation

- `bun test src/codex/binary-resolver.test.ts && bun test src/codex/binary-resolver-dev.test.ts` (from `packages/providers`) — 23 passed — Codex pin tiers, directory expansion, candidate diagnostics, and preserved resolution behavior.
- `bun test src/claude/binary-resolver.test.ts && bun test src/claude/binary-resolver-dev.test.ts` (from `packages/providers`) — 29 passed — Claude pin-tier diagnostic parity and existing resolver behavior.
- `bun test src/commands/doctor.test.ts` (from `packages/cli`) — 77 passed — doctor returns the resolver diagnostic verbatim.
- `bun run type-check` (from `packages/providers` and `packages/cli`) — passed.
- `bun run validate` — passed — full repository validation, including generated artifacts, type checks, lint, formatting, installer tests, package tests, and script tests.
- **Not verified:** Nothing material; focused resolver and doctor paths plus full validation passed.

## Links

- Closes #3006

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex and Claude binary detection for configured paths, directories, and stale settings.
  * Expanded diagnostics with clearer error messages, installation guidance, and available binary locations.
  * Prevented invalid or lower-priority directory paths from being treated as executable binaries.
  * Avoided exposing candidate paths in diagnostic logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->