### PR TITLE
fix(cli): --supersedes accepts short run-id prefixes like --adopt

### DIFF
--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -10455,6 +10455,55 @@ describe('workflowRunCommand — supersedes run-id prefix resolution (#2990)', (
       expect.objectContaining({ adopted_from_run_id: supersededRunId })
     );
   });
+
+  it('refuses a non-terminal supersedes run in the detach pre-flight before forking', async () => {
+    const supersededRunId = '0b1ee8da-1111-2222-3333-444455556666';
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    const workflowDb = await import('@archon/core/db/workflows');
+    const paths = await import('@archon/paths');
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'assist', description: 'Help' })],
+      errors: [],
+    });
+    (paths.getArchonHome as ReturnType<typeof mock>).mockImplementationOnce(() => {
+      throw new Error('no home in test');
+    });
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce(null);
+    (codebaseDb.findCodebaseByPathPrefix as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'cb-1',
+      name: 'test/folder',
+      default_cwd: '/test/path',
+      kind: 'folder',
+    });
+    (workflowDb.findWorkflowRunsByIdPrefix as ReturnType<typeof mock>).mockResolvedValueOnce([
+      { id: supersededRunId },
+    ]);
+    // Argument-aware on purpose: the queued-value mocks are argument-blind, which
+    // would let terminality pass here even if it ran on the raw prefix.
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockImplementation(async (id: string) =>
+      id === supersededRunId ? { id: supersededRunId, status: 'running' } : null
+    );
+
+    const spawnSpy = spyOn(Bun, 'spawn');
+    try {
+      // The refusal names the resolved full id, so terminality is checked on the
+      // resolution, not on the raw prefix.
+      await expect(
+        workflowRunCommand('/test/path/subdir', 'assist', 'hello', {
+          detach: true,
+          supersedesRunId: '0b1ee8da',
+        })
+      ).rejects.toThrow(`Cannot supersede run '${supersededRunId}': it is still running.`);
+    } finally {
+      spawnSpy.mockRestore();
+    }
+
+    // The refusal reached the parent: no child was forked and no pending run row
+    // was left behind for a launch that cannot proceed (#2872).
+    expect(spawnSpy).not.toHaveBeenCalled();
+    expect(mockCreateWorkflowRun).not.toHaveBeenCalled();
+  });
 });
 
 describe('workflowWaitCommand', () => {

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -10210,6 +10210,253 @@ describe('workflowRunCommand — adopt lane source recapture (#2660/#2747)', () 
   });
 });
 
+describe('workflowRunCommand — supersedes run-id prefix resolution (#2990)', () => {
+  let consoleSpy: ReturnType<typeof spyOn>;
+
+  // The suites above leave queued mockOnce values and call history behind on the shared
+  // module mocks. Re-install the module-mock defaults so this describe starts from a
+  // clean queue and leaves one behind for the suites after it.
+  function resetSharedMocks(): void {
+    const discoverMock = require('@archon/workflows/workflow-discovery')
+      .discoverWorkflowsWithConfig as ReturnType<typeof mock>;
+    discoverMock.mockReset();
+    discoverMock.mockImplementation(() => Promise.resolve({ workflows: [], errors: [] }));
+    const codebaseDb = require('@archon/core/db/codebases');
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockReset();
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockImplementation(() =>
+      Promise.resolve(null)
+    );
+    (codebaseDb.findCodebaseByPathPrefix as ReturnType<typeof mock>).mockReset();
+    (codebaseDb.findCodebaseByPathPrefix as ReturnType<typeof mock>).mockImplementation(() =>
+      Promise.resolve(null)
+    );
+    const conversationDb = require('@archon/core/db/conversations');
+    (conversationDb.getOrCreateConversation as ReturnType<typeof mock>).mockReset();
+    (conversationDb.getOrCreateConversation as ReturnType<typeof mock>).mockImplementation(() =>
+      Promise.resolve({
+        id: 'conv-123',
+        platform_type: 'cli',
+        platform_conversation_id: 'cli-123',
+      })
+    );
+    (conversationDb.updateConversation as ReturnType<typeof mock>).mockReset();
+    (conversationDb.updateConversation as ReturnType<typeof mock>).mockImplementation(() =>
+      Promise.resolve(undefined)
+    );
+    const workflowDb = require('@archon/core/db/workflows');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockReset();
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockImplementation(() =>
+      Promise.resolve(null)
+    );
+    (workflowDb.findWorkflowRunsByIdPrefix as ReturnType<typeof mock>).mockReset();
+    (workflowDb.findWorkflowRunsByIdPrefix as ReturnType<typeof mock>).mockImplementation(() =>
+      Promise.resolve([])
+    );
+    mockCreateWorkflowRun.mockReset();
+    mockCreateWorkflowRun.mockImplementation(
+      (data: { workflow_name: string; conversation_id: string }) =>
+        Promise.resolve({
+          id: 'run-detached-created',
+          workflow_name: data.workflow_name,
+          conversation_id: data.conversation_id,
+          status: 'pending',
+          working_path: null,
+          started_at: new Date(),
+          metadata: {},
+        })
+    );
+    const adoption = require('@archon/core/operations/workflow-adoption');
+    (adoption.resolveWorkflowAdoption as ReturnType<typeof mock>).mockReset();
+    (adoption.resolveWorkflowAdoption as ReturnType<typeof mock>).mockImplementation(() =>
+      Promise.reject(new Error('adoption not expected'))
+    );
+  }
+
+  beforeEach(() => {
+    consoleSpy = spyOn(console, 'log').mockImplementation(() => {});
+    resetSharedMocks();
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    resetSharedMocks();
+  });
+
+  function setupSupersedesMocks(): void {
+    const discoverMock = require('@archon/workflows/workflow-discovery')
+      .discoverWorkflowsWithConfig as ReturnType<typeof mock>;
+    discoverMock.mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'assist', description: 'Help' })],
+      errors: [],
+    });
+    const codebaseDb = require('@archon/core/db/codebases');
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'cb-sup',
+      name: 'test-repo',
+      default_cwd: '/test/path',
+      kind: 'repo',
+    });
+  }
+
+  it('supersedes a run from a unique short run-id prefix', async () => {
+    const supersededRunId = '0b1ee8da-1111-2222-3333-444455556666';
+    const workflowDb = await import('@archon/core/db/workflows');
+    setupSupersedesMocks();
+    (workflowDb.findWorkflowRunsByIdPrefix as ReturnType<typeof mock>).mockResolvedValueOnce([
+      { id: supersededRunId },
+    ]);
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: supersededRunId,
+      status: 'completed',
+    });
+
+    await workflowRunCommand('/test/path', 'assist', 'hello', {
+      supersedesRunId: '0b1ee8da',
+      noWorktree: true,
+    });
+
+    expect(workflowDb.findWorkflowRunsByIdPrefix).toHaveBeenCalledWith('0b1ee8da', 'cb-sup');
+    // The terminality check sees the resolved full id, not the typed prefix.
+    expect(workflowDb.getWorkflowRun).toHaveBeenCalledWith(supersededRunId);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`Superseding run ${supersededRunId}`)
+    );
+  });
+
+  it('rejects an ambiguous supersedes run prefix with its candidates', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const adoption = await import('@archon/core/operations/workflow-adoption');
+    setupSupersedesMocks();
+    (workflowDb.findWorkflowRunsByIdPrefix as ReturnType<typeof mock>).mockResolvedValueOnce([
+      { id: '0b1ee8da-1111-2222-3333-444455556666' },
+      { id: '0b1ee8da-9999-8888-7777-666655554444' },
+    ]);
+
+    await expect(
+      workflowRunCommand('/test/path', 'assist', 'hello', {
+        supersedesRunId: '0b1ee8da',
+        noWorktree: true,
+      })
+    ).rejects.toThrow(
+      '0b1ee8da-1111-2222-3333-444455556666\n  0b1ee8da-9999-8888-7777-666655554444'
+    );
+    expect(workflowDb.getWorkflowRun).not.toHaveBeenCalled();
+    expect(adoption.resolveWorkflowAdoption).not.toHaveBeenCalled();
+  });
+
+  it('passes a full supersedes run id through unchanged', async () => {
+    const supersededRunId = '0b1ee8da-1111-2222-3333-444455556666';
+    const workflowDb = await import('@archon/core/db/workflows');
+    setupSupersedesMocks();
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: supersededRunId,
+      status: 'completed',
+    });
+
+    await workflowRunCommand('/test/path', 'assist', 'hello', {
+      supersedesRunId: supersededRunId,
+      noWorktree: true,
+    });
+
+    expect(workflowDb.findWorkflowRunsByIdPrefix).not.toHaveBeenCalled();
+    expect(workflowDb.getWorkflowRun).toHaveBeenCalledWith(supersededRunId);
+  });
+
+  it('keeps the unknown-id refusal for a prefix that matches nothing', async () => {
+    setupSupersedesMocks();
+
+    await expect(
+      workflowRunCommand('/test/path', 'assist', 'hello', {
+        supersedesRunId: 'deadbeef',
+        noWorktree: true,
+      })
+    ).rejects.toThrow("Cannot supersede: no workflow run 'deadbeef' exists.");
+  });
+
+  it('still refuses a supersedes run that is not terminal', async () => {
+    const supersededRunId = '0b1ee8da-1111-2222-3333-444455556666';
+    const workflowDb = await import('@archon/core/db/workflows');
+    setupSupersedesMocks();
+    (workflowDb.findWorkflowRunsByIdPrefix as ReturnType<typeof mock>).mockResolvedValueOnce([
+      { id: supersededRunId },
+    ]);
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: supersededRunId,
+      status: 'running',
+    });
+
+    await expect(
+      workflowRunCommand('/test/path', 'assist', 'hello', {
+        supersedesRunId: '0b1ee8da',
+        noWorktree: true,
+      })
+    ).rejects.toThrow(`Cannot supersede run '${supersededRunId}': it is still running.`);
+  });
+
+  it('resolves a supersedes run prefix before passing it to the detached child', async () => {
+    const supersededRunId = '0b1ee8da-1111-2222-3333-444455556666';
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    const workflowDb = await import('@archon/core/db/workflows');
+    const paths = await import('@archon/paths');
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'assist', description: 'Help' })],
+      errors: [],
+    });
+    (paths.getArchonHome as ReturnType<typeof mock>).mockImplementationOnce(() => {
+      throw new Error('no home in test');
+    });
+    // The detach pre-flight resolves the project the same way the adopt pre-flight
+    // does: a subdir cwd misses the exact default-cwd lookup, then the path-prefix
+    // lookup resolves the covering folder project.
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce(null);
+    (codebaseDb.findCodebaseByPathPrefix as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'cb-1',
+      name: 'test/folder',
+      default_cwd: '/test/path',
+      kind: 'folder',
+    });
+    (workflowDb.findWorkflowRunsByIdPrefix as ReturnType<typeof mock>).mockResolvedValueOnce([
+      { id: supersededRunId },
+    ]);
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: supersededRunId,
+      status: 'completed',
+    });
+
+    const child = createDetachedChildFixture();
+    const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(child.child);
+    const savedArgv = process.argv;
+    process.argv = ['bun', '/abs/cli.ts', 'workflow', 'run', 'assist', 'hello', '--detach'];
+
+    let spawnCmd: string[] = [];
+    // finishStartupWindow advances the 500 ms startup window on fake timers.
+    jest.useFakeTimers();
+    try {
+      const commandPromise = workflowRunCommand('/test/path/subdir', 'assist', 'hello', {
+        detach: true,
+        supersedesRunId: '0b1ee8da',
+      });
+      await finishStartupWindow(commandPromise, spawnSpy);
+      spawnCmd = (
+        (spawnSpy.mock.calls[0]?.[0] as { cmd: string[] } | undefined)?.cmd ?? []
+      ).slice();
+    } finally {
+      jest.useRealTimers();
+      process.argv = savedArgv;
+      spawnSpy.mockRestore();
+    }
+
+    const supIndex = spawnCmd.indexOf('--supersedes');
+    expect(supIndex).toBeGreaterThan(-1);
+    expect(spawnCmd[supIndex + 1]).toBe(supersededRunId);
+    expect(workflowDb.findWorkflowRunsByIdPrefix).toHaveBeenCalledWith('0b1ee8da', 'cb-1');
+    expect(mockCreateWorkflowRun).toHaveBeenCalledWith(
+      expect.objectContaining({ adopted_from_run_id: supersededRunId })
+    );
+  });
+});
+
 describe('workflowWaitCommand', () => {
   const FULL_ID = '0b1ee8da-1111-2222-3333-444455556666';
   let consoleSpy: ReturnType<typeof spyOn>;

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -2105,6 +2105,7 @@ async function runWorkflowWithOwnedSource(
     // pre-flight costs nothing and the child still re-resolves it against the live
     // checkout when it starts (its lane binds a worktree this process never touches).
     let adoptedRunId: string | undefined;
+    let supersededRunId: string | undefined;
     if (options.adoptRunId !== undefined || options.supersedesRunId !== undefined) {
       if (!detachCodebase) {
         throw new Error(
@@ -2121,7 +2122,13 @@ async function runWorkflowWithOwnedSource(
           containerRequested: options.container === true,
         });
       } else if (options.supersedesRunId !== undefined) {
-        await resolveSupersededRun(options.supersedesRunId);
+        supersededRunId = await resolveRunIdArg(
+          options.supersedesRunId,
+          cwd,
+          false,
+          detachCodebase.id
+        );
+        await resolveSupersededRun(supersededRunId);
       }
     }
 
@@ -2158,8 +2165,8 @@ async function runWorkflowWithOwnedSource(
       const continuationDeclaration =
         adoptedRunId !== undefined
           ? { mode: 'adopt' as const, runId: adoptedRunId }
-          : options.supersedesRunId !== undefined
-            ? { mode: 'supersede' as const, runId: options.supersedesRunId }
+          : supersededRunId !== undefined
+            ? { mode: 'supersede' as const, runId: supersededRunId }
             : undefined;
       try {
         // No reserved id: this process's own capture is discarded on the way out, and
@@ -2213,8 +2220,7 @@ async function runWorkflowWithOwnedSource(
     // Between-run continuation (#2747) — the child re-resolves the adoption
     // against the live filesystem/database, so pass the declaration through.
     if (adoptedRunId !== undefined) extraArgs.push('--adopt', adoptedRunId);
-    if (options.supersedesRunId !== undefined)
-      extraArgs.push('--supersedes', options.supersedesRunId);
+    if (supersededRunId !== undefined) extraArgs.push('--supersedes', supersededRunId);
     // Re-pin the source as an ABSOLUTE path (parseArgs is last-wins, same as --cwd).
     // The original argv may hold a relative `--workflow-source`, and the child is
     // spawned with a different working directory, so passing it through unresolved
@@ -2368,7 +2374,7 @@ async function runWorkflowWithOwnedSource(
       adoptedFromRunId = await resolveRunIdArg(options.adoptRunId, cwd, false, codebase.id);
     } else if (options.supersedesRunId !== undefined) {
       continuationMode = 'supersede';
-      adoptedFromRunId = options.supersedesRunId;
+      adoptedFromRunId = await resolveRunIdArg(options.supersedesRunId, cwd, false, codebase.id);
     } else {
       throw new Error('--adopt/--supersedes requires a run id.');
     }


### PR DESCRIPTION
## Problem and outcome

`--adopt` resolves short run-id prefixes (merged in #2948), but `--supersedes` still demanded a full run id, so the documented short run IDs were unusable on this path and the two continuation flags behaved inconsistently.

- **Outcome:** `--supersedes` now accepts a unique run-id prefix and behaves like `--adopt` for the shared resolver cases: unique prefixes resolve, ambiguous prefixes are refused with the candidate list, full ids pass through unchanged, and unknown prefixes keep the existing refusal.
- **Invariant:** `resolveSupersededRun`'s existence and terminality checks, and both refusal messages, behave exactly as before.
- **Scope boundary:** No change to terminality checks, provenance recording mechanism, or any other `--supersedes` behavior.
- **Root cause:** The two `--supersedes` call sites passed the raw flag value through instead of routing it through the shared `resolveRunIdArg` resolver that `--adopt` already used.

## Review guidance

- **Feedback requested:** Correctness of prefix resolution at both call sites, and that the detached path threads the resolved id everywhere the adopt lane does.
- **Start here:** `packages/cli/src/commands/workflow.ts:2105` — the detached pre-flight now resolves the prefix before the terminality check and threads `supersededRunId` into the continuation declaration, provenance, and the child's `--supersedes` argv flag, mirroring `adoptedRunId`.
- **Review order:** First `packages/cli/src/commands/workflow.ts` (both call sites, ~line 2105 and ~line 2374), then the new tests in `packages/cli/src/commands/workflow.test.ts` under `workflowRunCommand — supersedes run-id prefix resolution (#2990)`.
- **Lower-attention areas:** The `resetSharedMocks` helper in the new test describe is mechanical test hygiene: 340 earlier tests in that file leave queued `mockOnce` values on the shared module mocks, and without the reset the new tests consumed stale queue entries and failed only in the full-file run.
- **Known risk or uncertainty:** One pre-existing flaky integration test (`workflow-terminal-event.integration.spec.ts`) failed once during full-suite validation and passed on re-run and in isolation; it is unrelated to this change.

## Solution

Both `--supersedes` call sites now resolve the flag value through the shared `resolveRunIdArg` resolver, using the same call shape the `--adopt` calls added in #2948 (`resolveRunIdArg(id, cwd, false, codebase.id)` — prefix allowed, not required). In the detached pre-flight the resolution happens before `resolveSupersededRun`, so refusal messages and the child's argv carry the resolved full id, and the pre-created row's provenance records the full id rather than an unresolved prefix. In the foreground path the resolved id flows into the same terminality check and provenance recording as before. This reuses the existing primitive with no new code paths, which is the smallest coherent fix for the inconsistency.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | `--supersedes 0b1ee8da` failed; only a full run id was accepted | A unique prefix resolves to the full id and the run proceeds; the child receives the full id |
| **Failure behavior** | A prefix produced `no workflow run '<prefix>' exists` even when the run did exist | Ambiguous prefixes list their candidates; unknown prefixes keep the existing refusal; non-terminal runs are still refused |

## Validation

- `bun test src/commands/workflow.test.ts -t supersedes` — 7 pass. Pre-fix (with the source change stashed): 4 fail (unique prefix, ambiguous prefix, detached resolution, detach pre-flight non-terminality) and 3 pass, confirming the tests cover the fix.
- `bun run test` in packages/cli — all files, 0 failures (the flaky integration test above passed on re-run and in isolation).
- `bun run type-check` in packages/cli — clean.
- `bun run validate` at repo root — exit 0, zero failing tests across all packages.
- **Not verified:** Nothing material; the resolver cases (unique, ambiguous, unknown, full id, detach pass-through) and the unchanged terminality refusal are each covered by a focused test.

## Links

- Closes #2990
- Related #2948



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resolving shortened workflow run IDs supplied with `--supersedes`.
  * Short IDs are expanded when they uniquely identify a run within the relevant codebase.
  * Ambiguous, unknown, or non-terminal run IDs are now rejected with clear feedback.
  * Detached workflow runs consistently forward the resolved full run ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->