### PR TITLE
docs(skill): teach the CLI skill its post-run duties: wait for attention, route discoveries

### DIFF
--- a/.claude/skills/archon-cli/SKILL.md
+++ b/.claude/skills/archon-cli/SKILL.md
@@ -51,8 +51,11 @@ Most requests land here. The short version; details in the running reference:
    archon workflow run <workflow> --branch <branch-name> "<the work, as a clear message>" --detach
    ```
 
-4. Find the run id and monitor: `archon workflow runs --json`, then
-   `archon workflow get <run-id> --json`.
+4. Find the run id (`archon workflow runs --json`), then arm
+   `archon workflow wait <run-id> --json` as a background task of your harness —
+   it blocks until the run ends or needs a human decision, waking you at exactly
+   the right moment. `archon workflow get <run-id> --json` is for on-demand state,
+   not a polling loop.
 5. When a run pauses at a gate, resolve it deliberately:
    see `manage-run/manage-runs.md`.
 

--- a/.claude/skills/archon-cli/manage-run/manage-runs.md
+++ b/.claude/skills/archon-cli/manage-run/manage-runs.md
@@ -51,6 +51,7 @@ For reusable alternate setups, prefer a config layer instead of long flag lists
 | One run with per-node detail | `archon workflow get <run-id> --verbose --json` |
 | One run with raw event rows | `archon workflow get <run-id> --verbose --events --json` |
 | Active runs only | `archon workflow status --json` |
+| Block until the run ends or needs a human decision | `archon workflow wait <run-id> --json` |
 | Resolve a gate with any declared decision | `archon workflow respond <run-id> <decision> [text]` |
 | Approve (default vocabulary) | `archon workflow approve <run-id> [text]` |
 | Reject (default vocabulary) | `archon workflow reject <run-id> "<reason>"` |

--- a/.claude/skills/archon-cli/manage-run/manage-runs.md
+++ b/.claude/skills/archon-cli/manage-run/manage-runs.md
@@ -131,6 +131,35 @@ the user.
 Report outcomes with their evidence: "completed, review verdict ready:false —
 2 findings remain, report at <path>" beats "done".
 
+## Discoveries: the sdlc pack's out-of-scope findings
+
+A convention of the bundled sdlc workflows (`archon-ship`, `archon-deliver`,
+`archon-review`, `archon-stabilize`, `archon-upkeep`), not of workflows in
+general. Their review lenses record *proven* findings that fall outside the
+run's accepted scope as discovery sidecars instead of blocking findings: raw
+per-producer files at `<artifacts>/discoveries/*.json` (records of `title`,
+`claim`, `evidence`, `relation: adjacent | scope_conflict`, `source_node`),
+consolidated by the review into `discoveries.json` plus a human-readable
+`discoveries.md`. The terminal report ends with a discoveries section addressed
+to you, the relaying agent — deliberately, because the run itself never files
+issues from them. **If you drop a discovery at this hop, nobody ever sees it.**
+
+When such a run reaches terminal:
+
+1. Read the report's Discoveries section; when it names any, open
+   `discoveries.md` (locate it through `leave_behind.artifactFiles`).
+2. On a **failed** run, also check the raw `discoveries/*.json` sidecars —
+   consolidation runs late, so a run that died mid-flight can hold raw records
+   no report mentions.
+3. Surface each worthwhile discovery to the user with its evidence, and ask
+   where it goes: an evidence comment on the existing issue it belongs to, a
+   new issue when it is a novel defect, or an explicit drop. File nothing
+   without the user's go unless they have given standing authorization.
+
+Discoveries arrive validated (`evidence` carries concrete `file:line` facts or
+command results), and `adjacent` ones never affected the run's readiness — do
+not re-litigate the verdict from them; route them.
+
 ## When a run looks wrong
 
 - Paused unexpectedly → `get --verbose`; look at the failing node's error and the

--- a/.claude/skills/archon-cli/running-workflows/running-workflows.md
+++ b/.claude/skills/archon-cli/running-workflows/running-workflows.md
@@ -139,6 +139,10 @@ unattended), and never funnel a batch through a single polling loop.
 `outcome`. Read it with `get --json`, locate the report under
 `leave_behind.artifactFiles`, and use a separate `get --verbose --json` call for
 node summaries. Read the report before telling the user what the run concluded.
+For the bundled sdlc workflows, the report may end with a discoveries section
+addressed to you — route it per `../manage-run/manage-runs.md` ("Discoveries"):
+surface each finding to the user and ask where to log it. The run deliberately
+files nothing itself, so a discovery dropped here is lost.
 
 ## Continuing finished work
 

--- a/.claude/skills/archon-cli/running-workflows/running-workflows.md
+++ b/.claude/skills/archon-cli/running-workflows/running-workflows.md
@@ -110,14 +110,30 @@ Rules:
 ## Monitoring
 
 ```bash
+archon workflow wait <run-id> --json        # block until the run ends or needs a human decision
 archon workflow runs --json                 # recent runs for this project
 archon workflow status --json               # active only (running/paused)
 archon workflow get <run-id> --json         # one run: status, error, metadata
 archon workflow get <run-id> --verbose --json  # + per-node detail
 ```
 
-Terminal statuses: `completed`, `failed`, `cancelled`. Poll `get` between other
-work rather than sleeping in a tight loop.
+Terminal statuses: `completed`, `failed`, `cancelled`.
+
+**Prefer `wait` over polling.** Immediately after a detached launch, arm
+`archon workflow wait <run-id> --json` as a *background task of your harness*:
+it blocks until the run reaches a terminal state or pauses needing a human
+decision, so you are woken exactly when there is something to act on instead of
+polling or forgetting the run. The wait is indefinite by default; `--timeout
+<seconds>` makes the *wait* give up — it never affects the run itself, and an
+indefinite wait is usually right because a killed wait silently orphans your
+attention, not the run. Fall back to polling `get` only when you cannot hold a
+background task open.
+
+**Batches: one wait per run.** `wait` takes a single run id. When you launch
+several runs in parallel, arm one background wait per run id — each completes
+independently, so you are woken per run, in whatever order they need attention.
+Never chain waits in one shell (`wait A && wait B` sleeps on A while B pauses
+unattended), and never funnel a batch through a single polling loop.
 
 **Status is not verdict.** A `completed` run can carry a normalized negative
 `outcome`. Read it with `get --json`, locate the report under


### PR DESCRIPTION
## Problem and outcome

The bundled `archon-cli` skill stops at launching: it teaches nothing about what the driving agent owes a run afterwards. Two gaps, both observed live today:

1. **It predates the #2745 run-attention wait surface.** The monitoring guidance told agents to poll `workflow get` between other work, and `workflow wait` appeared nowhere — the verb the engine grew precisely so a waiting host is woken on terminal states and human-decision gates. An agent following the skill launches detached and then polls, or forgets the run. Observed: a session that had just launched a detached run reported "nothing will wake me when it finishes" because the skill said so.
2. **It says nothing about the sdlc pack's discovery sidecars.** The pack's review lenses record proven out-of-scope findings as sidecars, the review consolidates them into `discoveries.json`/`discoveries.md`, and the terminal report ends with a relay instruction aimed at the agent reading it — deliberately, because the run never files issues from them. That makes the relaying agent the last hop, and the skill never told it so: a discovery dropped there is lost.

- **Outcome:** the skill teaches the agent's post-run duties. Arm `archon workflow wait <run-id> --json` as a background task right after a detached launch (one wait per run for parallel batches, never chained in one shell); after an sdlc run reaches terminal, read the report's discoveries section (raw sidecars on failed runs, where consolidation never ran), surface each finding with its evidence, and ask the user where it goes — evidence on an existing issue, a new issue, or an explicit drop.
- **Invariants:** `--timeout` is documented as giving up the *wait*, never affecting the run; the discoveries guidance is scoped to the bundled sdlc workflows, not workflows in general; nothing is filed without the user's go.
- **Scope boundary:** documentation only, three skill files. No CLI behavior changes; `bundled-skill.ts` imports these files as text, so no generated artifact moves.

## Review guidance

- **Start here:** `.claude/skills/archon-cli/running-workflows/running-workflows.md` — the rewritten Monitoring section and the extended "Status is not verdict" paragraph.
- **Review order:** running-workflows.md, then the new "Discoveries" section in manage-runs.md, then the SKILL.md launch-spine step 4 and the manage-runs verb-table row.
- **Known risk or uncertainty:** none; the wait semantics are quoted from the CLI's own help text and exercised against a live detached run before writing them down, and the discoveries flow is documented from the pack's own producer/consolidation/relay contracts (`review-*.md`, `review-synthesize.md`, the tails' `outcome.py`).

## Solution

Two commits, one concern each. The first teaches `wait`: the SKILL.md quick spine arms it as a background task after launch, the Monitoring section prefers it over polling with the `--timeout` caveat and the batch rule (one wait per run id — `wait A && wait B` sleeps on A while B pauses unattended), and manage-runs.md's verb table gains the row. The second documents the discovery relay: a "Discoveries" section in the judging-a-finished-run reference (the convention, the failed-run raw-sidecar case, the surface-and-ask flow) plus a pointer from "Status is not verdict".

## Validation

- `bun run check:bundled-skill` — up to date (9 files across 1 skill), metadata valid; content flows through the existing text imports.
- Prettier clean on all changed files (lint-staged ran it at both commits).
- The wait pattern was exercised against a live run before being written down: a background `archon workflow wait <run-id> --json` armed on a real detached `archon-ship` run.

## Links

- #2745 delivered the wait surface this documents (PR #2923); #2884 delivered the terminal-report discoveries section and relay instruction the second commit teaches agents to honor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for waiting on workflow runs until completion or human intervention.
  - Clarified when to use waiting versus checking workflow status on demand.
  - Documented timeout behavior and recommended running one background wait per workflow in batches.
  - Added guidance for handling out-of-scope findings recorded in workflow reports and routing them for follow-up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->