### PR TITLE
Refactor DAG executor to use named options

### DIFF
--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -84,6 +84,7 @@ import {
   containerCommandName,
   buildSubprocessDockerArgs,
   childOutcomeFromRun,
+  type ExecuteDagWorkflowOptions,
   type RunChildWorkflowFn,
 } from './dag-executor';
 import { writeNodeArtifact, readNodeArtifacts } from './artifacts-index';
@@ -376,6 +377,69 @@ const minimalConfig: WorkflowConfig = {
   commands: {},
   defaults: { loadDefaultCommands: false, loadDefaultWorkflows: false },
 };
+
+describe('executeDagWorkflow options type contract', () => {
+  it('requires one named object including workflowModel', () => {
+    const validOptions: ExecuteDagWorkflowOptions = {
+      deps: createMockDeps(),
+      platform: createMockPlatform(),
+      conversationId: 'type-contract',
+      cwd: '/tmp/type-contract',
+      workflow: { name: 'type-contract', nodes: [] },
+      workflowRun: makeWorkflowRun('type-contract'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: '/tmp/type-contract/artifacts',
+      stateDir: '/tmp/type-contract/state',
+      logDir: '/tmp/type-contract/logs',
+      baseBranch: 'main',
+      docsDir: 'docs',
+      config: minimalConfig,
+    };
+
+    const { workflowModel, ...withoutWorkflowModel } = validOptions;
+    expect(workflowModel).toBeUndefined();
+
+    // @ts-expect-error workflowModel is a required resolved-policy input, even when undefined.
+    const missingWorkflowModel: ExecuteDagWorkflowOptions = withoutWorkflowModel;
+    expect(missingWorkflowModel).not.toHaveProperty('workflowModel');
+
+    const legacyArguments = [
+      validOptions.deps,
+      validOptions.platform,
+      validOptions.conversationId,
+      validOptions.cwd,
+      validOptions.workflow,
+      validOptions.workflowRun,
+      validOptions.workflowProvider,
+      validOptions.workflowModel,
+      validOptions.artifactsDir,
+      validOptions.stateDir,
+      validOptions.logDir,
+      validOptions.baseBranch,
+      validOptions.docsDir,
+      validOptions.config,
+      validOptions.configuredCommandFolder,
+      validOptions.issueContext,
+      validOptions.priorCompletedNodes,
+      validOptions.source,
+      validOptions.aiProfile,
+      validOptions.workflowPreset,
+      validOptions.scopeArtifactsDir,
+      validOptions.execContext,
+      validOptions.containerCtx,
+      validOptions.runChildWorkflow,
+      validOptions.priorUsage,
+      validOptions.priorNodeSessions,
+      validOptions.workflowSourceRoots,
+    ] as const;
+    const legacyCall = (): Promise<string | undefined> => {
+      // @ts-expect-error executeDagWorkflow no longer accepts the positional contract.
+      return executeDagWorkflow(...legacyArguments);
+    };
+    expect(legacyCall).toBeFunction();
+  });
+});
 
 // --- Helpers ---
 

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -378,6 +378,39 @@ const minimalConfig: WorkflowConfig = {
   defaults: { loadDefaultCommands: false, loadDefaultWorkflows: false },
 };
 
+/**
+ * `deps`, `cwd`, `workflow`, and `workflowRun` carry each test's own fixtures, so every call
+ * supplies them; the run directories derive from `cwd` the way every call site built them.
+ */
+type DagOptionsOverrides = Partial<ExecuteDagWorkflowOptions> &
+  Pick<ExecuteDagWorkflowOptions, 'deps' | 'cwd' | 'workflow' | 'workflowRun'>;
+
+/**
+ * Options for a direct `executeDagWorkflow` call, built from only what a test varies. The
+ * defaults are the exact values these tests used to spell out at every call site, so a test
+ * reads as the run it configures rather than as the fields it does not care about.
+ *
+ * Supplying `workflowModel` here is a convenience for tests only. It stays a required
+ * `string | undefined` on `ExecuteDagWorkflowOptions` so a production caller cannot omit a
+ * resolved model decision (#2302); this builder is not that guard's audience.
+ */
+function dagOptions(overrides: DagOptionsOverrides): ExecuteDagWorkflowOptions {
+  const { cwd } = overrides;
+  return {
+    platform: createMockPlatform(),
+    conversationId: 'conv-dag',
+    workflowProvider: 'claude',
+    workflowModel: undefined,
+    artifactsDir: join(cwd, 'artifacts'),
+    stateDir: join(cwd, 'state'),
+    logDir: join(cwd, 'logs'),
+    baseBranch: 'main',
+    docsDir: 'docs/',
+    config: minimalConfig,
+    ...overrides,
+  };
+}
+
 describe('executeDagWorkflow options type contract', () => {
   it('requires one named object including workflowModel', () => {
     const validOptions: ExecuteDagWorkflowOptions = {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -1646,32 +1646,25 @@ describe('executeDagWorkflow -- tool restrictions', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'dag-tool-restriction',
-        nodes: [
-          {
-            id: 'review',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            allowed_tools: ['Read', 'Grep'],
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'dag-tool-restriction',
+          nodes: [
+            {
+              id: 'review',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              allowed_tools: ['Read', 'Grep'],
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     expect(mockSendQueryDag.mock.calls.length).toBeGreaterThan(0);
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
@@ -1684,32 +1677,25 @@ describe('executeDagWorkflow -- tool restrictions', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'dag-setting-sources',
-        nodes: [
-          {
-            id: 'lean-review',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            settingSources: ['project'],
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'dag-setting-sources',
+          nodes: [
+            {
+              id: 'lean-review',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              settingSources: ['project'],
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     expect(mockSendQueryDag.mock.calls.length).toBeGreaterThan(0);
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
@@ -1733,33 +1719,26 @@ describe('executeDagWorkflow -- tool restrictions', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'dag-setting-sources-codex',
-        nodes: [
-          {
-            id: 'step1',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            provider: 'codex',
-            settingSources: ['project'],
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'dag-setting-sources-codex',
+          nodes: [
+            {
+              id: 'step1',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              provider: 'codex',
+              settingSources: ['project'],
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     // Capability gate: codex declares settingSources: false, so the executor
     // must surface a visible "will be ignored" warning instead of a silent no-op.
@@ -1786,33 +1765,26 @@ describe('executeDagWorkflow -- tool restrictions', () => {
       },
     });
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'codex-tier-effort-test',
-        nodes: [
-          {
-            id: 'step1',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            model: 'medium',
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      aiProfile,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'codex-tier-effort-test',
+          nodes: [
+            {
+              id: 'step1',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              model: 'medium',
+            },
+          ],
+        },
+        workflowRun,
+        aiProfile,
+      })
+    );
 
     expect(mockGetAgentProviderDag.mock.calls[0][0]).toBe('codex');
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
@@ -1851,34 +1823,27 @@ describe('executeDagWorkflow -- tool restrictions', () => {
       },
     });
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'codex-explicit-effort-test',
-        nodes: [
-          {
-            id: 'step1',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            model: 'medium',
-            effort: 'high',
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      aiProfile,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'codex-explicit-effort-test',
+          nodes: [
+            {
+              id: 'step1',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              model: 'medium',
+              effort: 'high',
+            },
+          ],
+        },
+        workflowRun,
+        aiProfile,
+      })
+    );
 
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
     const nodeConfig = optionsArg.nodeConfig as Record<string, unknown>;
@@ -1906,27 +1871,22 @@ describe('executeDagWorkflow -- tool restrictions', () => {
       },
     });
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'inherited-workflow-tier-test',
-        nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
-      },
-      workflowRun,
-      workflowProvider: 'codex',
-      workflowModel: 'gpt-5.5',
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      aiProfile,
-      workflowPreset,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'inherited-workflow-tier-test',
+          nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
+        },
+        workflowRun,
+        workflowProvider: 'codex',
+        workflowModel: 'gpt-5.5',
+        aiProfile,
+        workflowPreset,
+      })
+    );
 
     expect(mockGetAgentProviderDag.mock.calls[0][0]).toBe('codex');
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
@@ -1956,33 +1916,26 @@ describe('executeDagWorkflow -- tool restrictions', () => {
       },
     });
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'opencode-tier-effort-test',
-        nodes: [
-          {
-            id: 'step1',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            model: 'medium',
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      aiProfile,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'opencode-tier-effort-test',
+          nodes: [
+            {
+              id: 'step1',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              model: 'medium',
+            },
+          ],
+        },
+        workflowRun,
+        aiProfile,
+      })
+    );
 
     expect(mockGetAgentProviderDag.mock.calls[0][0]).toBe('opencode');
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
@@ -2013,33 +1966,27 @@ describe('executeDagWorkflow -- tool restrictions', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'opencode-declared-effort-test',
-        nodes: [
-          {
-            id: 'step1',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            provider: 'opencode',
-            effort: 'high',
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'opencode',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'opencode-declared-effort-test',
+          nodes: [
+            {
+              id: 'step1',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              provider: 'opencode',
+              effort: 'high',
+            },
+          ],
+        },
+        workflowRun,
+        workflowProvider: 'opencode',
+      })
+    );
 
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
     const nodeConfig = optionsArg.nodeConfig as Record<string, unknown>;
@@ -2066,33 +2013,26 @@ describe('executeDagWorkflow -- tool restrictions', () => {
       },
     });
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'claude-tier-effort-test',
-        nodes: [
-          {
-            id: 'step1',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            model: 'large',
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      aiProfile,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'claude-tier-effort-test',
+          nodes: [
+            {
+              id: 'step1',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              model: 'large',
+            },
+          ],
+        },
+        workflowRun,
+        aiProfile,
+      })
+    );
 
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
     expect(optionsArg.model).toBe('opus');
@@ -2118,28 +2058,22 @@ describe('executeDagWorkflow -- tool restrictions', () => {
     const workflowRun = makeWorkflowRun();
     const aiProfile = buildAiProfile('claude');
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'workflow-level-tier-test',
-        model: 'medium',
-        nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      // The executor receives the already-resolved workflow-level `medium` tier.
-      workflowModel: 'sonnet',
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      aiProfile,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'workflow-level-tier-test',
+          model: 'medium',
+          nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
+        },
+        workflowRun,
+        // The executor receives the already-resolved workflow-level `medium` tier.
+        workflowModel: 'sonnet',
+        aiProfile,
+      })
+    );
 
     const createEventCalls = (mockDeps.store.createWorkflowEvent as ReturnType<typeof mock>).mock
       .calls as Array<[{ event_type: string; data?: Record<string, unknown> }]>;
@@ -2155,34 +2089,27 @@ describe('executeDagWorkflow -- tool restrictions', () => {
     const workflowRun = makeWorkflowRun();
     const aiProfile = buildAiProfile('claude');
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'literal-model-test',
-        nodes: [
-          {
-            id: 'step1',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            provider: 'claude',
-            model: 'opus',
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      aiProfile,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'literal-model-test',
+          nodes: [
+            {
+              id: 'step1',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              provider: 'claude',
+              model: 'opus',
+            },
+          ],
+        },
+        workflowRun,
+        aiProfile,
+      })
+    );
 
     expect(mockGetAgentProviderDag.mock.calls[0][0]).toBe('claude');
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
@@ -2204,34 +2131,27 @@ describe('executeDagWorkflow -- tool restrictions', () => {
       },
     });
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'alias-provider-conflict-test',
-        nodes: [
-          {
-            id: 'step1',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            provider: 'claude',
-            model: '@fast',
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      aiProfile,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'alias-provider-conflict-test',
+          nodes: [
+            {
+              id: 'step1',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              provider: 'claude',
+              model: '@fast',
+            },
+          ],
+        },
+        workflowRun,
+        aiProfile,
+      })
+    );
 
     expect(mockGetAgentProviderDag.mock.calls[0][0]).toBe('codex');
     expect(
@@ -2254,33 +2174,28 @@ describe('executeDagWorkflow -- tool restrictions', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'dag-codex-denied',
-        nodes: [
-          {
-            id: 'review',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            provider: 'codex',
-            denied_tools: ['WebSearch'],
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'codex',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: { ...minimalConfig, assistant: 'codex' },
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'dag-codex-denied',
+          nodes: [
+            {
+              id: 'review',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              provider: 'codex',
+              denied_tools: ['WebSearch'],
+            },
+          ],
+        },
+        workflowRun,
+        workflowProvider: 'codex',
+        config: { ...minimalConfig, assistant: 'codex' },
+      })
+    );
 
     const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
     const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
@@ -2295,32 +2210,25 @@ describe('executeDagWorkflow -- tool restrictions', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'dag-empty-tools',
-        nodes: [
-          {
-            id: 'review',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            allowed_tools: [],
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'dag-empty-tools',
+          nodes: [
+            {
+              id: 'review',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              allowed_tools: [],
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     expect(mockSendQueryDag.mock.calls.length).toBeGreaterThan(0);
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
@@ -2333,34 +2241,27 @@ describe('executeDagWorkflow -- tool restrictions', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'dag-hooks',
-        nodes: [
-          {
-            id: 'review',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            hooks: {
-              PreToolUse: [{ matcher: 'Bash', response: { decision: 'block' } }],
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'dag-hooks',
+          nodes: [
+            {
+              id: 'review',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              hooks: {
+                PreToolUse: [{ matcher: 'Bash', response: { decision: 'block' } }],
+              },
             },
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     expect(mockSendQueryDag.mock.calls.length).toBeGreaterThan(0);
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
@@ -2381,35 +2282,30 @@ describe('executeDagWorkflow -- tool restrictions', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'dag-codex-hooks',
-        nodes: [
-          {
-            id: 'review',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            provider: 'codex',
-            hooks: {
-              PreToolUse: [{ response: { decision: 'block' } }],
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'dag-codex-hooks',
+          nodes: [
+            {
+              id: 'review',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              provider: 'codex',
+              hooks: {
+                PreToolUse: [{ response: { decision: 'block' } }],
+              },
             },
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'codex',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: { ...minimalConfig, assistant: 'codex' },
-    });
+          ],
+        },
+        workflowRun,
+        workflowProvider: 'codex',
+        config: { ...minimalConfig, assistant: 'codex' },
+      })
+    );
 
     const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
     const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
@@ -2445,32 +2341,30 @@ describe('executeDagWorkflow -- AI node prompt substitution failure', () => {
       user_message: 'test',
     });
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-subst',
-      cwd: testDir,
-      workflow: {
-        name: 'subst-fail',
-        nodes: [
-          {
-            id: 'needs-base',
-            kind: 'agent',
-            source: { kind: 'inline', prompt: 'Diff the branch against $BASE_BRANCH and review.' },
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      // The prompt references $BASE_BRANCH, so leaving it unresolved makes substitution throw.
-      baseBranch: '',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-subst',
+        cwd: testDir,
+        workflow: {
+          name: 'subst-fail',
+          nodes: [
+            {
+              id: 'needs-base',
+              kind: 'agent',
+              source: {
+                kind: 'inline',
+                prompt: 'Diff the branch against $BASE_BRANCH and review.',
+              },
+            },
+          ],
+        },
+        workflowRun,
+        // The prompt references $BASE_BRANCH, so leaving it unresolved makes substitution throw.
+        baseBranch: '',
+      })
+    );
 
     // The substitution throw must surface as a node_failed event. Previously the
     // catch returned state:'failed' silently — the node emitted node_started and
@@ -2536,22 +2430,16 @@ describe('executeDagWorkflow -- bash nodes', () => {
       script: 'echo "hello world"',
     };
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-bash',
-      cwd: testDir,
-      workflow: { name: 'bash-exec-test', nodes: [bashNode] },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-bash',
+        cwd: testDir,
+        workflow: { name: 'bash-exec-test', nodes: [bashNode] },
+        workflowRun,
+      })
+    );
 
     // Bash node should NOT invoke AI client
     expect(mockSendQueryDag.mock.calls.length).toBe(0);
@@ -2581,22 +2469,16 @@ describe('executeDagWorkflow -- bash nodes', () => {
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-bash',
-      cwd: testDir,
-      workflow: { name: 'bash-subst-test', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-bash',
+        cwd: testDir,
+        workflow: { name: 'bash-subst-test', nodes },
+        workflowRun,
+      })
+    );
 
     // AI client should have been called for the downstream node
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -2621,22 +2503,16 @@ describe('executeDagWorkflow -- bash nodes', () => {
       script: 'exit 1',
     };
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-bash',
-      cwd: testDir,
-      workflow: { name: 'bash-fail-test', nodes: [bashNode] },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-bash',
+        cwd: testDir,
+        workflow: { name: 'bash-fail-test', nodes: [bashNode] },
+        workflowRun,
+      })
+    );
 
     // The workflow should complete (it handles failures) but the node failed
     // The mock platform should have received a failure message about the failed node
@@ -2667,22 +2543,16 @@ describe('executeDagWorkflow -- bash nodes', () => {
         'UNIQUE_CMDLINE_MARKER_1389=; echo "stdout context before failure"; echo "diagnostic from stderr" >&2; exit 1',
     };
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-1389b',
-      cwd: testDir,
-      workflow: { name: 'bash-1389', nodes: [bashNode] },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-1389b',
+        cwd: testDir,
+        workflow: { name: 'bash-1389', nodes: [bashNode] },
+        workflowRun,
+      })
+    );
 
     const eventCalls = (mockDeps.store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const failedEvent = eventCalls.find(
@@ -2718,22 +2588,16 @@ describe('executeDagWorkflow -- bash nodes', () => {
       script: 'echo "$ARGUMENTS"',
     };
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-bash',
-      cwd: testDir,
-      workflow: { name: 'bash-vars-test', nodes: [bashNode] },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-bash',
+        cwd: testDir,
+        workflow: { name: 'bash-vars-test', nodes: [bashNode] },
+        workflowRun,
+      })
+    );
 
     // Should complete without error (no AI calls)
     expect(mockSendQueryDag.mock.calls.length).toBe(0);
@@ -2758,22 +2622,16 @@ describe('executeDagWorkflow -- bash nodes', () => {
       { id: 'ai-b', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-bash',
-      cwd: testDir,
-      workflow: { name: 'bash-parallel-test', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-bash',
+        cwd: testDir,
+        workflow: { name: 'bash-parallel-test', nodes },
+        workflowRun,
+      })
+    );
 
     // AI client called only for the AI node, not the bash node
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -2785,25 +2643,20 @@ describe('executeDagWorkflow -- bash nodes', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun('bash-env-run-id');
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-bash-env',
-      cwd: testDir,
-      workflow: {
-        name: 'bash-env-test',
-        nodes: [{ id: 'stats', kind: 'exec', runtime: 'sh', script: 'echo ok' }],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: { ...minimalConfig, envVars: { MY_SECRET: 'abc123' } },
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-bash-env',
+        cwd: testDir,
+        workflow: {
+          name: 'bash-env-test',
+          nodes: [{ id: 'stats', kind: 'exec', runtime: 'sh', script: 'echo ok' }],
+        },
+        workflowRun,
+        config: { ...minimalConfig, envVars: { MY_SECRET: 'abc123' } },
+      })
+    );
 
     expect(execSpy).toHaveBeenCalledWith(
       git.resolveBashPath(),
@@ -2838,22 +2691,16 @@ describe('executeDagWorkflow -- bash nodes', () => {
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-injection',
-      cwd: testDir,
-      workflow: { name: 'bash-injection-test', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-injection',
+        cwd: testDir,
+        workflow: { name: 'bash-injection-test', nodes },
+        workflowRun,
+      })
+    );
 
     // No AI calls
     expect(mockSendQueryDag.mock.calls.length).toBe(0);
@@ -2884,22 +2731,16 @@ describe('executeDagWorkflow -- bash nodes', () => {
         script: 'echo $USER_MESSAGE',
       };
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-shell-safe',
-        cwd: testDir,
-        workflow: { name: 'bash-shell-safe-test', nodes: [bashNode] },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          conversationId: 'conv-shell-safe',
+          cwd: testDir,
+          workflow: { name: 'bash-shell-safe-test', nodes: [bashNode] },
+          workflowRun,
+        })
+      );
 
       expect(execSpy).toHaveBeenCalledTimes(1);
       const firstCall = execSpy.mock.calls[0];
@@ -2955,22 +2796,15 @@ describe('executeDagWorkflow -- script node injection hardening (#2115)', () => 
         runtime: 'bun',
       };
 
-      await executeDagWorkflow({
-        deps: createMockDeps(),
-        platform: createMockPlatform(),
-        conversationId: 'conv-script-inject',
-        cwd: testDir,
-        workflow: { name: 'script-inject-test', nodes: [scriptNode] },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: createMockDeps(),
+          conversationId: 'conv-script-inject',
+          cwd: testDir,
+          workflow: { name: 'script-inject-test', nodes: [scriptNode] },
+          workflowRun,
+        })
+      );
 
       expect(execSpy).toHaveBeenCalledTimes(1);
       const [cmd, args, opts] = execSpy.mock.calls[0] as [
@@ -3006,22 +2840,15 @@ describe('executeDagWorkflow -- script node injection hardening (#2115)', () => 
         runtime: 'bun',
       };
 
-      await executeDagWorkflow({
-        deps: createMockDeps(),
-        platform: createMockPlatform(),
-        conversationId: 'conv-script-literal',
-        cwd: testDir,
-        workflow: { name: 'script-literal-test', nodes: [scriptNode] },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: createMockDeps(),
+          conversationId: 'conv-script-literal',
+          cwd: testDir,
+          workflow: { name: 'script-literal-test', nodes: [scriptNode] },
+          workflowRun,
+        })
+      );
 
       const [, args] = execSpy.mock.calls[0] as [string, string[], unknown];
       // The dangerous payload is NOT interpolated into the source; $ARGUMENTS stays literal.
@@ -3048,23 +2875,16 @@ describe('executeDagWorkflow -- script node injection hardening (#2115)', () => 
         runtime: 'uv',
       };
 
-      await executeDagWorkflow({
-        deps: createMockDeps(),
-        platform: createMockPlatform(),
-        conversationId: 'conv-script-uv',
-        cwd: testDir,
-        workflow: { name: 'script-uv-test', nodes: [scriptNode] },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-        issueContext: 'ISSUE #42 body text',
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: createMockDeps(),
+          conversationId: 'conv-script-uv',
+          cwd: testDir,
+          workflow: { name: 'script-uv-test', nodes: [scriptNode] },
+          workflowRun,
+          issueContext: 'ISSUE #42 body text',
+        })
+      );
 
       const [cmd, args, opts] = execSpy.mock.calls[0] as [
         string,
@@ -3105,23 +2925,17 @@ describe('executeDagWorkflow -- script node injection hardening (#2115)', () => 
         envVars: { ARGUMENTS: 'PROJECT_OVERRIDE', CONTEXT: 'PROJECT_CTX', MY_VAR: 'keep-me' },
       };
 
-      await executeDagWorkflow({
-        deps: createMockDeps(),
-        platform: createMockPlatform(),
-        conversationId: 'conv-script-collision',
-        cwd: testDir,
-        workflow: { name: 'script-env-collision', nodes: [scriptNode] },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: configWithEnv,
-        issueContext: 'ENGINE_CONTEXT',
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: createMockDeps(),
+          conversationId: 'conv-script-collision',
+          cwd: testDir,
+          workflow: { name: 'script-env-collision', nodes: [scriptNode] },
+          workflowRun,
+          config: configWithEnv,
+          issueContext: 'ENGINE_CONTEXT',
+        })
+      );
 
       const [, , opts] = execSpy.mock.calls[0] as [string, string[], { env: NodeJS.ProcessEnv }];
       // Reserved workflow vars win over the colliding configured vars — the delivery
@@ -3161,22 +2975,15 @@ describe('executeDagWorkflow -- script node injection hardening (#2115)', () => 
         },
       ];
 
-      await executeDagWorkflow({
-        deps: createMockDeps(),
-        platform: createMockPlatform(),
-        conversationId: 'conv-script-nodeoutput',
-        cwd: testDir,
-        workflow: { name: 'script-nodeoutput-test', nodes },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: createMockDeps(),
+          conversationId: 'conv-script-nodeoutput',
+          cwd: testDir,
+          workflow: { name: 'script-nodeoutput-test', nodes },
+          workflowRun,
+        })
+      );
 
       const scriptCall = execSpy.mock.calls.find(
         c => (c[0] as string) === 'bun' && (c[1] as string[]).includes('-e')
@@ -3206,22 +3013,16 @@ describe('executeDagWorkflow -- script node injection hardening (#2115)', () => 
         runtime: 'bun',
       };
 
-      await executeDagWorkflow({
-        deps: createMockDeps(),
-        platform,
-        conversationId: 'conv-script-warn',
-        cwd: testDir,
-        workflow: { name: 'script-warn-test', nodes: [scriptNode] },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: createMockDeps(),
+          platform,
+          conversationId: 'conv-script-warn',
+          cwd: testDir,
+          workflow: { name: 'script-warn-test', nodes: [scriptNode] },
+          workflowRun,
+        })
+      );
 
       const messages = (platform.sendMessage as ReturnType<typeof mock>).mock.calls.map(
         (c: unknown[]) => c[1] as string
@@ -3254,22 +3055,16 @@ describe('executeDagWorkflow -- script node injection hardening (#2115)', () => 
         runtime: 'bun',
       };
 
-      await executeDagWorkflow({
-        deps: createMockDeps(),
-        platform,
-        conversationId: 'conv-script-nowarn',
-        cwd: testDir,
-        workflow: { name: 'script-nowarn-test', nodes: [scriptNode] },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: createMockDeps(),
+          platform,
+          conversationId: 'conv-script-nowarn',
+          cwd: testDir,
+          workflow: { name: 'script-nowarn-test', nodes: [scriptNode] },
+          workflowRun,
+        })
+      );
 
       const messages = (platform.sendMessage as ReturnType<typeof mock>).mock.calls.map(
         (c: unknown[]) => c[1] as string
@@ -3352,22 +3147,16 @@ describe('executeDagWorkflow -- output_format structured output', () => {
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-output-fmt',
-      cwd: testDir,
-      workflow: { name: 'output-fmt-test', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-output-fmt',
+        cwd: testDir,
+        workflow: { name: 'output-fmt-test', nodes },
+        workflowRun,
+      })
+    );
 
     // The review node's when condition should evaluate to true (run_code_review == 'true')
     // The test node's when condition should evaluate to false (run_tests == 'false', not 'true')
@@ -3398,22 +3187,16 @@ describe('executeDagWorkflow -- output_format structured output', () => {
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-no-fmt',
-      cwd: testDir,
-      workflow: { name: 'no-fmt-test', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-no-fmt',
+        cwd: testDir,
+        workflow: { name: 'no-fmt-test', nodes },
+        workflowRun,
+      })
+    );
 
     expect(mockSendQueryDag.mock.calls.length).toBe(2);
 
@@ -3446,22 +3229,16 @@ describe('executeDagWorkflow -- output_format structured output', () => {
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-fallback',
-      cwd: testDir,
-      workflow: { name: 'fallback-test', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-fallback',
+        cwd: testDir,
+        workflow: { name: 'fallback-test', nodes },
+        workflowRun,
+      })
+    );
 
     // Both nodes should execute (no output_format, no when conditions)
     expect(mockSendQueryDag.mock.calls.length).toBe(2);
@@ -3519,22 +3296,17 @@ describe('executeDagWorkflow -- output_format structured output', () => {
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-codex-fmt',
-      cwd: testDir,
-      workflow: { name: 'codex-output-fmt', nodes },
-      workflowRun,
-      workflowProvider: 'codex',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-codex-fmt',
+        cwd: testDir,
+        workflow: { name: 'codex-output-fmt', nodes },
+        workflowRun,
+        workflowProvider: 'codex',
+      })
+    );
 
     // classify + review = 2 calls (test node skipped because run_tests == 'false')
     expect(mockSendQueryDag.mock.calls.length).toBe(2);
@@ -3574,22 +3346,17 @@ describe('executeDagWorkflow -- output_format structured output', () => {
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-codex-no-warn',
-      cwd: testDir,
-      workflow: { name: 'codex-no-warn', nodes },
-      workflowRun,
-      workflowProvider: 'codex',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-codex-no-warn',
+        cwd: testDir,
+        workflow: { name: 'codex-no-warn', nodes },
+        workflowRun,
+        workflowProvider: 'codex',
+      })
+    );
 
     // Verify no "structured output missing" warning was sent to the user
     const sendCalls = (platform.sendMessage as Mock<(...args: unknown[]) => Promise<void>>).mock
@@ -3653,22 +3420,16 @@ describe('executeDagWorkflow -- when condition parse errors (fail-closed)', () =
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-parse-err-skip',
-      cwd: testDir,
-      workflow: { name: 'parse-err-skip-test', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-parse-err-skip',
+        cwd: testDir,
+        workflow: { name: 'parse-err-skip-test', nodes },
+        workflowRun,
+      })
+    );
 
     // Only the unconditional node should have triggered an AI call.
     // The guarded node must be skipped (fail-closed), not executed.
@@ -3689,22 +3450,16 @@ describe('executeDagWorkflow -- when condition parse errors (fail-closed)', () =
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-parse-err-warn',
-      cwd: testDir,
-      workflow: { name: 'parse-warn-test', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-parse-err-warn',
+        cwd: testDir,
+        workflow: { name: 'parse-warn-test', nodes },
+        workflowRun,
+      })
+    );
 
     const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
     const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
@@ -3729,22 +3484,16 @@ describe('executeDagWorkflow -- when condition parse errors (fail-closed)', () =
     ];
 
     await expect(
-      executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-all-skipped',
-        cwd: testDir,
-        workflow: { name: 'all-skipped-test', nodes },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      })
+      executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          conversationId: 'conv-all-skipped',
+          cwd: testDir,
+          workflow: { name: 'all-skipped-test', nodes },
+          workflowRun,
+        })
+      )
     ).resolves.toBeUndefined();
   });
 });
@@ -3822,22 +3571,16 @@ describe('executeDagWorkflow -- node-level retry for transient errors', () => {
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag-retry-succeed',
-      cwd: testDir,
-      workflow: { name: 'dag-retry-succeed', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-dag-retry-succeed',
+        cwd: testDir,
+        workflow: { name: 'dag-retry-succeed', nodes },
+        workflowRun,
+      })
+    );
 
     // Node was called at least twice (first fails transiently, second succeeds)
     expect(callCount).toBeGreaterThanOrEqual(2);
@@ -3873,22 +3616,16 @@ describe('executeDagWorkflow -- node-level retry for transient errors', () => {
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag-retry-exhaust',
-      cwd: testDir,
-      workflow: { name: 'dag-retry-exhaust', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-dag-retry-exhaust',
+        cwd: testDir,
+        workflow: { name: 'dag-retry-exhaust', nodes },
+        workflowRun,
+      })
+    );
 
     // max_attempts: 2 = 2 retries → 3 total attempts (delay_ms: 1 keeps test fast)
     expect(callCount).toBe(3);
@@ -3911,32 +3648,26 @@ describe('executeDagWorkflow -- node-level retry for transient errors', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('dag-retry-ratelimit-run');
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag-retry-ratelimit',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-retry-ratelimit',
-          nodes: [
-            {
-              id: 'my-node',
-              kind: 'agent',
-              source: { kind: 'command', name: 'my-cmd' },
-              retry: { max_attempts: 1, delay_ms: 1 },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          conversationId: 'conv-dag-retry-ratelimit',
+          cwd: testDir,
+          workflow: {
+            name: 'dag-retry-ratelimit',
+            nodes: [
+              {
+                id: 'my-node',
+                kind: 'agent',
+                source: { kind: 'command', name: 'my-cmd' },
+                retry: { max_attempts: 1, delay_ms: 1 },
+              },
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       // max_attempts would allow 2 attempts; a rate-limited failure widens the
       // budget to RATE_LIMIT_MAX_RETRIES retries.
@@ -3965,32 +3696,26 @@ describe('executeDagWorkflow -- node-level retry for transient errors', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('dag-ratelimit-recover-run');
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag-ratelimit-recover',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-ratelimit-recover',
-          nodes: [
-            {
-              id: 'my-node',
-              kind: 'agent',
-              source: { kind: 'command', name: 'my-cmd' },
-              retry: { max_attempts: 1, delay_ms: 1 },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          conversationId: 'conv-dag-ratelimit-recover',
+          cwd: testDir,
+          workflow: {
+            name: 'dag-ratelimit-recover',
+            nodes: [
+              {
+                id: 'my-node',
+                kind: 'agent',
+                source: { kind: 'command', name: 'my-cmd' },
+                retry: { max_attempts: 1, delay_ms: 1 },
+              },
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       expect(callCount).toBe(4);
       expect(mockDeps.store.failWorkflowRun as ReturnType<typeof mock>).not.toHaveBeenCalled();
@@ -4016,32 +3741,26 @@ describe('executeDagWorkflow -- node-level retry for transient errors', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun('dag-silent-stream-run');
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag-silent-stream',
-      cwd: testDir,
-      workflow: {
-        name: 'dag-silent-stream',
-        nodes: [
-          {
-            id: 'my-node',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            retry: { max_attempts: 1, delay_ms: 1 },
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-dag-silent-stream',
+        cwd: testDir,
+        workflow: {
+          name: 'dag-silent-stream',
+          nodes: [
+            {
+              id: 'my-node',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              retry: { max_attempts: 1, delay_ms: 1 },
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     expect(callCount).toBe(2);
     expect(mockDeps.store.failWorkflowRun as ReturnType<typeof mock>).not.toHaveBeenCalled();
@@ -4067,22 +3786,16 @@ describe('executeDagWorkflow -- node-level retry for transient errors', () => {
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag-retry-fatal',
-      cwd: testDir,
-      workflow: { name: 'dag-retry-fatal', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-dag-retry-fatal',
+        cwd: testDir,
+        workflow: { name: 'dag-retry-fatal', nodes },
+        workflowRun,
+      })
+    );
 
     // FATAL error must not be retried — exactly 1 attempt
     expect(callCount).toBe(1);
@@ -4113,22 +3826,16 @@ describe('executeDagWorkflow -- node-level retry for transient errors', () => {
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag-retry-notify',
-      cwd: testDir,
-      workflow: { name: 'dag-retry-notify', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-dag-retry-notify',
+        cwd: testDir,
+        workflow: { name: 'dag-retry-notify', nodes },
+        workflowRun,
+      })
+    );
 
     const sendCalls = (platform.sendMessage as ReturnType<typeof mock>).mock.calls;
     const retryMessages = sendCalls.filter(
@@ -4175,22 +3882,16 @@ describe('executeDagWorkflow -- retry on deterministic (bash/script) nodes (#208
       conversation_id: 'conv-det-retry',
       user_message: 'det retry message',
     });
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-det-retry',
-      cwd: testDir,
-      workflow: { name: 'det-retry', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-det-retry',
+        cwd: testDir,
+        workflow: { name: 'det-retry', nodes },
+        workflowRun,
+      })
+    );
     return { mockDeps, platform };
   }
 
@@ -4363,25 +4064,18 @@ describe('executeDagWorkflow -- tool_called event persistence', () => {
       yield { type: 'result', sessionId: 'dag-session-id' };
     });
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'tool-test-dag',
-        nodes: [node('my-cmd')],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'tool-test-dag',
+          nodes: [node('my-cmd')],
+        },
+        workflowRun,
+      })
+    );
 
     const eventCalls = (mockStore.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const toolCalledEvents = eventCalls.filter(
@@ -4410,22 +4104,16 @@ describe('executeDagWorkflow -- tool_called event persistence', () => {
       yield { type: 'result', sessionId: 'dag-session-tool' };
     });
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag-tool',
-      cwd: testDir,
-      workflow: { name: 'dag-tool-test', nodes: [node('my-cmd')] },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-dag-tool',
+        cwd: testDir,
+        workflow: { name: 'dag-tool-test', nodes: [node('my-cmd')] },
+        workflowRun,
+      })
+    );
 
     expect(platform.sendStructuredEvent).toHaveBeenCalledWith('conv-dag-tool', {
       type: 'tool',
@@ -4477,22 +4165,16 @@ describe('executeDagWorkflow -- tool_completed event emission', () => {
       yield { type: 'result', sessionId: 'dag-sess-1' };
     });
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag-complete',
-      cwd: testDir,
-      workflow: { name: 'dag-complete-test', nodes: [node('my-cmd')] },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-dag-complete',
+        cwd: testDir,
+        workflow: { name: 'dag-complete-test', nodes: [node('my-cmd')] },
+        workflowRun,
+      })
+    );
 
     const createEventCalls = (mockStore.createWorkflowEvent as ReturnType<typeof mock>).mock
       .calls as Array<[{ event_type: string; data?: Record<string, unknown> }]>;
@@ -4521,22 +4203,16 @@ describe('executeDagWorkflow -- tool_completed event emission', () => {
       yield { type: 'result', sessionId: 'dag-sess-2' };
     });
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag-last',
-      cwd: testDir,
-      workflow: { name: 'dag-last-test', nodes: [node('my-cmd')] },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-dag-last',
+        cwd: testDir,
+        workflow: { name: 'dag-last-test', nodes: [node('my-cmd')] },
+        workflowRun,
+      })
+    );
 
     const createEventCalls = (mockStore.createWorkflowEvent as ReturnType<typeof mock>).mock
       .calls as Array<[{ event_type: string; data?: Record<string, unknown> }]>;
@@ -4574,22 +4250,16 @@ describe('executeDagWorkflow -- tool_completed event emission', () => {
     });
 
     try {
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag-tool-result',
-        cwd: testDir,
-        workflow: { name: 'dag-tool-result-test', nodes: [node('my-cmd')] },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          conversationId: 'conv-dag-tool-result',
+          cwd: testDir,
+          workflow: { name: 'dag-tool-result-test', nodes: [node('my-cmd')] },
+          workflowRun,
+        })
+      );
     } finally {
       setSystemTime();
     }
@@ -4640,22 +4310,16 @@ describe('executeDagWorkflow -- tool_completed event emission', () => {
     });
 
     try {
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag-interleaved-tools',
-        cwd: testDir,
-        workflow: { name: 'dag-interleaved-tools', nodes: [node('my-cmd')] },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          conversationId: 'conv-dag-interleaved-tools',
+          cwd: testDir,
+          workflow: { name: 'dag-interleaved-tools', nodes: [node('my-cmd')] },
+          workflowRun,
+        })
+      );
     } finally {
       setSystemTime();
     }
@@ -4693,22 +4357,16 @@ describe('executeDagWorkflow -- tool_completed event emission', () => {
       yield { type: 'result', sessionId: 'dag-sess-3' };
     });
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag-notools',
-      cwd: testDir,
-      workflow: { name: 'dag-notools-test', nodes: [node('my-cmd')] },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-dag-notools',
+        cwd: testDir,
+        workflow: { name: 'dag-notools-test', nodes: [node('my-cmd')] },
+        workflowRun,
+      })
+    );
 
     const createEventCalls = (mockStore.createWorkflowEvent as ReturnType<typeof mock>).mock
       .calls as Array<[{ event_type: string; data?: Record<string, unknown> }]>;
@@ -5010,32 +4668,25 @@ describe('executeDagWorkflow -- skills options', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'dag-skills',
-        nodes: [
-          {
-            id: 'review',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            skills: ['codebase-search', 'test-runner'],
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'dag-skills',
+          nodes: [
+            {
+              id: 'review',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              skills: ['codebase-search', 'test-runner'],
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     expect(mockSendQueryDag.mock.calls.length).toBeGreaterThan(0);
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
@@ -5049,33 +4700,26 @@ describe('executeDagWorkflow -- skills options', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'dag-skills-tools',
-        nodes: [
-          {
-            id: 'review',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            skills: ['codebase-search'],
-            allowed_tools: ['Read', 'Grep'],
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'dag-skills-tools',
+          nodes: [
+            {
+              id: 'review',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              skills: ['codebase-search'],
+              allowed_tools: ['Read', 'Grep'],
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     expect(mockSendQueryDag.mock.calls.length).toBeGreaterThan(0);
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
@@ -5096,33 +4740,28 @@ describe('executeDagWorkflow -- skills options', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'dag-codex-skills',
-        nodes: [
-          {
-            id: 'review',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            provider: 'codex',
-            skills: ['codebase-search'],
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'codex',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: { ...minimalConfig, assistant: 'codex' },
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'dag-codex-skills',
+          nodes: [
+            {
+              id: 'review',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              provider: 'codex',
+              skills: ['codebase-search'],
+            },
+          ],
+        },
+        workflowRun,
+        workflowProvider: 'codex',
+        config: { ...minimalConfig, assistant: 'codex' },
+      })
+    );
 
     // Codex workflow nodes suppress the ambient catalog. Authors invoke installed
     // native skills explicitly in the command/prompt with `$skill-name` instead.
@@ -5146,32 +4785,25 @@ describe('executeDagWorkflow -- skills options', () => {
       },
     };
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'dag-agents',
-        nodes: [
-          {
-            id: 'review',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            agents: agentsMap,
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'dag-agents',
+          nodes: [
+            {
+              id: 'review',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              agents: agentsMap,
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     expect(mockSendQueryDag.mock.calls.length).toBeGreaterThan(0);
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
@@ -5190,35 +4822,30 @@ describe('executeDagWorkflow -- skills options', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'dag-codex-agents',
-        nodes: [
-          {
-            id: 'review',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            provider: 'codex',
-            agents: {
-              'brief-gen': { description: 'd', prompt: 'p' },
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'dag-codex-agents',
+          nodes: [
+            {
+              id: 'review',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              provider: 'codex',
+              agents: {
+                'brief-gen': { description: 'd', prompt: 'p' },
+              },
             },
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'codex',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: { ...minimalConfig, assistant: 'codex' },
-    });
+          ],
+        },
+        workflowRun,
+        workflowProvider: 'codex',
+        config: { ...minimalConfig, assistant: 'codex' },
+      })
+    );
 
     const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
     const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
@@ -5568,23 +5195,16 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     });
 
     const store = createMockStore();
-    const result = await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-resume',
-      cwd: testDir,
-      workflow: ready(rawLoopGroupWorkflow(field)),
-      workflowRun: makeWorkflowRun(runId),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+    const result = await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-resume',
+        cwd: testDir,
+        workflow: ready(rawLoopGroupWorkflow(field)),
+        workflowRun: makeWorkflowRun(runId),
+        priorCompletedNodes,
+      })
+    );
 
     const events = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls.map(
       (call: unknown[]) => call[0] as PersistedEvent
@@ -5600,34 +5220,28 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
 
     const priorCompletedNodes = new Map([['step1', { output: 'prior step1 output' }]]);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-resume',
-      cwd: testDir,
-      workflow: {
-        name: 'two-step',
-        nodes: [
-          { id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } },
-          {
-            id: 'step2',
-            kind: 'agent',
-            source: { kind: 'command', name: 'step2' },
-            depends_on: ['step1'],
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-resume',
+        cwd: testDir,
+        workflow: {
+          name: 'two-step',
+          nodes: [
+            { id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } },
+            {
+              id: 'step2',
+              kind: 'agent',
+              source: { kind: 'command', name: 'step2' },
+              depends_on: ['step1'],
+            },
+          ],
+        },
+        workflowRun,
+        priorCompletedNodes,
+      })
+    );
 
     // Only step2 should have been executed (step1 was skipped)
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -5648,34 +5262,28 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
 
     const priorCompletedNodes = new Map([['step1', { output: 'hello from prior run' }]]);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-resume',
-      cwd: testDir,
-      workflow: {
-        name: 'two-step',
-        nodes: [
-          { id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } },
-          {
-            id: 'step2',
-            kind: 'agent',
-            source: { kind: 'inline', prompt: 'Use this: $step1.output' },
-            depends_on: ['step1'],
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-resume',
+        cwd: testDir,
+        workflow: {
+          name: 'two-step',
+          nodes: [
+            { id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } },
+            {
+              id: 'step2',
+              kind: 'agent',
+              source: { kind: 'inline', prompt: 'Use this: $step1.output' },
+              depends_on: ['step1'],
+            },
+          ],
+        },
+        workflowRun,
+        priorCompletedNodes,
+      })
+    );
 
     // The prompt sent to AI should contain the prior run's output
     expect(capturedPrompt).toContain('hello from prior run');
@@ -5689,34 +5297,28 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
 
     const priorCompletedNodes = new Map([['step1', { output: 'prior output' }]]);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-resume',
-      cwd: testDir,
-      workflow: {
-        name: 'two-step',
-        nodes: [
-          { id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } },
-          {
-            id: 'step2',
-            kind: 'agent',
-            source: { kind: 'command', name: 'step2' },
-            depends_on: ['step1'],
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-resume',
+        cwd: testDir,
+        workflow: {
+          name: 'two-step',
+          nodes: [
+            { id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } },
+            {
+              id: 'step2',
+              kind: 'agent',
+              source: { kind: 'command', name: 'step2' },
+              depends_on: ['step1'],
+            },
+          ],
+        },
+        workflowRun,
+        priorCompletedNodes,
+      })
+    );
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const skippedEvent = eventCalls.find(
@@ -5742,34 +5344,29 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     const largeOutput = 'y'.repeat(40_000);
     const priorCompletedNodes = new Map([['step1', { output: largeOutput }]]);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-resume-large-skip',
-      cwd: testDir,
-      workflow: {
-        name: 'two-step',
-        nodes: [
-          { id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } },
-          {
-            id: 'step2',
-            kind: 'agent',
-            source: { kind: 'command', name: 'step2' },
-            depends_on: ['step1'],
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir,
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-resume-large-skip',
+        cwd: testDir,
+        workflow: {
+          name: 'two-step',
+          nodes: [
+            { id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } },
+            {
+              id: 'step2',
+              kind: 'agent',
+              source: { kind: 'command', name: 'step2' },
+              depends_on: ['step1'],
+            },
+          ],
+        },
+        workflowRun,
+        artifactsDir,
+        priorCompletedNodes,
+      })
+    );
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const skippedEvent = eventCalls.find(
@@ -5805,34 +5402,28 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       ['step1', { output: undefined as unknown as string }],
     ]);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-resume',
-      cwd: testDir,
-      workflow: {
-        name: 'two-step',
-        nodes: [
-          { id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } },
-          {
-            id: 'step2',
-            kind: 'agent',
-            source: { kind: 'command', name: 'step2' },
-            depends_on: ['step1'],
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-resume',
+        cwd: testDir,
+        workflow: {
+          name: 'two-step',
+          nodes: [
+            { id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } },
+            {
+              id: 'step2',
+              kind: 'agent',
+              source: { kind: 'command', name: 'step2' },
+              depends_on: ['step1'],
+            },
+          ],
+        },
+        workflowRun,
+        priorCompletedNodes,
+      })
+    );
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const skippedEvent = eventCalls.find(
@@ -5852,34 +5443,28 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-resume',
-      cwd: testDir,
-      workflow: {
-        name: 'two-step',
-        nodes: [
-          { id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } },
-          {
-            id: 'step2',
-            kind: 'agent',
-            source: { kind: 'command', name: 'step2' },
-            depends_on: ['step1'],
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes: new Map(),
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-resume',
+        cwd: testDir,
+        workflow: {
+          name: 'two-step',
+          nodes: [
+            { id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } },
+            {
+              id: 'step2',
+              kind: 'agent',
+              source: { kind: 'command', name: 'step2' },
+              depends_on: ['step1'],
+            },
+          ],
+        },
+        workflowRun,
+        priorCompletedNodes: new Map(),
+      })
+    );
 
     // Both nodes should execute
     expect(mockSendQueryDag.mock.calls.length).toBe(2);
@@ -5924,22 +5509,16 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       yield { type: 'result', sessionId: 'failed-step-session' };
     });
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-resume-tokens',
-      cwd: testDir,
-      workflow,
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-resume-tokens',
+        cwd: testDir,
+        workflow,
+        workflowRun,
+      })
+    );
 
     expect(store.failWorkflowRun).toHaveBeenCalled();
     expect(store.completeWorkflowRun).not.toHaveBeenCalled();
@@ -5998,24 +5577,18 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       };
     });
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-resume-tokens',
-      cwd: testDir,
-      workflow,
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-      priorUsage,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-resume-tokens',
+        cwd: testDir,
+        workflow,
+        workflowRun,
+        priorCompletedNodes,
+        priorUsage,
+      })
+    );
 
     // #2469 (AC4): the resumed run reports pass 1 + pass 2 on BOTH axes. Cost used to
     // reset to 0 on every pass, so a run that failed at 0.02 and then completed would
@@ -6116,48 +5689,41 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       yield { type: 'result', sessionId: 'structured-loop-resume-session' };
     });
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-resume',
-      cwd: testDir,
-      workflow: {
-        name: 'structured-loop-resume',
-        nodes: [
-          {
-            id: 'iterate',
-            output_format: {
-              type: 'object',
-              properties: { done: { type: 'boolean' }, note: { type: 'string' } },
-              required: ['done'],
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-resume',
+        cwd: testDir,
+        workflow: {
+          name: 'structured-loop-resume',
+          nodes: [
+            {
+              id: 'iterate',
+              output_format: {
+                type: 'object',
+                properties: { done: { type: 'boolean' }, note: { type: 'string' } },
+                required: ['done'],
+              },
+              kind: 'loop',
+              loop: {
+                prompt: 'iterate',
+                until_field: 'done',
+                max_iterations: 1,
+                fresh_context: false,
+              },
             },
-            kind: 'loop',
-            loop: {
-              prompt: 'iterate',
-              until_field: 'done',
-              max_iterations: 1,
-              fresh_context: false,
+            {
+              id: 'consumer',
+              kind: 'agent',
+              source: { kind: 'inline', prompt: 'note=[$iterate.output.note]' },
+              depends_on: ['iterate'],
             },
-          },
-          {
-            id: 'consumer',
-            kind: 'agent',
-            source: { kind: 'inline', prompt: 'note=[$iterate.output.note]' },
-            depends_on: ['iterate'],
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('structured-loop-resume'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes: new Map([['iterate', { output: '{"done":true}' }]]),
-    });
+          ],
+        },
+        workflowRun: makeWorkflowRun('structured-loop-resume'),
+        priorCompletedNodes: new Map([['iterate', { output: '{"done":true}' }]]),
+      })
+    );
 
     expect(mockSendQueryDag).toHaveBeenCalledTimes(1);
     expect(capturedPrompt).toBe('note=[]');
@@ -6183,43 +5749,37 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     // Prior JSON output omits the declared-optional `note` field.
     const priorCompletedNodes = new Map([['step1', { output: '{"type":"BUG"}' }]]);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-resume',
-      cwd: testDir,
-      workflow: {
-        name: 'declared-optional',
-        nodes: [
-          {
-            id: 'step1',
-            kind: 'agent',
-            source: { kind: 'inline', prompt: 'produce json' },
-            output_format: {
-              type: 'object',
-              properties: { type: { type: 'string' }, note: { type: 'string' } },
-              required: ['type'],
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-resume',
+        cwd: testDir,
+        workflow: {
+          name: 'declared-optional',
+          nodes: [
+            {
+              id: 'step1',
+              kind: 'agent',
+              source: { kind: 'inline', prompt: 'produce json' },
+              output_format: {
+                type: 'object',
+                properties: { type: { type: 'string' }, note: { type: 'string' } },
+                required: ['type'],
+              },
             },
-          },
-          {
-            id: 'step2',
-            kind: 'agent',
-            source: { kind: 'inline', prompt: 'note=[$step1.output.note]' },
-            depends_on: ['step1'],
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+            {
+              id: 'step2',
+              kind: 'agent',
+              source: { kind: 'inline', prompt: 'note=[$step1.output.note]' },
+              depends_on: ['step1'],
+            },
+          ],
+        },
+        workflowRun,
+        priorCompletedNodes,
+      })
+    );
 
     // The consumer must run (step1 was skipped, so exactly one AI call = step2),
     // and the declared-but-absent `note` resolves to '' — not a missing-key throw.
@@ -6236,43 +5796,37 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     // Prior JSON output carries an `extra` key that the schema does NOT declare.
     const priorCompletedNodes = new Map([['step1', { output: '{"type":"BUG","extra":"x"}' }]]);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-resume',
-      cwd: testDir,
-      workflow: {
-        name: 'undeclared-key',
-        nodes: [
-          {
-            id: 'step1',
-            kind: 'agent',
-            source: { kind: 'inline', prompt: 'produce json' },
-            output_format: {
-              type: 'object',
-              properties: { type: { type: 'string' } },
-              required: ['type'],
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-resume',
+        cwd: testDir,
+        workflow: {
+          name: 'undeclared-key',
+          nodes: [
+            {
+              id: 'step1',
+              kind: 'agent',
+              source: { kind: 'inline', prompt: 'produce json' },
+              output_format: {
+                type: 'object',
+                properties: { type: { type: 'string' } },
+                required: ['type'],
+              },
             },
-          },
-          {
-            id: 'step2',
-            kind: 'agent',
-            source: { kind: 'inline', prompt: 'extra=[$step1.output.extra]' },
-            depends_on: ['step1'],
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+            {
+              id: 'step2',
+              kind: 'agent',
+              source: { kind: 'inline', prompt: 'extra=[$step1.output.extra]' },
+              depends_on: ['step1'],
+            },
+          ],
+        },
+        workflowRun,
+        priorCompletedNodes,
+      })
+    );
 
     // The undeclared `extra` must fail the consumer before the AI runs (0 calls),
     // matching fresh-run behavior instead of silently resolving via the schemaless path.
@@ -6302,22 +5856,16 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       script: 'echo "bash output"',
     };
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-bash-output',
-      cwd: testDir,
-      workflow: { name: 'bash-output-test', nodes: [bashNode] },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-bash-output',
+        cwd: testDir,
+        workflow: { name: 'bash-output-test', nodes: [bashNode] },
+        workflowRun,
+      })
+    );
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const completedEvent = eventCalls.find(
@@ -6340,32 +5888,25 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const mockDeps = createMockDeps(store);
       const workflowRun = makeWorkflowRun(`bash-output-${nodeId}`);
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform: createMockPlatform(),
-        conversationId: `conv-${nodeId}`,
-        cwd: testDir,
-        workflow: {
-          name: `bash-output-${nodeId}`,
-          nodes: [
-            {
-              id: nodeId,
-              kind: 'exec',
-              runtime: 'sh',
-              script: `printf '%${String(byteCount)}s' '' | tr ' ' x`,
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          conversationId: `conv-${nodeId}`,
+          cwd: testDir,
+          workflow: {
+            name: `bash-output-${nodeId}`,
+            nodes: [
+              {
+                id: nodeId,
+                kind: 'exec',
+                runtime: 'sh',
+                script: `printf '%${String(byteCount)}s' '' | tr ' ' x`,
+              },
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
       const completedEvent = eventCalls.find(
@@ -6389,27 +5930,25 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     const mockDeps = createMockDeps(store);
     const workflowRun = makeWorkflowRun('bash-output-over-cap');
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-over-cap',
-      cwd: testDir,
-      workflow: {
-        name: 'bash-output-over-cap',
-        nodes: [
-          { id: 'over-cap', kind: 'exec', runtime: 'sh', script: "printf '%32769s' '' | tr ' ' x" },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        conversationId: 'conv-over-cap',
+        cwd: testDir,
+        workflow: {
+          name: 'bash-output-over-cap',
+          nodes: [
+            {
+              id: 'over-cap',
+              kind: 'exec',
+              runtime: 'sh',
+              script: "printf '%32769s' '' | tr ' ' x",
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const completedEvent = eventCalls.find(
@@ -6451,32 +5990,25 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     const mockDeps = createMockDeps(store);
     const workflowRun = makeWorkflowRun('bash-output-utf8-cap');
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-utf8-cap',
-      cwd: testDir,
-      workflow: {
-        name: 'bash-output-utf8-cap',
-        nodes: [
-          {
-            id: 'utf8-cap',
-            kind: 'exec',
-            runtime: 'sh',
-            script: `bun -e "process.stdout.write('🙂'.repeat(8193))"`,
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        conversationId: 'conv-utf8-cap',
+        cwd: testDir,
+        workflow: {
+          name: 'bash-output-utf8-cap',
+          nodes: [
+            {
+              id: 'utf8-cap',
+              kind: 'exec',
+              runtime: 'sh',
+              script: `bun -e "process.stdout.write('🙂'.repeat(8193))"`,
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const completedEvent = eventCalls.find(
@@ -6503,32 +6035,25 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const mockDeps = createMockDeps(store);
       const workflowRun = makeWorkflowRun(`script-output-${nodeId}`);
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform: createMockPlatform(),
-        conversationId: `conv-${nodeId}`,
-        cwd: testDir,
-        workflow: {
-          name: `script-output-${nodeId}`,
-          nodes: [
-            {
-              id: nodeId,
-              kind: 'exec',
-              runtime: 'bun',
-              script: `process.stdout.write('x'.repeat(${String(byteCount)}))`,
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          conversationId: `conv-${nodeId}`,
+          cwd: testDir,
+          workflow: {
+            name: `script-output-${nodeId}`,
+            nodes: [
+              {
+                id: nodeId,
+                kind: 'exec',
+                runtime: 'bun',
+                script: `process.stdout.write('x'.repeat(${String(byteCount)}))`,
+              },
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
       const completedEvent = eventCalls.find(
@@ -6553,32 +6078,25 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     const mockDeps = createMockDeps(store);
     const workflowRun = makeWorkflowRun('script-output-over-cap');
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-script-over-cap',
-      cwd: testDir,
-      workflow: {
-        name: 'script-output-over-cap',
-        nodes: [
-          {
-            id: 'script-over-cap',
-            kind: 'exec',
-            runtime: 'bun',
-            script: `process.stdout.write('x'.repeat(32769))`,
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        conversationId: 'conv-script-over-cap',
+        cwd: testDir,
+        workflow: {
+          name: 'script-output-over-cap',
+          nodes: [
+            {
+              id: 'script-over-cap',
+              kind: 'exec',
+              runtime: 'bun',
+              script: `process.stdout.write('x'.repeat(32769))`,
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const completedEvent = eventCalls.find(
@@ -6623,40 +6141,35 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     const producerOutput = `{"status":"PASS","padding":"${'x'.repeat(paddingBytes)}"}`;
     await mkdir(artifactsDir, { recursive: true });
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-live-full',
-      cwd: testDir,
-      workflow: {
-        name: 'bash-output-live-full',
-        nodes: [
-          {
-            id: 'producer',
-            kind: 'exec',
-            runtime: 'sh',
-            script: `printf '{"status":"PASS","padding":"'; printf '%${String(paddingBytes)}s' '' | tr ' ' x; printf '"}'`,
-          },
-          {
-            id: 'consumer',
-            kind: 'exec',
-            runtime: 'sh',
-            script: 'value=$producer.output; printf %s "${#value}"',
-            depends_on: ['producer'],
-            when: "$producer.output.status == 'PASS'",
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir,
-      stateDir: join(testDir, 'state'),
-      logDir,
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        conversationId: 'conv-live-full',
+        cwd: testDir,
+        workflow: {
+          name: 'bash-output-live-full',
+          nodes: [
+            {
+              id: 'producer',
+              kind: 'exec',
+              runtime: 'sh',
+              script: `printf '{"status":"PASS","padding":"'; printf '%${String(paddingBytes)}s' '' | tr ' ' x; printf '"}'`,
+            },
+            {
+              id: 'consumer',
+              kind: 'exec',
+              runtime: 'sh',
+              script: 'value=$producer.output; printf %s "${#value}"',
+              depends_on: ['producer'],
+              when: "$producer.output.status == 'PASS'",
+            },
+          ],
+        },
+        workflowRun,
+        artifactsDir,
+        logDir,
+      })
+    );
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const producerEvent = eventCalls.find(
@@ -6696,36 +6209,29 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     const producerOutput = `{"status":"PASS","padding":"${'z'.repeat(paddingBytes)}"}`;
     const priorCompletedNodes = new Map([['producer', { output: producerOutput }]]);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-resume-large-field',
-      cwd: testDir,
-      workflow: {
-        name: 'resume-large-field',
-        nodes: [
-          { id: 'producer', kind: 'exec', runtime: 'sh', script: 'echo unused' },
-          {
-            id: 'consumer',
-            kind: 'exec',
-            runtime: 'sh',
-            script: 'value=$producer.output; printf %s "${#value}"',
-            depends_on: ['producer'],
-            when: "$producer.output.status == 'PASS'",
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('resume-large-field'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        conversationId: 'conv-resume-large-field',
+        cwd: testDir,
+        workflow: {
+          name: 'resume-large-field',
+          nodes: [
+            { id: 'producer', kind: 'exec', runtime: 'sh', script: 'echo unused' },
+            {
+              id: 'consumer',
+              kind: 'exec',
+              runtime: 'sh',
+              script: 'value=$producer.output; printf %s "${#value}"',
+              depends_on: ['producer'],
+              when: "$producer.output.status == 'PASS'",
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun('resume-large-field'),
+        priorCompletedNodes,
+      })
+    );
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     // producer was resumed (skipped), so it must never re-execute.
@@ -6764,32 +6270,26 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
 
     // Pass 1: a real script node produces an over-cap JSON output and spills for real.
     const freshStore = createMockStore();
-    await executeDagWorkflow({
-      deps: createMockDeps(freshStore),
-      platform: createMockPlatform(),
-      conversationId: 'conv-script-fresh-large-field',
-      cwd: testDir,
-      workflow: {
-        name: 'script-fresh-large-field',
-        nodes: [
-          {
-            id: 'producer',
-            kind: 'exec',
-            runtime: 'bun',
-            script: `process.stdout.write(JSON.stringify({status:'PASS',padding:'z'.repeat(${String(paddingBytes)})}))`,
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('script-fresh-large-field'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir,
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(freshStore),
+        conversationId: 'conv-script-fresh-large-field',
+        cwd: testDir,
+        workflow: {
+          name: 'script-fresh-large-field',
+          nodes: [
+            {
+              id: 'producer',
+              kind: 'exec',
+              runtime: 'bun',
+              script: `process.stdout.write(JSON.stringify({status:'PASS',padding:'z'.repeat(${String(paddingBytes)})}))`,
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun('script-fresh-large-field'),
+        artifactsDir,
+      })
+    );
 
     const freshEventCalls = (freshStore.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const producerEvent = freshEventCalls.find(
@@ -6816,41 +6316,35 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     // access on it resolves rather than hard-failing.
     const resumedStore = createMockStore();
     const priorCompletedNodes = new Map([['producer', { output: spilledFullOutput }]]);
-    await executeDagWorkflow({
-      deps: createMockDeps(resumedStore),
-      platform: createMockPlatform(),
-      conversationId: 'conv-script-resumed-large-field',
-      cwd: testDir,
-      workflow: {
-        name: 'script-resumed-large-field',
-        nodes: [
-          {
-            id: 'producer',
-            kind: 'exec',
-            runtime: 'bun',
-            script: `process.stdout.write('unused')`,
-          },
-          {
-            id: 'consumer',
-            kind: 'exec',
-            runtime: 'sh',
-            script: 'value=$producer.output; printf %s "${#value}"',
-            depends_on: ['producer'],
-            when: "$producer.output.status == 'PASS'",
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('script-resumed-large-field'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir,
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(resumedStore),
+        conversationId: 'conv-script-resumed-large-field',
+        cwd: testDir,
+        workflow: {
+          name: 'script-resumed-large-field',
+          nodes: [
+            {
+              id: 'producer',
+              kind: 'exec',
+              runtime: 'bun',
+              script: `process.stdout.write('unused')`,
+            },
+            {
+              id: 'consumer',
+              kind: 'exec',
+              runtime: 'sh',
+              script: 'value=$producer.output; printf %s "${#value}"',
+              depends_on: ['producer'],
+              when: "$producer.output.status == 'PASS'",
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun('script-resumed-large-field'),
+        artifactsDir,
+        priorCompletedNodes,
+      })
+    );
 
     const resumedEventCalls = (resumedStore.createWorkflowEvent as ReturnType<typeof mock>).mock
       .calls;
@@ -6889,32 +6383,26 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       };
     });
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-output',
-      cwd: testDir,
-      workflow: {
-        name: 'single-node',
-        nodes: [
-          {
-            id: 'step1',
-            kind: 'agent',
-            source: { kind: 'command', name: 'step1' },
-            model: 'requested-model',
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-output',
+        cwd: testDir,
+        workflow: {
+          name: 'single-node',
+          nodes: [
+            {
+              id: 'step1',
+              kind: 'agent',
+              source: { kind: 'command', name: 'step1' },
+              model: 'requested-model',
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const completedEvent = eventCalls.find(
@@ -6950,25 +6438,18 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     const store = createMockStore();
     const mockDeps = createMockDeps(store);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-no-usage',
-      cwd: testDir,
-      workflow: {
-        name: 'no-usage',
-        nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } }],
-      },
-      workflowRun: makeWorkflowRun('no-usage-run'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        conversationId: 'conv-no-usage',
+        cwd: testDir,
+        workflow: {
+          name: 'no-usage',
+          nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } }],
+        },
+        workflowRun: makeWorkflowRun('no-usage-run'),
+      })
+    );
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls as Array<
       [{ event_type: string; step_name: string; data?: Record<string, unknown> }]
@@ -6996,25 +6477,18 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     const store = createMockStore();
     const mockDeps = createMockDeps(store);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-shape',
-      cwd: testDir,
-      workflow: {
-        name: 'token-shape',
-        nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } }],
-      },
-      workflowRun: makeWorkflowRun('token-shape-run'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        conversationId: 'conv-shape',
+        cwd: testDir,
+        workflow: {
+          name: 'token-shape',
+          nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } }],
+        },
+        workflowRun: makeWorkflowRun('token-shape-run'),
+      })
+    );
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls as Array<
       [{ event_type: string; step_name: string; data?: Record<string, unknown> }]
@@ -7034,25 +6508,18 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     const store = createMockStore();
     const mockDeps = createMockDeps(store);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-nan',
-      cwd: testDir,
-      workflow: {
-        name: 'nan-tokens',
-        nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } }],
-      },
-      workflowRun: makeWorkflowRun('nan-tokens-run'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        conversationId: 'conv-nan',
+        cwd: testDir,
+        workflow: {
+          name: 'nan-tokens',
+          nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } }],
+        },
+        workflowRun: makeWorkflowRun('nan-tokens-run'),
+      })
+    );
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls as Array<
       [{ event_type: string; step_name: string; data?: Record<string, unknown> }]
@@ -7081,25 +6548,19 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     const mockDeps = createMockDeps(store);
     const logDir = join(testDir, 'logs');
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-transcript-cost',
-      cwd: testDir,
-      workflow: {
-        name: 'transcript-cost',
-        nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } }],
-      },
-      workflowRun: makeWorkflowRun('transcript-cost-run'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir,
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        conversationId: 'conv-transcript-cost',
+        cwd: testDir,
+        workflow: {
+          name: 'transcript-cost',
+          nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } }],
+        },
+        workflowRun: makeWorkflowRun('transcript-cost-run'),
+        logDir,
+      })
+    );
 
     const transcript = await readTranscript(logDir, 'transcript-cost-run');
     const nodeRow = transcript.find(e => e.type === 'node_complete' && e.step === 'step1');
@@ -7133,25 +6594,19 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     const mockDeps = createMockDeps(store);
     const logDir = join(testDir, 'logs');
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-transcript-no-cost',
-      cwd: testDir,
-      workflow: {
-        name: 'transcript-no-cost',
-        nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } }],
-      },
-      workflowRun: makeWorkflowRun('transcript-no-cost-run'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir,
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        conversationId: 'conv-transcript-no-cost',
+        cwd: testDir,
+        workflow: {
+          name: 'transcript-no-cost',
+          nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } }],
+        },
+        workflowRun: makeWorkflowRun('transcript-no-cost-run'),
+        logDir,
+      })
+    );
 
     const transcript = await readTranscript(logDir, 'transcript-no-cost-run');
     const nodeRow = transcript.find(e => e.type === 'node_complete' && e.step === 'step1');
@@ -7176,25 +6631,19 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     ): Promise<void> => {
       const mockDeps = createMockDeps(store);
       const workflowRun = makeWorkflowRun(runId);
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-bg-tasks',
-        cwd: testDir,
-        workflow: {
-          name: 'bg-task-test',
-          nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } }],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          conversationId: 'conv-bg-tasks',
+          cwd: testDir,
+          workflow: {
+            name: 'bg-task-test',
+            nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } }],
+          },
+          workflowRun,
+        })
+      );
     };
 
     const findCompletedEvent = (
@@ -7390,36 +6839,29 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       });
 
       try {
-        await executeDagWorkflow({
-          deps: mockDeps,
-          platform,
-          conversationId: 'conv-dag',
-          cwd: testDir,
-          workflow: {
-            name: 'dag-loop-tool-result',
-            nodes: [
-              {
-                id: 'my-loop',
-                kind: 'loop',
-                loop: {
-                  fresh_context: false,
-                  prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
-                  until: 'COMPLETE',
-                  max_iterations: 5,
+        await executeDagWorkflow(
+          dagOptions({
+            deps: mockDeps,
+            platform,
+            cwd: testDir,
+            workflow: {
+              name: 'dag-loop-tool-result',
+              nodes: [
+                {
+                  id: 'my-loop',
+                  kind: 'loop',
+                  loop: {
+                    fresh_context: false,
+                    prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
+                    until: 'COMPLETE',
+                    max_iterations: 5,
+                  },
                 },
-              },
-            ],
-          },
-          workflowRun,
-          workflowProvider: 'claude',
-          workflowModel: undefined,
-          artifactsDir: join(testDir, 'artifacts'),
-          stateDir: join(testDir, 'state'),
-          logDir: join(testDir, 'logs'),
-          baseBranch: 'main',
-          docsDir: 'docs/',
-          config: minimalConfig,
-        });
+              ],
+            },
+            workflowRun,
+          })
+        );
       } finally {
         setSystemTime();
       }
@@ -7455,36 +6897,30 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         const platform = createMockPlatform();
         const workflowRun = makeWorkflowRun('loop-iteration-retry-run');
 
-        await executeDagWorkflow({
-          deps: mockDeps,
-          platform,
-          conversationId: 'conv-loop-retry',
-          cwd: testDir,
-          workflow: {
-            name: 'loop-iteration-retry',
-            nodes: [
-              {
-                id: 'my-loop',
-                kind: 'loop',
-                loop: {
-                  fresh_context: false,
-                  prompt: 'Complete the task.',
-                  until: 'COMPLETE',
-                  max_iterations: 3,
+        await executeDagWorkflow(
+          dagOptions({
+            deps: mockDeps,
+            platform,
+            conversationId: 'conv-loop-retry',
+            cwd: testDir,
+            workflow: {
+              name: 'loop-iteration-retry',
+              nodes: [
+                {
+                  id: 'my-loop',
+                  kind: 'loop',
+                  loop: {
+                    fresh_context: false,
+                    prompt: 'Complete the task.',
+                    until: 'COMPLETE',
+                    max_iterations: 3,
+                  },
                 },
-              },
-            ],
-          },
-          workflowRun,
-          workflowProvider: 'claude',
-          workflowModel: undefined,
-          artifactsDir: join(testDir, 'artifacts'),
-          stateDir: join(testDir, 'state'),
-          logDir: join(testDir, 'logs'),
-          baseBranch: 'main',
-          docsDir: 'docs/',
-          config: minimalConfig,
-        });
+              ],
+            },
+            workflowRun,
+          })
+        );
 
         // The failed attempt is re-streamed within iteration 1 and the run completes.
         expect(callCount).toBe(2);
@@ -7527,36 +6963,30 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       });
 
       try {
-        await executeDagWorkflow({
-          deps: mockDeps,
-          platform,
-          conversationId: 'conv-loop-interleaved-tools',
-          cwd: testDir,
-          workflow: {
-            name: 'loop-interleaved-tools',
-            nodes: [
-              {
-                id: 'my-loop',
-                kind: 'loop',
-                loop: {
-                  fresh_context: false,
-                  prompt: 'Complete the task.',
-                  until: 'COMPLETE',
-                  max_iterations: 1,
+        await executeDagWorkflow(
+          dagOptions({
+            deps: mockDeps,
+            platform,
+            conversationId: 'conv-loop-interleaved-tools',
+            cwd: testDir,
+            workflow: {
+              name: 'loop-interleaved-tools',
+              nodes: [
+                {
+                  id: 'my-loop',
+                  kind: 'loop',
+                  loop: {
+                    fresh_context: false,
+                    prompt: 'Complete the task.',
+                    until: 'COMPLETE',
+                    max_iterations: 1,
+                  },
                 },
-              },
-            ],
-          },
-          workflowRun,
-          workflowProvider: 'claude',
-          workflowModel: undefined,
-          artifactsDir: join(testDir, 'artifacts'),
-          stateDir: join(testDir, 'state'),
-          logDir: join(testDir, 'logs'),
-          baseBranch: 'main',
-          docsDir: 'docs/',
-          config: minimalConfig,
-        });
+              ],
+            },
+            workflowRun,
+          })
+        );
       } finally {
         setSystemTime();
       }
@@ -7592,36 +7022,29 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-test',
-          nodes: [
-            {
-              id: 'my-loop',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
-                until: 'COMPLETE',
-                max_iterations: 5,
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-test',
+            nodes: [
+              {
+                id: 'my-loop',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
+                  until: 'COMPLETE',
+                  max_iterations: 5,
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       // Should have called sendQuery exactly once (completed on iteration 1)
       expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -7661,38 +7084,31 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         repoTiers: { large: { provider: 'claude', model: 'opus', effort: 'max' } },
       });
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-model-usage',
-          nodes: [
-            {
-              id: 'my-loop',
-              model: 'large',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
-                until: 'COMPLETE',
-                max_iterations: 5,
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-model-usage',
+            nodes: [
+              {
+                id: 'my-loop',
+                model: 'large',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
+                  until: 'COMPLETE',
+                  max_iterations: 5,
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-        aiProfile,
-      });
+            ],
+          },
+          workflowRun,
+          aiProfile,
+        })
+      );
 
       const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls as Array<
         [{ event_type: string; step_name: string; data?: Record<string, unknown> }]
@@ -7730,36 +7146,29 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-no-model-run');
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-no-model-usage',
-          nodes: [
-            {
-              id: 'my-loop',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
-                until: 'COMPLETE',
-                max_iterations: 5,
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-no-model-usage',
+            nodes: [
+              {
+                id: 'my-loop',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
+                  until: 'COMPLETE',
+                  max_iterations: 5,
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls as Array<
         [{ event_type: string; step_name: string; data?: Record<string, unknown> }]
@@ -7797,36 +7206,29 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-stale-model-run');
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-stale-model',
-          nodes: [
-            {
-              id: 'my-loop',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
-                until: 'COMPLETE',
-                max_iterations: 5,
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-stale-model',
+            nodes: [
+              {
+                id: 'my-loop',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
+                  until: 'COMPLETE',
+                  max_iterations: 5,
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls as Array<
         [{ event_type: string; step_name: string; data?: Record<string, unknown> }]
@@ -7856,36 +7258,29 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-bg-cost-run');
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-bg-cost',
-          nodes: [
-            {
-              id: 'my-loop',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
-                until: 'COMPLETE',
-                max_iterations: 5,
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-bg-cost',
+            nodes: [
+              {
+                id: 'my-loop',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
+                  until: 'COMPLETE',
+                  max_iterations: 5,
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
       const completedEvent = eventCalls.find(
@@ -7912,36 +7307,28 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
 
       const store = createMockStore();
 
-      await executeDagWorkflow({
-        deps: createMockDeps(store),
-        platform: createMockPlatform(),
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-nan-cost',
-          nodes: [
-            {
-              id: 'my-loop',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
-                until: 'COMPLETE',
-                max_iterations: 5,
+      await executeDagWorkflow(
+        dagOptions({
+          deps: createMockDeps(store),
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-nan-cost',
+            nodes: [
+              {
+                id: 'my-loop',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
+                  until: 'COMPLETE',
+                  max_iterations: 5,
+                },
               },
-            },
-          ],
-        },
-        workflowRun: makeWorkflowRun('loop-nan-cost-run'),
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun: makeWorkflowRun('loop-nan-cost-run'),
+        })
+      );
 
       const completedEvent = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls.find(
         (call: unknown[]) =>
@@ -7992,36 +7379,29 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-bg-union-run');
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-bg-union',
-          nodes: [
-            {
-              id: 'my-loop',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
-                until: 'COMPLETE',
-                max_iterations: 5,
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-bg-union',
+            nodes: [
+              {
+                id: 'my-loop',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
+                  until: 'COMPLETE',
+                  max_iterations: 5,
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       expect(mockSendQueryDag.mock.calls.length).toBe(3);
       const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
@@ -8057,36 +7437,29 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-bg-clean-run');
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-bg-clean',
-          nodes: [
-            {
-              id: 'my-loop',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
-                until: 'COMPLETE',
-                max_iterations: 5,
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-bg-clean',
+            nodes: [
+              {
+                id: 'my-loop',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Do a task. When done, output <promise>COMPLETE</promise>.',
+                  until: 'COMPLETE',
+                  max_iterations: 5,
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
       const completedEvent = eventCalls.find(
@@ -8129,36 +7502,29 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const workflowRun = makeWorkflowRun('loop-bg-cancel-run');
 
       try {
-        await executeDagWorkflow({
-          deps: mockDeps,
-          platform,
-          conversationId: 'conv-dag',
-          cwd: testDir,
-          workflow: {
-            name: 'dag-loop-bg-cancel',
-            nodes: [
-              {
-                id: 'my-loop',
-                kind: 'loop',
-                loop: {
-                  fresh_context: false,
-                  prompt: 'Do tasks.',
-                  until: 'COMPLETE',
-                  max_iterations: 5,
+        await executeDagWorkflow(
+          dagOptions({
+            deps: mockDeps,
+            platform,
+            cwd: testDir,
+            workflow: {
+              name: 'dag-loop-bg-cancel',
+              nodes: [
+                {
+                  id: 'my-loop',
+                  kind: 'loop',
+                  loop: {
+                    fresh_context: false,
+                    prompt: 'Do tasks.',
+                    until: 'COMPLETE',
+                    max_iterations: 5,
+                  },
                 },
-              },
-            ],
-          },
-          workflowRun,
-          workflowProvider: 'claude',
-          workflowModel: undefined,
-          artifactsDir: join(testDir, 'artifacts'),
-          stateDir: join(testDir, 'state'),
-          logDir: join(testDir, 'logs'),
-          baseBranch: 'main',
-          docsDir: 'docs/',
-          config: minimalConfig,
-        });
+              ],
+            },
+            workflowRun,
+          })
+        );
       } finally {
         setSystemTime(); // restore the real clock
       }
@@ -8199,36 +7565,29 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-multi',
-          nodes: [
-            {
-              id: 'my-loop',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Do next task.',
-                until: 'COMPLETE',
-                max_iterations: 10,
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-multi',
+            nodes: [
+              {
+                id: 'my-loop',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Do next task.',
+                  until: 'COMPLETE',
+                  max_iterations: 10,
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       expect(mockSendQueryDag.mock.calls.length).toBe(3);
     });
@@ -8253,36 +7612,29 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-prev-output',
-          nodes: [
-            {
-              id: 'fix-loop',
-              kind: 'loop',
-              loop: {
-                prompt: 'Previous output: <<$LOOP_PREV_OUTPUT>>. Fix and emit COMPLETE.',
-                until: 'COMPLETE',
-                max_iterations: 5,
-                fresh_context: true,
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-prev-output',
+            nodes: [
+              {
+                id: 'fix-loop',
+                kind: 'loop',
+                loop: {
+                  prompt: 'Previous output: <<$LOOP_PREV_OUTPUT>>. Fix and emit COMPLETE.',
+                  until: 'COMPLETE',
+                  max_iterations: 5,
+                  fresh_context: true,
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       expect(mockSendQueryDag.mock.calls.length).toBe(2);
       const promptIter1 = mockSendQueryDag.mock.calls[0][0] as string;
@@ -8318,36 +7670,29 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-prev-clean',
-          nodes: [
-            {
-              id: 'fix-loop',
-              kind: 'loop',
-              loop: {
-                prompt: 'PREV=[$LOOP_PREV_OUTPUT]',
-                until: 'COMPLETE',
-                max_iterations: 5,
-                fresh_context: true,
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-prev-clean',
+            nodes: [
+              {
+                id: 'fix-loop',
+                kind: 'loop',
+                loop: {
+                  prompt: 'PREV=[$LOOP_PREV_OUTPUT]',
+                  until: 'COMPLETE',
+                  max_iterations: 5,
+                  fresh_context: true,
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       expect(mockSendQueryDag.mock.calls.length).toBe(2);
       const promptIter2 = mockSendQueryDag.mock.calls[1][0] as string;
@@ -8376,39 +7721,32 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform1 = createMockPlatform();
       const freshRun = makeWorkflowRun('resume-prev-fresh-run');
 
-      await executeDagWorkflow({
-        deps: mockDeps1,
-        platform: platform1,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'interactive-loop-resume-prev-output',
-          nodes: [
-            {
-              id: 'refine',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt:
-                  'User: $LOOP_USER_INPUT. PREV=<<$LOOP_PREV_OUTPUT>>. Continue or emit COMPLETE.',
-                until: 'COMPLETE',
-                max_iterations: 10,
-                interactive: true,
-                gate_message: 'Review and provide feedback.',
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps1,
+          platform: platform1,
+          cwd: testDir,
+          workflow: {
+            name: 'interactive-loop-resume-prev-output',
+            nodes: [
+              {
+                id: 'refine',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt:
+                    'User: $LOOP_USER_INPUT. PREV=<<$LOOP_PREV_OUTPUT>>. Continue or emit COMPLETE.',
+                  until: 'COMPLETE',
+                  max_iterations: 10,
+                  interactive: true,
+                  gate_message: 'Review and provide feedback.',
+                },
               },
-            },
-          ],
-        },
-        workflowRun: freshRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun: freshRun,
+        })
+      );
 
       // First iteration of a fresh interactive loop: $LOOP_PREV_OUTPUT empty;
       // $LOOP_USER_INPUT empty (no user has spoken yet).
@@ -8448,39 +7786,32 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         },
       });
 
-      await executeDagWorkflow({
-        deps: mockDeps2,
-        platform: platform2,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'interactive-loop-resume-prev-output',
-          nodes: [
-            {
-              id: 'refine',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt:
-                  'User: $LOOP_USER_INPUT. PREV=<<$LOOP_PREV_OUTPUT>>. Continue or emit COMPLETE.',
-                until: 'COMPLETE',
-                max_iterations: 10,
-                interactive: true,
-                gate_message: 'Review and provide feedback.',
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps2,
+          platform: platform2,
+          cwd: testDir,
+          workflow: {
+            name: 'interactive-loop-resume-prev-output',
+            nodes: [
+              {
+                id: 'refine',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt:
+                    'User: $LOOP_USER_INPUT. PREV=<<$LOOP_PREV_OUTPUT>>. Continue or emit COMPLETE.',
+                  until: 'COMPLETE',
+                  max_iterations: 10,
+                  interactive: true,
+                  gate_message: 'Review and provide feedback.',
+                },
               },
-            },
-          ],
-        },
-        workflowRun: resumedRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun: resumedRun,
+        })
+      );
 
       // Second executeDagWorkflow call started a fresh sendQuery generator (mock
       // call index 1 across the two runs). The resumed iteration must NOT carry
@@ -8509,36 +7840,29 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-max',
-          nodes: [
-            {
-              id: 'my-loop',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Do task.',
-                until: 'COMPLETE',
-                max_iterations: 2,
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-max',
+            nodes: [
+              {
+                id: 'my-loop',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Do task.',
+                  until: 'COMPLETE',
+                  max_iterations: 2,
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       // Should have called sendQuery exactly 2 times (max_iterations)
       expect(mockSendQueryDag.mock.calls.length).toBe(2);
@@ -8567,36 +7891,29 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-xml-tag',
-          nodes: [
-            {
-              id: 'fix-and-review',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Fix and review. When done, output <COMPLETE>ALL_CLEAN</COMPLETE>.',
-                until: 'ALL_CLEAN',
-                max_iterations: 3,
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-xml-tag',
+            nodes: [
+              {
+                id: 'fix-and-review',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Fix and review. When done, output <COMPLETE>ALL_CLEAN</COMPLETE>.',
+                  until: 'ALL_CLEAN',
+                  max_iterations: 3,
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       // 3 iterations run, signal found on iteration 3 → completed, NOT failed
       expect(mockSendQueryDag.mock.calls.length).toBe(3);
@@ -8643,42 +7960,35 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-output',
-          nodes: [
-            {
-              id: 'impl',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Do task. Output <promise>COMPLETE</promise> when done.',
-                until: 'COMPLETE',
-                max_iterations: 5,
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-output',
+            nodes: [
+              {
+                id: 'impl',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Do task. Output <promise>COMPLETE</promise> when done.',
+                  until: 'COMPLETE',
+                  max_iterations: 5,
+                },
               },
-            },
-            {
-              id: 'report',
-              kind: 'agent',
-              source: { kind: 'inline', prompt: 'Summarize: $impl.output' },
-              depends_on: ['impl'],
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+              {
+                id: 'report',
+                kind: 'agent',
+                source: { kind: 'inline', prompt: 'Summarize: $impl.output' },
+                depends_on: ['impl'],
+              },
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       // Loop ran 2 iterations + downstream ran once = 3 calls
       expect(mockSendQueryDag.mock.calls.length).toBe(3);
@@ -8700,36 +8010,29 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-fresh',
-          nodes: [
-            {
-              id: 'my-loop',
-              kind: 'loop',
-              loop: {
-                prompt: 'Do stuff.',
-                until: 'DONE',
-                max_iterations: 5,
-                fresh_context: true,
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-fresh',
+            nodes: [
+              {
+                id: 'my-loop',
+                kind: 'loop',
+                loop: {
+                  prompt: 'Do stuff.',
+                  until: 'DONE',
+                  max_iterations: 5,
+                  fresh_context: true,
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       // Both calls should have undefined resumeSessionId (fresh context)
       expect(mockSendQueryDag.mock.calls.length).toBe(2);
@@ -8755,36 +8058,29 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-stateful',
-          nodes: [
-            {
-              id: 'my-loop',
-              kind: 'loop',
-              loop: {
-                prompt: 'Do stuff.',
-                until: 'DONE',
-                max_iterations: 5,
-                fresh_context: false,
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-stateful',
+            nodes: [
+              {
+                id: 'my-loop',
+                kind: 'loop',
+                loop: {
+                  prompt: 'Do stuff.',
+                  until: 'DONE',
+                  max_iterations: 5,
+                  fresh_context: false,
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       expect(mockSendQueryDag.mock.calls.length).toBe(2);
       // First call: fresh (iteration 1 always fresh)
@@ -8818,37 +8114,30 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-until-bash-only');
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-until-bash-only',
-          nodes: [
-            {
-              id: 'my-loop',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Keep working.',
-                max_iterations: 5,
-                // Bumps a counter and exits 0 only on the second call.
-                until_bash: `n=$(cat ${counterRef} 2>/dev/null || echo 0); n=$((n+1)); echo $n > ${counterRef}; test $n -ge 2`,
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-until-bash-only',
+            nodes: [
+              {
+                id: 'my-loop',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Keep working.',
+                  max_iterations: 5,
+                  // Bumps a counter and exits 0 only on the second call.
+                  until_bash: `n=$(cat ${counterRef} 2>/dev/null || echo 0); n=$((n+1)); echo $n > ${counterRef}; test $n -ge 2`,
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       expect(calls).toBe(2);
       expect((await readFile(counterFile, 'utf8')).trim()).toBe('2');
@@ -8885,22 +8174,14 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         ],
       });
 
-      await executeDagWorkflow({
-        deps: createMockDeps(store),
-        platform: createMockPlatform(),
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: ready(workflow),
-        workflowRun: makeWorkflowRun('loop-required-output-ref'),
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: createMockDeps(store),
+          cwd: testDir,
+          workflow: ready(workflow),
+          workflowRun: makeWorkflowRun('loop-required-output-ref'),
+        })
+      );
 
       const failed = store.createWorkflowEvent.mock.calls
         .map(([event]) => event)
@@ -8926,43 +8207,38 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-large-until-bash');
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-large-until-bash',
-          nodes: [
-            {
-              id: 'producer',
-              kind: 'exec',
-              runtime: 'sh',
-              script: 'head -c 33000 /dev/zero | tr "\\0" x',
-            },
-            {
-              id: 'my-loop',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Keep working.',
-                max_iterations: 2,
-                until_bash: 'value=$producer.output; test "${#value}" -eq 33000',
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-large-until-bash',
+            nodes: [
+              {
+                id: 'producer',
+                kind: 'exec',
+                runtime: 'sh',
+                script: 'head -c 33000 /dev/zero | tr "\\0" x',
               },
-              depends_on: ['producer'],
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir,
-        stateDir: join(testDir, 'state'),
-        logDir,
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+              {
+                id: 'my-loop',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Keep working.',
+                  max_iterations: 2,
+                  until_bash: 'value=$producer.output; test "${#value}" -eq 33000',
+                },
+                depends_on: ['producer'],
+              },
+            ],
+          },
+          workflowRun,
+          artifactsDir,
+          logDir,
+        })
+      );
 
       expect(calls).toBe(1);
       expect(
@@ -8996,36 +8272,29 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-stray-sentinel');
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-stray-sentinel',
-          nodes: [
-            {
-              id: 'my-loop',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Keep working.',
-                max_iterations: 5,
-                until_bash: `n=$(cat ${counterRef} 2>/dev/null || echo 0); n=$((n+1)); echo $n > ${counterRef}; test $n -ge 2`,
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-stray-sentinel',
+            nodes: [
+              {
+                id: 'my-loop',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Keep working.',
+                  max_iterations: 5,
+                  until_bash: `n=$(cat ${counterRef} 2>/dev/null || echo 0); n=$((n+1)); echo $n > ${counterRef}; test $n -ge 2`,
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       // Two iterations, not one — the sentinel was inert.
       expect(calls).toBe(2);
@@ -9050,39 +8319,32 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-shortcircuit');
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-shortcircuit',
-          nodes: [
-            {
-              id: 'my-loop',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Do work, emit DONE.',
-                until: 'DONE',
-                max_iterations: 3,
-                // Creates the sentinel and exits 0. If the short-circuit works it
-                // never runs, so the file is never created.
-                until_bash: `touch ${sentinelRef}`,
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-shortcircuit',
+            nodes: [
+              {
+                id: 'my-loop',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Do work, emit DONE.',
+                  until: 'DONE',
+                  max_iterations: 3,
+                  // Creates the sentinel and exits 0. If the short-circuit works it
+                  // never runs, so the file is never created.
+                  until_bash: `touch ${sentinelRef}`,
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       expect(calls).toBe(1);
       let sentinelExists = true;
@@ -9119,37 +8381,30 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-until-field');
 
-      const result = await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-until-field',
-          nodes: [
-            {
-              id: 'my-loop',
-              output_format: untilFieldSchema,
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Work until done.',
-                max_iterations: 6,
-                until_field: 'done',
+      const result = await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-until-field',
+            nodes: [
+              {
+                id: 'my-loop',
+                output_format: untilFieldSchema,
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Work until done.',
+                  max_iterations: 6,
+                  until_field: 'done',
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       // false, false, true -> exactly three iterations.
       expect(calls).toBe(3);
@@ -9166,32 +8421,30 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-of-passthrough');
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-of-passthrough',
-          nodes: [
-            {
-              id: 'my-loop',
-              output_format: untilFieldSchema,
-              kind: 'loop',
-              loop: { fresh_context: false, prompt: 'go', max_iterations: 2, until_field: 'done' },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-of-passthrough',
+            nodes: [
+              {
+                id: 'my-loop',
+                output_format: untilFieldSchema,
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'go',
+                  max_iterations: 2,
+                  until_field: 'done',
+                },
+              },
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       // Before #2563 the parse transform dropped output_format for loop nodes, so
       // the schema never reached sendQuery at all.
@@ -9211,32 +8464,30 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-strict-bool');
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-strict-bool',
-          nodes: [
-            {
-              id: 'my-loop',
-              output_format: untilFieldSchema,
-              kind: 'loop',
-              loop: { fresh_context: false, prompt: 'go', max_iterations: 5, until_field: 'done' },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-strict-bool',
+            nodes: [
+              {
+                id: 'my-loop',
+                output_format: untilFieldSchema,
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'go',
+                  max_iterations: 5,
+                  until_field: 'done',
+                },
+              },
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       // Enforced provider -> zero reasks, fails on the first attempt.
       expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -9264,33 +8515,33 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-reask-recover');
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-reask-recover',
-          nodes: [
-            {
-              id: 'my-loop',
-              provider: 'pi',
-              output_format: untilFieldSchema,
-              kind: 'loop',
-              loop: { fresh_context: false, prompt: 'go', max_iterations: 4, until_field: 'done' },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'pi',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: { ...minimalConfig, assistant: 'pi' },
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-reask-recover',
+            nodes: [
+              {
+                id: 'my-loop',
+                provider: 'pi',
+                output_format: untilFieldSchema,
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'go',
+                  max_iterations: 4,
+                  until_field: 'done',
+                },
+              },
+            ],
+          },
+          workflowRun,
+          workflowProvider: 'pi',
+          config: { ...minimalConfig, assistant: 'pi' },
+        })
+      );
 
       expect(mockSendQueryDag.mock.calls.length).toBe(2);
       const events = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
@@ -9338,38 +8589,33 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-reask-threading');
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-reask-threading',
-          nodes: [
-            {
-              id: 'my-loop',
-              provider: 'pi',
-              output_format: untilFieldSchema,
-              kind: 'loop',
-              loop: {
-                prompt: 'go',
-                max_iterations: 5,
-                until_field: 'done',
-                fresh_context: false,
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-reask-threading',
+            nodes: [
+              {
+                id: 'my-loop',
+                provider: 'pi',
+                output_format: untilFieldSchema,
+                kind: 'loop',
+                loop: {
+                  prompt: 'go',
+                  max_iterations: 5,
+                  until_field: 'done',
+                  fresh_context: false,
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'pi',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: { ...minimalConfig, assistant: 'pi' },
-      });
+            ],
+          },
+          workflowRun,
+          workflowProvider: 'pi',
+          config: { ...minimalConfig, assistant: 'pi' },
+        })
+      );
 
       // 1: fresh (iteration 1 always is). 2: threads from iteration 1's session.
       // 3: the reask, deliberately fresh. 4: MUST thread from attempt 0's session,
@@ -9406,33 +8652,33 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-reask-iter1');
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-reask-iter1',
-          nodes: [
-            {
-              id: 'my-loop',
-              provider: 'pi',
-              output_format: untilFieldSchema,
-              kind: 'loop',
-              loop: { prompt: 'go', max_iterations: 5, until_field: 'done', fresh_context: false },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'pi',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: { ...minimalConfig, assistant: 'pi' },
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-reask-iter1',
+            nodes: [
+              {
+                id: 'my-loop',
+                provider: 'pi',
+                output_format: untilFieldSchema,
+                kind: 'loop',
+                loop: {
+                  prompt: 'go',
+                  max_iterations: 5,
+                  until_field: 'done',
+                  fresh_context: false,
+                },
+              },
+            ],
+          },
+          workflowRun,
+          workflowProvider: 'pi',
+          config: { ...minimalConfig, assistant: 'pi' },
+        })
+      );
 
       expect(sessions[0]).toBeUndefined(); // iteration 1, attempt 0 — always fresh
       expect(sessions[1]).toBeUndefined(); // the reask — deliberately fresh
@@ -9465,40 +8711,40 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-reask-crossnode');
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-reask-crossnode',
-          nodes: [
-            {
-              id: 'my-loop',
-              provider: 'pi',
-              output_format: untilFieldSchema,
-              kind: 'loop',
-              loop: { prompt: 'go', max_iterations: 3, until_field: 'done', fresh_context: false },
-            },
-            {
-              id: 'after',
-              provider: 'pi',
-              kind: 'agent',
-              source: { kind: 'inline', prompt: 'continue' },
-              depends_on: ['my-loop'],
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'pi',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: { ...minimalConfig, assistant: 'pi' },
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-reask-crossnode',
+            nodes: [
+              {
+                id: 'my-loop',
+                provider: 'pi',
+                output_format: untilFieldSchema,
+                kind: 'loop',
+                loop: {
+                  prompt: 'go',
+                  max_iterations: 3,
+                  until_field: 'done',
+                  fresh_context: false,
+                },
+              },
+              {
+                id: 'after',
+                provider: 'pi',
+                kind: 'agent',
+                source: { kind: 'inline', prompt: 'continue' },
+                depends_on: ['my-loop'],
+              },
+            ],
+          },
+          workflowRun,
+          workflowProvider: 'pi',
+          config: { ...minimalConfig, assistant: 'pi' },
+        })
+      );
 
       // The third call is the downstream node; it must inherit the loop's conversation.
       expect(sessions[2]).toBe('loop-conv');
@@ -9515,33 +8761,33 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-reask-exhausted');
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-reask-exhausted',
-          nodes: [
-            {
-              id: 'my-loop',
-              provider: 'pi',
-              output_format: untilFieldSchema,
-              kind: 'loop',
-              loop: { fresh_context: false, prompt: 'go', max_iterations: 4, until_field: 'done' },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'pi',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: { ...minimalConfig, assistant: 'pi' },
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-reask-exhausted',
+            nodes: [
+              {
+                id: 'my-loop',
+                provider: 'pi',
+                output_format: untilFieldSchema,
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'go',
+                  max_iterations: 4,
+                  until_field: 'done',
+                },
+              },
+            ],
+          },
+          workflowRun,
+          workflowProvider: 'pi',
+          config: { ...minimalConfig, assistant: 'pi' },
+        })
+      );
 
       // Original + 3 reasks, then fail — the loop does NOT keep iterating on a
       // broken completion channel until max_iterations.
@@ -9583,47 +8829,40 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         },
       });
 
-      const result = await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'finalize-declared-fields',
-          nodes: [
-            {
-              id: 'judge',
-              output_format: untilFieldSchema,
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'judge',
-                until: 'APPROVED',
-                max_iterations: 5,
-                until_field: 'done',
-                interactive: true,
-                gate_message: 'Review.',
+      const result = await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'finalize-declared-fields',
+            nodes: [
+              {
+                id: 'judge',
+                output_format: untilFieldSchema,
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'judge',
+                  until: 'APPROVED',
+                  max_iterations: 5,
+                  until_field: 'done',
+                  interactive: true,
+                  gate_message: 'Review.',
+                },
               },
-            },
-            {
-              id: 'report',
-              depends_on: ['judge'],
-              kind: 'exec',
-              runtime: 'sh',
-              script: 'echo "note=[$judge.output.note]"',
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+              {
+                id: 'report',
+                depends_on: ['judge'],
+                kind: 'exec',
+                runtime: 'sh',
+                script: 'echo "note=[$judge.output.note]"',
+              },
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       // Declared-but-absent optional resolves to empty (shell-quoted by the
       // bash-escaped substitution path), not a failed consumer.
@@ -9648,38 +8887,31 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-inline-sentinel');
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-inline-sentinel',
-          nodes: [
-            {
-              id: 'my-loop',
-              output_format: untilFieldSchema,
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'go',
-                until: 'ALLDONE',
-                max_iterations: 4,
-                until_field: 'done',
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-inline-sentinel',
+            nodes: [
+              {
+                id: 'my-loop',
+                output_format: untilFieldSchema,
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'go',
+                  until: 'ALLDONE',
+                  max_iterations: 4,
+                  until_field: 'done',
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       // `done` stays false, so only the prose sentinel can have ended this.
       expect(calls).toBe(1);
@@ -9703,38 +8935,31 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-signal-in-payload');
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-signal-in-payload',
-          nodes: [
-            {
-              id: 'my-loop',
-              output_format: untilFieldSchema,
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'go',
-                until: 'ALLDONE',
-                max_iterations: 4,
-                until_field: 'done',
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-signal-in-payload',
+            nodes: [
+              {
+                id: 'my-loop',
+                output_format: untilFieldSchema,
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'go',
+                  until: 'ALLDONE',
+                  max_iterations: 4,
+                  until_field: 'done',
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       // `done` stays false, so only the signal can have ended it.
       expect(calls).toBe(1);
@@ -9753,39 +8978,37 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-downstream-field');
 
-      const result = await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-downstream-field',
-          nodes: [
-            {
-              id: 'my-loop',
-              output_format: untilFieldSchema,
-              kind: 'loop',
-              loop: { fresh_context: false, prompt: 'go', max_iterations: 3, until_field: 'done' },
-            },
-            {
-              id: 'report',
-              depends_on: ['my-loop'],
-              kind: 'exec',
-              runtime: 'sh',
-              script: 'echo "note=$my-loop.output.note"',
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      const result = await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-downstream-field',
+            nodes: [
+              {
+                id: 'my-loop',
+                output_format: untilFieldSchema,
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'go',
+                  max_iterations: 3,
+                  until_field: 'done',
+                },
+              },
+              {
+                id: 'report',
+                depends_on: ['my-loop'],
+                kind: 'exec',
+                runtime: 'sh',
+                script: 'echo "note=$my-loop.output.note"',
+              },
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       // Shell-quoted by the bash-escaped substitution path, as any $node.output.field is.
       expect(result).toContain("note='shipped'");
@@ -9801,31 +9024,29 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-strip',
-          nodes: [
-            {
-              id: 'my-loop',
-              kind: 'loop',
-              loop: { fresh_context: false, prompt: 'Task.', until: 'COMPLETE', max_iterations: 3 },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-strip',
+            nodes: [
+              {
+                id: 'my-loop',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Task.',
+                  until: 'COMPLETE',
+                  max_iterations: 3,
+                },
+              },
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       // In batch mode, accumulated clean output is sent
       const sendCalls = (platform.sendMessage as Mock<IWorkflowPlatform['sendMessage']>).mock.calls;
@@ -9858,36 +9079,29 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-cancel',
-          nodes: [
-            {
-              id: 'my-loop',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Do tasks.',
-                until: 'COMPLETE',
-                max_iterations: 10,
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-cancel',
+            nodes: [
+              {
+                id: 'my-loop',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Do tasks.',
+                  until: 'COMPLETE',
+                  max_iterations: 10,
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       // Should have only done 1 iteration (cancelled before iteration 2)
       expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -9902,36 +9116,29 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-ai-error',
-          nodes: [
-            {
-              id: 'my-loop',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Do task.',
-                until: 'COMPLETE',
-                max_iterations: 5,
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-ai-error',
+            nodes: [
+              {
+                id: 'my-loop',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Do task.',
+                  until: 'COMPLETE',
+                  max_iterations: 5,
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       // Should have run exactly 1 iteration (failed on first)
       expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -9952,36 +9159,29 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-plain-signal',
-          nodes: [
-            {
-              id: 'my-loop',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Do task.',
-                until: 'COMPLETE',
-                max_iterations: 5,
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-plain-signal',
+            nodes: [
+              {
+                id: 'my-loop',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Do task.',
+                  until: 'COMPLETE',
+                  max_iterations: 5,
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       // Should complete on first iteration (plain signal on own line)
       expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -10004,31 +9204,29 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'dag-loop-false-positive',
-          nodes: [
-            {
-              id: 'my-loop',
-              kind: 'loop',
-              loop: { fresh_context: false, prompt: 'Work.', until: 'COMPLETE', max_iterations: 2 },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'dag-loop-false-positive',
+            nodes: [
+              {
+                id: 'my-loop',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Work.',
+                  until: 'COMPLETE',
+                  max_iterations: 2,
+                },
+              },
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       // Should have run max_iterations times (NOT detected as complete)
       expect(mockSendQueryDag.mock.calls.length).toBe(2);
@@ -10056,38 +9254,31 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'interactive-loop-test',
-          nodes: [
-            {
-              id: 'refine',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'User said: $LOOP_USER_INPUT. Refine the plan.',
-                until: 'APPROVED',
-                max_iterations: 10,
-                interactive: true,
-                gate_message: 'Review the plan and provide feedback.',
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'interactive-loop-test',
+            nodes: [
+              {
+                id: 'refine',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'User said: $LOOP_USER_INPUT. Refine the plan.',
+                  until: 'APPROVED',
+                  max_iterations: 10,
+                  interactive: true,
+                  gate_message: 'Review the plan and provide feedback.',
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       // Should have called sendQuery exactly once (paused after iteration 1)
       expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -10121,39 +9312,32 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const mockDeps = createMockDeps();
       const platform = createMockPlatform();
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'interactive-loop-bash-gate',
-          nodes: [
-            {
-              id: 'refine',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Validate.',
-                until: 'UNTIL_DONE',
-                until_bash: 'exit 0',
-                max_iterations: 3,
-                interactive: true,
-                gate_message: 'Review the checks.',
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'interactive-loop-bash-gate',
+            nodes: [
+              {
+                id: 'refine',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Validate.',
+                  until: 'UNTIL_DONE',
+                  until_bash: 'exit 0',
+                  max_iterations: 3,
+                  interactive: true,
+                  gate_message: 'Review the checks.',
+                },
               },
-            },
-          ],
-        },
-        workflowRun: makeWorkflowRun('loop-bash-gate'),
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun: makeWorkflowRun('loop-bash-gate'),
+        })
+      );
 
       expectLoopGateEvidence(
         mockDeps.store,
@@ -10177,40 +9361,33 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const mockDeps = createMockDeps();
       const platform = createMockPlatform();
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'interactive-loop-field-gate',
-          nodes: [
-            {
-              id: 'refine',
-              output_format: untilFieldSchema,
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Judge completion.',
-                until: 'UNTIL_DONE',
-                until_field: 'done',
-                max_iterations: 3,
-                interactive: true,
-                gate_message: 'Review the judgment.',
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'interactive-loop-field-gate',
+            nodes: [
+              {
+                id: 'refine',
+                output_format: untilFieldSchema,
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Judge completion.',
+                  until: 'UNTIL_DONE',
+                  until_field: 'done',
+                  max_iterations: 3,
+                  interactive: true,
+                  gate_message: 'Review the judgment.',
+                },
               },
-            },
-          ],
-        },
-        workflowRun: makeWorkflowRun('loop-field-gate'),
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun: makeWorkflowRun('loop-field-gate'),
+        })
+      );
 
       expectLoopGateEvidence(
         mockDeps.store,
@@ -10234,41 +9411,34 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const mockDeps = createMockDeps();
       const platform = createMockPlatform();
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'interactive-loop-unmet-gate',
-          nodes: [
-            {
-              id: 'refine',
-              output_format: untilFieldSchema,
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Judge completion.',
-                until: 'UNTIL_DONE',
-                until_bash: 'exit 1',
-                until_field: 'done',
-                max_iterations: 3,
-                interactive: true,
-                gate_message: 'Keep working.',
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'interactive-loop-unmet-gate',
+            nodes: [
+              {
+                id: 'refine',
+                output_format: untilFieldSchema,
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Judge completion.',
+                  until: 'UNTIL_DONE',
+                  until_bash: 'exit 1',
+                  until_field: 'done',
+                  max_iterations: 3,
+                  interactive: true,
+                  gate_message: 'Keep working.',
+                },
               },
-            },
-          ],
-        },
-        workflowRun: makeWorkflowRun('loop-unmet-gate'),
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun: makeWorkflowRun('loop-unmet-gate'),
+        })
+      );
 
       expectLoopGateEvidence(
         mockDeps.store,
@@ -10291,38 +9461,31 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'interactive-loop-signal',
-          nodes: [
-            {
-              id: 'refine',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Refine.',
-                until: 'APPROVED',
-                max_iterations: 10,
-                interactive: true,
-                gate_message: 'Review and provide feedback.',
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'interactive-loop-signal',
+            nodes: [
+              {
+                id: 'refine',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Refine.',
+                  until: 'APPROVED',
+                  max_iterations: 10,
+                  interactive: true,
+                  gate_message: 'Review and provide feedback.',
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       // On first iteration (fresh start, no user input), the loop MUST pause
       // at the gate even if the AI emits the completion signal. The user hasn't
@@ -10374,38 +9537,31 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         },
       });
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'interactive-loop-resume-signal',
-          nodes: [
-            {
-              id: 'refine',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'User said: $LOOP_USER_INPUT. Refine.',
-                until: 'APPROVED',
-                max_iterations: 10,
-                interactive: true,
-                gate_message: 'Review and provide feedback.',
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'interactive-loop-resume-signal',
+            nodes: [
+              {
+                id: 'refine',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'User said: $LOOP_USER_INPUT. Refine.',
+                  until: 'APPROVED',
+                  max_iterations: 10,
+                  interactive: true,
+                  gate_message: 'Review and provide feedback.',
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       // On resume with user input, the AI processes the approval and emits the
       // completion signal. The loop exits immediately without pausing at the gate.
@@ -10439,38 +9595,31 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         },
       });
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'interactive-loop-resume',
-          nodes: [
-            {
-              id: 'refine',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'User said: $LOOP_USER_INPUT. Refine the plan.',
-                until: 'APPROVED',
-                max_iterations: 10,
-                interactive: true,
-                gate_message: 'Review the plan.',
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'interactive-loop-resume',
+            nodes: [
+              {
+                id: 'refine',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'User said: $LOOP_USER_INPUT. Refine the plan.',
+                  until: 'APPROVED',
+                  max_iterations: 10,
+                  interactive: true,
+                  gate_message: 'Review the plan.',
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       // Should have called sendQuery once (starting from iteration 2, completed immediately)
       expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -10492,39 +9641,32 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('signal-completes-run');
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'signal-completes-test',
-          nodes: [
-            {
-              id: 'validate',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Validate. Emit VALIDATED on pass.',
-                until: 'VALIDATED',
-                max_iterations: 10,
-                interactive: true,
-                gate_message: 'Review the validation result.',
-                signal_completes: true,
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'signal-completes-test',
+            nodes: [
+              {
+                id: 'validate',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Validate. Emit VALIDATED on pass.',
+                  until: 'VALIDATED',
+                  max_iterations: 10,
+                  interactive: true,
+                  gate_message: 'Review the validation result.',
+                  signal_completes: true,
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       // No gate: the node completed autonomously on the signal.
       const pauseCalls = (
@@ -10573,38 +9715,31 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         },
       });
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'finalize-on-approve',
-          nodes: [
-            {
-              id: 'refine',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Refine.',
-                until: 'APPROVED',
-                max_iterations: 10,
-                interactive: true,
-                gate_message: 'Review.',
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'finalize-on-approve',
+            nodes: [
+              {
+                id: 'refine',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Refine.',
+                  until: 'APPROVED',
+                  max_iterations: 10,
+                  interactive: true,
+                  gate_message: 'Review.',
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       // No new iteration ran — the node finalized from the persisted output.
       expect(mockSendQueryDag.mock.calls.length).toBe(0);
@@ -10669,22 +9804,14 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         },
       ];
       const pausingDeps = createMockDeps();
-      await executeDagWorkflow({
-        deps: pausingDeps,
-        platform: createMockPlatform(),
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: { name: 'finalize-struct-pause', nodes: loopNodes },
-        workflowRun: makeWorkflowRun('finalize-struct-pause-run'),
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: pausingDeps,
+          cwd: testDir,
+          workflow: { name: 'finalize-struct-pause', nodes: loopNodes },
+          workflowRun: makeWorkflowRun('finalize-struct-pause-run'),
+        })
+      );
       const pauseCalls = (
         pausingDeps.store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>
       ).mock.calls;
@@ -10703,28 +9830,20 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         yield { type: 'result', sessionId: 'never' };
       });
       const resumingDeps = createMockDeps();
-      await executeDagWorkflow({
-        deps: resumingDeps,
-        platform: createMockPlatform(),
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: { name: 'finalize-struct-resume', nodes: loopNodes },
-        workflowRun: makeWorkflowRun('finalize-struct-resume-run', {
-          metadata: {
-            approval: { ...approval },
-            loop_user_input: 'Approved',
-            loop_feedback_given: false,
-          },
-        }),
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: resumingDeps,
+          cwd: testDir,
+          workflow: { name: 'finalize-struct-resume', nodes: loopNodes },
+          workflowRun: makeWorkflowRun('finalize-struct-resume-run', {
+            metadata: {
+              approval: { ...approval },
+              loop_user_input: 'Approved',
+              loop_feedback_given: false,
+            },
+          }),
+        })
+      );
       expect(mockSendQueryDag.mock.calls.length).toBe(0);
       const completed = (
         resumingDeps.store.createWorkflowEvent as Mock<
@@ -10763,38 +9882,30 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         },
       });
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform: createMockPlatform(),
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'finalize-on-approve',
-          nodes: [
-            {
-              id: 'refine',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Refine.',
-                until: 'APPROVED',
-                max_iterations: 10,
-                interactive: true,
-                gate_message: 'Review.',
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          cwd: testDir,
+          workflow: {
+            name: 'finalize-on-approve',
+            nodes: [
+              {
+                id: 'refine',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Refine.',
+                  until: 'APPROVED',
+                  max_iterations: 10,
+                  interactive: true,
+                  gate_message: 'Review.',
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       expect(mockSendQueryDag.mock.calls.length).toBe(0);
       const eventCalls = (
@@ -10837,38 +9948,30 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         },
       });
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform: createMockPlatform(),
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'finalize-invalid-tokens',
-          nodes: [
-            {
-              id: 'refine',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Refine.',
-                until: 'APPROVED',
-                max_iterations: 10,
-                interactive: true,
-                gate_message: 'Review.',
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          cwd: testDir,
+          workflow: {
+            name: 'finalize-invalid-tokens',
+            nodes: [
+              {
+                id: 'refine',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Refine.',
+                  until: 'APPROVED',
+                  max_iterations: 10,
+                  interactive: true,
+                  gate_message: 'Review.',
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       const warnCalls = mockLogFn.mock.calls.filter(
         (call: unknown[]) => call[1] === 'dag_loop.signaled_tokens_invalid_ignored'
@@ -10922,38 +10025,31 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         },
       });
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'feedback-iterates',
-          nodes: [
-            {
-              id: 'refine',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'User said: $LOOP_USER_INPUT. Refine.',
-                until: 'APPROVED',
-                max_iterations: 10,
-                interactive: true,
-                gate_message: 'Review.',
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'feedback-iterates',
+            nodes: [
+              {
+                id: 'refine',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'User said: $LOOP_USER_INPUT. Refine.',
+                  until: 'APPROVED',
+                  max_iterations: 10,
+                  interactive: true,
+                  gate_message: 'Review.',
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       // Feedback ⇒ a fresh iteration ran with $LOOP_USER_INPUT substituted.
       expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -11009,38 +10105,31 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         },
       });
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'nonsignaled-iterates',
-          nodes: [
-            {
-              id: 'refine',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Refine.',
-                until: 'APPROVED',
-                max_iterations: 10,
-                interactive: true,
-                gate_message: 'Review.',
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'nonsignaled-iterates',
+            nodes: [
+              {
+                id: 'refine',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Refine.',
+                  until: 'APPROVED',
+                  max_iterations: 10,
+                  interactive: true,
+                  gate_message: 'Review.',
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       // Nothing to finalize — a normal resumed iteration ran.
       expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -11070,38 +10159,31 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         },
       });
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'legacy-loop-resume',
-          nodes: [
-            {
-              id: 'refine',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'User said: $LOOP_USER_INPUT. Refine.',
-                until: 'APPROVED',
-                max_iterations: 10,
-                interactive: true,
-                gate_message: 'Review and provide feedback.',
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'legacy-loop-resume',
+            nodes: [
+              {
+                id: 'refine',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'User said: $LOOP_USER_INPUT. Refine.',
+                  until: 'APPROVED',
+                  max_iterations: 10,
+                  interactive: true,
+                  gate_message: 'Review and provide feedback.',
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       // A real iteration ran (no zero-duration finalize short-circuit).
       expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -11130,36 +10212,29 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'loop-iteration-err',
-          nodes: [
-            {
-              id: 'work',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Do the work. Say DONE.',
-                until: 'DONE',
-                max_iterations: 5,
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'loop-iteration-err',
+            nodes: [
+              {
+                id: 'work',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Do the work. Say DONE.',
+                  until: 'DONE',
+                  max_iterations: 5,
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       // Should fail after one iteration rather than burning through max_iterations
       expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -11212,36 +10287,29 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'loop-success-stop-seq-test',
-          nodes: [
-            {
-              id: 'work',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Do the work. Say DONE.',
-                until: 'DONE',
-                max_iterations: 3,
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'loop-success-stop-seq-test',
+            nodes: [
+              {
+                id: 'work',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Do the work. Say DONE.',
+                  until: 'DONE',
+                  max_iterations: 3,
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
       const failedEvents = eventCalls.filter((call: unknown[]) => {
@@ -11261,36 +10329,29 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'non-interactive-loop',
-          nodes: [
-            {
-              id: 'my-loop',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Do task.',
-                until: 'COMPLETE',
-                max_iterations: 2,
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'non-interactive-loop',
+            nodes: [
+              {
+                id: 'my-loop',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Do task.',
+                  until: 'COMPLETE',
+                  max_iterations: 2,
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       // pauseWorkflowRun should never be called for non-interactive loops
       const pauseCalls = (
@@ -11345,36 +10406,29 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'loop-cmd-read-once',
-          nodes: [
-            {
-              id: 'read-once-loop',
-              kind: 'loop',
-              loop: {
-                command: 'read-once-loop',
-                until: 'COMPLETE',
-                max_iterations: 5,
-                fresh_context: true,
-              },
-            } as unknown as DagNode,
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'loop-cmd-read-once',
+            nodes: [
+              {
+                id: 'read-once-loop',
+                kind: 'loop',
+                loop: {
+                  command: 'read-once-loop',
+                  until: 'COMPLETE',
+                  max_iterations: 5,
+                  fresh_context: true,
+                },
+              } as unknown as DagNode,
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       // Both iterations ran — the mid-run deletion did not break iteration 2.
       expect(mockSendQueryDag.mock.calls.length).toBe(2);
@@ -11411,36 +10465,29 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'loop-cmd-missing',
-          nodes: [
-            {
-              id: 'missing-loop',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                command: 'does-not-exist-anywhere',
-                until: 'COMPLETE',
-                max_iterations: 3,
-              },
-            } as unknown as DagNode,
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'loop-cmd-missing',
+            nodes: [
+              {
+                id: 'missing-loop',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  command: 'does-not-exist-anywhere',
+                  until: 'COMPLETE',
+                  max_iterations: 3,
+                },
+              } as unknown as DagNode,
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       // sendQuery must never have been invoked — load failed pre-iteration.
       expect(mockSendQueryDag.mock.calls.length).toBe(0);
@@ -11479,36 +10526,29 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'loop-cmd-empty',
-          nodes: [
-            {
-              id: 'empty-loop',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                command: 'empty-loop',
-                until: 'COMPLETE',
-                max_iterations: 3,
-              },
-            } as unknown as DagNode,
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'loop-cmd-empty',
+            nodes: [
+              {
+                id: 'empty-loop',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  command: 'empty-loop',
+                  until: 'COMPLETE',
+                  max_iterations: 3,
+                },
+              } as unknown as DagNode,
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       expect(mockSendQueryDag.mock.calls.length).toBe(0);
       const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
@@ -11533,36 +10573,29 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'loop-cmd-unsafe',
-          nodes: [
-            {
-              id: 'unsafe-loop',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                command: '../escape',
-                until: 'COMPLETE',
-                max_iterations: 3,
-              },
-            } as unknown as DagNode,
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'loop-cmd-unsafe',
+            nodes: [
+              {
+                id: 'unsafe-loop',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  command: '../escape',
+                  until: 'COMPLETE',
+                  max_iterations: 3,
+                },
+              } as unknown as DagNode,
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       expect(mockSendQueryDag.mock.calls.length).toBe(0);
       const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
@@ -11606,36 +10639,29 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'loop-cmd-subst',
-          nodes: [
-            {
-              id: 'subst-loop',
-              kind: 'loop',
-              loop: {
-                command: 'subst-loop',
-                until: 'COMPLETE',
-                max_iterations: 5,
-                fresh_context: true,
-              },
-            } as unknown as DagNode,
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'loop-cmd-subst',
+            nodes: [
+              {
+                id: 'subst-loop',
+                kind: 'loop',
+                loop: {
+                  command: 'subst-loop',
+                  until: 'COMPLETE',
+                  max_iterations: 5,
+                  fresh_context: true,
+                },
+              } as unknown as DagNode,
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       expect(mockSendQueryDag.mock.calls.length).toBe(2);
       const promptIter1 = mockSendQueryDag.mock.calls[0][0] as string;
@@ -11690,22 +10716,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         ],
       };
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: gatedWorkflow,
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: gatedWorkflow,
+          workflowRun,
+        })
+      );
 
       // Invocation 1 paused at the gate and persisted the loaded body.
       const pauseCalls = (
@@ -11737,22 +10756,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const store2 = createMockStore();
       const mockDeps2 = createMockDeps(store2);
 
-      await executeDagWorkflow({
-        deps: mockDeps2,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: gatedWorkflow,
-        workflowRun: resumedRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps2,
+          platform,
+          cwd: testDir,
+          workflow: gatedWorkflow,
+          workflowRun: resumedRun,
+        })
+      );
 
       // The resumed iteration ran from the snapshot: original body, user
       // feedback substituted, no trace of the tampered content, no failure
@@ -11824,22 +10836,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       )?.workflow;
       expect(originalWorkflow).toBeDefined();
 
-      await executeDagWorkflow({
-        deps: firstDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: ready(originalWorkflow!),
-        workflowRun: makeWorkflowRun(),
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: firstDeps,
+          platform,
+          cwd: testDir,
+          workflow: ready(originalWorkflow!),
+          workflowRun: makeWorkflowRun(),
+        })
+      );
 
       const pauseCalls = (
         firstDeps.store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>
@@ -11864,22 +10869,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       expect(rediscoveredWorkflow).toBeDefined();
       mockSendQueryDag.mockClear();
       const freshStore = createMockStore();
-      await executeDagWorkflow({
-        deps: createMockDeps(freshStore),
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: ready(rediscoveredWorkflow!),
-        workflowRun: makeWorkflowRun('fresh-invalid-command-run'),
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: createMockDeps(freshStore),
+          platform,
+          cwd: testDir,
+          workflow: ready(rediscoveredWorkflow!),
+          workflowRun: makeWorkflowRun('fresh-invalid-command-run'),
+        })
+      );
       expect(mockSendQueryDag).not.toHaveBeenCalled();
       const freshFailures = (
         freshStore.createWorkflowEvent as ReturnType<typeof mock>
@@ -11897,22 +10895,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       });
 
       mockSendQueryDag.mockClear();
-      await executeDagWorkflow({
-        deps: createMockDeps(createMockStore()),
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: ready(rediscoveredWorkflow!),
-        workflowRun: resumedRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: createMockDeps(createMockStore()),
+          platform,
+          cwd: testDir,
+          workflow: ready(rediscoveredWorkflow!),
+          workflowRun: resumedRun,
+        })
+      );
 
       const resumedPrompt = mockSendQueryDag.mock.calls[0]?.[0] as string;
       expect(resumedPrompt).toContain('ORIGINAL materialized command.');
@@ -11930,25 +10921,17 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       loop[COMPILED_LOOP_COMMAND] = {} as CompiledLoopCommand;
       const store = createMockStore();
 
-      await executeDagWorkflow({
-        deps: createMockDeps(store),
-        platform: createMockPlatform(),
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'malformed-compiled-command-workflow',
-          nodes: [{ id: 'repeat', kind: 'loop', loop }],
-        },
-        workflowRun: makeWorkflowRun('malformed-compiled-command-run'),
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: createMockDeps(store),
+          cwd: testDir,
+          workflow: {
+            name: 'malformed-compiled-command-workflow',
+            nodes: [{ id: 'repeat', kind: 'loop', loop }],
+          },
+          workflowRun: makeWorkflowRun('malformed-compiled-command-run'),
+        })
+      );
 
       expect(mockSendQueryDag).not.toHaveBeenCalled();
       const failures = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls.filter(
@@ -12001,22 +10984,14 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       expect(workflow).toBeDefined();
       const store = createMockStore();
 
-      await executeDagWorkflow({
-        deps: createMockDeps(store),
-        platform: createMockPlatform(),
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: ready(workflow!),
-        workflowRun: makeWorkflowRun('empty-included-loop-run'),
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: createMockDeps(store),
+          cwd: testDir,
+          workflow: ready(workflow!),
+          workflowRun: makeWorkflowRun('empty-included-loop-run'),
+        })
+      );
 
       expect(mockSendQueryDag).not.toHaveBeenCalled();
       const failures = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls.filter(
@@ -12047,36 +11022,29 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'loop-cmd-exhaust',
-          nodes: [
-            {
-              id: 'exhaust-loop',
-              kind: 'loop',
-              loop: {
-                command: 'exhaust-loop',
-                until: 'COMPLETE',
-                max_iterations: 2,
-                fresh_context: true,
-              },
-            } as unknown as DagNode,
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'loop-cmd-exhaust',
+            nodes: [
+              {
+                id: 'exhaust-loop',
+                kind: 'loop',
+                loop: {
+                  command: 'exhaust-loop',
+                  until: 'COMPLETE',
+                  max_iterations: 2,
+                  fresh_context: true,
+                },
+              } as unknown as DagNode,
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       expect(mockSendQueryDag.mock.calls.length).toBe(2);
       const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
@@ -12141,39 +11109,33 @@ describe('executeDagWorkflow -- always_run resume opt-out', () => {
 
     const priorCompletedNodes = new Map([['producer', { output: 'cached stale output' }]]);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-always-run',
-      cwd: testDir,
-      workflow: {
-        name: 'always-run-producer',
-        nodes: [
-          {
-            id: 'producer',
-            kind: 'agent',
-            source: { kind: 'command', name: 'producer' },
-            always_run: true,
-          },
-          {
-            id: 'consumer',
-            kind: 'agent',
-            source: { kind: 'command', name: 'consumer' },
-            depends_on: ['producer'],
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-always-run',
+        cwd: testDir,
+        workflow: {
+          name: 'always-run-producer',
+          nodes: [
+            {
+              id: 'producer',
+              kind: 'agent',
+              source: { kind: 'command', name: 'producer' },
+              always_run: true,
+            },
+            {
+              id: 'consumer',
+              kind: 'agent',
+              source: { kind: 'command', name: 'consumer' },
+              depends_on: ['producer'],
+            },
+          ],
+        },
+        workflowRun,
+        priorCompletedNodes,
+      })
+    );
 
     // Producer re-runs (instead of being skipped) AND consumer runs => 2 sendQuery calls
     expect(mockSendQueryDag.mock.calls.length).toBe(2);
@@ -12208,39 +11170,34 @@ describe('executeDagWorkflow -- always_run resume opt-out', () => {
 
     const priorCompletedNodes = new Map([['producer', { output: largeOutput }]]);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-always-run-large',
-      cwd: testDir,
-      workflow: {
-        name: 'always-run-producer-large',
-        nodes: [
-          {
-            id: 'producer',
-            kind: 'agent',
-            source: { kind: 'command', name: 'producer' },
-            always_run: true,
-          },
-          {
-            id: 'consumer',
-            kind: 'agent',
-            source: { kind: 'command', name: 'consumer' },
-            depends_on: ['producer'],
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir,
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-always-run-large',
+        cwd: testDir,
+        workflow: {
+          name: 'always-run-producer-large',
+          nodes: [
+            {
+              id: 'producer',
+              kind: 'agent',
+              source: { kind: 'command', name: 'producer' },
+              always_run: true,
+            },
+            {
+              id: 'consumer',
+              kind: 'agent',
+              source: { kind: 'command', name: 'consumer' },
+              depends_on: ['producer'],
+            },
+          ],
+        },
+        workflowRun,
+        artifactsDir,
+        priorCompletedNodes,
+      })
+    );
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const resetEvent = eventCalls.find(
@@ -12277,34 +11234,28 @@ describe('executeDagWorkflow -- always_run resume opt-out', () => {
       ['cached', { output: 'cached output' }],
     ]);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-mixed',
-      cwd: testDir,
-      workflow: {
-        name: 'mixed',
-        nodes: [
-          {
-            id: 'producer',
-            kind: 'agent',
-            source: { kind: 'command', name: 'producer' },
-            always_run: true,
-          },
-          { id: 'cached', kind: 'agent', source: { kind: 'command', name: 'cached' } },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-mixed',
+        cwd: testDir,
+        workflow: {
+          name: 'mixed',
+          nodes: [
+            {
+              id: 'producer',
+              kind: 'agent',
+              source: { kind: 'command', name: 'producer' },
+              always_run: true,
+            },
+            { id: 'cached', kind: 'agent', source: { kind: 'command', name: 'cached' } },
+          ],
+        },
+        workflowRun,
+        priorCompletedNodes,
+      })
+    );
 
     // Only producer re-runs; cached node stays skipped
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -12339,39 +11290,33 @@ describe('executeDagWorkflow -- always_run resume opt-out', () => {
 
     const priorCompletedNodes = new Map([['producer', { output: 'STALE_CACHED_VALUE' }]]);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-fresh-output',
-      cwd: testDir,
-      workflow: {
-        name: 'always-run-fresh',
-        nodes: [
-          {
-            id: 'producer',
-            kind: 'agent',
-            source: { kind: 'command', name: 'producer' },
-            always_run: true,
-          },
-          {
-            id: 'consumer',
-            kind: 'agent',
-            source: { kind: 'inline', prompt: 'See: $producer.output' },
-            depends_on: ['producer'],
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-fresh-output',
+        cwd: testDir,
+        workflow: {
+          name: 'always-run-fresh',
+          nodes: [
+            {
+              id: 'producer',
+              kind: 'agent',
+              source: { kind: 'command', name: 'producer' },
+              always_run: true,
+            },
+            {
+              id: 'consumer',
+              kind: 'agent',
+              source: { kind: 'inline', prompt: 'See: $producer.output' },
+              depends_on: ['producer'],
+            },
+          ],
+        },
+        workflowRun,
+        priorCompletedNodes,
+      })
+    );
 
     // Consumer's prompt should contain the fresh producer output, not the stale cached value
     const consumerPrompt = seenPrompts[1];
@@ -12445,39 +11390,33 @@ describe('executeDagWorkflow -- prior-success cache invalidated by dep re-execut
       ['consumer', { output: 'STALE_CACHED_CONSUMER' }],
     ]);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-2402-always-run',
-      cwd: testDir,
-      workflow: {
-        name: 'stale-cache-always-run',
-        nodes: [
-          {
-            id: 'producer',
-            kind: 'agent',
-            source: { kind: 'command', name: 'producer' },
-            always_run: true,
-          },
-          {
-            id: 'consumer',
-            kind: 'agent',
-            source: { kind: 'command', name: 'consumer' },
-            depends_on: ['producer'],
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-2402-always-run',
+        cwd: testDir,
+        workflow: {
+          name: 'stale-cache-always-run',
+          nodes: [
+            {
+              id: 'producer',
+              kind: 'agent',
+              source: { kind: 'command', name: 'producer' },
+              always_run: true,
+            },
+            {
+              id: 'consumer',
+              kind: 'agent',
+              source: { kind: 'command', name: 'consumer' },
+              depends_on: ['producer'],
+            },
+          ],
+        },
+        workflowRun,
+        priorCompletedNodes,
+      })
+    );
 
     // Producer re-runs (always_run) AND consumer re-runs (cache invalidated by dep) —
     // before the fix, consumer was skipped and only 1 sendQuery call happened.
@@ -12542,39 +11481,33 @@ describe('executeDagWorkflow -- prior-success cache invalidated by dep re-execut
       ['consumer', { output: 'cached consumer output' }],
     ]);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-2402-identical',
-      cwd: testDir,
-      workflow: {
-        name: 'stale-cache-identical',
-        nodes: [
-          {
-            id: 'producer',
-            kind: 'agent',
-            source: { kind: 'command', name: 'producer' },
-            always_run: true,
-          },
-          {
-            id: 'consumer',
-            kind: 'agent',
-            source: { kind: 'command', name: 'consumer' },
-            depends_on: ['producer'],
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-2402-identical',
+        cwd: testDir,
+        workflow: {
+          name: 'stale-cache-identical',
+          nodes: [
+            {
+              id: 'producer',
+              kind: 'agent',
+              source: { kind: 'command', name: 'producer' },
+              always_run: true,
+            },
+            {
+              id: 'consumer',
+              kind: 'agent',
+              source: { kind: 'command', name: 'consumer' },
+              depends_on: ['producer'],
+            },
+          ],
+        },
+        workflowRun,
+        priorCompletedNodes,
+      })
+    );
 
     // Producer re-runs (always_run) with output identical to its prior snapshot;
     // consumer stays cached because the comparison found no diff. A regression that
@@ -12621,34 +11554,28 @@ describe('executeDagWorkflow -- prior-success cache invalidated by dep re-execut
       ['consumer', { output: 'stale consumer output' }],
     ]);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-2402-uncached-dep',
-      cwd: testDir,
-      workflow: {
-        name: 'stale-cache-uncached-dep',
-        nodes: [
-          { id: 'producer', kind: 'agent', source: { kind: 'command', name: 'producer' } },
-          {
-            id: 'consumer',
-            kind: 'agent',
-            source: { kind: 'command', name: 'consumer' },
-            depends_on: ['producer'],
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-2402-uncached-dep',
+        cwd: testDir,
+        workflow: {
+          name: 'stale-cache-uncached-dep',
+          nodes: [
+            { id: 'producer', kind: 'agent', source: { kind: 'command', name: 'producer' } },
+            {
+              id: 'consumer',
+              kind: 'agent',
+              source: { kind: 'command', name: 'consumer' },
+              depends_on: ['producer'],
+            },
+          ],
+        },
+        workflowRun,
+        priorCompletedNodes,
+      })
+    );
 
     // Producer ran fresh + consumer was invalidated and re-ran = 2 sendQuery calls.
     expect(queryCount).toBe(2);
@@ -12685,34 +11612,29 @@ describe('executeDagWorkflow -- prior-success cache invalidated by dep re-execut
       ['consumer', { output: largeOutput }],
     ]);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-2402-large-invalidated',
-      cwd: testDir,
-      workflow: {
-        name: 'stale-cache-large-invalidated',
-        nodes: [
-          { id: 'producer', kind: 'agent', source: { kind: 'command', name: 'producer' } },
-          {
-            id: 'consumer',
-            kind: 'agent',
-            source: { kind: 'command', name: 'consumer' },
-            depends_on: ['producer'],
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir,
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-2402-large-invalidated',
+        cwd: testDir,
+        workflow: {
+          name: 'stale-cache-large-invalidated',
+          nodes: [
+            { id: 'producer', kind: 'agent', source: { kind: 'command', name: 'producer' } },
+            {
+              id: 'consumer',
+              kind: 'agent',
+              source: { kind: 'command', name: 'consumer' },
+              depends_on: ['producer'],
+            },
+          ],
+        },
+        workflowRun,
+        artifactsDir,
+        priorCompletedNodes,
+      })
+    );
 
     expect(queryCount).toBe(2);
 
@@ -12787,41 +11709,35 @@ describe('executeDagWorkflow -- prior-success cache invalidated by dep re-execut
       ['consumer', { output: 'STALE_CACHED_CONSUMER' }],
     ]);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-2402-fresh-failed-dep',
-      cwd: testDir,
-      workflow: {
-        name: 'stale-cache-fresh-failed-dep',
-        nodes: [
-          { id: 'producer', kind: 'agent', source: { kind: 'command', name: 'producer' } },
-          // `all_done` (not the default `all_success`) so the consumer's trigger
-          // rule permits re-execution against a failed producer. Without this,
-          // the default rule would silently skip consumer on the failure path —
-          // exercising the staleness arm but never landing the consumer's query,
-          // which would erase the queryCount === 2 discriminator between
-          // AFTER and BEFORE the fix.
-          {
-            id: 'consumer',
-            kind: 'agent',
-            source: { kind: 'command', name: 'consumer' },
-            depends_on: ['producer'],
-            trigger_rule: 'all_done',
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-2402-fresh-failed-dep',
+        cwd: testDir,
+        workflow: {
+          name: 'stale-cache-fresh-failed-dep',
+          nodes: [
+            { id: 'producer', kind: 'agent', source: { kind: 'command', name: 'producer' } },
+            // `all_done` (not the default `all_success`) so the consumer's trigger
+            // rule permits re-execution against a failed producer. Without this,
+            // the default rule would silently skip consumer on the failure path —
+            // exercising the staleness arm but never landing the consumer's query,
+            // which would erase the queryCount === 2 discriminator between
+            // AFTER and BEFORE the fix.
+            {
+              id: 'consumer',
+              kind: 'agent',
+              source: { kind: 'command', name: 'consumer' },
+              depends_on: ['producer'],
+              trigger_rule: 'all_done',
+            },
+          ],
+        },
+        workflowRun,
+        priorCompletedNodes,
+      })
+    );
 
     // Producer failed (1 sendQuery attempt) + consumer was invalidated by the
     // failed-dep arm and re-ran = 2 sendQuery calls in total. A regression that
@@ -12897,40 +11813,34 @@ describe('executeDagWorkflow -- prior-success cache invalidated by dep re-execut
       ['consumer', { output: 'STALE_CACHED_CONSUMER' }],
     ]);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-2705-r1-cached-dep-fresh-fail',
-      cwd: testDir,
-      workflow: {
-        name: 'stale-cache-cached-dep-fresh-fail',
-        nodes: [
-          {
-            id: 'producer',
-            kind: 'agent',
-            source: { kind: 'command', name: 'producer' },
-            always_run: true,
-          },
-          {
-            id: 'consumer',
-            kind: 'agent',
-            source: { kind: 'command', name: 'consumer' },
-            depends_on: ['producer'],
-            trigger_rule: 'all_done',
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-2705-r1-cached-dep-fresh-fail',
+        cwd: testDir,
+        workflow: {
+          name: 'stale-cache-cached-dep-fresh-fail',
+          nodes: [
+            {
+              id: 'producer',
+              kind: 'agent',
+              source: { kind: 'command', name: 'producer' },
+              always_run: true,
+            },
+            {
+              id: 'consumer',
+              kind: 'agent',
+              source: { kind: 'command', name: 'consumer' },
+              depends_on: ['producer'],
+              trigger_rule: 'all_done',
+            },
+          ],
+        },
+        workflowRun,
+        priorCompletedNodes,
+      })
+    );
 
     // Producer's failed attempt (1) + consumer invalidated and re-ran (1) = 2. A
     // regression that judges a previously-cached dep by value alone leaves consumer
@@ -12996,40 +11906,34 @@ describe('executeDagWorkflow -- prior-success cache invalidated by dep re-execut
       ['consumer', { output: 'cached consumer', structuredOutput: { stale: true } }],
     ]);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-2402-structured',
-      cwd: testDir,
-      workflow: {
-        name: 'stale-cache-structured',
-        nodes: [
-          // always_run forces the producer re-execution that surfaces case 3.
-          {
-            id: 'producer',
-            kind: 'agent',
-            source: { kind: 'inline', prompt: 'Run producer' },
-            always_run: true,
-          },
-          {
-            id: 'consumer',
-            kind: 'agent',
-            source: { kind: 'inline', prompt: 'Use $producer.output.status' },
-            depends_on: ['producer'],
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-2402-structured',
+        cwd: testDir,
+        workflow: {
+          name: 'stale-cache-structured',
+          nodes: [
+            // always_run forces the producer re-execution that surfaces case 3.
+            {
+              id: 'producer',
+              kind: 'agent',
+              source: { kind: 'inline', prompt: 'Run producer' },
+              always_run: true,
+            },
+            {
+              id: 'consumer',
+              kind: 'agent',
+              source: { kind: 'inline', prompt: 'Use $producer.output.status' },
+              depends_on: ['producer'],
+            },
+          ],
+        },
+        workflowRun,
+        priorCompletedNodes,
+      })
+    );
 
     // Producer re-ran (always_run) + consumer was invalidated (text-stable but
     // structured-output differs) = 2 sendQuery calls.
@@ -13088,43 +11992,37 @@ describe('executeDagWorkflow -- prior-success cache invalidated by dep re-execut
       ['consumer', { output: 'STALE consumer output' }],
     ]);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-2402-multi-dep',
-      cwd: testDir,
-      workflow: {
-        name: 'stale-cache-multi-dep',
-        nodes: [
-          // always_run forces producer to re-execute this resume (case 2 fires).
-          {
-            id: 'producer',
-            kind: 'agent',
-            source: { kind: 'command', name: 'producer' },
-            always_run: true,
-          },
-          // Stable dep — text matches prior so case 2 doesn't flag it.
-          { id: 'side', kind: 'agent', source: { kind: 'command', name: 'side' } },
-          // Consumer reads producer; its dep list has BOTH producer and side.
-          {
-            id: 'consumer',
-            kind: 'agent',
-            source: { kind: 'inline', prompt: 'Use $producer.output and $side.output' },
-            depends_on: ['producer', 'side'],
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-2402-multi-dep',
+        cwd: testDir,
+        workflow: {
+          name: 'stale-cache-multi-dep',
+          nodes: [
+            // always_run forces producer to re-execute this resume (case 2 fires).
+            {
+              id: 'producer',
+              kind: 'agent',
+              source: { kind: 'command', name: 'producer' },
+              always_run: true,
+            },
+            // Stable dep — text matches prior so case 2 doesn't flag it.
+            { id: 'side', kind: 'agent', source: { kind: 'command', name: 'side' } },
+            // Consumer reads producer; its dep list has BOTH producer and side.
+            {
+              id: 'consumer',
+              kind: 'agent',
+              source: { kind: 'inline', prompt: 'Use $producer.output and $side.output' },
+              depends_on: ['producer', 'side'],
+            },
+          ],
+        },
+        workflowRun,
+        priorCompletedNodes,
+      })
+    );
 
     // Exactly two queries: producer re-runs (always_run), consumer re-runs
     // (cache invalidated). Side is skipped via the pre-populate prior-success arm,
@@ -13225,25 +12123,18 @@ describe('executeDagWorkflow -- break after result (no hang on subprocess exit)'
 
     // Should complete promptly (not hang for 30 min)
     const result = await Promise.race([
-      executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'break-test',
-          nodes: [{ id: 'n1', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      }).then(() => 'completed'),
+      executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'break-test',
+            nodes: [{ id: 'n1', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
+          },
+          workflowRun,
+        })
+      ).then(() => 'completed'),
       new Promise<string>((_, reject) =>
         setTimeout(() => reject(new Error('Timed out — break after result not working')), 5000)
       ),
@@ -13265,36 +12156,29 @@ describe('executeDagWorkflow -- break after result (no hang on subprocess exit)'
     const workflowRun = makeWorkflowRun();
 
     const result = await Promise.race([
-      executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'loop-break-test',
-          nodes: [
-            {
-              id: 'loop1',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Do the thing. Say COMPLETE when done.',
-                until: 'COMPLETE',
-                max_iterations: 3,
+      executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'loop-break-test',
+            nodes: [
+              {
+                id: 'loop1',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Do the thing. Say COMPLETE when done.',
+                  until: 'COMPLETE',
+                  max_iterations: 3,
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      }).then(() => 'completed'),
+            ],
+          },
+          workflowRun,
+        })
+      ).then(() => 'completed'),
       new Promise<string>((_, reject) =>
         setTimeout(() => reject(new Error('Timed out — break after result not working')), 5000)
       ),
@@ -13353,33 +12237,26 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    const result = await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'linear-dag',
-        nodes: [
-          { id: 'step1', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } },
-          {
-            id: 'step2',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            depends_on: ['step1'],
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    const result = await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'linear-dag',
+          nodes: [
+            { id: 'step1', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } },
+            {
+              id: 'step2',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              depends_on: ['step1'],
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     expect(result).toBe('Final summary text');
   });
@@ -13403,32 +12280,25 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'empty-dag',
-        nodes: [
-          {
-            id: 'only',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            retry: { max_attempts: 1, delay_ms: 1 },
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'empty-dag',
+          nodes: [
+            {
+              id: 'only',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              retry: { max_attempts: 1, delay_ms: 1 },
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const nodeFailedEvents = eventCalls.filter(
@@ -13480,32 +12350,25 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'structured-only-dag',
-        nodes: [
-          {
-            id: 'classify',
-            kind: 'agent',
-            source: { kind: 'inline', prompt: 'Classify this' },
-            output_format: { type: 'object', properties: {} },
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'structured-only-dag',
+          nodes: [
+            {
+              id: 'classify',
+              kind: 'agent',
+              source: { kind: 'inline', prompt: 'Classify this' },
+              output_format: { type: 'object', properties: {} },
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const nodeFailedEvents = eventCalls.filter(
@@ -13542,36 +12405,29 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'idle-timeout-no-output',
-        nodes: [
-          {
-            id: 'classify',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            idle_timeout: 50,
-            // Disable retries so the test doesn't wait for retry delays (the
-            // "timed out" message matches TRANSIENT patterns, which would trigger
-            // the default 2-retry / 3s-delay policy otherwise).
-            retry: { max_attempts: 0 },
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'idle-timeout-no-output',
+          nodes: [
+            {
+              id: 'classify',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              idle_timeout: 50,
+              // Disable retries so the test doesn't wait for retry delays (the
+              // "timed out" message matches TRANSIENT patterns, which would trigger
+              // the default 2-retry / 3s-delay policy otherwise).
+              retry: { max_attempts: 0 },
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const nodeFailedEvents = eventCalls.filter(
@@ -13614,37 +12470,30 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const realSetTimeout = globalThis.setTimeout;
     globalThis.setTimeout = ((fn: () => void) => realSetTimeout(fn, 1)) as typeof setTimeout;
     try {
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'loop-idle-timeout-no-output',
-          nodes: [
-            {
-              id: 'implement',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'Implement the change.',
-                until: 'COMPLETE',
-                max_iterations: 1,
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'loop-idle-timeout-no-output',
+            nodes: [
+              {
+                id: 'implement',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Implement the change.',
+                  until: 'COMPLETE',
+                  max_iterations: 1,
+                },
+                idle_timeout: 50,
               },
-              idle_timeout: 50,
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       expect(mockSendQueryDag).toHaveBeenCalledTimes(2);
       const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
@@ -13699,42 +12548,35 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const realSetTimeout = globalThis.setTimeout;
     globalThis.setTimeout = ((fn: () => void) => realSetTimeout(fn, 1)) as typeof setTimeout;
     try {
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: {
-          name: 'structured-loop-idle-timeout',
-          nodes: [
-            {
-              id: 'implement',
-              kind: 'loop',
-              output_format: {
-                type: 'object',
-                properties: { done: { type: 'boolean' } },
-                required: ['done'],
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          cwd: testDir,
+          workflow: {
+            name: 'structured-loop-idle-timeout',
+            nodes: [
+              {
+                id: 'implement',
+                kind: 'loop',
+                output_format: {
+                  type: 'object',
+                  properties: { done: { type: 'boolean' } },
+                  required: ['done'],
+                },
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Implement the change.',
+                  max_iterations: 3,
+                  until_field: 'done',
+                },
+                idle_timeout: 50,
               },
-              loop: {
-                fresh_context: false,
-                prompt: 'Implement the change.',
-                max_iterations: 3,
-                until_field: 'done',
-              },
-              idle_timeout: 50,
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
 
       expect(mockSendQueryDag).toHaveBeenCalledTimes(1);
       const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
@@ -13768,37 +12610,30 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'outfmt-missing',
-        nodes: [
-          {
-            id: 'classify',
-            kind: 'agent',
-            source: { kind: 'inline', prompt: 'classify it' },
-            output_format: {
-              type: 'object',
-              properties: { verdict: { type: 'string' } },
-              required: ['verdict'],
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'outfmt-missing',
+          nodes: [
+            {
+              id: 'classify',
+              kind: 'agent',
+              source: { kind: 'inline', prompt: 'classify it' },
+              output_format: {
+                type: 'object',
+                properties: { verdict: { type: 'string' } },
+                required: ['verdict'],
+              },
+              retry: { max_attempts: 0 },
             },
-            retry: { max_attempts: 0 },
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const failed = eventCalls.filter(
@@ -13822,37 +12657,30 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'outfmt-invalid',
-        nodes: [
-          {
-            id: 'classify',
-            kind: 'agent',
-            source: { kind: 'inline', prompt: 'classify it' },
-            output_format: {
-              type: 'object',
-              properties: { verdict: { type: 'string' }, confidence: { type: 'number' } },
-              required: ['verdict'],
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'outfmt-invalid',
+          nodes: [
+            {
+              id: 'classify',
+              kind: 'agent',
+              source: { kind: 'inline', prompt: 'classify it' },
+              output_format: {
+                type: 'object',
+                properties: { verdict: { type: 'string' }, confidence: { type: 'number' } },
+                required: ['verdict'],
+              },
+              retry: { max_attempts: 0 },
             },
-            retry: { max_attempts: 0 },
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const failed = eventCalls.filter(
@@ -13878,45 +12706,38 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'when-badref',
-        nodes: [
-          {
-            id: 'gate',
-            kind: 'agent',
-            source: { kind: 'inline', prompt: 'decide' },
-            output_format: {
-              type: 'object',
-              properties: { verdict: { type: 'string' } },
-              required: ['verdict'],
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'when-badref',
+          nodes: [
+            {
+              id: 'gate',
+              kind: 'agent',
+              source: { kind: 'inline', prompt: 'decide' },
+              output_format: {
+                type: 'object',
+                properties: { verdict: { type: 'string' } },
+                required: ['verdict'],
+              },
+              retry: { max_attempts: 0 },
             },
-            retry: { max_attempts: 0 },
-          },
-          {
-            id: 'runme',
-            kind: 'agent',
-            source: { kind: 'inline', prompt: 'go' },
-            depends_on: ['gate'],
-            when: "$gate.output.nonexistent == 'x'",
-            retry: { max_attempts: 0 },
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+            {
+              id: 'runme',
+              kind: 'agent',
+              source: { kind: 'inline', prompt: 'go' },
+              depends_on: ['gate'],
+              when: "$gate.output.nonexistent == 'x'",
+              retry: { max_attempts: 0 },
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const runmeFailed = eventCalls.find(
@@ -13936,40 +12757,33 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'when-object-field',
-        nodes: [
-          {
-            id: 'producer',
-            kind: 'exec',
-            runtime: 'sh',
-            script: `printf '%s' '{"route":{"ready":true}}'`,
-          },
-          {
-            id: 'runme',
-            kind: 'exec',
-            runtime: 'sh',
-            script: 'exit 99',
-            depends_on: ['producer'],
-            when: "$producer.output.route == 'true'",
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'when-object-field',
+          nodes: [
+            {
+              id: 'producer',
+              kind: 'exec',
+              runtime: 'sh',
+              script: `printf '%s' '{"route":{"ready":true}}'`,
+            },
+            {
+              id: 'runme',
+              kind: 'exec',
+              runtime: 'sh',
+              script: 'exit 99',
+              depends_on: ['producer'],
+              when: "$producer.output.route == 'true'",
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const runmeEvents = eventCalls.filter(
@@ -14011,38 +12825,33 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'reask-recover',
-        nodes: [
-          {
-            id: 'classify',
-            kind: 'agent',
-            source: { kind: 'inline', prompt: 'decide' },
-            provider: 'pi',
-            output_format: {
-              type: 'object',
-              properties: { verdict: { type: 'string' } },
-              required: ['verdict'],
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'reask-recover',
+          nodes: [
+            {
+              id: 'classify',
+              kind: 'agent',
+              source: { kind: 'inline', prompt: 'decide' },
+              provider: 'pi',
+              output_format: {
+                type: 'object',
+                properties: { verdict: { type: 'string' } },
+                required: ['verdict'],
+              },
+              retry: { max_attempts: 0 },
             },
-            retry: { max_attempts: 0 },
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'pi',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: { ...minimalConfig, assistant: 'pi' },
-    });
+          ],
+        },
+        workflowRun,
+        workflowProvider: 'pi',
+        config: { ...minimalConfig, assistant: 'pi' },
+      })
+    );
 
     // sendQuery ran twice (original + 1 reask); node completed, not failed.
     expect(mockSendQueryDag.mock.calls.length).toBe(2);
@@ -14094,29 +12903,22 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'three-node-fold',
-        nodes: [
-          { id: 'a', kind: 'agent', source: { kind: 'inline', prompt: 'a' } },
-          { id: 'b', kind: 'agent', source: { kind: 'inline', prompt: 'b' }, depends_on: ['a'] },
-          { id: 'c', kind: 'agent', source: { kind: 'inline', prompt: 'c' }, depends_on: ['b'] },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'three-node-fold',
+          nodes: [
+            { id: 'a', kind: 'agent', source: { kind: 'inline', prompt: 'a' } },
+            { id: 'b', kind: 'agent', source: { kind: 'inline', prompt: 'b' }, depends_on: ['a'] },
+            { id: 'c', kind: 'agent', source: { kind: 'inline', prompt: 'c' }, depends_on: ['b'] },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     expect(runUsageWrites(mockDeps.store)).toEqual([
       {
@@ -14157,38 +12959,33 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'reask-partial-cache',
-        nodes: [
-          {
-            id: 'classify',
-            kind: 'agent',
-            source: { kind: 'inline', prompt: 'decide' },
-            provider: 'pi',
-            output_format: {
-              type: 'object',
-              properties: { verdict: { type: 'string' } },
-              required: ['verdict'],
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'reask-partial-cache',
+          nodes: [
+            {
+              id: 'classify',
+              kind: 'agent',
+              source: { kind: 'inline', prompt: 'decide' },
+              provider: 'pi',
+              output_format: {
+                type: 'object',
+                properties: { verdict: { type: 'string' } },
+                required: ['verdict'],
+              },
+              retry: { max_attempts: 0 },
             },
-            retry: { max_attempts: 0 },
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'pi',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: { ...minimalConfig, assistant: 'pi' },
-    });
+          ],
+        },
+        workflowRun,
+        workflowProvider: 'pi',
+        config: { ...minimalConfig, assistant: 'pi' },
+      })
+    );
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const completed = eventCalls.filter(
@@ -14236,38 +13033,32 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
 
     const store = createMockStore();
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'reask-nan-cost',
-        nodes: [
-          {
-            id: 'classify',
-            kind: 'agent',
-            source: { kind: 'inline', prompt: 'decide' },
-            provider: 'pi',
-            output_format: {
-              type: 'object',
-              properties: { verdict: { type: 'string' } },
-              required: ['verdict'],
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        cwd: testDir,
+        workflow: {
+          name: 'reask-nan-cost',
+          nodes: [
+            {
+              id: 'classify',
+              kind: 'agent',
+              source: { kind: 'inline', prompt: 'decide' },
+              provider: 'pi',
+              output_format: {
+                type: 'object',
+                properties: { verdict: { type: 'string' } },
+                required: ['verdict'],
+              },
+              retry: { max_attempts: 0 },
             },
-            retry: { max_attempts: 0 },
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun(),
-      workflowProvider: 'pi',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: { ...minimalConfig, assistant: 'pi' },
-    });
+          ],
+        },
+        workflowRun: makeWorkflowRun(),
+        workflowProvider: 'pi',
+        config: { ...minimalConfig, assistant: 'pi' },
+      })
+    );
 
     expect(runUsageWrites(store)).toEqual([{ total_cost_usd: 0.01 }]);
     expect(
@@ -14288,38 +13079,33 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'reask-exhaust',
-        nodes: [
-          {
-            id: 'classify',
-            kind: 'agent',
-            source: { kind: 'inline', prompt: 'decide' },
-            provider: 'pi',
-            output_format: {
-              type: 'object',
-              properties: { verdict: { type: 'string' } },
-              required: ['verdict'],
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'reask-exhaust',
+          nodes: [
+            {
+              id: 'classify',
+              kind: 'agent',
+              source: { kind: 'inline', prompt: 'decide' },
+              provider: 'pi',
+              output_format: {
+                type: 'object',
+                properties: { verdict: { type: 'string' } },
+                required: ['verdict'],
+              },
+              retry: { max_attempts: 0 },
             },
-            retry: { max_attempts: 0 },
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'pi',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: { ...minimalConfig, assistant: 'pi' },
-    });
+          ],
+        },
+        workflowRun,
+        workflowProvider: 'pi',
+        config: { ...minimalConfig, assistant: 'pi' },
+      })
+    );
 
     // 1 initial + 3 reasks = 4 sendQuery calls, then fail-fast.
     expect(mockSendQueryDag.mock.calls.length).toBe(4);
@@ -14345,38 +13131,31 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'enforced-no-reask',
-        nodes: [
-          {
-            id: 'classify',
-            kind: 'agent',
-            source: { kind: 'inline', prompt: 'decide' },
-            provider: 'claude',
-            output_format: {
-              type: 'object',
-              properties: { verdict: { type: 'string' } },
-              required: ['verdict'],
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'enforced-no-reask',
+          nodes: [
+            {
+              id: 'classify',
+              kind: 'agent',
+              source: { kind: 'inline', prompt: 'decide' },
+              provider: 'claude',
+              output_format: {
+                type: 'object',
+                properties: { verdict: { type: 'string' } },
+                required: ['verdict'],
+              },
+              retry: { max_attempts: 0 },
             },
-            retry: { max_attempts: 0 },
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
@@ -14401,38 +13180,33 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'reask-missing',
-        nodes: [
-          {
-            id: 'classify',
-            kind: 'agent',
-            source: { kind: 'inline', prompt: 'decide' },
-            provider: 'pi',
-            output_format: {
-              type: 'object',
-              properties: { verdict: { type: 'string' } },
-              required: ['verdict'],
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'reask-missing',
+          nodes: [
+            {
+              id: 'classify',
+              kind: 'agent',
+              source: { kind: 'inline', prompt: 'decide' },
+              provider: 'pi',
+              output_format: {
+                type: 'object',
+                properties: { verdict: { type: 'string' } },
+                required: ['verdict'],
+              },
+              retry: { max_attempts: 0 },
             },
-            retry: { max_attempts: 0 },
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'pi',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: { ...minimalConfig, assistant: 'pi' },
-    });
+          ],
+        },
+        workflowRun,
+        workflowProvider: 'pi',
+        config: { ...minimalConfig, assistant: 'pi' },
+      })
+    );
 
     expect(mockSendQueryDag.mock.calls.length).toBe(2);
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
@@ -14464,39 +13238,34 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'reask-idle',
-        nodes: [
-          {
-            id: 'classify',
-            kind: 'agent',
-            source: { kind: 'inline', prompt: 'decide' },
-            provider: 'pi',
-            idle_timeout: 50,
-            output_format: {
-              type: 'object',
-              properties: { verdict: { type: 'string' } },
-              required: ['verdict'],
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'reask-idle',
+          nodes: [
+            {
+              id: 'classify',
+              kind: 'agent',
+              source: { kind: 'inline', prompt: 'decide' },
+              provider: 'pi',
+              idle_timeout: 50,
+              output_format: {
+                type: 'object',
+                properties: { verdict: { type: 'string' } },
+                required: ['verdict'],
+              },
+              retry: { max_attempts: 0 },
             },
-            retry: { max_attempts: 0 },
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'pi',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: { ...minimalConfig, assistant: 'pi' },
-    });
+          ],
+        },
+        workflowRun,
+        workflowProvider: 'pi',
+        config: { ...minimalConfig, assistant: 'pi' },
+      })
+    );
 
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
@@ -14531,33 +13300,26 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'idle-timeout-with-output',
-        nodes: [
-          {
-            id: 'step1',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            idle_timeout: 50,
-            retry: { max_attempts: 0 },
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'idle-timeout-with-output',
+          nodes: [
+            {
+              id: 'step1',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              idle_timeout: 50,
+              retry: { max_attempts: 0 },
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const nodeFailedEvents = eventCalls.filter(
@@ -14583,32 +13345,25 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'unknown-provider-dag',
-        nodes: [
-          {
-            id: 'bad',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            provider: 'claud', // typo
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'unknown-provider-dag',
+          nodes: [
+            {
+              id: 'bad',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              provider: 'claud', // typo
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     expect(store.failWorkflowRun).toHaveBeenCalled();
     // The "unknown provider" detail surfaces on the node_failed event; the
@@ -14631,32 +13386,25 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'fail-msg-test',
-        nodes: [
-          {
-            id: 'fail-node',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            provider: 'nonexistent',
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'fail-msg-test',
+          nodes: [
+            {
+              id: 'fail-node',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              provider: 'nonexistent',
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     expect(store.failWorkflowRun).toHaveBeenCalled();
     const failCall = (store.failWorkflowRun as ReturnType<typeof mock>).mock.calls[0];
@@ -14682,34 +13430,27 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    const result = await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'fanin-dag',
-        nodes: [
-          { id: 'a', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } },
-          { id: 'b', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } },
-          {
-            id: 'c',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            depends_on: ['a', 'b'],
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    const result = await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'fanin-dag',
+          nodes: [
+            { id: 'a', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } },
+            { id: 'b', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } },
+            {
+              id: 'c',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              depends_on: ['a', 'b'],
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     // Only 'c' is terminal (no node depends on it); 'a' and 'b' are not terminal
     expect(result).toBe('C final output');
@@ -14755,28 +13496,21 @@ describe('executeDagWorkflow -- cancel node', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'cancel-test',
-        nodes: [
-          { id: 'check', kind: 'exec', runtime: 'sh', script: 'echo blocked' },
-          { id: 'stop', depends_on: ['check'], kind: 'halt', reason: 'Precondition failed' },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'cancel-test',
+          nodes: [
+            { id: 'check', kind: 'exec', runtime: 'sh', script: 'echo blocked' },
+            { id: 'stop', depends_on: ['check'], kind: 'halt', reason: 'Precondition failed' },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     // cancelWorkflowRun should have been called
     expect(store.cancelWorkflowRun.mock.calls.length).toBe(1);
@@ -14799,34 +13533,27 @@ describe('executeDagWorkflow -- cancel node', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'cancel-skip-test',
-        nodes: [
-          { id: 'check', kind: 'exec', runtime: 'sh', script: 'echo ok' },
-          {
-            id: 'stop',
-            depends_on: ['check'],
-            kind: 'halt',
-            reason: 'Should not fire',
-            when: '1 == 0',
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'cancel-skip-test',
+          nodes: [
+            { id: 'check', kind: 'exec', runtime: 'sh', script: 'echo ok' },
+            {
+              id: 'stop',
+              depends_on: ['check'],
+              kind: 'halt',
+              reason: 'Should not fire',
+              when: '1 == 0',
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     // cancelWorkflowRun should NOT have been called (when: condition is false)
     if (store.cancelWorkflowRun && typeof store.cancelWorkflowRun === 'function') {
@@ -14885,31 +13612,25 @@ describe('executeDagWorkflow -- credit exhaustion', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun('credit-exhaustion-run');
 
-    await executeDagWorkflow({
-      deps,
-      platform,
-      conversationId: 'conv-credit',
-      cwd: testDir,
-      workflow: {
-        name: 'credit-test',
-        nodes: [
-          {
-            id: 'investigate',
-            kind: 'agent',
-            source: { kind: 'inline', prompt: 'Investigate the issue' },
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps,
+        platform,
+        conversationId: 'conv-credit',
+        cwd: testDir,
+        workflow: {
+          name: 'credit-test',
+          nodes: [
+            {
+              id: 'investigate',
+              kind: 'agent',
+              source: { kind: 'inline', prompt: 'Investigate the issue' },
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     // node_failed (not node_completed) must have been stored
     const events = (
@@ -14939,39 +13660,33 @@ describe('executeDagWorkflow -- credit exhaustion', () => {
     });
     const store = createMockStore();
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-credit',
-      cwd: testDir,
-      workflow: {
-        name: 'credit-resume-test',
-        nodes: [
-          {
-            id: 'investigate',
-            kind: 'agent',
-            source: { kind: 'inline', prompt: 'Investigate the issue' },
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('credit-resume-run'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: {
-        ...minimalConfig,
-        workflows: {
-          autoResumeOnQuotaReset: true,
-          quotaFallbackDelayMs: 60_000,
-          quotaMaxAttempts: 1,
-          quotaDeadlineMs: 3_600_000,
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-credit',
+        cwd: testDir,
+        workflow: {
+          name: 'credit-resume-test',
+          nodes: [
+            {
+              id: 'investigate',
+              kind: 'agent',
+              source: { kind: 'inline', prompt: 'Investigate the issue' },
+            },
+          ],
         },
-      },
-    });
+        workflowRun: makeWorkflowRun('credit-resume-run'),
+        config: {
+          ...minimalConfig,
+          workflows: {
+            autoResumeOnQuotaReset: true,
+            quotaFallbackDelayMs: 60_000,
+            quotaMaxAttempts: 1,
+            quotaDeadlineMs: 3_600_000,
+          },
+        },
+      })
+    );
 
     const failRun = store.failWorkflowRun as Mock<IWorkflowStore['failWorkflowRun']>;
     expect(failRun).toHaveBeenCalledTimes(1);
@@ -15004,38 +13719,32 @@ describe('executeDagWorkflow -- credit exhaustion', () => {
     });
     const store = createMockStore();
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-credit',
-      cwd: testDir,
-      workflow: {
-        name: 'credit-resume-test',
-        nodes: [
-          {
-            id: 'investigate',
-            kind: 'agent',
-            source: { kind: 'inline', prompt: 'Investigate the issue' },
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('credit-resume-run'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: {
-        ...minimalConfig,
-        workflows: {
-          autoResumeOnQuotaReset: true,
-          quotaMaxAttempts: 1,
-          quotaDeadlineMs: 3_600_000,
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-credit',
+        cwd: testDir,
+        workflow: {
+          name: 'credit-resume-test',
+          nodes: [
+            {
+              id: 'investigate',
+              kind: 'agent',
+              source: { kind: 'inline', prompt: 'Investigate the issue' },
+            },
+          ],
         },
-      },
-    });
+        workflowRun: makeWorkflowRun('credit-resume-run'),
+        config: {
+          ...minimalConfig,
+          workflows: {
+            autoResumeOnQuotaReset: true,
+            quotaMaxAttempts: 1,
+            quotaDeadlineMs: 3_600_000,
+          },
+        },
+      })
+    );
 
     const failRun = store.failWorkflowRun as Mock<IWorkflowStore['failWorkflowRun']>;
     expect(failRun).toHaveBeenCalledTimes(1);
@@ -15062,40 +13771,34 @@ describe('executeDagWorkflow -- credit exhaustion', () => {
     });
     const store = createMockStore();
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-credit',
-      cwd: testDir,
-      workflow: {
-        name: 'container-credit-resume-test',
-        nodes: [
-          {
-            id: 'investigate',
-            kind: 'agent',
-            source: { kind: 'inline', prompt: 'Investigate the issue' },
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('container-credit-resume-run'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: {
-        ...minimalConfig,
-        workflows: {
-          autoResumeOnQuotaReset: true,
-          quotaFallbackDelayMs: 60_000,
-          quotaMaxAttempts: 1,
-          quotaDeadlineMs: 3_600_000,
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-credit',
+        cwd: testDir,
+        workflow: {
+          name: 'container-credit-resume-test',
+          nodes: [
+            {
+              id: 'investigate',
+              kind: 'agent',
+              source: { kind: 'inline', prompt: 'Investigate the issue' },
+            },
+          ],
         },
-      },
-      execContext: { kind: 'container', containerId: 'container-1' },
-    });
+        workflowRun: makeWorkflowRun('container-credit-resume-run'),
+        config: {
+          ...minimalConfig,
+          workflows: {
+            autoResumeOnQuotaReset: true,
+            quotaFallbackDelayMs: 60_000,
+            quotaMaxAttempts: 1,
+            quotaDeadlineMs: 3_600_000,
+          },
+        },
+        execContext: { kind: 'container', containerId: 'container-1' },
+      })
+    );
 
     const failRun = store.failWorkflowRun as Mock<IWorkflowStore['failWorkflowRun']>;
     expect(failRun.mock.calls[0]?.[2]).toBeUndefined();
@@ -15124,25 +13827,18 @@ describe('executeDagWorkflow -- durable wait node', () => {
   it('persists a future wait and returns without invoking a provider', async () => {
     const store = createMockStore();
     const deps = createMockDeps(store);
-    await executeDagWorkflow({
-      deps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-wait',
-      cwd: testDir,
-      workflow: {
-        name: 'wait-test',
-        nodes: [{ id: 'delay', kind: 'wait', wait: { duration_ms: 60_000 } }],
-      },
-      workflowRun: makeWorkflowRun(),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps,
+        conversationId: 'conv-wait',
+        cwd: testDir,
+        workflow: {
+          name: 'wait-test',
+          nodes: [{ id: 'delay', kind: 'wait', wait: { duration_ms: 60_000 } }],
+        },
+        workflowRun: makeWorkflowRun(),
+      })
+    );
     expect(store.pauseWorkflowRunForWait).toHaveBeenCalledTimes(1);
     const context = (store.pauseWorkflowRunForWait as ReturnType<typeof mock>).mock.calls[0]?.[1];
     expect(context).toMatchObject({ nodeId: 'delay', kind: 'time' });
@@ -15153,25 +13849,20 @@ describe('executeDagWorkflow -- durable wait node', () => {
     const store = createMockStore();
     const resumeAt = '2099-08-24T11:00:00.000Z';
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-wait-input',
-      cwd: testDir,
-      workflow: {
-        name: 'wait-input-test',
-        nodes: [{ id: 'delay', kind: 'wait', wait: { until: '$INPUTS.resume_at' } }],
-      },
-      workflowRun: makeWorkflowRun('wait-input', { metadata: { inputs: { resume_at: resumeAt } } }),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-wait-input',
+        cwd: testDir,
+        workflow: {
+          name: 'wait-input-test',
+          nodes: [{ id: 'delay', kind: 'wait', wait: { until: '$INPUTS.resume_at' } }],
+        },
+        workflowRun: makeWorkflowRun('wait-input', {
+          metadata: { inputs: { resume_at: resumeAt } },
+        }),
+      })
+    );
 
     expect(store.pauseWorkflowRunForWait).toHaveBeenCalledWith(
       'wait-input',
@@ -15183,33 +13874,26 @@ describe('executeDagWorkflow -- durable wait node', () => {
   it('resolves a child workflow input embedded in an event name', async () => {
     const store = createMockStore();
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-wait-input',
-      cwd: testDir,
-      workflow: {
-        name: 'wait-event-input-test',
-        nodes: [
-          {
-            id: 'deploy',
-            kind: 'wait',
-            wait: { event: 'deploy:$INPUTS.channel', deadline_ms: 60_000 },
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('wait-event-input', {
-        metadata: { inputs: { channel: 'prod' } },
-      }),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-wait-input',
+        cwd: testDir,
+        workflow: {
+          name: 'wait-event-input-test',
+          nodes: [
+            {
+              id: 'deploy',
+              kind: 'wait',
+              wait: { event: 'deploy:$INPUTS.channel', deadline_ms: 60_000 },
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun('wait-event-input', {
+          metadata: { inputs: { channel: 'prod' } },
+        }),
+      })
+    );
 
     expect(store.pauseWorkflowRunForWait).toHaveBeenCalledWith(
       'wait-event-input',
@@ -15233,27 +13917,20 @@ describe('executeDagWorkflow -- durable wait node', () => {
         },
       },
     });
-    await executeDagWorkflow({
-      deps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-wait',
-      cwd: testDir,
-      workflow: {
-        name: 'wait-expiry-test',
-        nodes: [
-          { id: 'ci', kind: 'wait', wait: { event: 'checks.complete', deadline_ms: 60_000 } },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps,
+        conversationId: 'conv-wait',
+        cwd: testDir,
+        workflow: {
+          name: 'wait-expiry-test',
+          nodes: [
+            { id: 'ci', kind: 'wait', wait: { event: 'checks.complete', deadline_ms: 60_000 } },
+          ],
+        },
+        workflowRun,
+      })
+    );
     expect(store.pauseWorkflowRunForWait).not.toHaveBeenCalled();
     expect(store.clearWorkflowWaitContext).toHaveBeenCalledWith(
       'wait-resume',
@@ -15275,25 +13952,18 @@ describe('executeDagWorkflow -- durable wait node', () => {
       resumeAt: '2099-08-24T11:00:00.000Z',
     };
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-wait',
-      cwd: testDir,
-      workflow: {
-        name: 'wait-early-resume-test',
-        nodes: [{ id: 'delay', kind: 'wait', wait: { duration_ms: 60_000 } }],
-      },
-      workflowRun: makeWorkflowRun('wait-early-resume', { metadata: { wait: persisted } }),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-wait',
+        cwd: testDir,
+        workflow: {
+          name: 'wait-early-resume-test',
+          nodes: [{ id: 'delay', kind: 'wait', wait: { duration_ms: 60_000 } }],
+        },
+        workflowRun: makeWorkflowRun('wait-early-resume', { metadata: { wait: persisted } }),
+      })
+    );
 
     expect(store.pauseWorkflowRunForWait).toHaveBeenCalledWith('wait-early-resume', persisted, {
       kind: 'continued',
@@ -15309,25 +13979,18 @@ describe('executeDagWorkflow -- durable wait node', () => {
     });
     store.getWorkflowRunStatus = mock(async () => (pauseAttempted ? 'cancelled' : 'running'));
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-wait-cancelled',
-      cwd: testDir,
-      workflow: {
-        name: 'wait-cancelled-race',
-        nodes: [{ id: 'delay', kind: 'wait', wait: { duration_ms: 60_000 } }],
-      },
-      workflowRun: makeWorkflowRun('wait-cancelled'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-wait-cancelled',
+        cwd: testDir,
+        workflow: {
+          name: 'wait-cancelled-race',
+          nodes: [{ id: 'delay', kind: 'wait', wait: { duration_ms: 60_000 } }],
+        },
+        workflowRun: makeWorkflowRun('wait-cancelled'),
+      })
+    );
 
     const events = store.createWorkflowEvent.mock.calls.map(call => call[0].event_type);
     expect(events).not.toContain('node_failed');
@@ -15373,40 +14036,34 @@ describe('executeDagWorkflow -- approval node', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-approval',
-      cwd: testDir,
-      workflow: {
-        name: 'approval-test',
-        nodes: [
-          {
-            id: 'review',
-            kind: 'gate',
-            message: 'Approve this plan?',
-            decisions: [
-              { id: 'approve' },
-              {
-                id: 'reject',
-                rework: { prompt: 'Fix based on: $REJECTION_REASON', maxAttempts: 3 },
-              },
-            ],
-            captureResponse: true,
-            decisionsAuthored: false,
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-approval',
+        cwd: testDir,
+        workflow: {
+          name: 'approval-test',
+          nodes: [
+            {
+              id: 'review',
+              kind: 'gate',
+              message: 'Approve this plan?',
+              decisions: [
+                { id: 'approve' },
+                {
+                  id: 'reject',
+                  rework: { prompt: 'Fix based on: $REJECTION_REASON', maxAttempts: 3 },
+                },
+              ],
+              captureResponse: true,
+              decisionsAuthored: false,
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     // AI should NOT have been called (fresh approval just pauses)
     expect(mockSendQueryDag.mock.calls.length).toBe(0);
@@ -15431,34 +14088,28 @@ describe('executeDagWorkflow -- approval node', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-approval',
-      cwd: testDir,
-      workflow: {
-        name: 'approval-no-capture',
-        nodes: [
-          {
-            id: 'review',
-            kind: 'gate',
-            message: 'Approve?',
-            decisions: [{ id: 'approve' }, { id: 'reject' }],
-            captureResponse: false,
-            decisionsAuthored: false,
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-approval',
+        cwd: testDir,
+        workflow: {
+          name: 'approval-no-capture',
+          nodes: [
+            {
+              id: 'review',
+              kind: 'gate',
+              message: 'Approve?',
+              decisions: [{ id: 'approve' }, { id: 'reject' }],
+              captureResponse: false,
+              decisionsAuthored: false,
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     // GateNode.captureResponse is a required boolean (#2486) — an undeclared
     // capture_response resolves to false, not undefined.
@@ -15498,40 +14149,34 @@ describe('executeDagWorkflow -- approval node', () => {
       },
     });
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-approval',
-      cwd: testDir,
-      workflow: {
-        name: 'approval-reject-resume',
-        nodes: [
-          {
-            id: 'review',
-            kind: 'gate',
-            message: 'Approve this plan?',
-            decisions: [
-              { id: 'approve' },
-              {
-                id: 'reject',
-                rework: { prompt: 'Fix based on: $REJECTION_REASON', maxAttempts: 3 },
-              },
-            ],
-            captureResponse: true,
-            decisionsAuthored: false,
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-approval',
+        cwd: testDir,
+        workflow: {
+          name: 'approval-reject-resume',
+          nodes: [
+            {
+              id: 'review',
+              kind: 'gate',
+              message: 'Approve this plan?',
+              decisions: [
+                { id: 'approve' },
+                {
+                  id: 'reject',
+                  rework: { prompt: 'Fix based on: $REJECTION_REASON', maxAttempts: 3 },
+                },
+              ],
+              captureResponse: true,
+              decisionsAuthored: false,
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     // AI should have been called once (on_reject prompt ran)
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -15569,40 +14214,34 @@ describe('executeDagWorkflow -- approval node', () => {
       },
     });
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-approval',
-      cwd: testDir,
-      workflow: {
-        name: 'approval-no-poison',
-        nodes: [
-          {
-            id: 'review',
-            kind: 'gate',
-            message: 'Approve this plan?',
-            decisions: [
-              { id: 'approve' },
-              {
-                id: 'reject',
-                rework: { prompt: 'Fix based on: $REJECTION_REASON', maxAttempts: 3 },
-              },
-            ],
-            captureResponse: false,
-            decisionsAuthored: false,
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-approval',
+        cwd: testDir,
+        workflow: {
+          name: 'approval-no-poison',
+          nodes: [
+            {
+              id: 'review',
+              kind: 'gate',
+              message: 'Approve this plan?',
+              decisions: [
+                { id: 'approve' },
+                {
+                  id: 'reject',
+                  rework: { prompt: 'Fix based on: $REJECTION_REASON', maxAttempts: 3 },
+                },
+              ],
+              captureResponse: false,
+              decisionsAuthored: false,
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     // The on_reject synthetic node must NOT produce a node_completed event with
     // step_name equal to the approval gate's own ID ('review'). If it did, a
@@ -15643,37 +14282,31 @@ describe('executeDagWorkflow -- approval node', () => {
       },
     });
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-approval',
-      cwd: testDir,
-      workflow: {
-        name: 'approval-exhausted',
-        nodes: [
-          {
-            id: 'review',
-            kind: 'gate',
-            message: 'Approve this plan?',
-            decisions: [
-              { id: 'approve' },
-              { id: 'reject', rework: { prompt: 'Fix: $REJECTION_REASON', maxAttempts: 3 } },
-            ],
-            captureResponse: false,
-            decisionsAuthored: false,
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-approval',
+        cwd: testDir,
+        workflow: {
+          name: 'approval-exhausted',
+          nodes: [
+            {
+              id: 'review',
+              kind: 'gate',
+              message: 'Approve this plan?',
+              decisions: [
+                { id: 'approve' },
+                { id: 'reject', rework: { prompt: 'Fix: $REJECTION_REASON', maxAttempts: 3 } },
+              ],
+              captureResponse: false,
+              decisionsAuthored: false,
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     // AI should NOT have been called (max attempts reached, straight to cancel)
     expect(mockSendQueryDag.mock.calls.length).toBe(0);
@@ -15711,37 +14344,31 @@ describe('executeDagWorkflow -- approval node', () => {
       },
     });
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-approval',
-      cwd: testDir,
-      workflow: {
-        name: 'approval-max1',
-        nodes: [
-          {
-            id: 'review',
-            kind: 'gate',
-            message: 'Approve?',
-            decisions: [
-              { id: 'approve' },
-              { id: 'reject', rework: { prompt: 'Fix: $REJECTION_REASON', maxAttempts: 1 } },
-            ],
-            captureResponse: false,
-            decisionsAuthored: false,
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-approval',
+        cwd: testDir,
+        workflow: {
+          name: 'approval-max1',
+          nodes: [
+            {
+              id: 'review',
+              kind: 'gate',
+              message: 'Approve?',
+              decisions: [
+                { id: 'approve' },
+                { id: 'reject', rework: { prompt: 'Fix: $REJECTION_REASON', maxAttempts: 1 } },
+              ],
+              captureResponse: false,
+              decisionsAuthored: false,
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     // Should cancel immediately, no AI call
     expect(mockSendQueryDag.mock.calls.length).toBe(0);
@@ -15773,49 +14400,43 @@ describe('executeDagWorkflow -- approval node', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun('approval-sub-run');
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-approval-sub',
-      cwd: testDir,
-      workflow: {
-        name: 'approval-sub-test',
-        nodes: [
-          {
-            id: 'gather-context',
-            kind: 'agent',
-            source: { kind: 'command', name: 'gather-context' },
-            output_format: {
-              type: 'object',
-              properties: {
-                repo_name: { type: 'string' },
-                app_code: { type: 'string' },
-                frontend_port: { type: 'number' },
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-approval-sub',
+        cwd: testDir,
+        workflow: {
+          name: 'approval-sub-test',
+          nodes: [
+            {
+              id: 'gather-context',
+              kind: 'agent',
+              source: { kind: 'command', name: 'gather-context' },
+              output_format: {
+                type: 'object',
+                properties: {
+                  repo_name: { type: 'string' },
+                  app_code: { type: 'string' },
+                  frontend_port: { type: 'number' },
+                },
               },
             },
-          },
-          {
-            id: 'confirm',
-            depends_on: ['gather-context'],
-            kind: 'gate',
-            message:
-              'Repo: $gather-context.output.repo_name | App: $gather-context.output.app_code | Port: $gather-context.output.frontend_port',
-            decisions: [{ id: 'approve' }, { id: 'reject' }],
-            captureResponse: false,
-            decisionsAuthored: false,
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+            {
+              id: 'confirm',
+              depends_on: ['gather-context'],
+              kind: 'gate',
+              message:
+                'Repo: $gather-context.output.repo_name | App: $gather-context.output.app_code | Port: $gather-context.output.frontend_port',
+              decisions: [{ id: 'approve' }, { id: 'reject' }],
+              captureResponse: false,
+              decisionsAuthored: false,
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     // gather-context AI call ran once; approval node does NOT call AI
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -15895,29 +14516,23 @@ describe('executeDagWorkflow -- env var injection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'dag-env-test',
-        nodes: [{ id: 'task', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: {
-        ...minimalConfig,
-        envVars: { MY_SECRET: 'abc123', ANTHROPIC_API_KEY: 'acting-user-secret' },
-        protectedEnvKeys: ['ANTHROPIC_API_KEY'],
-      },
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'dag-env-test',
+          nodes: [{ id: 'task', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
+        },
+        workflowRun,
+        config: {
+          ...minimalConfig,
+          envVars: { MY_SECRET: 'abc123', ANTHROPIC_API_KEY: 'acting-user-secret' },
+          protectedEnvKeys: ['ANTHROPIC_API_KEY'],
+        },
+      })
+    );
 
     expect(mockSendQueryDag.mock.calls.length).toBeGreaterThan(0);
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
@@ -15933,25 +14548,19 @@ describe('executeDagWorkflow -- env var injection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'dag-no-env',
-        nodes: [{ id: 'task', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: { ...minimalConfig, envVars: {} },
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'dag-no-env',
+          nodes: [{ id: 'task', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
+        },
+        workflowRun,
+        config: { ...minimalConfig, envVars: {} },
+      })
+    );
 
     expect(mockSendQueryDag.mock.calls.length).toBeGreaterThan(0);
     const optionsArg = mockSendQueryDag.mock.calls[0]?.[3] as Record<string, unknown> | undefined;
@@ -16009,32 +14618,25 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'budget-test',
-        nodes: [
-          {
-            id: 'step1',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            maxBudgetUsd: 2.5,
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'budget-test',
+          nodes: [
+            {
+              id: 'step1',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              maxBudgetUsd: 2.5,
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     expect(
       (store.failWorkflowRun as Mock<(id: string, msg: string) => Promise<void>>).mock.calls.length
@@ -16067,34 +14669,27 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'budget-msg-test',
-        nodes: [
-          { id: 'ok', kind: 'agent', source: { kind: 'inline', prompt: 'do work first' } },
-          {
-            id: 'capped',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            maxBudgetUsd: 2.5,
-            depends_on: ['ok'],
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'budget-msg-test',
+          nodes: [
+            { id: 'ok', kind: 'agent', source: { kind: 'inline', prompt: 'do work first' } },
+            {
+              id: 'capped',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              maxBudgetUsd: 2.5,
+              depends_on: ['ok'],
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
     const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
@@ -16123,25 +14718,18 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'err-exec-test',
-        nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'err-exec-test',
+          nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
+        },
+        workflowRun,
+      })
+    );
 
     // The node_failed event should carry the subtype and SDK errors detail
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
@@ -16195,25 +14783,18 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'success-stop-seq-test',
-        nodes: [{ id: 'classify', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'success-stop-seq-test',
+          nodes: [{ id: 'classify', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
+        },
+        workflowRun,
+      })
+    );
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const nodeFailedEvents = eventCalls.filter(
@@ -16230,26 +14811,19 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'workflow-effort-test',
-        nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
-        effort: 'high',
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'workflow-effort-test',
+          nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
+          effort: 'high',
+        },
+        workflowRun,
+      })
+    );
 
     expect(mockSendQueryDag.mock.calls.length).toBeGreaterThan(0);
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
@@ -16262,33 +14836,26 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'node-effort-override-test',
-        nodes: [
-          {
-            id: 'step1',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            effort: 'max',
-          },
-        ],
-        effort: 'low',
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'node-effort-override-test',
+          nodes: [
+            {
+              id: 'step1',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              effort: 'max',
+            },
+          ],
+          effort: 'low',
+        },
+        workflowRun,
+      })
+    );
 
     expect(mockSendQueryDag.mock.calls.length).toBeGreaterThan(0);
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
@@ -16310,33 +14877,28 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'codex-claude-opts-test',
-        nodes: [
-          {
-            id: 'step1',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            provider: 'codex',
-            effort: 'high',
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'codex',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: { ...minimalConfig, assistant: 'codex' },
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'codex-claude-opts-test',
+          nodes: [
+            {
+              id: 'step1',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              provider: 'codex',
+              effort: 'high',
+            },
+          ],
+        },
+        workflowRun,
+        workflowProvider: 'codex',
+        config: { ...minimalConfig, assistant: 'codex' },
+      })
+    );
 
     const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
     const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
@@ -16360,26 +14922,21 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'codex-workflow-effort-test',
-        nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
-        effort: 'xhigh',
-      },
-      workflowRun,
-      workflowProvider: 'codex',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: { ...minimalConfig, assistant: 'codex' },
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'codex-workflow-effort-test',
+          nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
+          effort: 'xhigh',
+        },
+        workflowRun,
+        workflowProvider: 'codex',
+        config: { ...minimalConfig, assistant: 'codex' },
+      })
+    );
 
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
     const nodeConfig = optionsArg?.nodeConfig as Record<string, unknown>;
@@ -16402,33 +14959,28 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: loaderBypassingWorkflow({
-        name: 'codex-node-effort-beats-deprecated-test',
-        nodes: [
-          {
-            id: 'step1',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            effort: 'minimal',
-          },
-        ],
-        modelReasoningEffort: 'high',
-      }),
-      workflowRun,
-      workflowProvider: 'codex',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: { ...minimalConfig, assistant: 'codex' },
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: loaderBypassingWorkflow({
+          name: 'codex-node-effort-beats-deprecated-test',
+          nodes: [
+            {
+              id: 'step1',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              effort: 'minimal',
+            },
+          ],
+          modelReasoningEffort: 'high',
+        }),
+        workflowRun,
+        workflowProvider: 'codex',
+        config: { ...minimalConfig, assistant: 'codex' },
+      })
+    );
 
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
     const nodeConfig = optionsArg?.nodeConfig as Record<string, unknown>;
@@ -16445,30 +14997,25 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'codex-workflow-options-test',
-        nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
-        // #2556: the loader translates `modelReasoningEffort:` into `effort:`,
-        // so the executor only ever sees the canonical field. `webSearchMode:`
-        // keeps its Codex gate and its assistantConfig home.
-        effort: 'minimal',
-        webSearchMode: 'live',
-      },
-      workflowRun,
-      workflowProvider: 'codex',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: { ...minimalConfig, assistant: 'codex' },
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'codex-workflow-options-test',
+          nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
+          // #2556: the loader translates `modelReasoningEffort:` into `effort:`,
+          // so the executor only ever sees the canonical field. `webSearchMode:`
+          // keeps its Codex gate and its assistantConfig home.
+          effort: 'minimal',
+          webSearchMode: 'live',
+        },
+        workflowRun,
+        workflowProvider: 'codex',
+        config: { ...minimalConfig, assistant: 'codex' },
+      })
+    );
 
     expect(mockSendQueryDag.mock.calls.length).toBeGreaterThan(0);
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
@@ -16493,34 +15040,27 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
       },
     });
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'codex-workflow-beats-preset-test',
-        nodes: [
-          {
-            id: 'step1',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            model: 'medium',
-          },
-        ],
-        effort: 'xhigh',
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      aiProfile,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'codex-workflow-beats-preset-test',
+          nodes: [
+            {
+              id: 'step1',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              model: 'medium',
+            },
+          ],
+          effort: 'xhigh',
+        },
+        workflowRun,
+        aiProfile,
+      })
+    );
 
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
     const nodeConfig = optionsArg?.nodeConfig as Record<string, unknown>;
@@ -16544,37 +15084,30 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
       },
     });
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: loaderBypassingWorkflow({
-        name: 'mixed-provider-preset-effort-test',
-        nodes: [
-          {
-            id: 'step1',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            model: 'medium',
-          },
-        ],
-        // A definition that still carries the deprecated field — only a
-        // loader-bypassing caller can produce one. It affects nothing: the
-        // executor never reads it (the loader translates it away).
-        modelReasoningEffort: 'high',
-      }),
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      aiProfile,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: loaderBypassingWorkflow({
+          name: 'mixed-provider-preset-effort-test',
+          nodes: [
+            {
+              id: 'step1',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              model: 'medium',
+            },
+          ],
+          // A definition that still carries the deprecated field — only a
+          // loader-bypassing caller can produce one. It affects nothing: the
+          // executor never reads it (the loader translates it away).
+          modelReasoningEffort: 'high',
+        }),
+        workflowRun,
+        aiProfile,
+      })
+    );
 
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
     const nodeConfig = optionsArg?.nodeConfig as Record<string, unknown>;
@@ -16588,26 +15121,19 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'codex-options-on-claude-test',
-        nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
-        webSearchMode: 'live',
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'codex-options-on-claude-test',
+          nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
+          webSearchMode: 'live',
+        },
+        workflowRun,
+      })
+    );
 
     const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
     const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
@@ -16635,27 +15161,22 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: loaderBypassingWorkflow({
-        name: 'codex-effort-telemetry-test',
-        nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
-        effort: 'max',
-        modelReasoningEffort: 'low',
-      }),
-      workflowRun,
-      workflowProvider: 'codex',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: { ...minimalConfig, assistant: 'codex' },
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: loaderBypassingWorkflow({
+          name: 'codex-effort-telemetry-test',
+          nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
+          effort: 'max',
+          modelReasoningEffort: 'low',
+        }),
+        workflowRun,
+        workflowProvider: 'codex',
+        config: { ...minimalConfig, assistant: 'codex' },
+      })
+    );
 
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
     const nodeConfig = optionsArg?.nodeConfig as Record<string, unknown>;
@@ -16682,34 +15203,28 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
       },
     });
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'codex-workflow-node-resolves-to-claude-test',
-        nodes: [
-          {
-            id: 'step1',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            model: 'medium',
-          },
-        ],
-        webSearchMode: 'live',
-      },
-      workflowRun,
-      workflowProvider: 'codex',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      aiProfile,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'codex-workflow-node-resolves-to-claude-test',
+          nodes: [
+            {
+              id: 'step1',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              model: 'medium',
+            },
+          ],
+          webSearchMode: 'live',
+        },
+        workflowRun,
+        workflowProvider: 'codex',
+        aiProfile,
+      })
+    );
 
     expect(mockGetAgentProviderDag.mock.calls[0][0]).toBe('claude');
 
@@ -16763,25 +15278,18 @@ describe('executeDagWorkflow -- cost tracking', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'dag-cost',
-        nodes: [{ id: 'step', kind: 'agent', source: { kind: 'inline', prompt: 'Do thing.' } }],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'dag-cost',
+          nodes: [{ id: 'step', kind: 'agent', source: { kind: 'inline', prompt: 'Do thing.' } }],
+        },
+        workflowRun,
+      })
+    );
 
     expect(runUsageWrites(store)).toEqual([{ total_cost_usd: 0.0042 }]);
     // Exactly one writer: completeWorkflowRun keeps node_counts, not usage (#2469).
@@ -16806,33 +15314,26 @@ describe('executeDagWorkflow -- cost tracking', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'dag-cost-multi',
-        nodes: [
-          { id: 'step1', kind: 'agent', source: { kind: 'inline', prompt: 'Step 1.' } },
-          {
-            id: 'step2',
-            kind: 'agent',
-            source: { kind: 'inline', prompt: 'Step 2.' },
-            depends_on: ['step1'],
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'dag-cost-multi',
+          nodes: [
+            { id: 'step1', kind: 'agent', source: { kind: 'inline', prompt: 'Step 1.' } },
+            {
+              id: 'step2',
+              kind: 'agent',
+              source: { kind: 'inline', prompt: 'Step 2.' },
+              depends_on: ['step1'],
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     expect(runUsageWrites(store)).toEqual([{ total_cost_usd: 0.002 }]);
   });
@@ -16848,25 +15349,18 @@ describe('executeDagWorkflow -- cost tracking', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'dag-no-cost',
-        nodes: [{ id: 'step', kind: 'agent', source: { kind: 'inline', prompt: 'Do thing.' } }],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'dag-no-cost',
+          nodes: [{ id: 'step', kind: 'agent', source: { kind: 'inline', prompt: 'Do thing.' } }],
+        },
+        workflowRun,
+      })
+    );
 
     // A zero must stay ABSENT, not written as 0 — a bash-only workflow reading as a
     // free AI run is the misleading shape the `> 0` guards exist to prevent.
@@ -16903,31 +15397,24 @@ describe('executeDagWorkflow -- cost tracking', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'dag-loop-cost',
-        nodes: [
-          {
-            id: 'my-loop',
-            kind: 'loop',
-            loop: { fresh_context: false, prompt: 'Work.', until: 'COMPLETE', max_iterations: 5 },
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'dag-loop-cost',
+          nodes: [
+            {
+              id: 'my-loop',
+              kind: 'loop',
+              loop: { fresh_context: false, prompt: 'Work.', until: 'COMPLETE', max_iterations: 5 },
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     // The final NaN is omitted without erasing the first three iterations.
     expect(runUsageWrites(store)).toEqual([{ total_cost_usd: 0.004 }]);
@@ -16992,34 +15479,27 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
     const store = createMockStore();
     const mockDeps = createMockDeps(store);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-usage',
-      cwd: testDir,
-      workflow: {
-        name: 'usage-on-failure',
-        nodes: [
-          { id: 'spend', kind: 'agent', source: { kind: 'inline', prompt: 'Burn some tokens.' } },
-          {
-            id: 'die',
-            kind: 'agent',
-            source: { kind: 'inline', prompt: 'Fail here.' },
-            depends_on: ['spend'],
-            retry: { max_attempts: 1, delay_ms: 1 },
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun(),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        conversationId: 'conv-usage',
+        cwd: testDir,
+        workflow: {
+          name: 'usage-on-failure',
+          nodes: [
+            { id: 'spend', kind: 'agent', source: { kind: 'inline', prompt: 'Burn some tokens.' } },
+            {
+              id: 'die',
+              kind: 'agent',
+              source: { kind: 'inline', prompt: 'Fail here.' },
+              depends_on: ['spend'],
+              retry: { max_attempts: 1, delay_ms: 1 },
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun(),
+      })
+    );
 
     expect(store.failWorkflowRun).toHaveBeenCalled();
     expect(store.completeWorkflowRun).not.toHaveBeenCalled();
@@ -17066,33 +15546,27 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
     const logDir = join(testDir, 'logs');
     const workflowRun = makeWorkflowRun('spend-transcript-run');
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-spend',
-      cwd: testDir,
-      workflow: {
-        name: 'spend-transcript',
-        nodes: [
-          { id: 'a', kind: 'agent', source: { kind: 'inline', prompt: 'Cheap work.' } },
-          {
-            id: 'b',
-            kind: 'agent',
-            source: { kind: 'inline', prompt: 'Expensive work that dies.' },
-            depends_on: ['a'],
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir,
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-spend',
+        cwd: testDir,
+        workflow: {
+          name: 'spend-transcript',
+          nodes: [
+            { id: 'a', kind: 'agent', source: { kind: 'inline', prompt: 'Cheap work.' } },
+            {
+              id: 'b',
+              kind: 'agent',
+              source: { kind: 'inline', prompt: 'Expensive work that dies.' },
+              depends_on: ['a'],
+            },
+          ],
+        },
+        workflowRun,
+        logDir,
+      })
+    );
 
     const rows = await readTranscript(logDir, workflowRun.id);
 
@@ -17155,25 +15629,19 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
     const workflowRun = makeWorkflowRun('cancel-transcript-run');
 
     try {
-      await executeDagWorkflow({
-        deps: createMockDeps(store),
-        platform: createMockPlatform(),
-        conversationId: 'conv-cancel',
-        cwd: testDir,
-        workflow: {
-          name: 'cancel-transcript',
-          nodes: [{ id: 'only', kind: 'agent', source: { kind: 'inline', prompt: 'Work.' } }],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir,
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: createMockDeps(store),
+          conversationId: 'conv-cancel',
+          cwd: testDir,
+          workflow: {
+            name: 'cancel-transcript',
+            nodes: [{ id: 'only', kind: 'agent', source: { kind: 'inline', prompt: 'Work.' } }],
+          },
+          workflowRun,
+          logDir,
+        })
+      );
     } finally {
       setSystemTime(); // restore the real clock
     }
@@ -17214,32 +15682,26 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
     const workflowRun = makeWorkflowRun('cancel-throw-run');
 
     try {
-      await executeDagWorkflow({
-        deps: createMockDeps(store),
-        platform: createMockPlatform(),
-        conversationId: 'conv-cancel-throw',
-        cwd: testDir,
-        workflow: {
-          name: 'cancel-throw',
-          nodes: [
-            {
-              id: 'only',
-              kind: 'agent',
-              source: { kind: 'inline', prompt: 'Work.' },
-              output_format: { type: 'object', properties: { status: { type: 'string' } } },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir,
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: createMockDeps(store),
+          conversationId: 'conv-cancel-throw',
+          cwd: testDir,
+          workflow: {
+            name: 'cancel-throw',
+            nodes: [
+              {
+                id: 'only',
+                kind: 'agent',
+                source: { kind: 'inline', prompt: 'Work.' },
+                output_format: { type: 'object', properties: { status: { type: 'string' } } },
+              },
+            ],
+          },
+          workflowRun,
+          logDir,
+        })
+      );
     } finally {
       setSystemTime();
     }
@@ -17280,27 +15742,20 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
     );
     const mockDeps = createMockDeps(store);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-usage',
-      cwd: testDir,
-      workflow: {
-        name: 'usage-on-cancel',
-        nodes: [
-          { id: 'spend', kind: 'agent', source: { kind: 'inline', prompt: 'Burn some tokens.' } },
-        ],
-      },
-      workflowRun: makeWorkflowRun(),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        conversationId: 'conv-usage',
+        cwd: testDir,
+        workflow: {
+          name: 'usage-on-cancel',
+          nodes: [
+            { id: 'spend', kind: 'agent', source: { kind: 'inline', prompt: 'Burn some tokens.' } },
+          ],
+        },
+        workflowRun: makeWorkflowRun(),
+      })
+    );
 
     expect(store.completeWorkflowRun).not.toHaveBeenCalled();
     expect(store.failWorkflowRun).not.toHaveBeenCalled();
@@ -17333,36 +15788,29 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
     );
     const mockDeps = createMockDeps(store);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-usage',
-      cwd: testDir,
-      workflow: {
-        name: 'usage-on-pause',
-        nodes: [
-          { id: 'analyze', kind: 'agent', source: { kind: 'inline', prompt: 'Analyze.' } },
-          {
-            id: 'review',
-            kind: 'gate',
-            message: 'Ship it?',
-            decisions: [{ id: 'approve' }, { id: 'reject' }],
-            captureResponse: false,
-            decisionsAuthored: false,
-            depends_on: ['analyze'],
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun(),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        conversationId: 'conv-usage',
+        cwd: testDir,
+        workflow: {
+          name: 'usage-on-pause',
+          nodes: [
+            { id: 'analyze', kind: 'agent', source: { kind: 'inline', prompt: 'Analyze.' } },
+            {
+              id: 'review',
+              kind: 'gate',
+              message: 'Ship it?',
+              decisions: [{ id: 'approve' }, { id: 'reject' }],
+              captureResponse: false,
+              decisionsAuthored: false,
+              depends_on: ['analyze'],
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun(),
+      })
+    );
 
     expect(store.pauseWorkflowRun).toHaveBeenCalled();
     expect(store.completeWorkflowRun).not.toHaveBeenCalled();
@@ -17395,33 +15843,26 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
     const store = createMockStore();
     const mockDeps = createMockDeps(store);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-usage',
-      cwd: testDir,
-      workflow: {
-        name: 'usage-nan-cost',
-        nodes: [
-          { id: 'good', kind: 'agent', source: { kind: 'inline', prompt: 'Spend normally.' } },
-          {
-            id: 'bad',
-            kind: 'agent',
-            source: { kind: 'inline', prompt: 'Report a broken cost.' },
-            depends_on: ['good'],
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun(),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        conversationId: 'conv-usage',
+        cwd: testDir,
+        workflow: {
+          name: 'usage-nan-cost',
+          nodes: [
+            { id: 'good', kind: 'agent', source: { kind: 'inline', prompt: 'Spend normally.' } },
+            {
+              id: 'bad',
+              kind: 'agent',
+              source: { kind: 'inline', prompt: 'Report a broken cost.' },
+              depends_on: ['good'],
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun(),
+      })
+    );
 
     // The healthy node's spend survives; only the broken node's contribution is dropped.
     // Tokens are unaffected — both nodes reported finite ones.
@@ -17459,27 +15900,20 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
     );
     const mockDeps = createMockDeps(store);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-usage',
-      cwd: testDir,
-      workflow: {
-        name: 'usage-write-fails',
-        nodes: [
-          { id: 'spend', kind: 'agent', source: { kind: 'inline', prompt: 'Burn some tokens.' } },
-        ],
-      },
-      workflowRun: makeWorkflowRun(),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        conversationId: 'conv-usage',
+        cwd: testDir,
+        workflow: {
+          name: 'usage-write-fails',
+          nodes: [
+            { id: 'spend', kind: 'agent', source: { kind: 'inline', prompt: 'Burn some tokens.' } },
+          ],
+        },
+        workflowRun: makeWorkflowRun(),
+      })
+    );
 
     // The run still completes normally — the usage figure is simply absent, and every
     // reader type-guards that. Absent is safe; plausible-and-wrong is the failure mode.
@@ -17564,39 +15998,33 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
     });
 
     await expect(
-      executeDagWorkflow({
-        deps: createMockDeps(store),
-        platform,
-        conversationId: 'conv-usage',
-        cwd: testDir,
-        workflow: {
-          name: 'usage-on-throw',
-          returns: 'spend',
-          outcome_field: 'green',
-          nodes: [
-            {
-              id: 'spend',
-              kind: 'agent',
-              source: { kind: 'inline', prompt: 'Burn some tokens.' },
-              output_format: {
-                type: 'object',
-                properties: { green: { type: 'boolean' } },
-                required: ['green'],
+      executeDagWorkflow(
+        dagOptions({
+          deps: createMockDeps(store),
+          platform,
+          conversationId: 'conv-usage',
+          cwd: testDir,
+          workflow: {
+            name: 'usage-on-throw',
+            returns: 'spend',
+            outcome_field: 'green',
+            nodes: [
+              {
+                id: 'spend',
+                kind: 'agent',
+                source: { kind: 'inline', prompt: 'Burn some tokens.' },
+                output_format: {
+                  type: 'object',
+                  properties: { green: { type: 'boolean' } },
+                  required: ['green'],
+                },
               },
-            },
-            { id: 'stop', kind: 'halt', reason: 'platform is gone' },
-          ],
-        },
-        workflowRun: makeWorkflowRun(),
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      })
+              { id: 'stop', kind: 'halt', reason: 'platform is gone' },
+            ],
+          },
+          workflowRun: makeWorkflowRun(),
+        })
+      )
     ).rejects.toThrow(/authentication\/permission/i);
 
     // Neither terminal writer ran — the throw skipped them both — yet the spend survived.
@@ -17667,22 +16095,16 @@ describe('executeDagWorkflow -- script nodes', () => {
       runtime: 'bun',
     };
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-script',
-      cwd: testDir,
-      workflow: { name: 'script-inline-bun-test', nodes: [scriptNode] },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-script',
+        cwd: testDir,
+        workflow: { name: 'script-inline-bun-test', nodes: [scriptNode] },
+        workflowRun,
+      })
+    );
 
     // Script node should NOT invoke AI client
     expect(mockSendQueryDag.mock.calls.length).toBe(0);
@@ -17712,22 +16134,16 @@ describe('executeDagWorkflow -- script nodes', () => {
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-script',
-      cwd: testDir,
-      workflow: { name: 'script-subst-test', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-script',
+        cwd: testDir,
+        workflow: { name: 'script-subst-test', nodes },
+        workflowRun,
+      })
+    );
 
     // AI client called for the downstream AI node
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -17751,22 +16167,16 @@ describe('executeDagWorkflow -- script nodes', () => {
       runtime: 'uv',
     };
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-script-uv',
-      cwd: testDir,
-      workflow: { name: 'script-inline-uv-test', nodes: [scriptNode] },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-script-uv',
+        cwd: testDir,
+        workflow: { name: 'script-inline-uv-test', nodes: [scriptNode] },
+        workflowRun,
+      })
+    );
 
     // Script node should NOT invoke AI client
     expect(mockSendQueryDag.mock.calls.length).toBe(0);
@@ -17793,22 +16203,16 @@ describe('executeDagWorkflow -- script nodes', () => {
       runtime: 'bun',
     };
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-named',
-      cwd: testDir,
-      workflow: { name: 'named-script-test', nodes: [scriptNode] },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-named',
+        cwd: testDir,
+        workflow: { name: 'named-script-test', nodes: [scriptNode] },
+        workflowRun,
+      })
+    );
 
     expect(mockSendQueryDag.mock.calls.length).toBe(0);
   });
@@ -17829,22 +16233,16 @@ describe('executeDagWorkflow -- script nodes', () => {
       runtime: 'bun',
     };
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-fail',
-      cwd: testDir,
-      workflow: { name: 'script-fail-test', nodes: [scriptNode] },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-fail',
+        cwd: testDir,
+        workflow: { name: 'script-fail-test', nodes: [scriptNode] },
+        workflowRun,
+      })
+    );
 
     const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
     const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
@@ -17873,22 +16271,16 @@ describe('executeDagWorkflow -- script nodes', () => {
       runtime: 'bun',
     };
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-1389s',
-      cwd: testDir,
-      workflow: { name: 'script-1389', nodes: [scriptNode] },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-1389s',
+        cwd: testDir,
+        workflow: { name: 'script-1389', nodes: [scriptNode] },
+        workflowRun,
+      })
+    );
 
     const eventCalls = (mockDeps.store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const failedEvent = eventCalls.find(
@@ -17927,22 +16319,16 @@ describe('executeDagWorkflow -- script nodes', () => {
       timeout: 500,
     };
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-timeout',
-      cwd: testDir,
-      workflow: { name: 'script-timeout-test', nodes: [scriptNode] },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-timeout',
+        cwd: testDir,
+        workflow: { name: 'script-timeout-test', nodes: [scriptNode] },
+        workflowRun,
+      })
+    );
 
     const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
     const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
@@ -17968,22 +16354,16 @@ describe('executeDagWorkflow -- script nodes', () => {
       runtime: 'bun',
     };
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-stderr',
-      cwd: testDir,
-      workflow: { name: 'script-stderr-test', nodes: [scriptNode] },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-stderr',
+        cwd: testDir,
+        workflow: { name: 'script-stderr-test', nodes: [scriptNode] },
+        workflowRun,
+      })
+    );
 
     const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
     const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
@@ -18024,22 +16404,17 @@ describe('executeDagWorkflow -- script nodes', () => {
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-subst',
-      cwd: testDir,
-      workflow: { name: 'script-subst-vars', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir,
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-subst',
+        cwd: testDir,
+        workflow: { name: 'script-subst-vars', nodes },
+        workflowRun,
+        artifactsDir,
+      })
+    );
 
     // The downstream AI node should have received the substituted output
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -18092,22 +16467,17 @@ describe('executeDagWorkflow -- script nodes', () => {
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-statedir',
-      cwd: testDir,
-      workflow: { name: 'state-dir-env', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir,
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-statedir',
+        cwd: testDir,
+        workflow: { name: 'state-dir-env', nodes },
+        workflowRun,
+        stateDir,
+      })
+    );
 
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
     const prompt = mockSendQueryDag.mock.calls[0][0] as string;
@@ -18155,22 +16525,16 @@ describe('executeDagWorkflow -- script nodes', () => {
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-wfid',
-      cwd: testDir,
-      workflow: { name: 'workflow-id-env', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-wfid',
+        cwd: testDir,
+        workflow: { name: 'workflow-id-env', nodes },
+        workflowRun,
+      })
+    );
 
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
     const prompt = mockSendQueryDag.mock.calls[0][0] as string;
@@ -18195,22 +16559,16 @@ describe('executeDagWorkflow -- script nodes', () => {
       runtime: 'bun',
     };
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-notfound',
-      cwd: testDir,
-      workflow: { name: 'script-notfound-test', nodes: [scriptNode] },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-notfound',
+        cwd: testDir,
+        workflow: { name: 'script-notfound-test', nodes: [scriptNode] },
+        workflowRun,
+      })
+    );
 
     const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
     const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
@@ -18239,22 +16597,16 @@ describe('executeDagWorkflow -- script nodes', () => {
       runtime: 'bun',
     };
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-env-leak',
-      cwd: testDir,
-      workflow: { name: 'env-leak-test', nodes: [scriptNode] },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-env-leak',
+        cwd: testDir,
+        workflow: { name: 'env-leak-test', nodes: [scriptNode] },
+        workflowRun,
+      })
+    );
 
     // The node output should be "CLEAN" — the repo .env was not loaded
     const eventCalls = (mockDeps.store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
@@ -18275,25 +16627,20 @@ describe('executeDagWorkflow -- script nodes', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun('script-env-run-id');
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-script-env',
-      cwd: testDir,
-      workflow: {
-        name: 'script-env-test',
-        nodes: [{ id: 'inline-bun', kind: 'exec', script: 'console.log("ok")', runtime: 'bun' }],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: { ...minimalConfig, envVars: { MY_SECRET: 'abc123' } },
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-script-env',
+        cwd: testDir,
+        workflow: {
+          name: 'script-env-test',
+          nodes: [{ id: 'inline-bun', kind: 'exec', script: 'console.log("ok")', runtime: 'bun' }],
+        },
+        workflowRun,
+        config: { ...minimalConfig, envVars: { MY_SECRET: 'abc123' } },
+      })
+    );
 
     expect(execSpy).toHaveBeenCalledWith(
       'bun',
@@ -18453,32 +16800,26 @@ describe('executeDagWorkflow -- MCP failure filtering', () => {
     });
 
     const platform = createMockPlatform();
-    await executeDagWorkflow({
-      deps: createMockDeps(),
-      platform,
-      conversationId: 'conv-mcp-filter',
-      cwd: testDir,
-      workflow: {
-        name: 'mcp-filter-test',
-        nodes: [
-          {
-            id: 'review',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            ...(nodeMcpPath ? { mcp: nodeMcpPath } : {}),
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun(),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(),
+        platform,
+        conversationId: 'conv-mcp-filter',
+        cwd: testDir,
+        workflow: {
+          name: 'mcp-filter-test',
+          nodes: [
+            {
+              id: 'review',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              ...(nodeMcpPath ? { mcp: nodeMcpPath } : {}),
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun(),
+      })
+    );
     return platform;
   }
 
@@ -18609,27 +16950,20 @@ describe('executeDagWorkflow -- authored run outcome (#2618)', () => {
       priorCompletedNodes?: Map<string, PersistedNodeOutput>;
     } = {}
   ): Promise<void> => {
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-outcome',
-      cwd: testDir,
-      workflow: {
-        name: 'authored-outcome',
-        nodes,
-        ...(options.declared === false ? {} : { returns: 'result', outcome_field: 'green' }),
-      },
-      workflowRun: options.workflowRun ?? makeWorkflowRun('authored-outcome-run'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes: options.priorCompletedNodes,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-outcome',
+        cwd: testDir,
+        workflow: {
+          name: 'authored-outcome',
+          nodes,
+          ...(options.declared === false ? {} : { returns: 'result', outcome_field: 'green' }),
+        },
+        workflowRun: options.workflowRun ?? makeWorkflowRun('authored-outcome-run'),
+        priorCompletedNodes: options.priorCompletedNodes,
+      })
+    );
   };
 
   beforeEach(async () => {
@@ -18882,25 +17216,18 @@ describe('executeDagWorkflow -- final status derivation', () => {
   it('a failed-only DAG delegates its terminal event to failWorkflowRun', async () => {
     const mockStore = createMockStore();
 
-    await executeDagWorkflow({
-      deps: createMockDeps(mockStore),
-      platform: createMockPlatform(),
-      conversationId: 'conv-status',
-      cwd: testDir,
-      workflow: {
-        name: 'status-test',
-        nodes: [{ id: 'fail', kind: 'exec', runtime: 'sh', script: 'exit 1' } as ExecNode],
-      },
-      workflowRun: makeWorkflowRun('dag-status-failed-only'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(mockStore),
+        conversationId: 'conv-status',
+        cwd: testDir,
+        workflow: {
+          name: 'status-test',
+          nodes: [{ id: 'fail', kind: 'exec', runtime: 'sh', script: 'exit 1' } as ExecNode],
+        },
+        workflowRun: makeWorkflowRun('dag-status-failed-only'),
+      })
+    );
 
     expect(mockStore.failWorkflowRun).toHaveBeenCalledTimes(1);
     expect(mockStore.createWorkflowEvent).not.toHaveBeenCalledWith(
@@ -18919,22 +17246,16 @@ describe('executeDagWorkflow -- final status derivation', () => {
       { id: 'fail', kind: 'exec', runtime: 'sh', script: 'exit 1' } as ExecNode,
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-status',
-      cwd: testDir,
-      workflow: { name: 'status-test', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-status',
+        cwd: testDir,
+        workflow: { name: 'status-test', nodes },
+        workflowRun,
+      })
+    );
 
     expect((mockStore.failWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(1);
     expect((mockStore.completeWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(0);
@@ -18967,22 +17288,16 @@ describe('executeDagWorkflow -- final status derivation', () => {
       { id: 'fail', kind: 'exec', runtime: 'sh', script: 'exit 1' } as ExecNode,
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-status',
-      cwd: testDir,
-      workflow: { name: 'status-test-multi', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-status',
+        cwd: testDir,
+        workflow: { name: 'status-test-multi', nodes },
+        workflowRun,
+      })
+    );
 
     expect((mockStore.failWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(1);
     expect((mockStore.completeWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(0);
@@ -19020,22 +17335,16 @@ describe('executeDagWorkflow -- final status derivation', () => {
       } as ExecNode,
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-status',
-      cwd: testDir,
-      workflow: { name: 'status-test-skip', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-status',
+        cwd: testDir,
+        workflow: { name: 'status-test-skip', nodes },
+        workflowRun,
+      })
+    );
 
     expect((mockStore.failWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(1);
     expect((mockStore.completeWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(0);
@@ -19085,27 +17394,22 @@ describe('executeDagWorkflow -- evidence gate (#2230)', () => {
       { id: 'work', kind: 'exec', runtime: 'sh', script: 'echo done' } as ExecNode,
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform: opts.platform,
-      conversationId: 'conv-evidence',
-      cwd: testDir,
-      workflow: {
-        name: 'evidence-test',
-        nodes,
-        ...(opts.evidencePolicy ? { evidence_policy: opts.evidencePolicy } : {}),
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir,
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes: opts.priorCompletedNodes,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform: opts.platform,
+        conversationId: 'conv-evidence',
+        cwd: testDir,
+        workflow: {
+          name: 'evidence-test',
+          nodes,
+          ...(opts.evidencePolicy ? { evidence_policy: opts.evidencePolicy } : {}),
+        },
+        workflowRun,
+        artifactsDir,
+        priorCompletedNodes: opts.priorCompletedNodes,
+      })
+    );
   }
 
   it('required: true + missing evidence.json -> failWorkflowRun with explicit reason, never completed', async () => {
@@ -19338,34 +17642,30 @@ describe('provider resolution -- regression for #1610', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-provider',
-      cwd: testDir,
-      // Node has model: opus[1m] but NO provider: — must inherit workflowProvider
-      workflow: {
-        name: 'provider-regression',
-        nodes: [
-          {
-            id: 'implement',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            model: 'opus[1m]',
-          },
-        ],
-      },
-      workflowRun,
-      // Simulates defaultAssistant: codex.
-      workflowProvider: 'codex',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: { ...minimalConfig, assistant: 'codex' },
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-provider',
+        cwd: testDir,
+        // Node has model: opus[1m] but NO provider: — must inherit workflowProvider
+        workflow: {
+          name: 'provider-regression',
+          nodes: [
+            {
+              id: 'implement',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              model: 'opus[1m]',
+            },
+          ],
+        },
+        workflowRun,
+        // Simulates defaultAssistant: codex.
+        workflowProvider: 'codex',
+        config: { ...minimalConfig, assistant: 'codex' },
+      })
+    );
 
     // getAgentProvider must have been called with 'codex', not 'claude'
     expect(mockGetAgentProviderDag).toHaveBeenCalledWith('codex');
@@ -19378,34 +17678,30 @@ describe('provider resolution -- regression for #1610', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-provider',
-      cwd: testDir,
-      // Node has both model: opus[1m] AND provider: claude
-      workflow: {
-        name: 'provider-explicit',
-        nodes: [
-          {
-            id: 'implement',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            model: 'opus[1m]',
-            provider: 'claude',
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'codex',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: { ...minimalConfig, assistant: 'codex' },
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-provider',
+        cwd: testDir,
+        // Node has both model: opus[1m] AND provider: claude
+        workflow: {
+          name: 'provider-explicit',
+          nodes: [
+            {
+              id: 'implement',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              model: 'opus[1m]',
+              provider: 'claude',
+            },
+          ],
+        },
+        workflowRun,
+        workflowProvider: 'codex',
+        config: { ...minimalConfig, assistant: 'codex' },
+      })
+    );
 
     // getAgentProvider must have been called with 'claude'
     expect(mockGetAgentProviderDag).toHaveBeenCalledWith('claude');
@@ -19491,32 +17787,24 @@ describe('executeDagWorkflow -- typed artifacts (output_type)', () => {
   });
 
   it('node with output_type writes nodes/<id>.md + .meta.json with the declared type', async () => {
-    await executeDagWorkflow({
-      deps: createMockDeps(),
-      platform: createMockPlatform(),
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'typed-test',
-        nodes: [
-          {
-            id: 'planner',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            output_type: 'plan',
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun(),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(),
+        cwd: testDir,
+        workflow: {
+          name: 'typed-test',
+          nodes: [
+            {
+              id: 'planner',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              output_type: 'plan',
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun(),
+      })
+    );
 
     const body = await readFile(join(testDir, 'artifacts', 'nodes', 'planner.md'), 'utf8');
     expect(body).toBe('AI response');
@@ -19535,33 +17823,25 @@ describe('executeDagWorkflow -- typed artifacts (output_type)', () => {
   });
 
   it('bash node with output_type writes a sidecar with no sessionId', async () => {
-    await executeDagWorkflow({
-      deps: createMockDeps(),
-      platform: createMockPlatform(),
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'bash-typed',
-        nodes: [
-          {
-            id: 'metrics',
-            kind: 'exec',
-            runtime: 'sh',
-            script: 'echo "result-data"',
-            output_type: 'metrics',
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun(),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(),
+        cwd: testDir,
+        workflow: {
+          name: 'bash-typed',
+          nodes: [
+            {
+              id: 'metrics',
+              kind: 'exec',
+              runtime: 'sh',
+              script: 'echo "result-data"',
+              output_type: 'metrics',
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun(),
+      })
+    );
 
     const body = await readFile(join(testDir, 'artifacts', 'nodes', 'metrics.md'), 'utf8');
     expect(body).toContain('result-data');
@@ -19583,57 +17863,42 @@ describe('executeDagWorkflow -- typed artifacts (output_type)', () => {
     await writeFile(join(artifactsDir, 'nodes'), 'not a directory', 'utf8');
 
     // Resolves without throwing — the best-effort catch swallows the write failure.
-    await executeDagWorkflow({
-      deps: createMockDeps(),
-      platform: createMockPlatform(),
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'typed-fail',
-        nodes: [
-          {
-            id: 'planner',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            output_type: 'plan',
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun(),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir,
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(),
+        cwd: testDir,
+        workflow: {
+          name: 'typed-fail',
+          nodes: [
+            {
+              id: 'planner',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              output_type: 'plan',
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun(),
+        artifactsDir,
+      })
+    );
 
     // The node executed despite the artifact write being impossible.
     expect(mockSendQueryDag.mock.calls.length).toBeGreaterThan(0);
   });
 
   it('node without output_type writes no sidecar artifact', async () => {
-    await executeDagWorkflow({
-      deps: createMockDeps(),
-      platform: createMockPlatform(),
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'untyped-test',
-        nodes: [{ id: 'planner', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
-      },
-      workflowRun: makeWorkflowRun(),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(),
+        cwd: testDir,
+        workflow: {
+          name: 'untyped-test',
+          nodes: [{ id: 'planner', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
+        },
+        workflowRun: makeWorkflowRun(),
+      })
+    );
 
     let wrote = true;
     try {
@@ -19679,32 +17944,24 @@ describe('executeDagWorkflow -- persist_session', () => {
     const store = createMockStore();
     const mockDeps = createMockDeps(store);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'persist-test',
-        nodes: [
-          {
-            id: 'planner',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            persist_session: true,
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun(),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        cwd: testDir,
+        workflow: {
+          name: 'persist-test',
+          nodes: [
+            {
+              id: 'planner',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              persist_session: true,
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun(),
+      })
+    );
 
     const getMock = store.getWorkflowNodeSession as Mock<typeof store.getWorkflowNodeSession>;
     const upsertMock = store.upsertWorkflowNodeSession as Mock<
@@ -19744,32 +18001,24 @@ describe('executeDagWorkflow -- persist_session', () => {
     });
     const mockDeps = createMockDeps(store);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'persist-test',
-        nodes: [
-          {
-            id: 'planner',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            persist_session: true,
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun(),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        cwd: testDir,
+        workflow: {
+          name: 'persist-test',
+          nodes: [
+            {
+              id: 'planner',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              persist_session: true,
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun(),
+      })
+    );
 
     expect(mockSendQueryDag.mock.calls[0][2]).toBe('prior-session-id');
     // A warm resume (resumed not false) runs the node exactly once — never replayed.
@@ -19810,32 +18059,25 @@ describe('executeDagWorkflow -- persist_session', () => {
       yield { type: 'result', sessionId: 'cold-id', resumed: false };
     });
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'persist-test',
-        nodes: [
-          {
-            id: 'planner',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            persist_session: true,
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun(),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'persist-test',
+          nodes: [
+            {
+              id: 'planner',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              persist_session: true,
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun(),
+      })
+    );
 
     // Ran exactly once — a cold resume is NOT replayed (the cold run is already fresh).
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -19890,33 +18132,26 @@ describe('executeDagWorkflow -- persist_session', () => {
     armColdResume(store);
     const platform = createMockPlatform();
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'persist-test',
-        nodes: [
-          {
-            id: 'planner',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            persist_session: true,
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun(),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      scopeArtifactsDir: scopeDir,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'persist-test',
+          nodes: [
+            {
+              id: 'planner',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              persist_session: true,
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun(),
+        scopeArtifactsDir: scopeDir,
+      })
+    );
 
     const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
     const messages = sendMessage.mock.calls.map(c => String(c[1]));
@@ -19947,33 +18182,26 @@ describe('executeDagWorkflow -- persist_session', () => {
     armColdResume(store);
     const platform = createMockPlatform();
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'persist-test',
-        nodes: [
-          {
-            id: 'planner',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            persist_session: true,
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun(),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      scopeArtifactsDir: scopeDir,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'persist-test',
+          nodes: [
+            {
+              id: 'planner',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              persist_session: true,
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun(),
+        scopeArtifactsDir: scopeDir,
+      })
+    );
 
     const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
     const messages = sendMessage.mock.calls.map(c => String(c[1]));
@@ -19986,33 +18214,26 @@ describe('executeDagWorkflow -- persist_session', () => {
     armColdResume(store);
     const platform = createMockPlatform();
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'persist-test',
-        nodes: [
-          {
-            id: 'planner',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            persist_session: true,
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun(),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      scopeArtifactsDir: join(testDir, 'scope-artifacts-never-created'),
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'persist-test',
+          nodes: [
+            {
+              id: 'planner',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              persist_session: true,
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun(),
+        scopeArtifactsDir: join(testDir, 'scope-artifacts-never-created'),
+      })
+    );
 
     const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
     const messages = sendMessage.mock.calls.map(c => String(c[1]));
@@ -20023,34 +18244,26 @@ describe('executeDagWorkflow -- persist_session', () => {
   it('persist node with output_type mirrors its typed sidecar into the scope dir', async () => {
     const scopeDir = join(testDir, 'scope-artifacts');
 
-    await executeDagWorkflow({
-      deps: createMockDeps(),
-      platform: createMockPlatform(),
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'persist-test',
-        nodes: [
-          {
-            id: 'planner',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            persist_session: true,
-            output_type: 'plan',
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun(),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      scopeArtifactsDir: scopeDir,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(),
+        cwd: testDir,
+        workflow: {
+          name: 'persist-test',
+          nodes: [
+            {
+              id: 'planner',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              persist_session: true,
+              output_type: 'plan',
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun(),
+        scopeArtifactsDir: scopeDir,
+      })
+    );
 
     // Written to BOTH the per-run dir and the durable scope dir.
     const runCopy = await readFile(join(testDir, 'artifacts', 'nodes', 'planner.md'), 'utf8');
@@ -20070,34 +18283,26 @@ describe('executeDagWorkflow -- persist_session', () => {
   it('non-persist node with output_type does NOT mirror into the scope dir', async () => {
     const scopeDir = join(testDir, 'scope-artifacts');
 
-    await executeDagWorkflow({
-      deps: createMockDeps(),
-      platform: createMockPlatform(),
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'persist-test',
-        // scope dir present (another node opted in), but THIS node doesn't persist.
-        nodes: [
-          {
-            id: 'planner',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            output_type: 'plan',
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun(),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      scopeArtifactsDir: scopeDir,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(),
+        cwd: testDir,
+        workflow: {
+          name: 'persist-test',
+          // scope dir present (another node opted in), but THIS node doesn't persist.
+          nodes: [
+            {
+              id: 'planner',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              output_type: 'plan',
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun(),
+        scopeArtifactsDir: scopeDir,
+      })
+    );
 
     // Run-dir sidecar exists; the scope dir stays untouched.
     const runCopy = await readFile(join(testDir, 'artifacts', 'nodes', 'planner.md'), 'utf8');
@@ -20117,34 +18322,26 @@ describe('executeDagWorkflow -- persist_session', () => {
     await mkdir(scopeDir, { recursive: true });
     await writeFile(join(scopeDir, 'nodes'), 'not a directory', 'utf8');
 
-    await executeDagWorkflow({
-      deps: createMockDeps(),
-      platform: createMockPlatform(),
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'persist-test',
-        nodes: [
-          {
-            id: 'planner',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            persist_session: true,
-            output_type: 'plan',
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun(),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      scopeArtifactsDir: scopeDir,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(),
+        cwd: testDir,
+        workflow: {
+          name: 'persist-test',
+          nodes: [
+            {
+              id: 'planner',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              persist_session: true,
+              output_type: 'plan',
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun(),
+        scopeArtifactsDir: scopeDir,
+      })
+    );
 
     // Node ran and the run-dir sidecar was still written (mirror is best-effort).
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -20160,32 +18357,24 @@ describe('executeDagWorkflow -- persist_session', () => {
     const store = createMockStore();
     const mockDeps = createMockDeps(store);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'persist-test',
-        nodes: [
-          {
-            id: 'planner',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            persist_session: true,
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun(),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        cwd: testDir,
+        workflow: {
+          name: 'persist-test',
+          nodes: [
+            {
+              id: 'planner',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              persist_session: true,
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun(),
+      })
+    );
 
     const upsertMock = store.upsertWorkflowNodeSession as Mock<
       typeof store.upsertWorkflowNodeSession
@@ -20208,25 +18397,17 @@ describe('executeDagWorkflow -- persist_session', () => {
     const store = createMockStore();
     const mockDeps = createMockDeps(store);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'no-persist',
-        nodes: [{ id: 'planner', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
-      },
-      workflowRun: makeWorkflowRun(),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        cwd: testDir,
+        workflow: {
+          name: 'no-persist',
+          nodes: [{ id: 'planner', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
+        },
+        workflowRun: makeWorkflowRun(),
+      })
+    );
 
     expect(store.getWorkflowNodeSession).not.toHaveBeenCalled();
     expect(store.upsertWorkflowNodeSession).not.toHaveBeenCalled();
@@ -20237,33 +18418,25 @@ describe('executeDagWorkflow -- persist_session', () => {
     const store = createMockStore();
     const mockDeps = createMockDeps(store);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'wf-default-on',
-        nodes: [
-          {
-            id: 'planner',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            persist_session: false,
-          },
-        ],
-        persist_sessions: true,
-      },
-      workflowRun: makeWorkflowRun(),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        cwd: testDir,
+        workflow: {
+          name: 'wf-default-on',
+          nodes: [
+            {
+              id: 'planner',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              persist_session: false,
+            },
+          ],
+          persist_sessions: true,
+        },
+        workflowRun: makeWorkflowRun(),
+      })
+    );
 
     expect(store.getWorkflowNodeSession).not.toHaveBeenCalled();
     expect(store.upsertWorkflowNodeSession).not.toHaveBeenCalled();
@@ -20283,33 +18456,25 @@ describe('executeDagWorkflow -- persist_session', () => {
     });
     const mockDeps = createMockDeps(store);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'persist-test',
-        nodes: [
-          {
-            id: 'planner',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            persist_session: true,
-            context: 'fresh',
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun(),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        cwd: testDir,
+        workflow: {
+          name: 'persist-test',
+          nodes: [
+            {
+              id: 'planner',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              persist_session: true,
+              context: 'fresh',
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun(),
+      })
+    );
 
     expect(store.getWorkflowNodeSession).not.toHaveBeenCalled();
     expect(mockSendQueryDag.mock.calls[0][2]).toBeUndefined();
@@ -20331,32 +18496,25 @@ describe('executeDagWorkflow -- persist_session', () => {
     const mockDeps = createMockDeps(store);
     const platform = createMockPlatform();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'persist-test',
-        nodes: [
-          {
-            id: 'planner',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            persist_session: true,
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun(),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'persist-test',
+          nodes: [
+            {
+              id: 'planner',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              persist_session: true,
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun(),
+      })
+    );
 
     // executeDagWorkflow catches per-node errors and emits a failure message.
     const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
@@ -20370,26 +18528,18 @@ describe('executeDagWorkflow -- persist_session', () => {
     const store = createMockStore();
     const mockDeps = createMockDeps(store);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'wf-inherit',
-        nodes: [{ id: 'planner', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
-        persist_sessions: true,
-      },
-      workflowRun: makeWorkflowRun(),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        cwd: testDir,
+        workflow: {
+          name: 'wf-inherit',
+          nodes: [{ id: 'planner', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
+          persist_sessions: true,
+        },
+        workflowRun: makeWorkflowRun(),
+      })
+    );
 
     expect(store.getWorkflowNodeSession).toHaveBeenCalledWith({
       workflow_name: 'wf-inherit',
@@ -20418,32 +18568,25 @@ describe('executeDagWorkflow -- persist_session', () => {
     const mockDeps = createMockDeps(store);
     const platform = createMockPlatform();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'persist-test',
-        nodes: [
-          {
-            id: 'planner',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            persist_session: true,
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun(),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'persist-test',
+          nodes: [
+            {
+              id: 'planner',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              persist_session: true,
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun(),
+      })
+    );
 
     // Lookup threw → node still runs, with no resume session.
     expect(mockSendQueryDag.mock.calls[0][2]).toBeUndefined();
@@ -20465,32 +18608,25 @@ describe('executeDagWorkflow -- persist_session', () => {
     const mockDeps = createMockDeps(store);
     const platform = createMockPlatform();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'persist-test',
-        nodes: [
-          {
-            id: 'planner',
-            kind: 'agent',
-            source: { kind: 'command', name: 'my-cmd' },
-            persist_session: true,
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun(),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        cwd: testDir,
+        workflow: {
+          name: 'persist-test',
+          nodes: [
+            {
+              id: 'planner',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              persist_session: true,
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun(),
+      })
+    );
 
     // Upsert threw, but the node executed (sendQuery ran) and the user was warned —
     // the failure did not abort the node.
@@ -20537,23 +18673,15 @@ describe('executeDagWorkflow -- completion telemetry', () => {
   });
 
   async function runDag(workflow: { name: string; nodes: DagNode[] }): Promise<void> {
-    await executeDagWorkflow({
-      deps: createMockDeps(createMockStore()),
-      platform: createMockPlatform(),
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow,
-      workflowRun: makeWorkflowRun(),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      source: 'bundled',
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(createMockStore()),
+        cwd: testDir,
+        workflow,
+        workflowRun: makeWorkflowRun(),
+        source: 'bundled',
+      })
+    );
   }
 
   it('emits outcome=completed with node counts and the threaded source on success', async () => {
@@ -20780,22 +18908,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    const result = await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: { name: 'dag-loopgroup-done', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    const result = await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: { name: 'dag-loopgroup-done', nodes },
+        workflowRun,
+      })
+    );
 
     // Two iterations: iter 1 (no signal) → iter 2 (DONE signal) → complete.
     expect(callCount).toBe(2);
@@ -20845,22 +18967,15 @@ describe('executeDagWorkflow -- loop_group node', () => {
     if (!expanded) throw new Error('expected expanded workflow');
 
     const store = createMockStore();
-    const result = await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: ready(expanded),
-      workflowRun: makeWorkflowRun('dag-loopgroup-included'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    const result = await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: ready(expanded),
+        workflowRun: makeWorkflowRun('dag-loopgroup-included'),
+      })
+    );
 
     expect(callCount).toBe(2);
     expect(result).toContain('iteration 2\nDONE');
@@ -20916,22 +19031,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
     if (!expanded) throw new Error('expected expanded workflow');
 
     const artifactsDir = join(testDir, 'artifacts');
-    await executeDagWorkflow({
-      deps: createMockDeps(createMockStore()),
-      platform: createMockPlatform(),
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: ready(expanded),
-      workflowRun: makeWorkflowRun('dag-loopgroup-typed-included'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir,
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(createMockStore()),
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: ready(expanded),
+        workflowRun: makeWorkflowRun('dag-loopgroup-typed-included'),
+        artifactsDir,
+      })
+    );
 
     expect(callCount).toBe(3);
     const artifacts = (await readNodeArtifacts(artifactsDir)).sort(
@@ -20975,54 +19084,48 @@ describe('executeDagWorkflow -- loop_group node', () => {
     });
 
     const artifactsDir = join(testDir, 'artifacts');
-    await executeDagWorkflow({
-      deps: createMockDeps(createMockStore()),
-      platform: createMockPlatform(),
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: {
-        name: 'nested-typed-loop-group',
-        nodes: [
-          {
-            id: 'outer',
-            kind: 'loop_group',
-            loop_group: {
-              until: 'OUTER_DONE',
-              max_iterations: 2,
-              fresh_context: false,
-              nodes: [
-                {
-                  id: 'inner',
-                  kind: 'loop_group',
-                  loop_group: {
-                    until: 'INNER_DONE',
-                    max_iterations: 1,
-                    fresh_context: false,
-                    nodes: [
-                      {
-                        id: 'leaf',
-                        kind: 'agent',
-                        source: { kind: 'inline', prompt: 'produce nested result' },
-                        output_type: 'findings',
-                      },
-                    ],
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(createMockStore()),
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: {
+          name: 'nested-typed-loop-group',
+          nodes: [
+            {
+              id: 'outer',
+              kind: 'loop_group',
+              loop_group: {
+                until: 'OUTER_DONE',
+                max_iterations: 2,
+                fresh_context: false,
+                nodes: [
+                  {
+                    id: 'inner',
+                    kind: 'loop_group',
+                    loop_group: {
+                      until: 'INNER_DONE',
+                      max_iterations: 1,
+                      fresh_context: false,
+                      nodes: [
+                        {
+                          id: 'leaf',
+                          kind: 'agent',
+                          source: { kind: 'inline', prompt: 'produce nested result' },
+                          output_type: 'findings',
+                        },
+                      ],
+                    },
                   },
-                },
-              ],
+                ],
+              },
             },
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('dag-nested-loopgroup-typed'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir,
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+          ],
+        },
+        workflowRun: makeWorkflowRun('dag-nested-loopgroup-typed'),
+        artifactsDir,
+      })
+    );
 
     expect(callCount).toBe(2);
     const artifacts = (await readNodeArtifacts(artifactsDir)).sort(
@@ -21073,22 +19176,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
       yield { type: 'result', sessionId: 'typed-resume-1' };
     });
     const firstDeps = createMockDeps(createMockStore());
-    await executeDagWorkflow({
-      deps: firstDeps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow,
-      workflowRun: makeWorkflowRun('dag-loopgroup-typed-resume'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir,
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: firstDeps,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow,
+        workflowRun: makeWorkflowRun('dag-loopgroup-typed-resume'),
+        artifactsDir,
+      })
+    );
 
     const beforeResume = await readNodeArtifacts(artifactsDir);
     expect(beforeResume).toHaveLength(1);
@@ -21101,34 +19198,28 @@ describe('executeDagWorkflow -- loop_group node', () => {
       yield { type: 'assistant', content: 'iteration 2 final DONE' };
       yield { type: 'result', sessionId: 'typed-resume-2' };
     });
-    await executeDagWorkflow({
-      deps: createMockDeps(createMockStore()),
-      platform: createMockPlatform(),
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow,
-      workflowRun: makeWorkflowRun('dag-loopgroup-typed-resume', {
-        metadata: {
-          approval: {
-            type: 'interactive_loop',
-            nodeId: 'refine',
-            iteration: 1,
-            sessionId: 'typed-resume-1',
-            sessionProvider: 'claude',
-            message: 'Review the typed result.',
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(createMockStore()),
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow,
+        workflowRun: makeWorkflowRun('dag-loopgroup-typed-resume', {
+          metadata: {
+            approval: {
+              type: 'interactive_loop',
+              nodeId: 'refine',
+              iteration: 1,
+              sessionId: 'typed-resume-1',
+              sessionProvider: 'claude',
+              message: 'Review the typed result.',
+            },
+            loop_user_input: 'continue',
           },
-          loop_user_input: 'continue',
-        },
-      }),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir,
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+        }),
+        artifactsDir,
+      })
+    );
 
     const afterResume = (await readNodeArtifacts(artifactsDir)).sort(
       (left, right) =>
@@ -21266,22 +19357,15 @@ describe('executeDagWorkflow -- loop_group node', () => {
     let result: Awaited<ReturnType<typeof executeDagWorkflow>>;
     try {
       store = createMockStore();
-      result = await executeDagWorkflow({
-        deps: createMockDeps(store),
-        platform: createMockPlatform(),
-        conversationId: 'conv-lg',
-        cwd: testDir,
-        workflow: ready(expanded),
-        workflowRun: makeWorkflowRun('dag-nested-loopgroup-included-prev'),
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      result = await executeDagWorkflow(
+        dagOptions({
+          deps: createMockDeps(store),
+          conversationId: 'conv-lg',
+          cwd: testDir,
+          workflow: ready(expanded),
+          workflowRun: makeWorkflowRun('dag-nested-loopgroup-included-prev'),
+        })
+      );
     } finally {
       execSpy.mockRestore();
     }
@@ -21360,22 +19444,15 @@ describe('executeDagWorkflow -- loop_group node', () => {
     if (!expanded) throw new Error('expected expanded workflow');
 
     const store = createMockStore();
-    const result = await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: ready(expanded),
-      workflowRun: makeWorkflowRun('dag-included-untilbash-shellsafe'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    const result = await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: ready(expanded),
+        workflowRun: makeWorkflowRun('dag-included-untilbash-shellsafe'),
+      })
+    );
 
     // The gate's quoted comparisons parsed correctly: the loop completed via until_bash
     // on its second iteration only after reading BOTH the included body's previous
@@ -21433,22 +19510,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: { name: 'dag-loopgroup-cmd', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: { name: 'dag-loopgroup-cmd', nodes },
+        workflowRun,
+      })
+    );
 
     // The command file's body (not a YAML inline prompt) reached the AI.
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -21510,22 +19581,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
         },
       ];
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-lg-userinput',
-        cwd: testDir,
-        workflow: { name: 'lg-userinput-script', nodes },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          conversationId: 'conv-lg-userinput',
+          cwd: testDir,
+          workflow: { name: 'lg-userinput-script', nodes },
+          workflowRun,
+        })
+      );
 
       const scriptCall = execSpy.mock.calls.find(
         c => (c[0] as string) === 'bun' && (c[1] as string[]).includes('-e')
@@ -21591,22 +19656,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
         },
       ];
 
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-lg-userinput-bash',
-        cwd: testDir,
-        workflow: { name: 'lg-userinput-bash', nodes },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          conversationId: 'conv-lg-userinput-bash',
+          cwd: testDir,
+          workflow: { name: 'lg-userinput-bash', nodes },
+          workflowRun,
+        })
+      );
 
       const bashCall = execSpy.mock.calls.find(
         c => (c[0] as string) === git.resolveBashPath() && (c[1] as string[])[0] === '-c'
@@ -21653,22 +19712,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    const result = await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: { name: 'dag-loopgroup-maxiter', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    const result = await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: { name: 'dag-loopgroup-maxiter', nodes },
+        workflowRun,
+      })
+    );
 
     // The negated prose does not complete the group, so it exhausts max_iterations.
     expect(callCount).toBe(2);
@@ -21731,22 +19784,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    const result = await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: { name: 'lg-multinode', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    const result = await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: { name: 'lg-multinode', nodes },
+        workflowRun,
+      })
+    );
 
     // 2 iterations (review called once per iteration); DONE on iteration 2.
     expect(reviewCalls).toBe(2);
@@ -21793,22 +19840,17 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg-spill',
-      cwd: testDir,
-      workflow: { name: 'lg-spill-overwrite', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir,
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg-spill',
+        cwd: testDir,
+        workflow: { name: 'lg-spill-overwrite', nodes },
+        workflowRun,
+        artifactsDir,
+      })
+    );
 
     expect((await readFile(counterFile, 'utf8')).trim()).toBe('2');
 
@@ -21879,22 +19921,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: { name: 'lg-loopprev', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: { name: 'lg-loopprev', nodes },
+        workflowRun,
+      })
+    );
 
     // Iteration 1 prompt: $LOOP_PREV resolved to '' (no prior iteration).
     expect(callCount).toBeGreaterThanOrEqual(1);
@@ -21953,22 +19989,15 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: { name: 'lg-binding-loopprev', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: { name: 'lg-binding-loopprev', nodes },
+        workflowRun,
+      })
+    );
 
     const consumeRows = (
       mockDeps.store.createWorkflowEvent as Mock<
@@ -21996,48 +20025,44 @@ describe('executeDagWorkflow -- loop_group node', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun('lg-large-loopprev');
 
-    const result = await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: {
-        name: 'lg-large-loopprev',
-        nodes: [
-          {
-            id: 'draft-loop',
-            kind: 'loop_group',
-            loop_group: {
-              until: 'DONE',
-              max_iterations: 2,
-              fresh_context: false,
-              nodes: [
-                {
-                  id: 'work',
-                  kind: 'exec',
-                  runtime: 'sh',
-                  script:
-                    'previous=$LOOP_PREV.work.output; ' +
-                    'if [ -z "$previous" ]; then head -c 33000 /dev/zero | tr "\\0" x; ' +
-                    'else printf "%s\\nDONE\\n" "${#previous}"; fi',
-                  depends_on: [],
-                },
-              ],
+    const result = await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: {
+          name: 'lg-large-loopprev',
+          nodes: [
+            {
+              id: 'draft-loop',
+              kind: 'loop_group',
+              loop_group: {
+                until: 'DONE',
+                max_iterations: 2,
+                fresh_context: false,
+                nodes: [
+                  {
+                    id: 'work',
+                    kind: 'exec',
+                    runtime: 'sh',
+                    script:
+                      'previous=$LOOP_PREV.work.output; ' +
+                      'if [ -z "$previous" ]; then head -c 33000 /dev/zero | tr "\\0" x; ' +
+                      'else printf "%s\\nDONE\\n" "${#previous}"; fi',
+                    depends_on: [],
+                  },
+                ],
+              },
+              depends_on: [],
             },
-            depends_on: [],
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir,
-      stateDir: join(testDir, 'state'),
-      logDir,
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+          ],
+        },
+        workflowRun,
+        artifactsDir,
+        logDir,
+      })
+    );
 
     expect(result).toContain('33000');
     expect(
@@ -22085,22 +20110,18 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    const result = await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: { name: 'lg-untilbash', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir,
-      stateDir: join(testDir, 'state'),
-      logDir,
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    const result = await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: { name: 'lg-untilbash', nodes },
+        workflowRun,
+        artifactsDir,
+        logDir,
+      })
+    );
 
     expect(result).toBe(largeOutput);
     expect(
@@ -22138,22 +20159,15 @@ describe('executeDagWorkflow -- loop_group node', () => {
       ],
     });
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: ready(workflow),
-      workflowRun: makeWorkflowRun('group-required-output-ref'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: ready(workflow),
+        workflowRun: makeWorkflowRun('group-required-output-ref'),
+      })
+    );
 
     const failed = store.createWorkflowEvent.mock.calls
       .map(([event]) => event)
@@ -22198,22 +20212,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    const result = await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: { name: 'lg-single', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    const result = await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: { name: 'lg-single', nodes },
+        workflowRun,
+      })
+    );
 
     // Single iteration, completed immediately.
     expect(calls).toBe(1);
@@ -22258,22 +20266,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    const result = await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: { name: 'lg-body-fail', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    const result = await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: { name: 'lg-body-fail', nodes },
+        workflowRun,
+      })
+    );
 
     // Fail-fast: exactly ONE iteration ran — no burn-to-max_iterations.
     expect(calls).toBe(1);
@@ -22333,22 +20335,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    const result = await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: { name: 'lg-outer-dep', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    const result = await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: { name: 'lg-outer-dep', nodes },
+        workflowRun,
+      })
+    );
 
     // The body prompt received the outer node's output (seeded into the scoped map).
     expect(receivedPrompt).toContain('setup-context-123');
@@ -22645,22 +20641,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: { name: 'lg-nested-prev', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: { name: 'lg-nested-prev', nodes },
+        workflowRun,
+      })
+    );
 
     // Two inner iterations ran within the single outer iteration.
     expect(capturedPrompts.length).toBe(2);
@@ -22742,51 +20732,44 @@ describe('executeDagWorkflow -- loop_group node', () => {
       yield { type: 'result', sessionId: `loop-prev-when-${calls}` };
     });
 
-    const result = await executeDagWorkflow({
-      deps: createMockDeps(),
-      platform: createMockPlatform(),
-      conversationId: 'conv-loop-prev-when',
-      cwd: testDir,
-      workflow: {
-        name: 'loop-prev-when',
-        nodes: [
-          {
-            id: 'refine',
-            kind: 'loop_group',
-            loop_group: {
-              until: 'DONE',
-              max_iterations: 2,
-              fresh_context: false,
-              nodes: [
-                {
-                  id: 'work',
-                  kind: 'agent',
-                  source: { kind: 'inline', prompt: 'work' },
-                  depends_on: [],
-                },
-                {
-                  id: 'guarded',
-                  kind: 'agent',
-                  source: { kind: 'inline', prompt: 'guarded' },
-                  when: "$LOOP_PREV.work.output == 'done'",
-                  depends_on: ['work'],
-                },
-              ],
+    const result = await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(),
+        conversationId: 'conv-loop-prev-when',
+        cwd: testDir,
+        workflow: {
+          name: 'loop-prev-when',
+          nodes: [
+            {
+              id: 'refine',
+              kind: 'loop_group',
+              loop_group: {
+                until: 'DONE',
+                max_iterations: 2,
+                fresh_context: false,
+                nodes: [
+                  {
+                    id: 'work',
+                    kind: 'agent',
+                    source: { kind: 'inline', prompt: 'work' },
+                    depends_on: [],
+                  },
+                  {
+                    id: 'guarded',
+                    kind: 'agent',
+                    source: { kind: 'inline', prompt: 'guarded' },
+                    when: "$LOOP_PREV.work.output == 'done'",
+                    depends_on: ['work'],
+                  },
+                ],
+              },
+              depends_on: [],
             },
-            depends_on: [],
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('loop-prev-when'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+          ],
+        },
+        workflowRun: makeWorkflowRun('loop-prev-when'),
+      })
+    );
 
     expect(calls).toBe(3);
     expect(result).toContain('guarded');
@@ -23014,22 +20997,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    const result = await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: { name: 'lg-multiterminal', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    const result = await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: { name: 'lg-multiterminal', nodes },
+        workflowRun,
+      })
+    );
 
     // Both parallel terminal nodes ran on the completing iteration (iter 1).
     expect(aCalls).toBeGreaterThanOrEqual(1);
@@ -23074,22 +21051,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    const result = await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: { name: 'lg-fresh', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    const result = await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: { name: 'lg-fresh', nodes },
+        workflowRun,
+      })
+    );
 
     expect(calls).toBe(2);
     expect(result).toContain('final');
@@ -23137,22 +21108,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    const result = await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: { name: 'lg-cancel', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    const result = await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: { name: 'lg-cancel', nodes },
+        workflowRun,
+      })
+    );
 
     // Only iteration 1 ran before cancellation halted the loop. The run did not complete
     // (no DONE) → outer DAG sees no terminal output.
@@ -23200,22 +21165,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    const result = await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: { name: 'lg-or', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    const result = await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: { name: 'lg-or', nodes },
+        workflowRun,
+      })
+    );
 
     // Signal completed on iteration 1.
     expect(calls).toBe(1);
@@ -23264,22 +21223,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    const result = await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: { name: 'lg-single-shot', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    const result = await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: { name: 'lg-single-shot', nodes },
+        workflowRun,
+      })
+    );
 
     expect(calls).toBe(1);
     expect(result).toContain('one-shot');
@@ -23343,22 +21296,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    const result = await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: { name: 'lg-nested', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    const result = await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: { name: 'lg-nested', nodes },
+        workflowRun,
+      })
+    );
 
     // Inner ran (1 call), then outer review ran (1 call) emitting OUTER_DONE → outer completes.
     expect(calls).toBe(2);
@@ -23401,22 +21348,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: { name: 'lg-interactive', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: { name: 'lg-interactive', nodes },
+        workflowRun,
+      })
+    );
 
     // One AI call (iteration 1), then paused.
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -23444,47 +21385,41 @@ describe('executeDagWorkflow -- loop_group node', () => {
     const mockDeps = createMockDeps();
     const platform = createMockPlatform();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: {
-        name: 'lg-bash-gate',
-        nodes: [
-          {
-            id: 'refine',
-            kind: 'loop_group',
-            loop_group: {
-              until: 'UNTIL_DONE',
-              until_bash: 'exit 0',
-              max_iterations: 3,
-              fresh_context: false,
-              interactive: true,
-              gate_message: 'Review the checks.',
-              nodes: [
-                {
-                  id: 'work',
-                  kind: 'agent',
-                  source: { kind: 'inline', prompt: 'validate' },
-                  depends_on: [],
-                },
-              ],
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: {
+          name: 'lg-bash-gate',
+          nodes: [
+            {
+              id: 'refine',
+              kind: 'loop_group',
+              loop_group: {
+                until: 'UNTIL_DONE',
+                until_bash: 'exit 0',
+                max_iterations: 3,
+                fresh_context: false,
+                interactive: true,
+                gate_message: 'Review the checks.',
+                nodes: [
+                  {
+                    id: 'work',
+                    kind: 'agent',
+                    source: { kind: 'inline', prompt: 'validate' },
+                    depends_on: [],
+                  },
+                ],
+              },
+              depends_on: [],
             },
-            depends_on: [],
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('lg-bash-gate'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+          ],
+        },
+        workflowRun: makeWorkflowRun('lg-bash-gate'),
+      })
+    );
 
     expectLoopGateEvidence(
       mockDeps.store,
@@ -23532,22 +21467,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: { name: 'lg-signal-gate', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: { name: 'lg-signal-gate', nodes },
+        workflowRun,
+      })
+    );
 
     const pauseCalls = (mockDeps.store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>)
       .mock.calls;
@@ -23602,22 +21531,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: { name: 'lg-signal-completes', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: { name: 'lg-signal-completes', nodes },
+        workflowRun,
+      })
+    );
 
     const pauseCalls = (mockDeps.store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>)
       .mock.calls;
@@ -23685,22 +21608,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: { name: 'lg-finalize', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: { name: 'lg-finalize', nodes },
+        workflowRun,
+      })
+    );
 
     // No body iteration ran — the group finalized from the persisted output.
     expect(mockSendQueryDag.mock.calls.length).toBe(0);
@@ -23767,22 +21684,15 @@ describe('executeDagWorkflow -- loop_group node', () => {
     };
 
     const pausingDeps = createMockDeps();
-    await executeDagWorkflow({
-      deps: pausingDeps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow,
-      workflowRun: makeWorkflowRun('lg-struct-pause'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: pausingDeps,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow,
+        workflowRun: makeWorkflowRun('lg-struct-pause'),
+      })
+    );
     const pauseCalls = (
       pausingDeps.store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>
     ).mock.calls;
@@ -23796,28 +21706,21 @@ describe('executeDagWorkflow -- loop_group node', () => {
       yield { type: 'result', sessionId: 'never' };
     });
     const resumingDeps = createMockDeps();
-    await executeDagWorkflow({
-      deps: resumingDeps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow,
-      workflowRun: makeWorkflowRun('lg-struct-resume', {
-        metadata: {
-          approval: { ...approval },
-          loop_user_input: 'Approved',
-          loop_feedback_given: false,
-        },
-      }),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: resumingDeps,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow,
+        workflowRun: makeWorkflowRun('lg-struct-resume', {
+          metadata: {
+            approval: { ...approval },
+            loop_user_input: 'Approved',
+            loop_feedback_given: false,
+          },
+        }),
+      })
+    );
     expect(mockSendQueryDag.mock.calls.length).toBe(0);
     const eventCalls2 = (
       resumingDeps.store.createWorkflowEvent as Mock<
@@ -23882,22 +21785,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
       ] as DagNode[],
     };
 
-    await executeDagWorkflow({
-      deps: mockDeps1,
-      platform: platform1,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow,
-      workflowRun: freshRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps1,
+        platform: platform1,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow,
+        workflowRun: freshRun,
+      })
+    );
     // Call 1 paused at iteration 1, persisting the body's session cursor so a
     // fresh_context: false resume can continue the same conversation.
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -23931,22 +21828,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     });
 
-    await executeDagWorkflow({
-      deps: mockDeps2,
-      platform: platform2,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow,
-      workflowRun: resumedRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps2,
+        platform: platform2,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow,
+        workflowRun: resumedRun,
+      })
+    );
 
     // Resumed iteration (iteration 2) ran once more and completed via APPROVED.
     expect(mockSendQueryDag.mock.calls.length).toBe(2);
@@ -24005,22 +21896,15 @@ describe('executeDagWorkflow -- loop_group node', () => {
         },
       ] as DagNode[],
     };
-    await executeDagWorkflow({
-      deps: mockDeps1,
-      platform: createMockPlatform(),
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow,
-      workflowRun: makeWorkflowRun('lg-prev-fresh'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps1,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow,
+        workflowRun: makeWorkflowRun('lg-prev-fresh'),
+      })
+    );
 
     // Iteration 1 prompt: $LOOP_PREV resolved to '' (no prior iteration in this process).
     const iter1Prompt = mockSendQueryDag.mock.calls[0][0] as string;
@@ -24035,34 +21919,27 @@ describe('executeDagWorkflow -- loop_group node', () => {
       yield { type: 'assistant', content: 'final\nAPPROVED' };
       yield { type: 'result', sessionId: 'lg-prev-sess-2' };
     });
-    await executeDagWorkflow({
-      deps: createMockDeps(),
-      platform: createMockPlatform(),
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow,
-      workflowRun: makeWorkflowRun('lg-prev-resume', {
-        metadata: {
-          approval: {
-            type: 'interactive_loop',
-            nodeId: 'refine',
-            iteration: 1,
-            sessionId: 'lg-prev-sess-1',
-            message: 'Review.',
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(),
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow,
+        workflowRun: makeWorkflowRun('lg-prev-resume', {
+          metadata: {
+            approval: {
+              type: 'interactive_loop',
+              nodeId: 'refine',
+              iteration: 1,
+              sessionId: 'lg-prev-sess-1',
+              message: 'Review.',
+            },
+            loop_user_input: 'ok',
           },
-          loop_user_input: 'ok',
-        },
-      }),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+        }),
+        priorCompletedNodes,
+      })
+    );
 
     // Resumed iteration 2: $LOOP_PREV resolves to the real persisted iteration-1 output.
     const resumePrompt = mockSendQueryDag.mock.calls[1][0] as string;
@@ -24130,33 +22007,26 @@ describe('executeDagWorkflow -- loop_group node', () => {
       yield { type: 'result', sessionId: 'lg-declared-fields-sess' };
     });
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-lg-declared-fields',
-      cwd: testDir,
-      workflow,
-      workflowRun: makeWorkflowRun('lg-resume-declared-fields', {
-        metadata: {
-          approval: {
-            type: 'interactive_loop',
-            nodeId: 'refine',
-            iteration: 1,
-            message: 'Review.',
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        conversationId: 'conv-lg-declared-fields',
+        cwd: testDir,
+        workflow,
+        workflowRun: makeWorkflowRun('lg-resume-declared-fields', {
+          metadata: {
+            approval: {
+              type: 'interactive_loop',
+              nodeId: 'refine',
+              iteration: 1,
+              message: 'Review.',
+            },
+            loop_user_input: '',
           },
-          loop_user_input: '',
-        },
-      }),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+        }),
+        priorCompletedNodes,
+      })
+    );
 
     // The undeclared `extra` field must fail loudly (not-in-schema) on the resumed
     // iteration — exactly as it would fail an in-process iteration — instead of
@@ -24211,22 +22081,17 @@ describe('executeDagWorkflow -- loop_group node', () => {
       ] as DagNode[],
     };
 
-    await executeDagWorkflow({
-      deps: createMockDeps(freshStore),
-      platform: createMockPlatform(),
-      conversationId: 'conv-lg-large',
-      cwd: testDir,
-      workflow: freshWorkflow,
-      workflowRun: makeWorkflowRun('lg-prev-large-fresh'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir,
-      stateDir: join(testDir, 'state'),
-      logDir,
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(freshStore),
+        conversationId: 'conv-lg-large',
+        cwd: testDir,
+        workflow: freshWorkflow,
+        workflowRun: makeWorkflowRun('lg-prev-large-fresh'),
+        artifactsDir,
+        logDir,
+      })
+    );
 
     const freshEventCalls = (freshStore.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const bodyEvent = freshEventCalls.find(
@@ -24278,33 +22143,28 @@ describe('executeDagWorkflow -- loop_group node', () => {
         },
       ] as DagNode[],
     };
-    const result = await executeDagWorkflow({
-      deps: createMockDeps(createMockStore()),
-      platform: createMockPlatform(),
-      conversationId: 'conv-lg-large-resume',
-      cwd: testDir,
-      workflow: resumedWorkflow,
-      workflowRun: makeWorkflowRun('lg-prev-large-resume', {
-        metadata: {
-          approval: {
-            type: 'interactive_loop',
-            nodeId: 'refine',
-            iteration: 1,
-            message: 'Review.',
+    const result = await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(createMockStore()),
+        conversationId: 'conv-lg-large-resume',
+        cwd: testDir,
+        workflow: resumedWorkflow,
+        workflowRun: makeWorkflowRun('lg-prev-large-resume', {
+          metadata: {
+            approval: {
+              type: 'interactive_loop',
+              nodeId: 'refine',
+              iteration: 1,
+              message: 'Review.',
+            },
+            loop_user_input: '',
           },
-          loop_user_input: '',
-        },
-      }),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir,
-      stateDir: join(testDir, 'state'),
-      logDir,
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+        }),
+        artifactsDir,
+        logDir,
+        priorCompletedNodes,
+      })
+    );
 
     // The resumed body script measured $LOOP_PREV.work.output's length as the FULL
     // padding size — proving the real spilled bytes (not a truncated preview) survived
@@ -24353,22 +22213,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: { name: 'lg-cost', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: { name: 'lg-cost', nodes },
+        workflowRun,
+      })
+    );
 
     expect(calls).toBe(2);
     // 0.01 + 0.02 = 0.03 accumulated across the group's 2 iterations.
@@ -24443,22 +22297,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: { name: 'lg-tokens', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: { name: 'lg-tokens', nodes },
+        workflowRun,
+      })
+    );
 
     expect(calls).toBe(2);
     // The group sums tokens across iterations into its result; the outer runLayers
@@ -24542,22 +22390,15 @@ describe('executeDagWorkflow -- loop_group node', () => {
       yield { type: 'result', sessionId: 'lg-dbl-sess-1', tokens: { input: 100, output: 10 } };
     });
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow,
-      workflowRun: makeWorkflowRun('lg-finalize-tokens-run'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow,
+        workflowRun: makeWorkflowRun('lg-finalize-tokens-run'),
+      })
+    );
 
     const pauseCalls = (store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>).mock
       .calls;
@@ -24571,28 +22412,21 @@ describe('executeDagWorkflow -- loop_group node', () => {
     });
     const aiCallsBeforeResume = mockSendQueryDag.mock.calls.length;
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow,
-      workflowRun: makeWorkflowRun('lg-finalize-tokens-run', {
-        metadata: {
-          approval: pauseCalls[0][1],
-          loop_user_input: '',
-          loop_feedback_given: false,
-        },
-      }),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow,
+        workflowRun: makeWorkflowRun('lg-finalize-tokens-run', {
+          metadata: {
+            approval: pauseCalls[0][1],
+            loop_user_input: '',
+            loop_feedback_given: false,
+          },
+        }),
+      })
+    );
 
     // Finalized from the persisted output — no body iteration re-ran.
     expect(mockSendQueryDag.mock.calls.length).toBe(aiCallsBeforeResume);
@@ -24648,22 +22482,15 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-lg-no-usage',
-      cwd: testDir,
-      workflow: { name: 'lg-no-usage', nodes },
-      workflowRun: makeWorkflowRun('lg-no-usage-run'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        conversationId: 'conv-lg-no-usage',
+        cwd: testDir,
+        workflow: { name: 'lg-no-usage', nodes },
+        workflowRun: makeWorkflowRun('lg-no-usage-run'),
+      })
+    );
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls as Array<
       [{ event_type: string; step_name: string; data?: Record<string, unknown> }]
@@ -24714,22 +22541,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: { name: 'lg-session-thread', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: { name: 'lg-session-thread', nodes },
+        workflowRun,
+      })
+    );
 
     expect(mockSendQueryDag.mock.calls.length).toBe(2);
     // Iteration 1: always fresh.
@@ -24771,22 +22592,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: { name: 'lg-session-fresh', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: { name: 'lg-session-fresh', nodes },
+        workflowRun,
+      })
+    );
 
     expect(mockSendQueryDag.mock.calls.length).toBe(2);
     expect(mockSendQueryDag.mock.calls[0][2]).toBeUndefined();
@@ -24842,22 +22657,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    const result = await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: { name: 'lg-when', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    const result = await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: { name: 'lg-when', nodes },
+        workflowRun,
+      })
+    );
 
     // gate ran twice (both iterations); work ran once (iteration 2 only).
     expect(gateCalls).toBe(2);
@@ -24909,22 +22718,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    const result = await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: { name: 'lg-multi-fail', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    const result = await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: { name: 'lg-multi-fail', nodes },
+        workflowRun,
+      })
+    );
 
     // Only implement's single (failing) call ran — verify was skipped, no iteration 2.
     expect(calls).toBe(1);
@@ -24977,22 +22780,17 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: { name: 'lg-artifact', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir,
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: { name: 'lg-artifact', nodes },
+        workflowRun,
+        artifactsDir,
+      })
+    );
 
     expect(calls).toBe(2);
     // The sidecar artifact carries the final iteration's terminal output.
@@ -25081,22 +22879,16 @@ describe('executeDagWorkflow -- loop_group body step_name namespacing (#2090)', 
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: { name: 'lg-ns', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: { name: 'lg-ns', nodes },
+        workflowRun,
+      })
+    );
 
     expect(calls).toBe(2);
 
@@ -25180,22 +22972,16 @@ describe('executeDagWorkflow -- loop_group body step_name namespacing (#2090)', 
       },
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: { name: 'lg-nested-ns', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: { name: 'lg-nested-ns', nodes },
+        workflowRun,
+      })
+    );
 
     expect(calls).toBe(2);
 
@@ -25231,44 +23017,38 @@ describe('executeDagWorkflow -- loop_group body step_name namespacing (#2090)', 
     });
 
     try {
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-lg',
-        cwd: testDir,
-        workflow: {
-          name: 'lg-emit-raw',
-          nodes: [
-            {
-              id: 'fixer',
-              kind: 'loop_group',
-              loop_group: {
-                until: 'DONE',
-                max_iterations: 3,
-                fresh_context: false,
-                nodes: [
-                  {
-                    id: 'work',
-                    kind: 'agent',
-                    source: { kind: 'inline', prompt: 'do work, emit DONE' },
-                    depends_on: [],
-                  },
-                ],
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          conversationId: 'conv-lg',
+          cwd: testDir,
+          workflow: {
+            name: 'lg-emit-raw',
+            nodes: [
+              {
+                id: 'fixer',
+                kind: 'loop_group',
+                loop_group: {
+                  until: 'DONE',
+                  max_iterations: 3,
+                  fresh_context: false,
+                  nodes: [
+                    {
+                      id: 'work',
+                      kind: 'agent',
+                      source: { kind: 'inline', prompt: 'do work, emit DONE' },
+                      depends_on: [],
+                    },
+                  ],
+                },
+                depends_on: [],
               },
-              depends_on: [],
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
     } finally {
       unsubscribe();
     }
@@ -25339,23 +23119,17 @@ describe('executeDagWorkflow -- loop_group body step_name namespacing (#2090)', 
       yield { type: 'result', sessionId: `s-${calls}` };
     });
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-lg',
-      cwd: testDir,
-      workflow: { name: 'lg-resume', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: { name: 'lg-resume', nodes },
+        workflowRun,
+        priorCompletedNodes,
+      })
+    );
 
     // Only `finalize` executes: the loop_group `fixer` was skipped as a unit (body never
     // re-ran), and the namespaced `fixer.work` key skipped nothing at the top level.
@@ -25400,24 +23174,17 @@ describe('executeDagWorkflow -- addressable session resume', () => {
     priorCompletedNodes?: Map<string, PersistedNodeOutput>,
     priorNodeSessions?: readonly WorkflowRunNodeSession[]
   ): Promise<MockWorkflowStore> {
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-addressable',
-      cwd: testDir,
-      workflow: { name: 'addressable', nodes },
-      workflowRun: makeWorkflowRun('addressable-run'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-      priorNodeSessions,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-addressable',
+        cwd: testDir,
+        workflow: { name: 'addressable', nodes },
+        workflowRun: makeWorkflowRun('addressable-run'),
+        priorCompletedNodes,
+        priorNodeSessions,
+      })
+    );
     return store;
   }
 
@@ -26019,22 +23786,16 @@ describe('executeDagWorkflow -- provider-boundary session threading (#1992)', ()
   ): Promise<WorkflowDeps> {
     const mockDeps = createMockDeps();
     const platform = createMockPlatform();
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId,
-      cwd: testDir,
-      workflow,
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId,
+        cwd: testDir,
+        workflow,
+        workflowRun,
+      })
+    );
     return mockDeps;
   }
 
@@ -26637,23 +24398,16 @@ describe('executeDagWorkflow -- flattened include expansion', () => {
     output: string | undefined;
   }> {
     const mockDeps = createMockDeps();
-    const output = await executeDagWorkflow({
-      deps: mockDeps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-inc',
-      cwd: testDir,
-      workflow: { name: 'gated-parent', nodes },
-      workflowRun: makeWorkflowRun(runId, { workflow_name: 'gated-parent' }),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+    const output = await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        conversationId: 'conv-inc',
+        cwd: testDir,
+        workflow: { name: 'gated-parent', nodes },
+        workflowRun: makeWorkflowRun(runId, { workflow_name: 'gated-parent' }),
+        priorCompletedNodes,
+      })
+    );
     return { events: eventList(mockDeps), output };
   }
 
@@ -26860,22 +24614,16 @@ describe('executeDagWorkflow -- flattened include expansion', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun('inc-run-id', { workflow_name: 'inc-parent' });
 
-    const terminalOutput = await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-inc',
-      cwd: testDir,
-      workflow: { name: 'inc-parent', nodes: expandedParentNodes() },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    const terminalOutput = await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-inc',
+        cwd: testDir,
+        workflow: { name: 'inc-parent', nodes: expandedParentNodes() },
+        workflowRun,
+      })
+    );
 
     const events = eventList(mockDeps);
     const completedStepNames = events
@@ -26901,23 +24649,17 @@ describe('executeDagWorkflow -- flattened include expansion', () => {
     // Prior run completed the namespaced entry node inc__a.
     const prior = new Map([['inc__a', { output: 'AAA' }]]);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-inc',
-      cwd: testDir,
-      workflow: { name: 'inc-parent', nodes: expandedParentNodes() },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes: prior,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-inc',
+        cwd: testDir,
+        workflow: { name: 'inc-parent', nodes: expandedParentNodes() },
+        workflowRun,
+        priorCompletedNodes: prior,
+      })
+    );
 
     const events = eventList(mockDeps);
     // inc__a skipped as prior-success (its namespaced id matched the persisted map).
@@ -26938,23 +24680,17 @@ describe('executeDagWorkflow -- flattened include expansion', () => {
 
     const prior = new Map([['inc__a', { output: 'AAA' }]]);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-inc',
-      cwd: testDir,
-      workflow: { name: 'inc-parent', nodes: expandedParentNodes(true) },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes: prior,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-inc',
+        cwd: testDir,
+        workflow: { name: 'inc-parent', nodes: expandedParentNodes(true) },
+        workflowRun,
+        priorCompletedNodes: prior,
+      })
+    );
 
     const events = eventList(mockDeps);
     // always_run survived inlining: inc__a is force-reset (re-executed), not skipped.
@@ -27009,23 +24745,17 @@ describe('executeDagWorkflow -- unexpanded include node fail-fast guard', () => 
     const includeNode = dagNodeSchema.parse({ id: 'inc', include: 'some-block' }) as DagNode;
     const prior = new Map([['inc', { output: 'stale prior output' }]]);
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-inc-guard',
-      cwd: testDir,
-      workflow: { name: 'inc-guard', nodes: [includeNode] },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes: prior,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-inc-guard',
+        cwd: testDir,
+        workflow: { name: 'inc-guard', nodes: [includeNode] },
+        workflowRun,
+        priorCompletedNodes: prior,
+      })
+    );
 
     const evs = events(mockDeps);
     const failed = evs.find(e => e.event_type === 'node_failed' && e.step_name === 'inc');
@@ -27052,24 +24782,18 @@ describe('executeDagWorkflow -- unexpanded include node fail-fast guard', () => 
       }),
     ];
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-inc-guard',
-      cwd: testDir,
-      // Deliberately includes an unexpanded include directive — the test exercises the
-      // `when:` guard firing BEFORE the executor would ever need to resolve it.
-      workflow: { name: 'inc-guard', nodes: nodes as DagNode[] },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-inc-guard',
+        cwd: testDir,
+        // Deliberately includes an unexpanded include directive — the test exercises the
+        // `when:` guard firing BEFORE the executor would ever need to resolve it.
+        workflow: { name: 'inc-guard', nodes: nodes as DagNode[] },
+        workflowRun,
+      })
+    );
 
     const evs = events(mockDeps);
     const failed = evs.find(e => e.event_type === 'node_failed' && e.step_name === 'inc');
@@ -27142,22 +24866,16 @@ describe('executeDagWorkflow -- approval node inside an included block', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun('inc-approval-run', { workflow_name: 'apparent' });
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-inc-approval',
-      cwd: testDir,
-      workflow: { name: 'apparent', nodes: expanded.nodes as DagNode[] },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-inc-approval',
+        cwd: testDir,
+        workflow: { name: 'apparent', nodes: expanded.nodes as DagNode[] },
+        workflowRun,
+      })
+    );
 
     const pauseCalls = (store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>).mock
       .calls;
@@ -27376,38 +25094,34 @@ describe('subprocess credential redaction', () => {
     );
 
     try {
-      await executeDagWorkflow({
-        deps: createMockDeps(store),
-        platform,
-        conversationId: workflowRun.conversation_id,
-        cwd: testDir,
-        workflow: {
-          name: workflowRun.workflow_name,
-          nodes: [{ id: 'fail', kind: 'exec', runtime: 'sh', script: 'exit 1' }],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir,
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: {
-          ...minimalConfig,
-          // Secret-suffixed keys redact automatically; BASE_BRANCH is the visible control.
-          envVars: {
-            OPENAI_API_KEY: openAiSecret,
-            CUSTOM_AUTH: otherInjectedSecret,
-            PROJECT_SECRET: projectSecret,
-            DATABASE_URL: databaseUrl,
-            BASE_BRANCH: 'main',
+      await executeDagWorkflow(
+        dagOptions({
+          deps: createMockDeps(store),
+          platform,
+          conversationId: workflowRun.conversation_id,
+          cwd: testDir,
+          workflow: {
+            name: workflowRun.workflow_name,
+            nodes: [{ id: 'fail', kind: 'exec', runtime: 'sh', script: 'exit 1' }],
           },
-          protectedEnvKeys: ['OPENAI_API_KEY', 'CUSTOM_AUTH', 'DATABASE_URL'],
-          protectedCredentialValues: [fileDeliveredSecret],
-        },
-        execContext,
-      });
+          workflowRun,
+          logDir,
+          config: {
+            ...minimalConfig,
+            // Secret-suffixed keys redact automatically; BASE_BRANCH is the visible control.
+            envVars: {
+              OPENAI_API_KEY: openAiSecret,
+              CUSTOM_AUTH: otherInjectedSecret,
+              PROJECT_SECRET: projectSecret,
+              DATABASE_URL: databaseUrl,
+              BASE_BRANCH: 'main',
+            },
+            protectedEnvKeys: ['OPENAI_API_KEY', 'CUSTOM_AUTH', 'DATABASE_URL'],
+            protectedCredentialValues: [fileDeliveredSecret],
+          },
+          execContext,
+        })
+      );
 
       expect(execSpy).toHaveBeenCalledTimes(1);
       const dockerArgs = execSpy.mock.calls[0]?.[1] as string[];
@@ -27496,30 +25210,28 @@ describe('subprocess credential redaction', () => {
     );
 
     try {
-      await executeDagWorkflow({
-        deps: createMockDeps(store),
-        platform,
-        conversationId: workflowRun.conversation_id,
-        cwd: testDir,
-        workflow: {
-          name: workflowRun.workflow_name,
-          nodes: [{ id: 'fail', kind: 'exec', runtime: 'sh', script: 'exit 1' }],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'host-artifacts'),
-        stateDir: join(testDir, 'host-state'),
-        logDir,
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: {
-          ...minimalConfig,
-          envVars: { CODEX_HOME: '/run/codex-home', BASE_BRANCH: 'main' },
-          protectedEnvKeys: ['CODEX_HOME'],
-          protectedCredentialValues: [protectedSecret],
-        },
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: createMockDeps(store),
+          platform,
+          conversationId: workflowRun.conversation_id,
+          cwd: testDir,
+          workflow: {
+            name: workflowRun.workflow_name,
+            nodes: [{ id: 'fail', kind: 'exec', runtime: 'sh', script: 'exit 1' }],
+          },
+          workflowRun,
+          artifactsDir: join(testDir, 'host-artifacts'),
+          stateDir: join(testDir, 'host-state'),
+          logDir,
+          config: {
+            ...minimalConfig,
+            envVars: { CODEX_HOME: '/run/codex-home', BASE_BRANCH: 'main' },
+            protectedEnvKeys: ['CODEX_HOME'],
+            protectedCredentialValues: [protectedSecret],
+          },
+        })
+      );
 
       expect(execSpy).toHaveBeenCalledTimes(1);
       expect(execSpy.mock.calls[0]?.[0]).not.toBe('docker');
@@ -27573,41 +25285,38 @@ describe('subprocess credential redaction', () => {
     });
     const store = createMockStore();
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: workflowRun.conversation_id,
-      cwd: testDir,
-      workflow: {
-        name: workflowRun.workflow_name,
-        nodes: [
-          {
-            id: 'leaky',
-            kind: 'exec',
-            runtime: 'sh',
-            // Real subprocess, both streams, exit 0.
-            script: 'printf "%s\\n" "$OPENAI_API_KEY"; printf "%s\\n" "$SIDECAR_AUTH" >&2',
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'success-redaction-artifacts'),
-      stateDir: join(testDir, 'success-redaction-state'),
-      logDir,
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: {
-        ...minimalConfig,
-        envVars: {
-          OPENAI_API_KEY: suffixNamedSecret,
-          SIDECAR_AUTH: explicitlyProtectedSecret,
-          BASE_BRANCH: 'main',
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: workflowRun.conversation_id,
+        cwd: testDir,
+        workflow: {
+          name: workflowRun.workflow_name,
+          nodes: [
+            {
+              id: 'leaky',
+              kind: 'exec',
+              runtime: 'sh',
+              // Real subprocess, both streams, exit 0.
+              script: 'printf "%s\\n" "$OPENAI_API_KEY"; printf "%s\\n" "$SIDECAR_AUTH" >&2',
+            },
+          ],
         },
-        protectedCredentialValues: [explicitlyProtectedSecret],
-      },
-    });
+        workflowRun,
+        artifactsDir: join(testDir, 'success-redaction-artifacts'),
+        stateDir: join(testDir, 'success-redaction-state'),
+        logDir,
+        config: {
+          ...minimalConfig,
+          envVars: {
+            OPENAI_API_KEY: suffixNamedSecret,
+            SIDECAR_AUTH: explicitlyProtectedSecret,
+            BASE_BRANCH: 'main',
+          },
+          protectedCredentialValues: [explicitlyProtectedSecret],
+        },
+      })
+    );
 
     const transcriptText = await readFile(join(logDir, `${workflowRun.id}.jsonl`), 'utf-8');
     expect(transcriptText).not.toContain(suffixNamedSecret);
@@ -27654,22 +25363,18 @@ describe('retained exec output', () => {
     const logDir = join(testDir, `${runId}-logs`);
     const store = createMockStore();
     const workflowRun = makeWorkflowRun(runId);
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-retained',
-      cwd: testDir,
-      workflow: { name: runId, nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, `${runId}-artifacts`),
-      stateDir: join(testDir, `${runId}-state`),
-      logDir,
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-retained',
+        cwd: testDir,
+        workflow: { name: runId, nodes },
+        workflowRun,
+        artifactsDir: join(testDir, `${runId}-artifacts`),
+        stateDir: join(testDir, `${runId}-state`),
+        logDir,
+      })
+    );
     return { logDir, rows: await readTranscript(logDir, workflowRun.id), store };
   };
 
@@ -27787,37 +25492,33 @@ describe('retained exec output', () => {
     });
     const workflowRun = makeWorkflowRun('retain-until-bash');
 
-    await executeDagWorkflow({
-      deps: createMockDeps(),
-      platform: createMockPlatform(),
-      conversationId: 'conv-retained-probe',
-      cwd: testDir,
-      workflow: {
-        name: 'retain-until-bash',
-        nodes: [
-          {
-            id: 'poll',
-            kind: 'loop',
-            loop: {
-              fresh_context: false,
-              prompt: 'Keep working.',
-              max_iterations: 2,
-              // Iteration 1 prints and exits 1 (keep looping); iteration 2 exits 0.
-              until_bash: `printf 'x' >> ${JSON.stringify(counterPath)}; printf 'checked\\n'; printf 'not ready\\n' >&2; test "$(wc -c < ${JSON.stringify(counterPath)} | tr -d ' ')" -ge 2`,
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(),
+        conversationId: 'conv-retained-probe',
+        cwd: testDir,
+        workflow: {
+          name: 'retain-until-bash',
+          nodes: [
+            {
+              id: 'poll',
+              kind: 'loop',
+              loop: {
+                fresh_context: false,
+                prompt: 'Keep working.',
+                max_iterations: 2,
+                // Iteration 1 prints and exits 1 (keep looping); iteration 2 exits 0.
+                until_bash: `printf 'x' >> ${JSON.stringify(counterPath)}; printf 'checked\\n'; printf 'not ready\\n' >&2; test "$(wc -c < ${JSON.stringify(counterPath)} | tr -d ' ')" -ge 2`,
+              },
             },
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'until-bash-artifacts'),
-      stateDir: join(testDir, 'until-bash-state'),
-      logDir,
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+          ],
+        },
+        workflowRun,
+        artifactsDir: join(testDir, 'until-bash-artifacts'),
+        stateDir: join(testDir, 'until-bash-state'),
+        logDir,
+      })
+    );
 
     const rows = await readTranscript(logDir, workflowRun.id);
     const probeRows = rows.filter(candidate => candidate.type === 'exec_output');
@@ -27863,39 +25564,41 @@ describe('retained exec output', () => {
     const counterPath = join(testDir, 'group-iterations');
     const workflowRun = makeWorkflowRun('retain-group-probe');
 
-    await executeDagWorkflow({
-      deps: createMockDeps(),
-      platform: createMockPlatform(),
-      conversationId: 'conv-group-probe',
-      cwd: testDir,
-      workflow: {
-        name: 'retain-group-probe',
-        nodes: [
-          {
-            id: 'group',
-            kind: 'loop_group',
-            loop_group: {
-              max_iterations: 2,
-              fresh_context: false,
-              until_bash: `printf 'x' >> ${JSON.stringify(counterPath)}; printf 'probe spoke\\n'; test "$(wc -c < ${JSON.stringify(counterPath)} | tr -d ' ')" -ge 2`,
-              nodes: [
-                { id: 'body', kind: 'exec', runtime: 'sh', script: 'printf body', depends_on: [] },
-              ],
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(),
+        conversationId: 'conv-group-probe',
+        cwd: testDir,
+        workflow: {
+          name: 'retain-group-probe',
+          nodes: [
+            {
+              id: 'group',
+              kind: 'loop_group',
+              loop_group: {
+                max_iterations: 2,
+                fresh_context: false,
+                until_bash: `printf 'x' >> ${JSON.stringify(counterPath)}; printf 'probe spoke\\n'; test "$(wc -c < ${JSON.stringify(counterPath)} | tr -d ' ')" -ge 2`,
+                nodes: [
+                  {
+                    id: 'body',
+                    kind: 'exec',
+                    runtime: 'sh',
+                    script: 'printf body',
+                    depends_on: [],
+                  },
+                ],
+              },
+              depends_on: [],
             },
-            depends_on: [],
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'group-probe-artifacts'),
-      stateDir: join(testDir, 'group-probe-state'),
-      logDir,
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+          ],
+        },
+        workflowRun,
+        artifactsDir: join(testDir, 'group-probe-artifacts'),
+        stateDir: join(testDir, 'group-probe-state'),
+        logDir,
+      })
+    );
 
     const rows = await readTranscript(logDir, workflowRun.id);
     const probeRows = rows.filter(
@@ -27977,32 +25680,25 @@ describe('executeDagWorkflow -- container write-back gate', () => {
     );
     store.claimWriteback = mock(() => Promise.resolve({ claimed: opts.claimed ?? true }));
     const deps = createMockDeps(store);
-    await executeDagWorkflow({
-      deps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-wb',
-      cwd: wbTestDir,
-      workflow: {
-        name: 'wb',
-        nodes: [{ id: 'a', kind: 'exec', runtime: 'sh', script: 'echo hi' }],
-      },
-      workflowRun: makeWorkflowRun('wb-run'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(wbTestDir, 'artifacts'),
-      stateDir: join(wbTestDir, 'state'),
-      logDir: join(wbTestDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes: new Map([['a', { output: 'out' }]]),
-      execContext: CONTAINER_EXEC,
-      containerCtx: {
-        envId: 'env-x',
-        writeBack: opts.writeBack ?? 'approve',
-        backend: opts.backend,
-      },
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps,
+        conversationId: 'conv-wb',
+        cwd: wbTestDir,
+        workflow: {
+          name: 'wb',
+          nodes: [{ id: 'a', kind: 'exec', runtime: 'sh', script: 'echo hi' }],
+        },
+        workflowRun: makeWorkflowRun('wb-run'),
+        priorCompletedNodes: new Map([['a', { output: 'out' }]]),
+        execContext: CONTAINER_EXEC,
+        containerCtx: {
+          envId: 'env-x',
+          writeBack: opts.writeBack ?? 'approve',
+          backend: opts.backend,
+        },
+      })
+    );
     return store;
   }
 
@@ -28162,28 +25858,21 @@ describe('executeDagWorkflow -- container write-back gate', () => {
     );
     store.claimWriteback = mock(() => Promise.resolve({ claimed: true }));
     try {
-      await executeDagWorkflow({
-        deps: createMockDeps(store),
-        platform: createMockPlatform(),
-        conversationId: 'conv-wb',
-        cwd: wbTestDir,
-        workflow: {
-          name: 'wb',
-          nodes: [{ id: 'a', kind: 'exec', runtime: 'sh', script: 'echo hi' }],
-        },
-        workflowRun: makeWorkflowRun('wb-run'),
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(wbTestDir, 'artifacts'),
-        stateDir: join(wbTestDir, 'state'),
-        logDir: join(wbTestDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-        priorCompletedNodes: new Map([['a', { output: 'out' }]]),
-        execContext: CONTAINER_EXEC,
-        containerCtx: { envId: 'env-x', writeBack: 'approve', backend },
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: createMockDeps(store),
+          conversationId: 'conv-wb',
+          cwd: wbTestDir,
+          workflow: {
+            name: 'wb',
+            nodes: [{ id: 'a', kind: 'exec', runtime: 'sh', script: 'echo hi' }],
+          },
+          workflowRun: makeWorkflowRun('wb-run'),
+          priorCompletedNodes: new Map([['a', { output: 'out' }]]),
+          execContext: CONTAINER_EXEC,
+          containerCtx: { envId: 'env-x', writeBack: 'approve', backend },
+        })
+      );
     } catch {
       threw = true;
     }
@@ -28225,28 +25914,21 @@ describe('executeDagWorkflow -- container write-back gate', () => {
     backend: ReturnType<typeof makeWritebackBackend>,
     writeBack: 'approve' | 'auto'
   ): Promise<void> {
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-wb',
-      cwd: wbTestDir,
-      workflow: {
-        name: 'wb',
-        nodes: [{ id: 'a', kind: 'exec', runtime: 'sh', script: 'echo hi' }],
-      },
-      workflowRun: makeWorkflowRun('wb-run'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(wbTestDir, 'artifacts'),
-      stateDir: join(wbTestDir, 'state'),
-      logDir: join(wbTestDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes: new Map([['a', { output: 'out' }]]),
-      execContext: CONTAINER_EXEC,
-      containerCtx: { envId: 'env-x', writeBack, backend },
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-wb',
+        cwd: wbTestDir,
+        workflow: {
+          name: 'wb',
+          nodes: [{ id: 'a', kind: 'exec', runtime: 'sh', script: 'echo hi' }],
+        },
+        workflowRun: makeWorkflowRun('wb-run'),
+        priorCompletedNodes: new Map([['a', { output: 'out' }]]),
+        execContext: CONTAINER_EXEC,
+        containerCtx: { envId: 'env-x', writeBack, backend },
+      })
+    );
   }
 
   // N1/item-2 — an apply-throw in APPROVE mode leaves the run with pending_writeback set
@@ -28439,34 +26121,28 @@ describe('executeDagWorkflow -- gate pause vs external transition (#1123)', () =
     });
 
     try {
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-pause-race',
-        cwd: testDir,
-        workflow: {
-          name: 'pause-race-approval',
-          nodes: [
-            {
-              id: 'review',
-              kind: 'gate',
-              message: 'Approve this plan?',
-              decisions: [{ id: 'approve' }, { id: 'reject' }],
-              captureResponse: false,
-              decisionsAuthored: false,
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          conversationId: 'conv-pause-race',
+          cwd: testDir,
+          workflow: {
+            name: 'pause-race-approval',
+            nodes: [
+              {
+                id: 'review',
+                kind: 'gate',
+                message: 'Approve this plan?',
+                decisions: [{ id: 'approve' }, { id: 'reject' }],
+                captureResponse: false,
+                decisionsAuthored: false,
+              },
+            ],
+          },
+          workflowRun,
+        })
+      );
     } finally {
       unsubscribe();
     }
@@ -28501,38 +26177,32 @@ describe('executeDagWorkflow -- gate pause vs external transition (#1123)', () =
     });
 
     try {
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-pause-race-loop',
-        cwd: testDir,
-        workflow: {
-          name: 'pause-race-loop',
-          nodes: [
-            {
-              id: 'refine',
-              kind: 'loop',
-              loop: {
-                fresh_context: false,
-                prompt: 'User said: $LOOP_USER_INPUT. Refine the plan.',
-                until: 'APPROVED',
-                max_iterations: 10,
-                interactive: true,
-                gate_message: 'Review the plan and provide feedback.',
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          conversationId: 'conv-pause-race-loop',
+          cwd: testDir,
+          workflow: {
+            name: 'pause-race-loop',
+            nodes: [
+              {
+                id: 'refine',
+                kind: 'loop',
+                loop: {
+                  fresh_context: false,
+                  prompt: 'User said: $LOOP_USER_INPUT. Refine the plan.',
+                  until: 'APPROVED',
+                  max_iterations: 10,
+                  interactive: true,
+                  gate_message: 'Review the plan and provide feedback.',
+                },
               },
-            },
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+            ],
+          },
+          workflowRun,
+        })
+      );
     } finally {
       unsubscribe();
     }
@@ -28573,30 +26243,24 @@ describe('executeDagWorkflow -- gate pause vs external transition (#1123)', () =
     });
 
     try {
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-pause-race-child',
-        cwd: testDir,
-        workflow: {
-          name: 'pause-race-child',
-          nodes: [{ id: 'sub', kind: 'workflow', workflow: 'child-wf' } as DagNode],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-        runChildWorkflow: async () => {
-          throw new Error(
-            'runChildWorkflow should not be called — an existing paused child was found'
-          );
-        },
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          conversationId: 'conv-pause-race-child',
+          cwd: testDir,
+          workflow: {
+            name: 'pause-race-child',
+            nodes: [{ id: 'sub', kind: 'workflow', workflow: 'child-wf' } as DagNode],
+          },
+          workflowRun,
+          runChildWorkflow: async () => {
+            throw new Error(
+              'runChildWorkflow should not be called — an existing paused child was found'
+            );
+          },
+        })
+      );
     } finally {
       unsubscribe();
     }
@@ -28641,35 +26305,29 @@ describe('executeDagWorkflow -- gate pause vs external transition (#1123)', () =
       const mockDeps = createMockDeps(store);
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
-      await executeDagWorkflow({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-subrun-contract',
-        cwd: testDir,
-        workflow: {
-          name: 'subrun-contract',
-          nodes: [
-            {
-              id: 'sub',
-              kind: 'workflow',
-              workflow: 'child-wf',
-              ...(outputFormat !== undefined ? { output_format: outputFormat } : {}),
-            } as unknown as DagNode,
-          ],
-        },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-        runChildWorkflow: async () => {
-          throw new Error('runChildWorkflow should not be called — a completed child exists');
-        },
-      });
+      await executeDagWorkflow(
+        dagOptions({
+          deps: mockDeps,
+          platform,
+          conversationId: 'conv-subrun-contract',
+          cwd: testDir,
+          workflow: {
+            name: 'subrun-contract',
+            nodes: [
+              {
+                id: 'sub',
+                kind: 'workflow',
+                workflow: 'child-wf',
+                ...(outputFormat !== undefined ? { output_format: outputFormat } : {}),
+              } as unknown as DagNode,
+            ],
+          },
+          workflowRun,
+          runChildWorkflow: async () => {
+            throw new Error('runChildWorkflow should not be called — a completed child exists');
+          },
+        })
+      );
       return platform;
     };
 
@@ -28790,34 +26448,28 @@ describe('executeDagWorkflow -- gate pause vs external transition (#1123)', () =
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-pause-genuine-failure',
-      cwd: testDir,
-      workflow: {
-        name: 'pause-genuine-failure',
-        nodes: [
-          {
-            id: 'review',
-            kind: 'gate',
-            message: 'Approve this plan?',
-            decisions: [{ id: 'approve' }, { id: 'reject' }],
-            captureResponse: false,
-            decisionsAuthored: false,
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-pause-genuine-failure',
+        cwd: testDir,
+        workflow: {
+          name: 'pause-genuine-failure',
+          nodes: [
+            {
+              id: 'review',
+              kind: 'gate',
+              message: 'Approve this plan?',
+              decisions: [{ id: 'approve' }, { id: 'reject' }],
+              captureResponse: false,
+              decisionsAuthored: false,
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     const events = (
       store.createWorkflowEvent as Mock<IWorkflowStore['createWorkflowEvent']>
@@ -28954,24 +26606,20 @@ describe('executeDagWorkflow -- a workflow runs as authored, standalone or compo
       loadConfig: mock<WorkflowDeps['loadConfig']>(async _cwd => collapseConfig),
     };
 
-    await executeDagWorkflow({
-      deps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-collapse',
-      cwd: testDir,
-      workflow: ready(workflow),
-      workflowRun: makeWorkflowRun(`collapse-${runName}`, { workflow_name: runName }),
-      workflowProvider,
-      workflowModel,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: collapseConfig,
-      aiProfile,
-      workflowPreset,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps,
+        conversationId: 'conv-collapse',
+        cwd: testDir,
+        workflow: ready(workflow),
+        workflowRun: makeWorkflowRun(`collapse-${runName}`, { workflow_name: runName }),
+        workflowProvider,
+        workflowModel,
+        config: collapseConfig,
+        aiProfile,
+        workflowPreset,
+      })
+    );
 
     const result = new Map<string, EffectiveConfig>();
     for (const { provider, options: queryOptions } of seen) {
@@ -29204,22 +26852,14 @@ describe('executeDagWorkflow -- composed-workflow run-time boundaries', () => {
   ): Promise<void> {
     const { workflows, errors } = expandWorkflowIncludes(new Map(defs.map(d => [d.name, d])));
     expect(errors).toEqual([]);
-    await executeDagWorkflow({
-      deps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: ready(workflows.get(runName)!),
-      workflowRun: makeWorkflowRun(`comp-${runName}`, { workflow_name: runName }),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps,
+        cwd: testDir,
+        workflow: ready(workflows.get(runName)!),
+        workflowRun: makeWorkflowRun(`comp-${runName}`, { workflow_name: runName }),
+      })
+    );
   }
 
   it('AC7 — a composed block entry starts a fresh session even after a same-provider node', async () => {
@@ -29347,28 +26987,21 @@ describe('executeDagWorkflow -- composed-workflow run-time boundaries', () => {
       ])
     );
     expect(errors).toEqual([]);
-    await executeDagWorkflow({
-      deps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: ready(workflows.get('env-parent')!),
-      workflowRun: makeWorkflowRun('comp-env', {
-        workflow_name: 'env-parent',
-        user_message: 'real-args',
-      }),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: {
-        ...minimalConfig,
-        envVars: { INPUTS_PLAN: 'from-project-env', ARGUMENTS: 'hijacked' },
-      },
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps,
+        cwd: testDir,
+        workflow: ready(workflows.get('env-parent')!),
+        workflowRun: makeWorkflowRun('comp-env', {
+          workflow_name: 'env-parent',
+          user_message: 'real-args',
+        }),
+        config: {
+          ...minimalConfig,
+          envVars: { INPUTS_PLAN: 'from-project-env', ARGUMENTS: 'hijacked' },
+        },
+      })
+    );
 
     const output = nodeOutputOf(store, 'inc__run');
     expect(output).toBe('from-with|real-args');
@@ -29423,22 +27056,14 @@ describe('executeDagWorkflow -- systemPrompt and agents are runtime substitution
     nodes: unknown[],
     run = makeWorkflowRun('aicfg-run')
   ): Promise<SendQueryOptions[]> {
-    await executeDagWorkflow({
-      deps: createMockDeps(),
-      platform: createMockPlatform(),
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: { name: 'aicfg', nodes: nodes.map(n => dagNodeSchema.parse(n) as DagNode) },
-      workflowRun: run,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(),
+        cwd: testDir,
+        workflow: { name: 'aicfg', nodes: nodes.map(n => dagNodeSchema.parse(n) as DagNode) },
+        workflowRun: run,
+      })
+    );
     return mockSendQueryDag.mock.calls.map(call => {
       const options = call[3];
       if (!options) throw new Error('Expected provider query options');
@@ -29476,22 +27101,14 @@ describe('executeDagWorkflow -- systemPrompt and agents are runtime substitution
       prompt: 'go',
       systemPrompt: 'dir=$ARTIFACTS_DIR',
     }) as DagNode;
-    await executeDagWorkflow({
-      deps: createMockDeps(),
-      platform: createMockPlatform(),
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: { name: 'aicfg2', nodes: [definition] },
-      workflowRun: makeWorkflowRun('aicfg-run-2'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(),
+        cwd: testDir,
+        workflow: { name: 'aicfg2', nodes: [definition] },
+        workflowRun: makeWorkflowRun('aicfg-run-2'),
+      })
+    );
     expect(definition.systemPrompt).toBe('dir=$ARTIFACTS_DIR');
   });
 
@@ -29524,22 +27141,14 @@ describe('executeDagWorkflow -- systemPrompt and agents are runtime substitution
       ])
     );
     expect(errors).toEqual([]);
-    await executeDagWorkflow({
-      deps: createMockDeps(),
-      platform: createMockPlatform(),
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: ready(workflows.get('sp-parent')!),
-      workflowRun: makeWorkflowRun('sp-composed'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(),
+        cwd: testDir,
+        workflow: ready(workflows.get('sp-parent')!),
+        workflowRun: makeWorkflowRun('sp-composed'),
+      })
+    );
     expect(mockSendQueryDag.mock.calls.at(-1)?.[3]?.systemPrompt).toBe('mode=strict');
   });
 });
@@ -29629,23 +27238,16 @@ describe('executeDagWorkflow -- composition governance survives the collapse', (
       loadConfig: mock<WorkflowDeps['loadConfig']>(async _cwd => minimalConfig),
     };
 
-    await executeDagWorkflow({
-      deps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-gov',
-      cwd: testDir,
-      workflow: ready(workflows.get('resume-parent')!),
-      workflowRun: makeWorkflowRun('gov-resume', { workflow_name: 'resume-parent' }),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes: prior,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps,
+        conversationId: 'conv-gov',
+        cwd: testDir,
+        workflow: ready(workflows.get('resume-parent')!),
+        workflowRun: makeWorkflowRun('gov-resume', { workflow_name: 'resume-parent' }),
+        priorCompletedNodes: prior,
+      })
+    );
 
     const events = store.createWorkflowEvent.mock.calls.map(call => call[0]);
     expect(
@@ -29683,22 +27285,15 @@ describe('executeDagWorkflow -- composition governance survives the collapse', (
 
     const store = createMockStore();
     const runId = 'gov-gate-run';
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-gov',
-      cwd: testDir,
-      workflow: ready(workflows.get('gate-parent')!),
-      workflowRun: makeWorkflowRun(runId, { workflow_name: 'gate-parent' }),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-gov',
+        cwd: testDir,
+        workflow: ready(workflows.get('gate-parent')!),
+        workflowRun: makeWorkflowRun(runId, { workflow_name: 'gate-parent' }),
+      })
+    );
 
     const pauseCalls = store.pauseWorkflowRun.mock.calls;
     expect(pauseCalls.length).toBe(1);
@@ -29762,25 +27357,19 @@ describe('executeDagWorkflow -- a workflow-level provider/model conflict is repo
     expect(errors).toEqual([]);
 
     const platform = createMockPlatform();
-    await executeDagWorkflow({
-      deps: createMockDeps(),
-      platform,
-      conversationId: 'conv-conflict',
-      cwd: testDir,
-      workflow: ready(workflows.get('conflict')!),
-      workflowRun: makeWorkflowRun('conflict-run', { workflow_name: 'conflict' }),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      aiProfile: buildAiProfile('claude', {
-        repoTiers: { large: { provider: 'codex', model: 'gpt-5.6-sol' } },
-      }),
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(),
+        platform,
+        conversationId: 'conv-conflict',
+        cwd: testDir,
+        workflow: ready(workflows.get('conflict')!),
+        workflowRun: makeWorkflowRun('conflict-run', { workflow_name: 'conflict' }),
+        aiProfile: buildAiProfile('claude', {
+          repoTiers: { large: { provider: 'codex', model: 'gpt-5.6-sol' } },
+        }),
+      })
+    );
 
     const conflictMessages = platform.sendMessage.mock.calls
       .map(c => c[1])
@@ -30063,25 +27652,18 @@ describe('TokenUsage axis seam guard', () => {
     const store = createMockStore();
     const logDir = join(testDir, 'logs');
     const workflowRun = makeWorkflowRun(`axis-seam-run-${outcome}`);
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: {
-        name: 'axis-seam',
-        nodes: [{ id: 'step', kind: 'agent', source: { kind: 'inline', prompt: 'Do thing.' } }],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir,
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        cwd: testDir,
+        workflow: {
+          name: 'axis-seam',
+          nodes: [{ id: 'step', kind: 'agent', source: { kind: 'inline', prompt: 'Do thing.' } }],
+        },
+        workflowRun,
+        logDir,
+      })
+    );
     return { store, runId: workflowRun.id, logDir };
   }
 
@@ -30194,22 +27776,14 @@ describe('TokenUsage axis seam guard', () => {
       },
     ];
     const pausingDeps = createMockDeps();
-    await executeDagWorkflow({
-      deps: pausingDeps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: { name: 'axis-loop-pause', nodes: loopNodes },
-      workflowRun: makeWorkflowRun('axis-loop-pause-run'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: pausingDeps,
+        cwd: testDir,
+        workflow: { name: 'axis-loop-pause', nodes: loopNodes },
+        workflowRun: makeWorkflowRun('axis-loop-pause-run'),
+      })
+    );
     const pauseCalls = (
       pausingDeps.store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>
     ).mock.calls;
@@ -30228,37 +27802,29 @@ describe('TokenUsage axis seam guard', () => {
       yield { type: 'result', sessionId: 'never' };
     });
     const resumingDeps = createMockDeps();
-    await executeDagWorkflow({
-      deps: resumingDeps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: { name: 'axis-loop-resume', nodes: loopNodes },
-      workflowRun: makeWorkflowRun('axis-loop-resume-run', {
-        metadata: {
-          approval: {
-            type: 'interactive_loop',
-            nodeId: 'refine',
-            iteration: 1,
-            sessionId: 'axis-loop-sid',
-            message: 'gate',
-            completionSignaled: true,
-            signaledOutput: 'REPORT',
-            signaledTokens,
+    await executeDagWorkflow(
+      dagOptions({
+        deps: resumingDeps,
+        cwd: testDir,
+        workflow: { name: 'axis-loop-resume', nodes: loopNodes },
+        workflowRun: makeWorkflowRun('axis-loop-resume-run', {
+          metadata: {
+            approval: {
+              type: 'interactive_loop',
+              nodeId: 'refine',
+              iteration: 1,
+              sessionId: 'axis-loop-sid',
+              message: 'gate',
+              completionSignaled: true,
+              signaledOutput: 'REPORT',
+              signaledTokens,
+            },
+            loop_user_input: 'Approved',
+            loop_feedback_given: false,
           },
-          loop_user_input: 'Approved',
-          loop_feedback_given: false,
-        },
-      }),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+        }),
+      })
+    );
     expect(mockSendQueryDag.mock.calls.length).toBe(0);
     expectSeamCarriesAxes(
       'loop gate (read)',
@@ -30335,23 +27901,16 @@ describe('value transport (#2637): persistence, resume, and node-local bindings'
     workflowRunOverrides?: Partial<WorkflowRun>
   ): Promise<{ events: PersistedEvent[]; store: MockWorkflowStore }> {
     const store = createMockStore();
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-2637',
-      cwd: testDir,
-      workflow: ready(workflow),
-      workflowRun: makeWorkflowRun(runId, workflowRunOverrides),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-2637',
+        cwd: testDir,
+        workflow: ready(workflow),
+        workflowRun: makeWorkflowRun(runId, workflowRunOverrides),
+        priorCompletedNodes,
+      })
+    );
     const events = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls.map(
       (call: unknown[]) => call[0] as PersistedEvent
     );
@@ -30846,22 +28405,15 @@ describe('value transport (#2637): persistence, resume, and node-local bindings'
       }),
     ];
 
-    const result = await executeDagWorkflow({
-      deps: createMockDeps(),
-      platform: createMockPlatform(),
-      conversationId: 'conv-lg-binding',
-      cwd: testDir,
-      workflow: { name: 'lg-binding-completed', nodes: nodes as DagNode[] },
-      workflowRun: makeWorkflowRun('lg-binding-completed'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    const result = await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(),
+        conversationId: 'conv-lg-binding',
+        cwd: testDir,
+        workflow: { name: 'lg-binding-completed', nodes: nodes as DagNode[] },
+        workflowRun: makeWorkflowRun('lg-binding-completed'),
+      })
+    );
 
     // The group's real whole-ref output resolved — the `if_skipped` default never fired.
     expect(result).toBe('CORRECTIONS_APPLIED');
@@ -30893,22 +28445,15 @@ describe('value transport (#2637): persistence, resume, and node-local bindings'
       }),
     ];
 
-    const result = await executeDagWorkflow({
-      deps: createMockDeps(),
-      platform: createMockPlatform(),
-      conversationId: 'conv-lg-binding',
-      cwd: testDir,
-      workflow: { name: 'lg-binding-skipped', nodes: nodes as DagNode[] },
-      workflowRun: makeWorkflowRun('lg-binding-skipped'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    const result = await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(),
+        conversationId: 'conv-lg-binding',
+        cwd: testDir,
+        workflow: { name: 'lg-binding-skipped', nodes: nodes as DagNode[] },
+        workflowRun: makeWorkflowRun('lg-binding-skipped'),
+      })
+    );
 
     // The group never ran — the binding took its declared default, unchanged by #2696.
     expect(result).toBe('NO_CORRECTIONS_RAN');
@@ -30948,22 +28493,16 @@ describe('value transport (#2637): persistence, resume, and node-local bindings'
     ];
 
     const platform = createMockPlatform();
-    await executeDagWorkflow({
-      deps: createMockDeps(),
-      platform,
-      conversationId: 'conv-lg-binding',
-      cwd: testDir,
-      workflow: { name: 'lg-binding-failed', nodes: nodes as DagNode[] },
-      workflowRun: makeWorkflowRun('lg-binding-failed'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(),
+        platform,
+        conversationId: 'conv-lg-binding',
+        cwd: testDir,
+        workflow: { name: 'lg-binding-failed', nodes: nodes as DagNode[] },
+        workflowRun: makeWorkflowRun('lg-binding-failed'),
+      })
+    );
 
     // gate-ready's body never executed — no public-write consequence from a failed group.
     expect(await Bun.file(markerPath).exists()).toBe(false);
@@ -31012,22 +28551,16 @@ describe('value transport (#2637): persistence, resume, and node-local bindings'
     ];
 
     const platform = createMockPlatform();
-    await executeDagWorkflow({
-      deps: createMockDeps(),
-      platform,
-      conversationId: 'conv-lg-binding-plain',
-      cwd: testDir,
-      workflow: { name: 'lg-binding-plain-with-failed', nodes: nodes as DagNode[] },
-      workflowRun: makeWorkflowRun('lg-binding-plain-with-failed'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(),
+        platform,
+        conversationId: 'conv-lg-binding-plain',
+        cwd: testDir,
+        workflow: { name: 'lg-binding-plain-with-failed', nodes: nodes as DagNode[] },
+        workflowRun: makeWorkflowRun('lg-binding-plain-with-failed'),
+      })
+    );
 
     // gate-ready's body never executed — no public-write consequence from a failed group.
     expect(await Bun.file(markerPath).exists()).toBe(false);
@@ -31256,22 +28789,15 @@ describe('#2707 step 3: gate-terminated loop_group pause escalation', () => {
     const store = createEscalationStore('run-escalation-1');
     const platform = createMockPlatform();
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: ready(gateTerminatedLoopGroupWorkflow()),
-      workflowRun: makeWorkflowRun('run-escalation-1'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        platform,
+        cwd: testDir,
+        workflow: ready(gateTerminatedLoopGroupWorkflow()),
+        workflowRun: makeWorkflowRun('run-escalation-1'),
+      })
+    );
 
     // Only 'work' ran once — proves the loop did NOT barrel through remaining
     // iterations re-running the body every time the gate re-paused.
@@ -31298,22 +28824,15 @@ describe('#2707 step 3: gate-terminated loop_group pause escalation', () => {
     const deps = createMockDeps(store);
     const platform = createMockPlatform();
 
-    await executeDagWorkflow({
-      deps,
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: ready(waitTerminatedLoopGroupWorkflow()),
-      workflowRun: makeWorkflowRun('run-wait-escalation'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps,
+        platform,
+        cwd: testDir,
+        workflow: ready(waitTerminatedLoopGroupWorkflow()),
+        workflowRun: makeWorkflowRun('run-wait-escalation'),
+      })
+    );
 
     const paused = store.getState();
     expect(paused.status).toBe('paused');
@@ -31333,22 +28852,15 @@ describe('#2707 step 3: gate-terminated loop_group pause escalation', () => {
     });
     const resumedStore = createEscalationStore('run-wait-escalation');
 
-    await executeDagWorkflow({
-      deps: createMockDeps(resumedStore),
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: ready(waitTerminatedLoopGroupWorkflow()),
-      workflowRun: resumeRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(resumedStore),
+        platform,
+        cwd: testDir,
+        workflow: ready(waitTerminatedLoopGroupWorkflow()),
+        workflowRun: resumeRun,
+      })
+    );
 
     expect(resumedStore.completeWorkflowRun).toHaveBeenCalledTimes(1);
     expect(resumedStore.pauseWorkflowRunForWait).not.toHaveBeenCalled();
@@ -31368,22 +28880,14 @@ describe('#2707 step 3: gate-terminated loop_group pause escalation', () => {
     };
     const store = createEscalationStore('run-repeating-wait');
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: ready(repeatingWaitTerminatedLoopGroupWorkflow()),
-      workflowRun: makeWorkflowRun('run-repeating-wait', { metadata: { wait: expiredWait } }),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        cwd: testDir,
+        workflow: ready(repeatingWaitTerminatedLoopGroupWorkflow()),
+        workflowRun: makeWorkflowRun('run-repeating-wait', { metadata: { wait: expiredWait } }),
+      })
+    );
 
     expect(store.getState().status).toBe('paused');
     expect(store.pauseWorkflowRunForWait).toHaveBeenCalledTimes(1);
@@ -31418,25 +28922,17 @@ describe('#2707 step 3: gate-terminated loop_group pause escalation', () => {
     };
     const store = createEscalationStore('run-included-missing-probe');
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: ready(workflow),
-      workflowRun: makeWorkflowRun('run-included-missing-probe', {
-        metadata: { wait: expiredWait },
-      }),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes: new Map(),
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        cwd: testDir,
+        workflow: ready(workflow),
+        workflowRun: makeWorkflowRun('run-included-missing-probe', {
+          metadata: { wait: expiredWait },
+        }),
+        priorCompletedNodes: new Map(),
+      })
+    );
 
     expect(store.completeWorkflowRun).not.toHaveBeenCalled();
     expect(store.failWorkflowRun).toHaveBeenCalledTimes(1);
@@ -31470,25 +28966,17 @@ describe('#2707 step 3: gate-terminated loop_group pause escalation', () => {
     ]);
     const store = createEscalationStore('run-included-restored-probe');
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: ready(workflow),
-      workflowRun: makeWorkflowRun('run-included-restored-probe', {
-        metadata: { wait: expiredWait },
-      }),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        cwd: testDir,
+        workflow: ready(workflow),
+        workflowRun: makeWorkflowRun('run-included-restored-probe', {
+          metadata: { wait: expiredWait },
+        }),
+        priorCompletedNodes,
+      })
+    );
 
     expect(await Bun.file(markerPath).exists()).toBe(true);
     expect(store.completeWorkflowRun).not.toHaveBeenCalled();
@@ -31523,25 +29011,17 @@ describe('#2707 step 3: gate-terminated loop_group pause escalation', () => {
     ]);
     const store = createEscalationStore('run-included-double-quoted-probe');
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: ready(workflow),
-      workflowRun: makeWorkflowRun('run-included-double-quoted-probe', {
-        metadata: { wait: expiredWait },
-      }),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        cwd: testDir,
+        workflow: ready(workflow),
+        workflowRun: makeWorkflowRun('run-included-double-quoted-probe', {
+          metadata: { wait: expiredWait },
+        }),
+        priorCompletedNodes,
+      })
+    );
 
     expect(await Bun.file(markerPath).exists()).toBe(true);
     expect(store.completeWorkflowRun).toHaveBeenCalledTimes(1);
@@ -31554,22 +29034,14 @@ describe('#2707 step 3: gate-terminated loop_group pause escalation', () => {
       signaledAt: new Date().toISOString(),
     }));
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: ready(eventWaitTerminatedLoopGroupWorkflow()),
-      workflowRun: makeWorkflowRun('run-immediate-signal'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        cwd: testDir,
+        workflow: ready(eventWaitTerminatedLoopGroupWorkflow()),
+        workflowRun: makeWorkflowRun('run-immediate-signal'),
+      })
+    );
 
     expect(store.pauseWorkflowRunForWait).toHaveBeenCalledTimes(1);
     expect(store.getState().metadata.wait).toMatchObject({
@@ -31612,23 +29084,16 @@ describe('#2707 step 3: gate-terminated loop_group pause escalation', () => {
       },
     });
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: ready(gateTerminatedLoopGroupWorkflow()),
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        platform,
+        cwd: testDir,
+        workflow: ready(gateTerminatedLoopGroupWorkflow()),
+        workflowRun,
+        priorCompletedNodes,
+      })
+    );
 
     // No fresh iteration ran — the resumed iteration's completion was decided
     // from the reconstructed data, not by re-running the body.
@@ -31678,23 +29143,16 @@ describe('#2707 step 3: gate-terminated loop_group pause escalation', () => {
       },
     });
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: ready(gateTerminatedLoopGroupWorkflow()),
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        platform,
+        cwd: testDir,
+        workflow: ready(gateTerminatedLoopGroupWorkflow()),
+        workflowRun,
+        priorCompletedNodes,
+      })
+    );
 
     // A genuinely fresh iteration 2 ran (the "revise" decision did not satisfy
     // until_bash), seeded with the human's feedback via the ordinary $LOOP_PREV
@@ -31765,23 +29223,16 @@ describe('#2707 step 3: gate-terminated loop_group pause escalation', () => {
       ],
     };
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: ready(outerRefWorkflow),
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        platform,
+        cwd: testDir,
+        workflow: ready(outerRefWorkflow),
+        workflowRun,
+        priorCompletedNodes,
+      })
+    );
 
     // No fresh iteration ran — the outer ref resolved correctly on resume, so
     // until_bash saw both halves satisfied and completed without re-running the body.
@@ -31852,23 +29303,17 @@ describe('#2707 step 3: gate-terminated loop_group pause escalation', () => {
       ],
     };
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform,
-      conversationId: 'conv-dag',
-      cwd: testDir,
-      workflow: ready(talkativeProbeWorkflow),
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir,
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      priorCompletedNodes,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        platform,
+        cwd: testDir,
+        workflow: ready(talkativeProbeWorkflow),
+        workflowRun,
+        logDir,
+        priorCompletedNodes,
+      })
+    );
 
     // Zero provider calls means no fresh iteration ran, so the single retained row
     // below can only have come from the resume branch's probe — not the ordinary
@@ -31933,22 +29378,15 @@ describe('#2707 step 3: gate-terminated loop_group pause escalation', () => {
 
     // Must not throw — the fallthrough path is a normal, tolerated outcome.
     await expect(
-      executeDagWorkflow({
-        deps: createMockDeps(store),
-        platform,
-        conversationId: 'conv-dag',
-        cwd: testDir,
-        workflow: ready(singleIterationWorkflow),
-        workflowRun: makeWorkflowRun('run-escalation-4'),
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      })
+      executeDagWorkflow(
+        dagOptions({
+          deps: createMockDeps(store),
+          platform,
+          cwd: testDir,
+          workflow: ready(singleIterationWorkflow),
+          workflowRun: makeWorkflowRun('run-escalation-4'),
+        })
+      )
     ).resolves.toBeUndefined();
 
     // The escalation was attempted and correctly observed the lost race.
@@ -32026,40 +29464,34 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun('compose-run-id');
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-compose',
-      cwd: testDir,
-      workflow: {
-        name: 'compose-parent',
-        nodes: [
-          {
-            id: 'list',
-            kind: 'exec',
-            runtime: 'sh',
-            script: `echo '${JSON.stringify(['a', 'b'])}'`,
-          },
-          {
-            id: 'fan',
-            kind: 'compose_fan_out',
-            include: 'compose-blk',
-            depends_on: ['list'],
-            with: { item: 'unused' },
-            fan_out: { items: '$list.output', as: 'item', max_parallel: 2, join: 'all_done' },
-          },
-        ],
-      },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-compose',
+        cwd: testDir,
+        workflow: {
+          name: 'compose-parent',
+          nodes: [
+            {
+              id: 'list',
+              kind: 'exec',
+              runtime: 'sh',
+              script: `echo '${JSON.stringify(['a', 'b'])}'`,
+            },
+            {
+              id: 'fan',
+              kind: 'compose_fan_out',
+              include: 'compose-blk',
+              depends_on: ['list'],
+              with: { item: 'unused' },
+              fan_out: { items: '$list.output', as: 'item', max_parallel: 2, join: 'all_done' },
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
 
     const events = eventsOf(mockDeps.store);
     // One audit snapshot BEFORE any instance schedules.
@@ -32098,34 +29530,27 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
     );
     const store = createMockStore();
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-compose',
-      cwd: testDir,
-      workflow: {
-        name: 'compose-parent',
-        nodes: [
-          { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a"]'` },
-          {
-            id: 'fan',
-            kind: 'compose_fan_out',
-            include: 'compose-blk',
-            depends_on: ['list'],
-            fan_out: { items: '$list.output', as: 'item', max_parallel: 1, join: 'all_done' },
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('compose-return-id'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-compose',
+        cwd: testDir,
+        workflow: {
+          name: 'compose-parent',
+          nodes: [
+            { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a"]'` },
+            {
+              id: 'fan',
+              kind: 'compose_fan_out',
+              include: 'compose-blk',
+              depends_on: ['list'],
+              fan_out: { items: '$list.output', as: 'item', max_parallel: 1, join: 'all_done' },
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun('compose-return-id'),
+      })
+    );
 
     const wrapper = eventsOf(store).find(
       event => event.event_type === 'node_completed' && event.step_name === 'fan'
@@ -32142,34 +29567,27 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
       new Error('disk full')
     );
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-compose',
-      cwd: testDir,
-      workflow: {
-        name: 'compose-parent',
-        nodes: [
-          { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a"]'` },
-          {
-            id: 'fan',
-            kind: 'compose_fan_out',
-            include: 'compose-blk',
-            depends_on: ['list'],
-            fan_out: { items: '$list.output', as: 'item', max_parallel: 1, join: 'all_done' },
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('compose-snapshot-fail-id'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-compose',
+        cwd: testDir,
+        workflow: {
+          name: 'compose-parent',
+          nodes: [
+            { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a"]'` },
+            {
+              id: 'fan',
+              kind: 'compose_fan_out',
+              include: 'compose-blk',
+              depends_on: ['list'],
+              fan_out: { items: '$list.output', as: 'item', max_parallel: 1, join: 'all_done' },
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun('compose-snapshot-fail-id'),
+      })
+    );
 
     expect(eventsOf(store).some(event => /__work$/.test(event.step_name))).toBe(false);
     expect(
@@ -32206,34 +29624,27 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
       costUsd: 0,
     });
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-compose',
-      cwd: testDir,
-      workflow: {
-        name: 'compose-parent',
-        nodes: [
-          { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["changed"]'` },
-          {
-            id: 'fan',
-            kind: 'compose_fan_out',
-            include: 'compose-blk',
-            depends_on: ['list'],
-            fan_out: { items: '$list.output', as: 'item', max_parallel: 1, join: 'all_done' },
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('compose-partial-resume-id'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-compose',
+        cwd: testDir,
+        workflow: {
+          name: 'compose-parent',
+          nodes: [
+            { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["changed"]'` },
+            {
+              id: 'fan',
+              kind: 'compose_fan_out',
+              include: 'compose-blk',
+              depends_on: ['list'],
+              fan_out: { items: '$list.output', as: 'item', max_parallel: 1, join: 'all_done' },
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun('compose-partial-resume-id'),
+      })
+    );
 
     const events = eventsOf(store);
     expect(
@@ -32263,34 +29674,27 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
       costUsd: 0,
     });
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-compose',
-      cwd: testDir,
-      workflow: {
-        name: 'compose-parent',
-        nodes: [
-          { id: 'list', kind: 'exec', runtime: 'sh', script: 'echo not-json' },
-          {
-            id: 'fan',
-            kind: 'compose_fan_out',
-            include: 'compose-blk',
-            depends_on: ['list'],
-            fan_out: { items: '$list.output', as: 'item', max_parallel: 1, join: 'all_done' },
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('compose-malformed-drift-id'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-compose',
+        cwd: testDir,
+        workflow: {
+          name: 'compose-parent',
+          nodes: [
+            { id: 'list', kind: 'exec', runtime: 'sh', script: 'echo not-json' },
+            {
+              id: 'fan',
+              kind: 'compose_fan_out',
+              include: 'compose-blk',
+              depends_on: ['list'],
+              fan_out: { items: '$list.output', as: 'item', max_parallel: 1, join: 'all_done' },
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun('compose-malformed-drift-id'),
+      })
+    );
 
     const wrapper = eventsOf(store).find(
       event => event.event_type === 'node_completed' && event.step_name === 'fan'
@@ -32321,42 +29725,35 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
       costUsd: 0,
     });
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-compose',
-      cwd: testDir,
-      workflow: {
-        name: 'compose-parent',
-        nodes: [
-          { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a"]'` },
-          {
-            id: 'changed-seed',
-            kind: 'exec',
-            runtime: 'sh',
-            script: 'echo changed',
-            always_run: true,
-          },
-          {
-            id: 'fan',
-            kind: 'compose_fan_out',
-            include: 'compose-blk',
-            depends_on: ['list', 'changed-seed'],
-            with: { seed: '$changed-seed.output' },
-            fan_out: { items: '$list.output', as: 'item', max_parallel: 1, join: 'all_done' },
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('compose-frozen-inputs-id'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-compose',
+        cwd: testDir,
+        workflow: {
+          name: 'compose-parent',
+          nodes: [
+            { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a"]'` },
+            {
+              id: 'changed-seed',
+              kind: 'exec',
+              runtime: 'sh',
+              script: 'echo changed',
+              always_run: true,
+            },
+            {
+              id: 'fan',
+              kind: 'compose_fan_out',
+              include: 'compose-blk',
+              depends_on: ['list', 'changed-seed'],
+              with: { seed: '$changed-seed.output' },
+              fan_out: { items: '$list.output', as: 'item', max_parallel: 1, join: 'all_done' },
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun('compose-frozen-inputs-id'),
+      })
+    );
 
     const wrapper = eventsOf(store).find(
       event => event.event_type === 'node_completed' && event.step_name === 'fan'
@@ -32377,34 +29774,27 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
       costUsd: 0,
     });
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-compose',
-      cwd: testDir,
-      workflow: {
-        name: 'compose-parent',
-        nodes: [
-          { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a"]'` },
-          {
-            id: 'fan',
-            kind: 'compose_fan_out',
-            include: 'compose-blk',
-            depends_on: ['list'],
-            fan_out: { items: '$list.output', as: 'item', max_parallel: 1, join: 'all_done' },
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('compose-ambiguous-id'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-compose',
+        cwd: testDir,
+        workflow: {
+          name: 'compose-parent',
+          nodes: [
+            { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a"]'` },
+            {
+              id: 'fan',
+              kind: 'compose_fan_out',
+              include: 'compose-blk',
+              depends_on: ['list'],
+              fan_out: { items: '$list.output', as: 'item', max_parallel: 1, join: 'all_done' },
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun('compose-ambiguous-id'),
+      })
+    );
 
     expect(eventsOf(store).some(event => /__work$/.test(event.step_name))).toBe(false);
     expect(
@@ -32440,36 +29830,29 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
     }));
     const store = createMockStore();
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-compose',
-      cwd: testDir,
-      workflow: {
-        name: 'compose-parent',
-        nodes: [
-          { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a"]'` },
-          {
-            id: 'fan',
-            kind: 'compose_fan_out',
-            include: 'compose-blk',
-            depends_on: ['list'],
-            fan_out: { items: '$list.output', as: 'item', max_parallel: 1, join: 'all_done' },
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('compose-child-id'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      execContext: { kind: 'host' },
-      runChildWorkflow,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-compose',
+        cwd: testDir,
+        workflow: {
+          name: 'compose-parent',
+          nodes: [
+            { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a"]'` },
+            {
+              id: 'fan',
+              kind: 'compose_fan_out',
+              include: 'compose-blk',
+              depends_on: ['list'],
+              fan_out: { items: '$list.output', as: 'item', max_parallel: 1, join: 'all_done' },
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun('compose-child-id'),
+        execContext: { kind: 'host' },
+        runChildWorkflow,
+      })
+    );
 
     expect(runChildWorkflow).toHaveBeenCalledTimes(1);
     const wrapper = eventsOf(store).find(
@@ -32517,55 +29900,48 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
       async _parentRunId => childRuns
     );
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-compose-child-loop',
-      cwd: testDir,
-      workflow: {
-        name: 'compose-parent-child-loop',
-        nodes: [
-          {
-            id: 'grp',
-            kind: 'loop_group',
-            loop_group: {
-              until_bash:
-                'n=$(cat .compose-child-loop 2>/dev/null || echo 0); ' +
-                'n=$((n + 1)); echo "$n" > .compose-child-loop; test "$n" -eq 2',
-              max_iterations: 2,
-              fresh_context: true,
-              nodes: [
-                { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a"]'` },
-                {
-                  id: 'fan',
-                  kind: 'compose_fan_out',
-                  include: 'compose-blk',
-                  depends_on: ['list'],
-                  fan_out: {
-                    items: '$list.output',
-                    as: 'item',
-                    max_parallel: 1,
-                    join: 'all_done',
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-compose-child-loop',
+        cwd: testDir,
+        workflow: {
+          name: 'compose-parent-child-loop',
+          nodes: [
+            {
+              id: 'grp',
+              kind: 'loop_group',
+              loop_group: {
+                until_bash:
+                  'n=$(cat .compose-child-loop 2>/dev/null || echo 0); ' +
+                  'n=$((n + 1)); echo "$n" > .compose-child-loop; test "$n" -eq 2',
+                max_iterations: 2,
+                fresh_context: true,
+                nodes: [
+                  { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a"]'` },
+                  {
+                    id: 'fan',
+                    kind: 'compose_fan_out',
+                    include: 'compose-blk',
+                    depends_on: ['list'],
+                    fan_out: {
+                      items: '$list.output',
+                      as: 'item',
+                      max_parallel: 1,
+                      join: 'all_done',
+                    },
                   },
-                },
-              ],
+                ],
+              },
+              depends_on: [],
             },
-            depends_on: [],
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('compose-child-loop-id'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      execContext: { kind: 'host' },
-      runChildWorkflow,
-    });
+          ],
+        },
+        workflowRun: makeWorkflowRun('compose-child-loop-id'),
+        execContext: { kind: 'host' },
+        runChildWorkflow,
+      })
+    );
 
     expect(runChildWorkflow).toHaveBeenCalledTimes(2);
     const ownedNodeIds = runChildWorkflow.mock.calls.map(([args]) => args.nodeId);
@@ -32619,55 +29995,48 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
       async _parentRunId => childRuns
     );
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-compose-child-fan-loop',
-      cwd: testDir,
-      workflow: {
-        name: 'compose-parent-child-fan-loop',
-        nodes: [
-          {
-            id: 'grp',
-            kind: 'loop_group',
-            loop_group: {
-              until_bash:
-                'n=$(cat .compose-child-fan-loop 2>/dev/null || echo 0); ' +
-                'n=$((n + 1)); echo "$n" > .compose-child-fan-loop; test "$n" -eq 2',
-              max_iterations: 2,
-              fresh_context: true,
-              nodes: [
-                { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '[["a"]]'` },
-                {
-                  id: 'fan',
-                  kind: 'compose_fan_out',
-                  include: 'compose-blk',
-                  depends_on: ['list'],
-                  fan_out: {
-                    items: '$list.output',
-                    as: 'items',
-                    max_parallel: 1,
-                    join: 'all_done',
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-compose-child-fan-loop',
+        cwd: testDir,
+        workflow: {
+          name: 'compose-parent-child-fan-loop',
+          nodes: [
+            {
+              id: 'grp',
+              kind: 'loop_group',
+              loop_group: {
+                until_bash:
+                  'n=$(cat .compose-child-fan-loop 2>/dev/null || echo 0); ' +
+                  'n=$((n + 1)); echo "$n" > .compose-child-fan-loop; test "$n" -eq 2',
+                max_iterations: 2,
+                fresh_context: true,
+                nodes: [
+                  { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '[["a"]]'` },
+                  {
+                    id: 'fan',
+                    kind: 'compose_fan_out',
+                    include: 'compose-blk',
+                    depends_on: ['list'],
+                    fan_out: {
+                      items: '$list.output',
+                      as: 'items',
+                      max_parallel: 1,
+                      join: 'all_done',
+                    },
                   },
-                },
-              ],
+                ],
+              },
+              depends_on: [],
             },
-            depends_on: [],
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('compose-child-fan-loop-id'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-      execContext: { kind: 'host' },
-      runChildWorkflow,
-    });
+          ],
+        },
+        workflowRun: makeWorkflowRun('compose-child-fan-loop-id'),
+        execContext: { kind: 'host' },
+        runChildWorkflow,
+      })
+    );
 
     expect(runChildWorkflow).toHaveBeenCalledTimes(2);
     const ownedNodeIds = runChildWorkflow.mock.calls.map(([args]) => args.nodeId);
@@ -32696,34 +30065,27 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
       return { persisted: true };
     });
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-compose-claim',
-      cwd: testDir,
-      workflow: {
-        name: 'compose-parent-claim',
-        nodes: [
-          { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a","b"]'` },
-          {
-            id: 'fan',
-            kind: 'compose_fan_out',
-            include: 'compose-blk',
-            depends_on: ['list'],
-            fan_out: { items: '$list.output', as: 'item', max_parallel: 1, join: 'all_done' },
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('compose-claim-id'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-compose-claim',
+        cwd: testDir,
+        workflow: {
+          name: 'compose-parent-claim',
+          nodes: [
+            { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a","b"]'` },
+            {
+              id: 'fan',
+              kind: 'compose_fan_out',
+              include: 'compose-blk',
+              depends_on: ['list'],
+              fan_out: { items: '$list.output', as: 'item', max_parallel: 1, join: 'all_done' },
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun('compose-claim-id'),
+      })
+    );
 
     expect(claimCount).toBe(2);
     expect(await readFile(join(testDir, '.compose-claimed-items'), 'utf8')).toBe('a\n');
@@ -32776,34 +30138,27 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
       return { persisted: true };
     });
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-compose-sibling-pause',
-      cwd: testDir,
-      workflow: {
-        name: 'compose-parent-sibling-pause',
-        nodes: [
-          { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a","b"]'` },
-          {
-            id: 'fan',
-            kind: 'compose_fan_out',
-            include: 'compose-blk',
-            depends_on: ['list'],
-            fan_out: { items: '$list.output', as: 'item', max_parallel: 1, join: 'all_done' },
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('compose-sibling-pause-id'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-compose-sibling-pause',
+        cwd: testDir,
+        workflow: {
+          name: 'compose-parent-sibling-pause',
+          nodes: [
+            { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a","b"]'` },
+            {
+              id: 'fan',
+              kind: 'compose_fan_out',
+              include: 'compose-blk',
+              depends_on: ['list'],
+              fan_out: { items: '$list.output', as: 'item', max_parallel: 1, join: 'all_done' },
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun('compose-sibling-pause-id'),
+      })
+    );
 
     expect(claimCount).toBe(2);
     expect(await readFile(join(testDir, '.compose-paused-first'), 'utf8')).toBe('a\n');
@@ -32877,34 +30232,27 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
       return { persisted: true };
     });
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-compose-paused-nested',
-      cwd: testDir,
-      workflow: {
-        name: 'compose-parent-paused-nested',
-        nodes: [
-          { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a","b"]'` },
-          {
-            id: 'fan',
-            kind: 'compose_fan_out',
-            include: 'compose-blk',
-            depends_on: ['list'],
-            fan_out: { items: '$list.output', as: 'item', max_parallel: 1, join: 'all_done' },
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('compose-paused-nested-id'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-compose-paused-nested',
+        cwd: testDir,
+        workflow: {
+          name: 'compose-parent-paused-nested',
+          nodes: [
+            { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a","b"]'` },
+            {
+              id: 'fan',
+              kind: 'compose_fan_out',
+              include: 'compose-blk',
+              depends_on: ['list'],
+              fan_out: { items: '$list.output', as: 'item', max_parallel: 1, join: 'all_done' },
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun('compose-paused-nested-id'),
+      })
+    );
 
     expect(claimCount).toBe(3);
     expect(await readFile(join(testDir, '.compose-paused-nested'), 'utf8')).toBe('x\n');
@@ -32958,34 +30306,27 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
     claimCount = 0;
     (store.createWorkflowEvent as Mock<IWorkflowStore['createWorkflowEvent']>).mockClear();
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-compose-paused-nested',
-      cwd: testDir,
-      workflow: {
-        name: 'compose-parent-paused-nested',
-        nodes: [
-          { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a","b"]'` },
-          {
-            id: 'fan',
-            kind: 'compose_fan_out',
-            include: 'compose-blk',
-            depends_on: ['list'],
-            fan_out: { items: '$list.output', as: 'item', max_parallel: 1, join: 'all_done' },
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('compose-paused-nested-id'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-compose-paused-nested',
+        cwd: testDir,
+        workflow: {
+          name: 'compose-parent-paused-nested',
+          nodes: [
+            { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a","b"]'` },
+            {
+              id: 'fan',
+              kind: 'compose_fan_out',
+              include: 'compose-blk',
+              depends_on: ['list'],
+              fan_out: { items: '$list.output', as: 'item', max_parallel: 1, join: 'all_done' },
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun('compose-paused-nested-id'),
+      })
+    );
 
     expect(claimCount).toBe(2);
     expect(await readFile(join(testDir, '.compose-paused-nested'), 'utf8')).toBe('x\nx\n');
@@ -33036,34 +30377,27 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
       return { persisted: true };
     });
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-compose-paused-loop',
-      cwd: testDir,
-      workflow: {
-        name: 'compose-parent-paused-loop',
-        nodes: [
-          { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a","b"]'` },
-          {
-            id: 'fan',
-            kind: 'compose_fan_out',
-            include: 'compose-blk',
-            depends_on: ['list'],
-            fan_out: { items: '$list.output', as: 'item', max_parallel: 1, join: 'all_done' },
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('compose-paused-loop-id'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-compose-paused-loop',
+        cwd: testDir,
+        workflow: {
+          name: 'compose-parent-paused-loop',
+          nodes: [
+            { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a","b"]'` },
+            {
+              id: 'fan',
+              kind: 'compose_fan_out',
+              include: 'compose-blk',
+              depends_on: ['list'],
+              fan_out: { items: '$list.output', as: 'item', max_parallel: 1, join: 'all_done' },
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun('compose-paused-loop-id'),
+      })
+    );
 
     expect(claimCount).toBe(2);
     expect(await readFile(join(testDir, '.compose-paused-loop-first'), 'utf8')).toBe('a\n');
@@ -33136,34 +30470,27 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
       return { persisted: true };
     });
 
-    await executeDagWorkflow({
-      deps: createMockDeps(store),
-      platform: createMockPlatform(),
-      conversationId: 'conv-compose-cancelled-nested',
-      cwd: testDir,
-      workflow: {
-        name: 'compose-parent-cancelled-nested',
-        nodes: [
-          { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a"]'` },
-          {
-            id: 'fan',
-            kind: 'compose_fan_out',
-            include: 'compose-blk',
-            depends_on: ['list'],
-            fan_out: { items: '$list.output', as: 'item', max_parallel: 1, join: 'all_done' },
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('compose-cancelled-nested-id'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        conversationId: 'conv-compose-cancelled-nested',
+        cwd: testDir,
+        workflow: {
+          name: 'compose-parent-cancelled-nested',
+          nodes: [
+            { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a"]'` },
+            {
+              id: 'fan',
+              kind: 'compose_fan_out',
+              include: 'compose-blk',
+              depends_on: ['list'],
+              fan_out: { items: '$list.output', as: 'item', max_parallel: 1, join: 'all_done' },
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun('compose-cancelled-nested-id'),
+      })
+    );
 
     expect(await readFile(join(testDir, '.compose-cancelled-nested-first'), 'utf8')).toBe('x\n');
     await expect(
@@ -33189,34 +30516,28 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
     const mockDeps = createMockDeps();
     const platform = createMockPlatform();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-compose',
-      cwd: testDir,
-      workflow: {
-        name: 'compose-parent',
-        nodes: [
-          { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '[]'` },
-          {
-            id: 'fan',
-            kind: 'compose_fan_out',
-            include: 'compose-blk',
-            depends_on: ['list'],
-            fan_out: { items: '$list.output', as: 'item', max_parallel: 3, join: 'all_done' },
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('compose-empty-id'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-compose',
+        cwd: testDir,
+        workflow: {
+          name: 'compose-parent',
+          nodes: [
+            { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '[]'` },
+            {
+              id: 'fan',
+              kind: 'compose_fan_out',
+              include: 'compose-blk',
+              depends_on: ['list'],
+              fan_out: { items: '$list.output', as: 'item', max_parallel: 3, join: 'all_done' },
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun('compose-empty-id'),
+      })
+    );
 
     const wrapper = eventsOf(mockDeps.store).find(
       e => e.event_type === 'node_completed' && e.step_name === 'fan'
@@ -33249,34 +30570,28 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
     const mockDeps = createMockDeps();
     const platform = createMockPlatform();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-compose',
-      cwd: testDir,
-      workflow: {
-        name: 'compose-parent',
-        nodes: [
-          { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a"]'` },
-          {
-            id: 'fan',
-            kind: 'compose_fan_out',
-            include: 'compose-blk',
-            depends_on: ['list'],
-            fan_out: { items: '$list.output', as: 'item', max_parallel: 2, join: 'all_done' },
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('compose-gate-id'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-compose',
+        cwd: testDir,
+        workflow: {
+          name: 'compose-parent',
+          nodes: [
+            { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a"]'` },
+            {
+              id: 'fan',
+              kind: 'compose_fan_out',
+              include: 'compose-blk',
+              depends_on: ['list'],
+              fan_out: { items: '$list.output', as: 'item', max_parallel: 2, join: 'all_done' },
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun('compose-gate-id'),
+      })
+    );
 
     const failed = eventsOf(mockDeps.store).find(
       e => e.event_type === 'node_failed' && e.step_name === 'fan'
@@ -33303,34 +30618,28 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
     const mockDeps = createMockDeps();
     const platform = createMockPlatform();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-compose',
-      cwd: testDir,
-      workflow: {
-        name: 'compose-parent',
-        nodes: [
-          { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a", "b"]'` },
-          {
-            id: 'fan',
-            kind: 'compose_fan_out',
-            include: 'compose-blk',
-            depends_on: ['list'],
-            fan_out: { items: '$list.output', as: 'item', max_parallel: 2, join: 'all_done' },
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('compose-checkout-id'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-compose',
+        cwd: testDir,
+        workflow: {
+          name: 'compose-parent',
+          nodes: [
+            { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a", "b"]'` },
+            {
+              id: 'fan',
+              kind: 'compose_fan_out',
+              include: 'compose-blk',
+              depends_on: ['list'],
+              fan_out: { items: '$list.output', as: 'item', max_parallel: 2, join: 'all_done' },
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun('compose-checkout-id'),
+      })
+    );
 
     const failed = eventsOf(mockDeps.store).find(
       e => e.event_type === 'node_failed' && e.step_name === 'fan'
@@ -33348,34 +30657,28 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
     const mockDeps = createMockDeps();
     const platform = createMockPlatform();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-compose',
-      cwd: testDir,
-      workflow: {
-        name: 'compose-parent',
-        nodes: [
-          { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a", "b"]'` },
-          {
-            id: 'fan',
-            kind: 'compose_fan_out',
-            include: 'compose-blk',
-            depends_on: ['list'],
-            fan_out: { items: '$list.output', as: 'item', max_parallel: 2, join: 'all_success' },
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('compose-fail-id'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-compose',
+        cwd: testDir,
+        workflow: {
+          name: 'compose-parent',
+          nodes: [
+            { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a", "b"]'` },
+            {
+              id: 'fan',
+              kind: 'compose_fan_out',
+              include: 'compose-blk',
+              depends_on: ['list'],
+              fan_out: { items: '$list.output', as: 'item', max_parallel: 2, join: 'all_success' },
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun('compose-fail-id'),
+      })
+    );
 
     const failed = eventsOf(mockDeps.store).find(
       e => e.event_type === 'node_failed' && e.step_name === 'fan'
@@ -33398,39 +30701,33 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
     const mockDeps = createMockDeps();
     const platform = createMockPlatform();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-compose',
-      cwd: testDir,
-      workflow: {
-        name: 'compose-parent',
-        nodes: [
-          {
-            id: 'list',
-            kind: 'exec',
-            runtime: 'sh',
-            script: `echo '${JSON.stringify(['keep', 'drop'])}'`,
-          },
-          {
-            id: 'fan',
-            kind: 'compose_fan_out',
-            include: 'compose-blk',
-            depends_on: ['list'],
-            fan_out: { items: '$list.output', as: 'item', max_parallel: 2, join: 'all_done' },
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('compose-partial-id'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-compose',
+        cwd: testDir,
+        workflow: {
+          name: 'compose-parent',
+          nodes: [
+            {
+              id: 'list',
+              kind: 'exec',
+              runtime: 'sh',
+              script: `echo '${JSON.stringify(['keep', 'drop'])}'`,
+            },
+            {
+              id: 'fan',
+              kind: 'compose_fan_out',
+              include: 'compose-blk',
+              depends_on: ['list'],
+              fan_out: { items: '$list.output', as: 'item', max_parallel: 2, join: 'all_done' },
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun('compose-partial-id'),
+      })
+    );
 
     const wrapper = eventsOf(mockDeps.store).find(
       e => e.event_type === 'node_completed' && e.step_name === 'fan'
@@ -33473,35 +30770,29 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
     const mockDeps = createMockDeps(storeOverride);
     const platform = createMockPlatform();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-compose',
-      cwd: testDir,
-      workflow: {
-        name: 'compose-parent',
-        nodes: [
-          { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '${JSON.stringify(items)}'` },
-          {
-            id: 'fan',
-            kind: 'compose_fan_out',
-            include: 'compose-blk',
-            depends_on: ['list'],
-            with: { item: 'x' },
-            fan_out: { items: '$list.output', as: 'item', max_parallel: 2, join: 'all_done' },
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('compose-resume-id'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-compose',
+        cwd: testDir,
+        workflow: {
+          name: 'compose-parent',
+          nodes: [
+            { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '${JSON.stringify(items)}'` },
+            {
+              id: 'fan',
+              kind: 'compose_fan_out',
+              include: 'compose-blk',
+              depends_on: ['list'],
+              with: { item: 'x' },
+              fan_out: { items: '$list.output', as: 'item', max_parallel: 2, join: 'all_done' },
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun('compose-resume-id'),
+      })
+    );
 
     const wrapper = eventsOf(storeOverride).find(
       e => e.event_type === 'node_completed' && e.step_name === 'fan'
@@ -33556,40 +30847,34 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
     const mockDeps = createMockDeps();
     const platform = createMockPlatform();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-compose-nested',
-      cwd: testDir,
-      workflow: {
-        name: 'compose-parent-nested',
-        nodes: [
-          {
-            id: 'list',
-            kind: 'exec',
-            runtime: 'sh',
-            script: `echo '${JSON.stringify(['a', 'b'])}'`,
-          },
-          {
-            id: 'fan',
-            kind: 'compose_fan_out',
-            include: 'compose-blk',
-            depends_on: ['list'],
-            with: { item: 'unused' },
-            fan_out: { items: '$list.output', as: 'item', max_parallel: 1, join: 'all_done' },
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('compose-nested-id'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-compose-nested',
+        cwd: testDir,
+        workflow: {
+          name: 'compose-parent-nested',
+          nodes: [
+            {
+              id: 'list',
+              kind: 'exec',
+              runtime: 'sh',
+              script: `echo '${JSON.stringify(['a', 'b'])}'`,
+            },
+            {
+              id: 'fan',
+              kind: 'compose_fan_out',
+              include: 'compose-blk',
+              depends_on: ['list'],
+              with: { item: 'unused' },
+              fan_out: { items: '$list.output', as: 'item', max_parallel: 1, join: 'all_done' },
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun('compose-nested-id'),
+      })
+    );
 
     const events = eventsOf(mockDeps.store);
     expect(events.some(e => String(e.data.error ?? '').includes('failed to compose'))).toBe(false);
@@ -33636,39 +30921,32 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
     );
 
     const mockDeps = createMockDeps();
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform: createMockPlatform(),
-      conversationId: 'conv-compose-nested-gate',
-      cwd: testDir,
-      workflow: {
-        name: 'compose-parent-nested-gate',
-        nodes: [
-          {
-            id: 'list',
-            kind: 'exec',
-            runtime: 'sh',
-            script: `echo '${JSON.stringify(['a'])}'`,
-          },
-          {
-            id: 'fan',
-            kind: 'compose_fan_out',
-            include: 'compose-blk',
-            depends_on: ['list'],
-            fan_out: { items: '$list.output', as: 'item', max_parallel: 1, join: 'all_done' },
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('compose-nested-gate-id'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        conversationId: 'conv-compose-nested-gate',
+        cwd: testDir,
+        workflow: {
+          name: 'compose-parent-nested-gate',
+          nodes: [
+            {
+              id: 'list',
+              kind: 'exec',
+              runtime: 'sh',
+              script: `echo '${JSON.stringify(['a'])}'`,
+            },
+            {
+              id: 'fan',
+              kind: 'compose_fan_out',
+              include: 'compose-blk',
+              depends_on: ['list'],
+              fan_out: { items: '$list.output', as: 'item', max_parallel: 1, join: 'all_done' },
+            },
+          ],
+        },
+        workflowRun: makeWorkflowRun('compose-nested-gate-id'),
+      })
+    );
 
     const events = eventsOf(mockDeps.store);
     expect(events.some(event => event.event_type === 'fan_out_instances')).toBe(false);
@@ -33713,49 +30991,48 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
     const mockDeps = createMockDeps(storeOverride);
     const platform = createMockPlatform();
 
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-compose-loop',
-      cwd: testDir,
-      workflow: {
-        name: 'compose-parent-loop',
-        nodes: [
-          {
-            id: 'grp',
-            kind: 'loop_group',
-            loop_group: {
-              until_bash:
-                'n=$(cat .compose-loop-iteration 2>/dev/null || echo 0); ' +
-                'n=$((n + 1)); echo "$n" > .compose-loop-iteration; test "$n" -eq 2',
-              max_iterations: 2,
-              fresh_context: true,
-              nodes: [
-                { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a"]'` },
-                {
-                  id: 'fan',
-                  kind: 'compose_fan_out',
-                  include: 'compose-blk',
-                  depends_on: ['list'],
-                  with: { item: 'x' },
-                  fan_out: { items: '$list.output', as: 'item', max_parallel: 1, join: 'all_done' },
-                },
-              ],
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-compose-loop',
+        cwd: testDir,
+        workflow: {
+          name: 'compose-parent-loop',
+          nodes: [
+            {
+              id: 'grp',
+              kind: 'loop_group',
+              loop_group: {
+                until_bash:
+                  'n=$(cat .compose-loop-iteration 2>/dev/null || echo 0); ' +
+                  'n=$((n + 1)); echo "$n" > .compose-loop-iteration; test "$n" -eq 2',
+                max_iterations: 2,
+                fresh_context: true,
+                nodes: [
+                  { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a"]'` },
+                  {
+                    id: 'fan',
+                    kind: 'compose_fan_out',
+                    include: 'compose-blk',
+                    depends_on: ['list'],
+                    with: { item: 'x' },
+                    fan_out: {
+                      items: '$list.output',
+                      as: 'item',
+                      max_parallel: 1,
+                      join: 'all_done',
+                    },
+                  },
+                ],
+              },
+              depends_on: [],
             },
-            depends_on: [],
-          },
-        ],
-      },
-      workflowRun: makeWorkflowRun('compose-loop-id'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+          ],
+        },
+        workflowRun: makeWorkflowRun('compose-loop-id'),
+      })
+    );
 
     const events = eventsOf(mockDeps.store);
     // The instance actually executed in BOTH iterations under iteration-scoped names.
@@ -33812,22 +31089,16 @@ describe('executeDagWorkflow -- node-level mutates_checkout: false (#2771)', () 
       script,
       ...(declareReadOnly ? { mutates_checkout: false as const } : {}),
     };
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-mc',
-      cwd: testDir,
-      workflow: { name: 'mc-test', nodes: [bashNode] },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-mc',
+        cwd: testDir,
+        workflow: { name: 'mc-test', nodes: [bashNode] },
+        workflowRun,
+      })
+    );
     return mockDeps;
   };
 
@@ -33925,22 +31196,16 @@ describe('executeDagWorkflow -- node-level mutates_checkout: false (#2771)', () 
       },
       { id: 'mutator', kind: 'exec', runtime: 'sh', script: 'touch sibling.txt' },
     ];
-    await executeDagWorkflow({
-      deps: mockDeps,
-      platform,
-      conversationId: 'conv-mc',
-      cwd: testDir,
-      workflow: { name: 'mc-test', nodes },
-      workflowRun,
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-mc',
+        cwd: testDir,
+        workflow: { name: 'mc-test', nodes },
+        workflowRun,
+      })
+    );
     expect(nodeFailedError(mockDeps, 'guarded')).toBeUndefined();
   });
 
@@ -33994,22 +31259,16 @@ describe('executeDagWorkflow -- side effects survive a failed terminal write', (
       if ('runId' in event && event.runId === workflowRun.id) emitted.push(event.type);
     });
     try {
-      return await executeDagWorkflow({
-        deps: createMockDeps(store),
-        platform,
-        conversationId: 'conv-terminal-order',
-        cwd: testDir,
-        workflow: { name: 'terminal-order', nodes },
-        workflowRun,
-        workflowProvider: 'claude',
-        workflowModel: undefined,
-        artifactsDir: join(testDir, 'artifacts'),
-        stateDir: join(testDir, 'state'),
-        logDir: join(testDir, 'logs'),
-        baseBranch: 'main',
-        docsDir: 'docs/',
-        config: minimalConfig,
-      });
+      return await executeDagWorkflow(
+        dagOptions({
+          deps: createMockDeps(store),
+          platform,
+          conversationId: 'conv-terminal-order',
+          cwd: testDir,
+          workflow: { name: 'terminal-order', nodes },
+          workflowRun,
+        })
+      );
     } finally {
       unsubscribe();
     }

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -485,8 +485,10 @@ function expectLoopGateEvidence(
 }
 
 function loaderBypassingWorkflow(
-  workflow: Parameters<typeof executeDagWorkflow>[4] & { modelReasoningEffort: string }
-): Parameters<typeof executeDagWorkflow>[4] {
+  workflow: Parameters<typeof executeDagWorkflow>[0]['workflow'] & {
+    modelReasoningEffort: string;
+  }
+): Parameters<typeof executeDagWorkflow>[0]['workflow'] {
   return workflow;
 }
 
@@ -1547,12 +1549,12 @@ describe('executeDagWorkflow -- tool restrictions', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'dag-tool-restriction',
         nodes: [
           {
@@ -1564,15 +1566,15 @@ describe('executeDagWorkflow -- tool restrictions', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(mockSendQueryDag.mock.calls.length).toBeGreaterThan(0);
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
@@ -1585,12 +1587,12 @@ describe('executeDagWorkflow -- tool restrictions', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'dag-setting-sources',
         nodes: [
           {
@@ -1602,15 +1604,15 @@ describe('executeDagWorkflow -- tool restrictions', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(mockSendQueryDag.mock.calls.length).toBeGreaterThan(0);
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
@@ -1634,12 +1636,12 @@ describe('executeDagWorkflow -- tool restrictions', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'dag-setting-sources-codex',
         nodes: [
           {
@@ -1652,15 +1654,15 @@ describe('executeDagWorkflow -- tool restrictions', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // Capability gate: codex declares settingSources: false, so the executor
     // must surface a visible "will be ignored" warning instead of a silent no-op.
@@ -1687,12 +1689,12 @@ describe('executeDagWorkflow -- tool restrictions', () => {
       },
     });
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'codex-tier-effort-test',
         nodes: [
           {
@@ -1704,20 +1706,16 @@ describe('executeDagWorkflow -- tool restrictions', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      aiProfile
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      aiProfile,
+    });
 
     expect(mockGetAgentProviderDag.mock.calls[0][0]).toBe('codex');
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
@@ -1756,12 +1754,12 @@ describe('executeDagWorkflow -- tool restrictions', () => {
       },
     });
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'codex-explicit-effort-test',
         nodes: [
           {
@@ -1774,20 +1772,16 @@ describe('executeDagWorkflow -- tool restrictions', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      aiProfile
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      aiProfile,
+    });
 
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
     const nodeConfig = optionsArg.nodeConfig as Record<string, unknown>;
@@ -1815,31 +1809,27 @@ describe('executeDagWorkflow -- tool restrictions', () => {
       },
     });
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'inherited-workflow-tier-test',
         nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
       },
       workflowRun,
-      'codex',
-      'gpt-5.5',
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
+      workflowProvider: 'codex',
+      workflowModel: 'gpt-5.5',
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
       aiProfile,
-      workflowPreset
-    );
+      workflowPreset,
+    });
 
     expect(mockGetAgentProviderDag.mock.calls[0][0]).toBe('codex');
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
@@ -1869,12 +1859,12 @@ describe('executeDagWorkflow -- tool restrictions', () => {
       },
     });
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'opencode-tier-effort-test',
         nodes: [
           {
@@ -1886,20 +1876,16 @@ describe('executeDagWorkflow -- tool restrictions', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      aiProfile
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      aiProfile,
+    });
 
     expect(mockGetAgentProviderDag.mock.calls[0][0]).toBe('opencode');
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
@@ -1930,12 +1916,12 @@ describe('executeDagWorkflow -- tool restrictions', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'opencode-declared-effort-test',
         nodes: [
           {
@@ -1948,15 +1934,15 @@ describe('executeDagWorkflow -- tool restrictions', () => {
         ],
       },
       workflowRun,
-      'opencode',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'opencode',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
     const nodeConfig = optionsArg.nodeConfig as Record<string, unknown>;
@@ -1983,12 +1969,12 @@ describe('executeDagWorkflow -- tool restrictions', () => {
       },
     });
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'claude-tier-effort-test',
         nodes: [
           {
@@ -2000,20 +1986,16 @@ describe('executeDagWorkflow -- tool restrictions', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      aiProfile
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      aiProfile,
+    });
 
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
     expect(optionsArg.model).toBe('opus');
@@ -2039,31 +2021,28 @@ describe('executeDagWorkflow -- tool restrictions', () => {
     const workflowRun = makeWorkflowRun();
     const aiProfile = buildAiProfile('claude');
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'workflow-level-tier-test',
         model: 'medium',
         nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
       },
       workflowRun,
-      'claude',
-      'sonnet', // executor resolves the workflow-level `medium` -> `sonnet`
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      aiProfile
-    );
+      workflowProvider: 'claude',
+      // The executor receives the already-resolved workflow-level `medium` tier.
+      workflowModel: 'sonnet',
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      aiProfile,
+    });
 
     const createEventCalls = (mockDeps.store.createWorkflowEvent as ReturnType<typeof mock>).mock
       .calls as Array<[{ event_type: string; data?: Record<string, unknown> }]>;
@@ -2079,12 +2058,12 @@ describe('executeDagWorkflow -- tool restrictions', () => {
     const workflowRun = makeWorkflowRun();
     const aiProfile = buildAiProfile('claude');
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'literal-model-test',
         nodes: [
           {
@@ -2097,20 +2076,16 @@ describe('executeDagWorkflow -- tool restrictions', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      aiProfile
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      aiProfile,
+    });
 
     expect(mockGetAgentProviderDag.mock.calls[0][0]).toBe('claude');
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
@@ -2132,12 +2107,12 @@ describe('executeDagWorkflow -- tool restrictions', () => {
       },
     });
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'alias-provider-conflict-test',
         nodes: [
           {
@@ -2150,20 +2125,16 @@ describe('executeDagWorkflow -- tool restrictions', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      aiProfile
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      aiProfile,
+    });
 
     expect(mockGetAgentProviderDag.mock.calls[0][0]).toBe('codex');
     expect(
@@ -2186,12 +2157,12 @@ describe('executeDagWorkflow -- tool restrictions', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'dag-codex-denied',
         nodes: [
           {
@@ -2204,15 +2175,15 @@ describe('executeDagWorkflow -- tool restrictions', () => {
         ],
       },
       workflowRun,
-      'codex',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      { ...minimalConfig, assistant: 'codex' }
-    );
+      workflowProvider: 'codex',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: { ...minimalConfig, assistant: 'codex' },
+    });
 
     const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
     const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
@@ -2227,12 +2198,12 @@ describe('executeDagWorkflow -- tool restrictions', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'dag-empty-tools',
         nodes: [
           {
@@ -2244,15 +2215,15 @@ describe('executeDagWorkflow -- tool restrictions', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(mockSendQueryDag.mock.calls.length).toBeGreaterThan(0);
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
@@ -2265,12 +2236,12 @@ describe('executeDagWorkflow -- tool restrictions', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'dag-hooks',
         nodes: [
           {
@@ -2284,15 +2255,15 @@ describe('executeDagWorkflow -- tool restrictions', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(mockSendQueryDag.mock.calls.length).toBeGreaterThan(0);
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
@@ -2313,12 +2284,12 @@ describe('executeDagWorkflow -- tool restrictions', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'dag-codex-hooks',
         nodes: [
           {
@@ -2333,15 +2304,15 @@ describe('executeDagWorkflow -- tool restrictions', () => {
         ],
       },
       workflowRun,
-      'codex',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      { ...minimalConfig, assistant: 'codex' }
-    );
+      workflowProvider: 'codex',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: { ...minimalConfig, assistant: 'codex' },
+    });
 
     const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
     const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
@@ -2377,12 +2348,12 @@ describe('executeDagWorkflow -- AI node prompt substitution failure', () => {
       user_message: 'test',
     });
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-subst',
-      testDir,
-      {
+      conversationId: 'conv-subst',
+      cwd: testDir,
+      workflow: {
         name: 'subst-fail',
         nodes: [
           {
@@ -2393,15 +2364,16 @@ describe('executeDagWorkflow -- AI node prompt substitution failure', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      '', // base branch unresolved — the prompt references $BASE_BRANCH so substitution throws
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      // The prompt references $BASE_BRANCH, so leaving it unresolved makes substitution throw.
+      baseBranch: '',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // The substitution throw must surface as a node_failed event. Previously the
     // catch returned state:'failed' silently — the node emitted node_started and
@@ -2467,22 +2439,22 @@ describe('executeDagWorkflow -- bash nodes', () => {
       script: 'echo "hello world"',
     };
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-bash',
-      testDir,
-      { name: 'bash-exec-test', nodes: [bashNode] },
+      conversationId: 'conv-bash',
+      cwd: testDir,
+      workflow: { name: 'bash-exec-test', nodes: [bashNode] },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // Bash node should NOT invoke AI client
     expect(mockSendQueryDag.mock.calls.length).toBe(0);
@@ -2512,22 +2484,22 @@ describe('executeDagWorkflow -- bash nodes', () => {
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-bash',
-      testDir,
-      { name: 'bash-subst-test', nodes },
+      conversationId: 'conv-bash',
+      cwd: testDir,
+      workflow: { name: 'bash-subst-test', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // AI client should have been called for the downstream node
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -2552,22 +2524,22 @@ describe('executeDagWorkflow -- bash nodes', () => {
       script: 'exit 1',
     };
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-bash',
-      testDir,
-      { name: 'bash-fail-test', nodes: [bashNode] },
+      conversationId: 'conv-bash',
+      cwd: testDir,
+      workflow: { name: 'bash-fail-test', nodes: [bashNode] },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // The workflow should complete (it handles failures) but the node failed
     // The mock platform should have received a failure message about the failed node
@@ -2598,22 +2570,22 @@ describe('executeDagWorkflow -- bash nodes', () => {
         'UNIQUE_CMDLINE_MARKER_1389=; echo "stdout context before failure"; echo "diagnostic from stderr" >&2; exit 1',
     };
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-1389b',
-      testDir,
-      { name: 'bash-1389', nodes: [bashNode] },
+      conversationId: 'conv-1389b',
+      cwd: testDir,
+      workflow: { name: 'bash-1389', nodes: [bashNode] },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const eventCalls = (mockDeps.store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const failedEvent = eventCalls.find(
@@ -2649,22 +2621,22 @@ describe('executeDagWorkflow -- bash nodes', () => {
       script: 'echo "$ARGUMENTS"',
     };
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-bash',
-      testDir,
-      { name: 'bash-vars-test', nodes: [bashNode] },
+      conversationId: 'conv-bash',
+      cwd: testDir,
+      workflow: { name: 'bash-vars-test', nodes: [bashNode] },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // Should complete without error (no AI calls)
     expect(mockSendQueryDag.mock.calls.length).toBe(0);
@@ -2689,22 +2661,22 @@ describe('executeDagWorkflow -- bash nodes', () => {
       { id: 'ai-b', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-bash',
-      testDir,
-      { name: 'bash-parallel-test', nodes },
+      conversationId: 'conv-bash',
+      cwd: testDir,
+      workflow: { name: 'bash-parallel-test', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // AI client called only for the AI node, not the bash node
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -2716,25 +2688,25 @@ describe('executeDagWorkflow -- bash nodes', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun('bash-env-run-id');
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-bash-env',
-      testDir,
-      {
+      conversationId: 'conv-bash-env',
+      cwd: testDir,
+      workflow: {
         name: 'bash-env-test',
         nodes: [{ id: 'stats', kind: 'exec', runtime: 'sh', script: 'echo ok' }],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      { ...minimalConfig, envVars: { MY_SECRET: 'abc123' } }
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: { ...minimalConfig, envVars: { MY_SECRET: 'abc123' } },
+    });
 
     expect(execSpy).toHaveBeenCalledWith(
       git.resolveBashPath(),
@@ -2769,22 +2741,22 @@ describe('executeDagWorkflow -- bash nodes', () => {
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-injection',
-      testDir,
-      { name: 'bash-injection-test', nodes },
+      conversationId: 'conv-injection',
+      cwd: testDir,
+      workflow: { name: 'bash-injection-test', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // No AI calls
     expect(mockSendQueryDag.mock.calls.length).toBe(0);
@@ -2815,22 +2787,22 @@ describe('executeDagWorkflow -- bash nodes', () => {
         script: 'echo $USER_MESSAGE',
       };
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-shell-safe',
-        testDir,
-        { name: 'bash-shell-safe-test', nodes: [bashNode] },
+        conversationId: 'conv-shell-safe',
+        cwd: testDir,
+        workflow: { name: 'bash-shell-safe-test', nodes: [bashNode] },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       expect(execSpy).toHaveBeenCalledTimes(1);
       const firstCall = execSpy.mock.calls[0];
@@ -2886,22 +2858,22 @@ describe('executeDagWorkflow -- script node injection hardening (#2115)', () => 
         runtime: 'bun',
       };
 
-      await executeDagWorkflow(
-        createMockDeps(),
-        createMockPlatform(),
-        'conv-script-inject',
-        testDir,
-        { name: 'script-inject-test', nodes: [scriptNode] },
+      await executeDagWorkflow({
+        deps: createMockDeps(),
+        platform: createMockPlatform(),
+        conversationId: 'conv-script-inject',
+        cwd: testDir,
+        workflow: { name: 'script-inject-test', nodes: [scriptNode] },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       expect(execSpy).toHaveBeenCalledTimes(1);
       const [cmd, args, opts] = execSpy.mock.calls[0] as [
@@ -2937,22 +2909,22 @@ describe('executeDagWorkflow -- script node injection hardening (#2115)', () => 
         runtime: 'bun',
       };
 
-      await executeDagWorkflow(
-        createMockDeps(),
-        createMockPlatform(),
-        'conv-script-literal',
-        testDir,
-        { name: 'script-literal-test', nodes: [scriptNode] },
+      await executeDagWorkflow({
+        deps: createMockDeps(),
+        platform: createMockPlatform(),
+        conversationId: 'conv-script-literal',
+        cwd: testDir,
+        workflow: { name: 'script-literal-test', nodes: [scriptNode] },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       const [, args] = execSpy.mock.calls[0] as [string, string[], unknown];
       // The dangerous payload is NOT interpolated into the source; $ARGUMENTS stays literal.
@@ -2979,24 +2951,23 @@ describe('executeDagWorkflow -- script node injection hardening (#2115)', () => 
         runtime: 'uv',
       };
 
-      await executeDagWorkflow(
-        createMockDeps(),
-        createMockPlatform(),
-        'conv-script-uv',
-        testDir,
-        { name: 'script-uv-test', nodes: [scriptNode] },
+      await executeDagWorkflow({
+        deps: createMockDeps(),
+        platform: createMockPlatform(),
+        conversationId: 'conv-script-uv',
+        cwd: testDir,
+        workflow: { name: 'script-uv-test', nodes: [scriptNode] },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig,
-        undefined, // configuredCommandFolder
-        'ISSUE #42 body text' // issueContext
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+        issueContext: 'ISSUE #42 body text',
+      });
 
       const [cmd, args, opts] = execSpy.mock.calls[0] as [
         string,
@@ -3037,24 +3008,23 @@ describe('executeDagWorkflow -- script node injection hardening (#2115)', () => 
         envVars: { ARGUMENTS: 'PROJECT_OVERRIDE', CONTEXT: 'PROJECT_CTX', MY_VAR: 'keep-me' },
       };
 
-      await executeDagWorkflow(
-        createMockDeps(),
-        createMockPlatform(),
-        'conv-script-collision',
-        testDir,
-        { name: 'script-env-collision', nodes: [scriptNode] },
+      await executeDagWorkflow({
+        deps: createMockDeps(),
+        platform: createMockPlatform(),
+        conversationId: 'conv-script-collision',
+        cwd: testDir,
+        workflow: { name: 'script-env-collision', nodes: [scriptNode] },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        configWithEnv,
-        undefined, // configuredCommandFolder
-        'ENGINE_CONTEXT' // issueContext
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: configWithEnv,
+        issueContext: 'ENGINE_CONTEXT',
+      });
 
       const [, , opts] = execSpy.mock.calls[0] as [string, string[], { env: NodeJS.ProcessEnv }];
       // Reserved workflow vars win over the colliding configured vars — the delivery
@@ -3094,22 +3064,22 @@ describe('executeDagWorkflow -- script node injection hardening (#2115)', () => 
         },
       ];
 
-      await executeDagWorkflow(
-        createMockDeps(),
-        createMockPlatform(),
-        'conv-script-nodeoutput',
-        testDir,
-        { name: 'script-nodeoutput-test', nodes },
+      await executeDagWorkflow({
+        deps: createMockDeps(),
+        platform: createMockPlatform(),
+        conversationId: 'conv-script-nodeoutput',
+        cwd: testDir,
+        workflow: { name: 'script-nodeoutput-test', nodes },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       const scriptCall = execSpy.mock.calls.find(
         c => (c[0] as string) === 'bun' && (c[1] as string[]).includes('-e')
@@ -3139,22 +3109,22 @@ describe('executeDagWorkflow -- script node injection hardening (#2115)', () => 
         runtime: 'bun',
       };
 
-      await executeDagWorkflow(
-        createMockDeps(),
+      await executeDagWorkflow({
+        deps: createMockDeps(),
         platform,
-        'conv-script-warn',
-        testDir,
-        { name: 'script-warn-test', nodes: [scriptNode] },
+        conversationId: 'conv-script-warn',
+        cwd: testDir,
+        workflow: { name: 'script-warn-test', nodes: [scriptNode] },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       const messages = (platform.sendMessage as ReturnType<typeof mock>).mock.calls.map(
         (c: unknown[]) => c[1] as string
@@ -3187,22 +3157,22 @@ describe('executeDagWorkflow -- script node injection hardening (#2115)', () => 
         runtime: 'bun',
       };
 
-      await executeDagWorkflow(
-        createMockDeps(),
+      await executeDagWorkflow({
+        deps: createMockDeps(),
         platform,
-        'conv-script-nowarn',
-        testDir,
-        { name: 'script-nowarn-test', nodes: [scriptNode] },
+        conversationId: 'conv-script-nowarn',
+        cwd: testDir,
+        workflow: { name: 'script-nowarn-test', nodes: [scriptNode] },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       const messages = (platform.sendMessage as ReturnType<typeof mock>).mock.calls.map(
         (c: unknown[]) => c[1] as string
@@ -3285,22 +3255,22 @@ describe('executeDagWorkflow -- output_format structured output', () => {
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-output-fmt',
-      testDir,
-      { name: 'output-fmt-test', nodes },
+      conversationId: 'conv-output-fmt',
+      cwd: testDir,
+      workflow: { name: 'output-fmt-test', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // The review node's when condition should evaluate to true (run_code_review == 'true')
     // The test node's when condition should evaluate to false (run_tests == 'false', not 'true')
@@ -3331,22 +3301,22 @@ describe('executeDagWorkflow -- output_format structured output', () => {
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-no-fmt',
-      testDir,
-      { name: 'no-fmt-test', nodes },
+      conversationId: 'conv-no-fmt',
+      cwd: testDir,
+      workflow: { name: 'no-fmt-test', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(mockSendQueryDag.mock.calls.length).toBe(2);
 
@@ -3379,22 +3349,22 @@ describe('executeDagWorkflow -- output_format structured output', () => {
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-fallback',
-      testDir,
-      { name: 'fallback-test', nodes },
+      conversationId: 'conv-fallback',
+      cwd: testDir,
+      workflow: { name: 'fallback-test', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // Both nodes should execute (no output_format, no when conditions)
     expect(mockSendQueryDag.mock.calls.length).toBe(2);
@@ -3452,22 +3422,22 @@ describe('executeDagWorkflow -- output_format structured output', () => {
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-codex-fmt',
-      testDir,
-      { name: 'codex-output-fmt', nodes },
+      conversationId: 'conv-codex-fmt',
+      cwd: testDir,
+      workflow: { name: 'codex-output-fmt', nodes },
       workflowRun,
-      'codex',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'codex',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // classify + review = 2 calls (test node skipped because run_tests == 'false')
     expect(mockSendQueryDag.mock.calls.length).toBe(2);
@@ -3507,22 +3477,22 @@ describe('executeDagWorkflow -- output_format structured output', () => {
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-codex-no-warn',
-      testDir,
-      { name: 'codex-no-warn', nodes },
+      conversationId: 'conv-codex-no-warn',
+      cwd: testDir,
+      workflow: { name: 'codex-no-warn', nodes },
       workflowRun,
-      'codex',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'codex',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // Verify no "structured output missing" warning was sent to the user
     const sendCalls = (platform.sendMessage as Mock<(...args: unknown[]) => Promise<void>>).mock
@@ -3586,22 +3556,22 @@ describe('executeDagWorkflow -- when condition parse errors (fail-closed)', () =
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-parse-err-skip',
-      testDir,
-      { name: 'parse-err-skip-test', nodes },
+      conversationId: 'conv-parse-err-skip',
+      cwd: testDir,
+      workflow: { name: 'parse-err-skip-test', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // Only the unconditional node should have triggered an AI call.
     // The guarded node must be skipped (fail-closed), not executed.
@@ -3622,22 +3592,22 @@ describe('executeDagWorkflow -- when condition parse errors (fail-closed)', () =
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-parse-err-warn',
-      testDir,
-      { name: 'parse-warn-test', nodes },
+      conversationId: 'conv-parse-err-warn',
+      cwd: testDir,
+      workflow: { name: 'parse-warn-test', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
     const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
@@ -3662,22 +3632,22 @@ describe('executeDagWorkflow -- when condition parse errors (fail-closed)', () =
     ];
 
     await expect(
-      executeDagWorkflow(
-        mockDeps,
+      executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-all-skipped',
-        testDir,
-        { name: 'all-skipped-test', nodes },
+        conversationId: 'conv-all-skipped',
+        cwd: testDir,
+        workflow: { name: 'all-skipped-test', nodes },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      )
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      })
     ).resolves.toBeUndefined();
   });
 });
@@ -3755,22 +3725,22 @@ describe('executeDagWorkflow -- node-level retry for transient errors', () => {
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag-retry-succeed',
-      testDir,
-      { name: 'dag-retry-succeed', nodes },
+      conversationId: 'conv-dag-retry-succeed',
+      cwd: testDir,
+      workflow: { name: 'dag-retry-succeed', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // Node was called at least twice (first fails transiently, second succeeds)
     expect(callCount).toBeGreaterThanOrEqual(2);
@@ -3806,22 +3776,22 @@ describe('executeDagWorkflow -- node-level retry for transient errors', () => {
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag-retry-exhaust',
-      testDir,
-      { name: 'dag-retry-exhaust', nodes },
+      conversationId: 'conv-dag-retry-exhaust',
+      cwd: testDir,
+      workflow: { name: 'dag-retry-exhaust', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // max_attempts: 2 = 2 retries → 3 total attempts (delay_ms: 1 keeps test fast)
     expect(callCount).toBe(3);
@@ -3844,12 +3814,12 @@ describe('executeDagWorkflow -- node-level retry for transient errors', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('dag-retry-ratelimit-run');
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag-retry-ratelimit',
-        testDir,
-        {
+        conversationId: 'conv-dag-retry-ratelimit',
+        cwd: testDir,
+        workflow: {
           name: 'dag-retry-ratelimit',
           nodes: [
             {
@@ -3861,15 +3831,15 @@ describe('executeDagWorkflow -- node-level retry for transient errors', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // max_attempts would allow 2 attempts; a rate-limited failure widens the
       // budget to RATE_LIMIT_MAX_RETRIES retries.
@@ -3898,12 +3868,12 @@ describe('executeDagWorkflow -- node-level retry for transient errors', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('dag-ratelimit-recover-run');
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag-ratelimit-recover',
-        testDir,
-        {
+        conversationId: 'conv-dag-ratelimit-recover',
+        cwd: testDir,
+        workflow: {
           name: 'dag-ratelimit-recover',
           nodes: [
             {
@@ -3915,15 +3885,15 @@ describe('executeDagWorkflow -- node-level retry for transient errors', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       expect(callCount).toBe(4);
       expect(mockDeps.store.failWorkflowRun as ReturnType<typeof mock>).not.toHaveBeenCalled();
@@ -3949,12 +3919,12 @@ describe('executeDagWorkflow -- node-level retry for transient errors', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun('dag-silent-stream-run');
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag-silent-stream',
-      testDir,
-      {
+      conversationId: 'conv-dag-silent-stream',
+      cwd: testDir,
+      workflow: {
         name: 'dag-silent-stream',
         nodes: [
           {
@@ -3966,15 +3936,15 @@ describe('executeDagWorkflow -- node-level retry for transient errors', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(callCount).toBe(2);
     expect(mockDeps.store.failWorkflowRun as ReturnType<typeof mock>).not.toHaveBeenCalled();
@@ -4000,22 +3970,22 @@ describe('executeDagWorkflow -- node-level retry for transient errors', () => {
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag-retry-fatal',
-      testDir,
-      { name: 'dag-retry-fatal', nodes },
+      conversationId: 'conv-dag-retry-fatal',
+      cwd: testDir,
+      workflow: { name: 'dag-retry-fatal', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // FATAL error must not be retried — exactly 1 attempt
     expect(callCount).toBe(1);
@@ -4046,22 +4016,22 @@ describe('executeDagWorkflow -- node-level retry for transient errors', () => {
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag-retry-notify',
-      testDir,
-      { name: 'dag-retry-notify', nodes },
+      conversationId: 'conv-dag-retry-notify',
+      cwd: testDir,
+      workflow: { name: 'dag-retry-notify', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const sendCalls = (platform.sendMessage as ReturnType<typeof mock>).mock.calls;
     const retryMessages = sendCalls.filter(
@@ -4108,22 +4078,22 @@ describe('executeDagWorkflow -- retry on deterministic (bash/script) nodes (#208
       conversation_id: 'conv-det-retry',
       user_message: 'det retry message',
     });
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-det-retry',
-      testDir,
-      { name: 'det-retry', nodes },
+      conversationId: 'conv-det-retry',
+      cwd: testDir,
+      workflow: { name: 'det-retry', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
     return { mockDeps, platform };
   }
 
@@ -4296,25 +4266,25 @@ describe('executeDagWorkflow -- tool_called event persistence', () => {
       yield { type: 'result', sessionId: 'dag-session-id' };
     });
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'tool-test-dag',
         nodes: [node('my-cmd')],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const eventCalls = (mockStore.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const toolCalledEvents = eventCalls.filter(
@@ -4343,22 +4313,22 @@ describe('executeDagWorkflow -- tool_called event persistence', () => {
       yield { type: 'result', sessionId: 'dag-session-tool' };
     });
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag-tool',
-      testDir,
-      { name: 'dag-tool-test', nodes: [node('my-cmd')] },
+      conversationId: 'conv-dag-tool',
+      cwd: testDir,
+      workflow: { name: 'dag-tool-test', nodes: [node('my-cmd')] },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(platform.sendStructuredEvent).toHaveBeenCalledWith('conv-dag-tool', {
       type: 'tool',
@@ -4410,22 +4380,22 @@ describe('executeDagWorkflow -- tool_completed event emission', () => {
       yield { type: 'result', sessionId: 'dag-sess-1' };
     });
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag-complete',
-      testDir,
-      { name: 'dag-complete-test', nodes: [node('my-cmd')] },
+      conversationId: 'conv-dag-complete',
+      cwd: testDir,
+      workflow: { name: 'dag-complete-test', nodes: [node('my-cmd')] },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const createEventCalls = (mockStore.createWorkflowEvent as ReturnType<typeof mock>).mock
       .calls as Array<[{ event_type: string; data?: Record<string, unknown> }]>;
@@ -4454,22 +4424,22 @@ describe('executeDagWorkflow -- tool_completed event emission', () => {
       yield { type: 'result', sessionId: 'dag-sess-2' };
     });
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag-last',
-      testDir,
-      { name: 'dag-last-test', nodes: [node('my-cmd')] },
+      conversationId: 'conv-dag-last',
+      cwd: testDir,
+      workflow: { name: 'dag-last-test', nodes: [node('my-cmd')] },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const createEventCalls = (mockStore.createWorkflowEvent as ReturnType<typeof mock>).mock
       .calls as Array<[{ event_type: string; data?: Record<string, unknown> }]>;
@@ -4507,22 +4477,22 @@ describe('executeDagWorkflow -- tool_completed event emission', () => {
     });
 
     try {
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag-tool-result',
-        testDir,
-        { name: 'dag-tool-result-test', nodes: [node('my-cmd')] },
+        conversationId: 'conv-dag-tool-result',
+        cwd: testDir,
+        workflow: { name: 'dag-tool-result-test', nodes: [node('my-cmd')] },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
     } finally {
       setSystemTime();
     }
@@ -4573,22 +4543,22 @@ describe('executeDagWorkflow -- tool_completed event emission', () => {
     });
 
     try {
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag-interleaved-tools',
-        testDir,
-        { name: 'dag-interleaved-tools', nodes: [node('my-cmd')] },
+        conversationId: 'conv-dag-interleaved-tools',
+        cwd: testDir,
+        workflow: { name: 'dag-interleaved-tools', nodes: [node('my-cmd')] },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
     } finally {
       setSystemTime();
     }
@@ -4626,22 +4596,22 @@ describe('executeDagWorkflow -- tool_completed event emission', () => {
       yield { type: 'result', sessionId: 'dag-sess-3' };
     });
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag-notools',
-      testDir,
-      { name: 'dag-notools-test', nodes: [node('my-cmd')] },
+      conversationId: 'conv-dag-notools',
+      cwd: testDir,
+      workflow: { name: 'dag-notools-test', nodes: [node('my-cmd')] },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const createEventCalls = (mockStore.createWorkflowEvent as ReturnType<typeof mock>).mock
       .calls as Array<[{ event_type: string; data?: Record<string, unknown> }]>;
@@ -4943,12 +4913,12 @@ describe('executeDagWorkflow -- skills options', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'dag-skills',
         nodes: [
           {
@@ -4960,15 +4930,15 @@ describe('executeDagWorkflow -- skills options', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(mockSendQueryDag.mock.calls.length).toBeGreaterThan(0);
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
@@ -4982,12 +4952,12 @@ describe('executeDagWorkflow -- skills options', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'dag-skills-tools',
         nodes: [
           {
@@ -5000,15 +4970,15 @@ describe('executeDagWorkflow -- skills options', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(mockSendQueryDag.mock.calls.length).toBeGreaterThan(0);
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
@@ -5029,12 +4999,12 @@ describe('executeDagWorkflow -- skills options', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'dag-codex-skills',
         nodes: [
           {
@@ -5047,15 +5017,15 @@ describe('executeDagWorkflow -- skills options', () => {
         ],
       },
       workflowRun,
-      'codex',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      { ...minimalConfig, assistant: 'codex' }
-    );
+      workflowProvider: 'codex',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: { ...minimalConfig, assistant: 'codex' },
+    });
 
     // Codex workflow nodes suppress the ambient catalog. Authors invoke installed
     // native skills explicitly in the command/prompt with `$skill-name` instead.
@@ -5079,12 +5049,12 @@ describe('executeDagWorkflow -- skills options', () => {
       },
     };
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'dag-agents',
         nodes: [
           {
@@ -5096,15 +5066,15 @@ describe('executeDagWorkflow -- skills options', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(mockSendQueryDag.mock.calls.length).toBeGreaterThan(0);
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
@@ -5123,12 +5093,12 @@ describe('executeDagWorkflow -- skills options', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'dag-codex-agents',
         nodes: [
           {
@@ -5143,15 +5113,15 @@ describe('executeDagWorkflow -- skills options', () => {
         ],
       },
       workflowRun,
-      'codex',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      { ...minimalConfig, assistant: 'codex' }
-    );
+      workflowProvider: 'codex',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: { ...minimalConfig, assistant: 'codex' },
+    });
 
     const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
     const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
@@ -5501,25 +5471,23 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     });
 
     const store = createMockStore();
-    const result = await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-resume',
-      testDir,
-      ready(rawLoopGroupWorkflow(field)),
-      makeWorkflowRun(runId),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+    const result = await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-resume',
+      cwd: testDir,
+      workflow: ready(rawLoopGroupWorkflow(field)),
+      workflowRun: makeWorkflowRun(runId),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
 
     const events = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls.map(
       (call: unknown[]) => call[0] as PersistedEvent
@@ -5535,12 +5503,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
 
     const priorCompletedNodes = new Map([['step1', { output: 'prior step1 output' }]]);
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-resume',
-      testDir,
-      {
+      conversationId: 'conv-resume',
+      cwd: testDir,
+      workflow: {
         name: 'two-step',
         nodes: [
           { id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } },
@@ -5553,18 +5521,16 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
 
     // Only step2 should have been executed (step1 was skipped)
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -5585,12 +5551,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
 
     const priorCompletedNodes = new Map([['step1', { output: 'hello from prior run' }]]);
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-resume',
-      testDir,
-      {
+      conversationId: 'conv-resume',
+      cwd: testDir,
+      workflow: {
         name: 'two-step',
         nodes: [
           { id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } },
@@ -5603,18 +5569,16 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
 
     // The prompt sent to AI should contain the prior run's output
     expect(capturedPrompt).toContain('hello from prior run');
@@ -5628,12 +5592,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
 
     const priorCompletedNodes = new Map([['step1', { output: 'prior output' }]]);
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-resume',
-      testDir,
-      {
+      conversationId: 'conv-resume',
+      cwd: testDir,
+      workflow: {
         name: 'two-step',
         nodes: [
           { id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } },
@@ -5646,18 +5610,16 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const skippedEvent = eventCalls.find(
@@ -5683,12 +5645,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     const largeOutput = 'y'.repeat(40_000);
     const priorCompletedNodes = new Map([['step1', { output: largeOutput }]]);
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-resume-large-skip',
-      testDir,
-      {
+      conversationId: 'conv-resume-large-skip',
+      cwd: testDir,
+      workflow: {
         name: 'two-step',
         nodes: [
           { id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } },
@@ -5701,18 +5663,16 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
+      workflowProvider: 'claude',
+      workflowModel: undefined,
       artifactsDir,
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const skippedEvent = eventCalls.find(
@@ -5748,12 +5708,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       ['step1', { output: undefined as unknown as string }],
     ]);
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-resume',
-      testDir,
-      {
+      conversationId: 'conv-resume',
+      cwd: testDir,
+      workflow: {
         name: 'two-step',
         nodes: [
           { id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } },
@@ -5766,18 +5726,16 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const skippedEvent = eventCalls.find(
@@ -5797,12 +5755,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-resume',
-      testDir,
-      {
+      conversationId: 'conv-resume',
+      cwd: testDir,
+      workflow: {
         name: 'two-step',
         nodes: [
           { id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } },
@@ -5815,18 +5773,16 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      new Map()
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes: new Map(),
+    });
 
     // Both nodes should execute
     expect(mockSendQueryDag.mock.calls.length).toBe(2);
@@ -5871,22 +5827,22 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       yield { type: 'result', sessionId: 'failed-step-session' };
     });
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-resume-tokens',
-      testDir,
+      conversationId: 'conv-resume-tokens',
+      cwd: testDir,
       workflow,
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(store.failWorkflowRun).toHaveBeenCalled();
     expect(store.completeWorkflowRun).not.toHaveBeenCalled();
@@ -5945,33 +5901,24 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       };
     });
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-resume-tokens',
-      testDir,
+      conversationId: 'conv-resume-tokens',
+      cwd: testDir,
       workflow,
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
       priorCompletedNodes,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      priorUsage
-    );
+      priorUsage,
+    });
 
     // #2469 (AC4): the resumed run reports pass 1 + pass 2 on BOTH axes. Cost used to
     // reset to 0 on every pass, so a run that failed at 0.02 and then completed would
@@ -6072,12 +6019,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       yield { type: 'result', sessionId: 'structured-loop-resume-session' };
     });
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-resume',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-resume',
+      cwd: testDir,
+      workflow: {
         name: 'structured-loop-resume',
         nodes: [
           {
@@ -6103,19 +6050,17 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           },
         ],
       },
-      makeWorkflowRun('structured-loop-resume'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      new Map([['iterate', { output: '{"done":true}' }]])
-    );
+      workflowRun: makeWorkflowRun('structured-loop-resume'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes: new Map([['iterate', { output: '{"done":true}' }]]),
+    });
 
     expect(mockSendQueryDag).toHaveBeenCalledTimes(1);
     expect(capturedPrompt).toBe('note=[]');
@@ -6141,12 +6086,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     // Prior JSON output omits the declared-optional `note` field.
     const priorCompletedNodes = new Map([['step1', { output: '{"type":"BUG"}' }]]);
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-resume',
-      testDir,
-      {
+      conversationId: 'conv-resume',
+      cwd: testDir,
+      workflow: {
         name: 'declared-optional',
         nodes: [
           {
@@ -6168,18 +6113,16 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
 
     // The consumer must run (step1 was skipped, so exactly one AI call = step2),
     // and the declared-but-absent `note` resolves to '' — not a missing-key throw.
@@ -6196,12 +6139,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     // Prior JSON output carries an `extra` key that the schema does NOT declare.
     const priorCompletedNodes = new Map([['step1', { output: '{"type":"BUG","extra":"x"}' }]]);
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-resume',
-      testDir,
-      {
+      conversationId: 'conv-resume',
+      cwd: testDir,
+      workflow: {
         name: 'undeclared-key',
         nodes: [
           {
@@ -6223,18 +6166,16 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
 
     // The undeclared `extra` must fail the consumer before the AI runs (0 calls),
     // matching fresh-run behavior instead of silently resolving via the schemaless path.
@@ -6264,22 +6205,22 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       script: 'echo "bash output"',
     };
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-bash-output',
-      testDir,
-      { name: 'bash-output-test', nodes: [bashNode] },
+      conversationId: 'conv-bash-output',
+      cwd: testDir,
+      workflow: { name: 'bash-output-test', nodes: [bashNode] },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const completedEvent = eventCalls.find(
@@ -6302,12 +6243,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const mockDeps = createMockDeps(store);
       const workflowRun = makeWorkflowRun(`bash-output-${nodeId}`);
 
-      await executeDagWorkflow(
-        mockDeps,
-        createMockPlatform(),
-        `conv-${nodeId}`,
-        testDir,
-        {
+      await executeDagWorkflow({
+        deps: mockDeps,
+        platform: createMockPlatform(),
+        conversationId: `conv-${nodeId}`,
+        cwd: testDir,
+        workflow: {
           name: `bash-output-${nodeId}`,
           nodes: [
             {
@@ -6319,15 +6260,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
       const completedEvent = eventCalls.find(
@@ -6351,27 +6292,27 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     const mockDeps = createMockDeps(store);
     const workflowRun = makeWorkflowRun('bash-output-over-cap');
 
-    await executeDagWorkflow(
-      mockDeps,
-      createMockPlatform(),
-      'conv-over-cap',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: mockDeps,
+      platform: createMockPlatform(),
+      conversationId: 'conv-over-cap',
+      cwd: testDir,
+      workflow: {
         name: 'bash-output-over-cap',
         nodes: [
           { id: 'over-cap', kind: 'exec', runtime: 'sh', script: "printf '%32769s' '' | tr ' ' x" },
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const completedEvent = eventCalls.find(
@@ -6413,12 +6354,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     const mockDeps = createMockDeps(store);
     const workflowRun = makeWorkflowRun('bash-output-utf8-cap');
 
-    await executeDagWorkflow(
-      mockDeps,
-      createMockPlatform(),
-      'conv-utf8-cap',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: mockDeps,
+      platform: createMockPlatform(),
+      conversationId: 'conv-utf8-cap',
+      cwd: testDir,
+      workflow: {
         name: 'bash-output-utf8-cap',
         nodes: [
           {
@@ -6430,15 +6371,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const completedEvent = eventCalls.find(
@@ -6465,12 +6406,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const mockDeps = createMockDeps(store);
       const workflowRun = makeWorkflowRun(`script-output-${nodeId}`);
 
-      await executeDagWorkflow(
-        mockDeps,
-        createMockPlatform(),
-        `conv-${nodeId}`,
-        testDir,
-        {
+      await executeDagWorkflow({
+        deps: mockDeps,
+        platform: createMockPlatform(),
+        conversationId: `conv-${nodeId}`,
+        cwd: testDir,
+        workflow: {
           name: `script-output-${nodeId}`,
           nodes: [
             {
@@ -6482,15 +6423,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
       const completedEvent = eventCalls.find(
@@ -6515,12 +6456,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     const mockDeps = createMockDeps(store);
     const workflowRun = makeWorkflowRun('script-output-over-cap');
 
-    await executeDagWorkflow(
-      mockDeps,
-      createMockPlatform(),
-      'conv-script-over-cap',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: mockDeps,
+      platform: createMockPlatform(),
+      conversationId: 'conv-script-over-cap',
+      cwd: testDir,
+      workflow: {
         name: 'script-output-over-cap',
         nodes: [
           {
@@ -6532,15 +6473,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const completedEvent = eventCalls.find(
@@ -6585,12 +6526,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     const producerOutput = `{"status":"PASS","padding":"${'x'.repeat(paddingBytes)}"}`;
     await mkdir(artifactsDir, { recursive: true });
 
-    await executeDagWorkflow(
-      mockDeps,
-      createMockPlatform(),
-      'conv-live-full',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: mockDeps,
+      platform: createMockPlatform(),
+      conversationId: 'conv-live-full',
+      cwd: testDir,
+      workflow: {
         name: 'bash-output-live-full',
         nodes: [
           {
@@ -6610,15 +6551,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
+      workflowProvider: 'claude',
+      workflowModel: undefined,
       artifactsDir,
-      join(testDir, 'state'),
+      stateDir: join(testDir, 'state'),
       logDir,
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const producerEvent = eventCalls.find(
@@ -6658,12 +6599,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     const producerOutput = `{"status":"PASS","padding":"${'z'.repeat(paddingBytes)}"}`;
     const priorCompletedNodes = new Map([['producer', { output: producerOutput }]]);
 
-    await executeDagWorkflow(
-      mockDeps,
-      createMockPlatform(),
-      'conv-resume-large-field',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: mockDeps,
+      platform: createMockPlatform(),
+      conversationId: 'conv-resume-large-field',
+      cwd: testDir,
+      workflow: {
         name: 'resume-large-field',
         nodes: [
           { id: 'producer', kind: 'exec', runtime: 'sh', script: 'echo unused' },
@@ -6677,19 +6618,17 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           },
         ],
       },
-      makeWorkflowRun('resume-large-field'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+      workflowRun: makeWorkflowRun('resume-large-field'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     // producer was resumed (skipped), so it must never re-execute.
@@ -6728,12 +6667,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
 
     // Pass 1: a real script node produces an over-cap JSON output and spills for real.
     const freshStore = createMockStore();
-    await executeDagWorkflow(
-      createMockDeps(freshStore),
-      createMockPlatform(),
-      'conv-script-fresh-large-field',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(freshStore),
+      platform: createMockPlatform(),
+      conversationId: 'conv-script-fresh-large-field',
+      cwd: testDir,
+      workflow: {
         name: 'script-fresh-large-field',
         nodes: [
           {
@@ -6744,16 +6683,16 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           },
         ],
       },
-      makeWorkflowRun('script-fresh-large-field'),
-      'claude',
-      undefined,
+      workflowRun: makeWorkflowRun('script-fresh-large-field'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
       artifactsDir,
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const freshEventCalls = (freshStore.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const producerEvent = freshEventCalls.find(
@@ -6780,12 +6719,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     // access on it resolves rather than hard-failing.
     const resumedStore = createMockStore();
     const priorCompletedNodes = new Map([['producer', { output: spilledFullOutput }]]);
-    await executeDagWorkflow(
-      createMockDeps(resumedStore),
-      createMockPlatform(),
-      'conv-script-resumed-large-field',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(resumedStore),
+      platform: createMockPlatform(),
+      conversationId: 'conv-script-resumed-large-field',
+      cwd: testDir,
+      workflow: {
         name: 'script-resumed-large-field',
         nodes: [
           {
@@ -6804,19 +6743,17 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           },
         ],
       },
-      makeWorkflowRun('script-resumed-large-field'),
-      'claude',
-      undefined,
+      workflowRun: makeWorkflowRun('script-resumed-large-field'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
       artifactsDir,
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
 
     const resumedEventCalls = (resumedStore.createWorkflowEvent as ReturnType<typeof mock>).mock
       .calls;
@@ -6855,12 +6792,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       };
     });
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-output',
-      testDir,
-      {
+      conversationId: 'conv-output',
+      cwd: testDir,
+      workflow: {
         name: 'single-node',
         nodes: [
           {
@@ -6872,15 +6809,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const completedEvent = eventCalls.find(
@@ -6916,25 +6853,25 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     const store = createMockStore();
     const mockDeps = createMockDeps(store);
 
-    await executeDagWorkflow(
-      mockDeps,
-      createMockPlatform(),
-      'conv-no-usage',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: mockDeps,
+      platform: createMockPlatform(),
+      conversationId: 'conv-no-usage',
+      cwd: testDir,
+      workflow: {
         name: 'no-usage',
         nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } }],
       },
-      makeWorkflowRun('no-usage-run'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('no-usage-run'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls as Array<
       [{ event_type: string; step_name: string; data?: Record<string, unknown> }]
@@ -6962,25 +6899,25 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     const store = createMockStore();
     const mockDeps = createMockDeps(store);
 
-    await executeDagWorkflow(
-      mockDeps,
-      createMockPlatform(),
-      'conv-shape',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: mockDeps,
+      platform: createMockPlatform(),
+      conversationId: 'conv-shape',
+      cwd: testDir,
+      workflow: {
         name: 'token-shape',
         nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } }],
       },
-      makeWorkflowRun('token-shape-run'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('token-shape-run'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls as Array<
       [{ event_type: string; step_name: string; data?: Record<string, unknown> }]
@@ -7000,25 +6937,25 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     const store = createMockStore();
     const mockDeps = createMockDeps(store);
 
-    await executeDagWorkflow(
-      mockDeps,
-      createMockPlatform(),
-      'conv-nan',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: mockDeps,
+      platform: createMockPlatform(),
+      conversationId: 'conv-nan',
+      cwd: testDir,
+      workflow: {
         name: 'nan-tokens',
         nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } }],
       },
-      makeWorkflowRun('nan-tokens-run'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('nan-tokens-run'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls as Array<
       [{ event_type: string; step_name: string; data?: Record<string, unknown> }]
@@ -7047,25 +6984,25 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     const mockDeps = createMockDeps(store);
     const logDir = join(testDir, 'logs');
 
-    await executeDagWorkflow(
-      mockDeps,
-      createMockPlatform(),
-      'conv-transcript-cost',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: mockDeps,
+      platform: createMockPlatform(),
+      conversationId: 'conv-transcript-cost',
+      cwd: testDir,
+      workflow: {
         name: 'transcript-cost',
         nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } }],
       },
-      makeWorkflowRun('transcript-cost-run'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
+      workflowRun: makeWorkflowRun('transcript-cost-run'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
       logDir,
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const transcript = await readTranscript(logDir, 'transcript-cost-run');
     const nodeRow = transcript.find(e => e.type === 'node_complete' && e.step === 'step1');
@@ -7099,25 +7036,25 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     const mockDeps = createMockDeps(store);
     const logDir = join(testDir, 'logs');
 
-    await executeDagWorkflow(
-      mockDeps,
-      createMockPlatform(),
-      'conv-transcript-no-cost',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: mockDeps,
+      platform: createMockPlatform(),
+      conversationId: 'conv-transcript-no-cost',
+      cwd: testDir,
+      workflow: {
         name: 'transcript-no-cost',
         nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } }],
       },
-      makeWorkflowRun('transcript-no-cost-run'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
+      workflowRun: makeWorkflowRun('transcript-no-cost-run'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
       logDir,
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const transcript = await readTranscript(logDir, 'transcript-no-cost-run');
     const nodeRow = transcript.find(e => e.type === 'node_complete' && e.step === 'step1');
@@ -7142,25 +7079,25 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
     ): Promise<void> => {
       const mockDeps = createMockDeps(store);
       const workflowRun = makeWorkflowRun(runId);
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-bg-tasks',
-        testDir,
-        {
+        conversationId: 'conv-bg-tasks',
+        cwd: testDir,
+        workflow: {
           name: 'bg-task-test',
           nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'step1' } }],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
     };
 
     const findCompletedEvent = (
@@ -7356,12 +7293,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       });
 
       try {
-        await executeDagWorkflow(
-          mockDeps,
+        await executeDagWorkflow({
+          deps: mockDeps,
           platform,
-          'conv-dag',
-          testDir,
-          {
+          conversationId: 'conv-dag',
+          cwd: testDir,
+          workflow: {
             name: 'dag-loop-tool-result',
             nodes: [
               {
@@ -7377,15 +7314,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             ],
           },
           workflowRun,
-          'claude',
-          undefined,
-          join(testDir, 'artifacts'),
-          join(testDir, 'state'),
-          join(testDir, 'logs'),
-          'main',
-          'docs/',
-          minimalConfig
-        );
+          workflowProvider: 'claude',
+          workflowModel: undefined,
+          artifactsDir: join(testDir, 'artifacts'),
+          stateDir: join(testDir, 'state'),
+          logDir: join(testDir, 'logs'),
+          baseBranch: 'main',
+          docsDir: 'docs/',
+          config: minimalConfig,
+        });
       } finally {
         setSystemTime();
       }
@@ -7421,12 +7358,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         const platform = createMockPlatform();
         const workflowRun = makeWorkflowRun('loop-iteration-retry-run');
 
-        await executeDagWorkflow(
-          mockDeps,
+        await executeDagWorkflow({
+          deps: mockDeps,
           platform,
-          'conv-loop-retry',
-          testDir,
-          {
+          conversationId: 'conv-loop-retry',
+          cwd: testDir,
+          workflow: {
             name: 'loop-iteration-retry',
             nodes: [
               {
@@ -7442,15 +7379,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             ],
           },
           workflowRun,
-          'claude',
-          undefined,
-          join(testDir, 'artifacts'),
-          join(testDir, 'state'),
-          join(testDir, 'logs'),
-          'main',
-          'docs/',
-          minimalConfig
-        );
+          workflowProvider: 'claude',
+          workflowModel: undefined,
+          artifactsDir: join(testDir, 'artifacts'),
+          stateDir: join(testDir, 'state'),
+          logDir: join(testDir, 'logs'),
+          baseBranch: 'main',
+          docsDir: 'docs/',
+          config: minimalConfig,
+        });
 
         // The failed attempt is re-streamed within iteration 1 and the run completes.
         expect(callCount).toBe(2);
@@ -7493,12 +7430,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       });
 
       try {
-        await executeDagWorkflow(
-          mockDeps,
+        await executeDagWorkflow({
+          deps: mockDeps,
           platform,
-          'conv-loop-interleaved-tools',
-          testDir,
-          {
+          conversationId: 'conv-loop-interleaved-tools',
+          cwd: testDir,
+          workflow: {
             name: 'loop-interleaved-tools',
             nodes: [
               {
@@ -7514,15 +7451,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             ],
           },
           workflowRun,
-          'claude',
-          undefined,
-          join(testDir, 'artifacts'),
-          join(testDir, 'state'),
-          join(testDir, 'logs'),
-          'main',
-          'docs/',
-          minimalConfig
-        );
+          workflowProvider: 'claude',
+          workflowModel: undefined,
+          artifactsDir: join(testDir, 'artifacts'),
+          stateDir: join(testDir, 'state'),
+          logDir: join(testDir, 'logs'),
+          baseBranch: 'main',
+          docsDir: 'docs/',
+          config: minimalConfig,
+        });
       } finally {
         setSystemTime();
       }
@@ -7558,12 +7495,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-test',
           nodes: [
             {
@@ -7579,15 +7516,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // Should have called sendQuery exactly once (completed on iteration 1)
       expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -7627,12 +7564,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         repoTiers: { large: { provider: 'claude', model: 'opus', effort: 'max' } },
       });
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-model-usage',
           nodes: [
             {
@@ -7649,20 +7586,16 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        aiProfile
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+        aiProfile,
+      });
 
       const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls as Array<
         [{ event_type: string; step_name: string; data?: Record<string, unknown> }]
@@ -7700,12 +7633,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-no-model-run');
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-no-model-usage',
           nodes: [
             {
@@ -7721,15 +7654,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls as Array<
         [{ event_type: string; step_name: string; data?: Record<string, unknown> }]
@@ -7767,12 +7700,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-stale-model-run');
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-stale-model',
           nodes: [
             {
@@ -7788,15 +7721,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls as Array<
         [{ event_type: string; step_name: string; data?: Record<string, unknown> }]
@@ -7826,12 +7759,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-bg-cost-run');
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-bg-cost',
           nodes: [
             {
@@ -7847,15 +7780,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
       const completedEvent = eventCalls.find(
@@ -7882,12 +7815,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
 
       const store = createMockStore();
 
-      await executeDagWorkflow(
-        createMockDeps(store),
-        createMockPlatform(),
-        'conv-dag',
-        testDir,
-        {
+      await executeDagWorkflow({
+        deps: createMockDeps(store),
+        platform: createMockPlatform(),
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-nan-cost',
           nodes: [
             {
@@ -7902,16 +7835,16 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             },
           ],
         },
-        makeWorkflowRun('loop-nan-cost-run'),
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowRun: makeWorkflowRun('loop-nan-cost-run'),
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       const completedEvent = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls.find(
         (call: unknown[]) =>
@@ -7962,12 +7895,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-bg-union-run');
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-bg-union',
           nodes: [
             {
@@ -7983,15 +7916,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       expect(mockSendQueryDag.mock.calls.length).toBe(3);
       const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
@@ -8027,12 +7960,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-bg-clean-run');
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-bg-clean',
           nodes: [
             {
@@ -8048,15 +7981,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
       const completedEvent = eventCalls.find(
@@ -8099,12 +8032,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const workflowRun = makeWorkflowRun('loop-bg-cancel-run');
 
       try {
-        await executeDagWorkflow(
-          mockDeps,
+        await executeDagWorkflow({
+          deps: mockDeps,
           platform,
-          'conv-dag',
-          testDir,
-          {
+          conversationId: 'conv-dag',
+          cwd: testDir,
+          workflow: {
             name: 'dag-loop-bg-cancel',
             nodes: [
               {
@@ -8120,15 +8053,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             ],
           },
           workflowRun,
-          'claude',
-          undefined,
-          join(testDir, 'artifacts'),
-          join(testDir, 'state'),
-          join(testDir, 'logs'),
-          'main',
-          'docs/',
-          minimalConfig
-        );
+          workflowProvider: 'claude',
+          workflowModel: undefined,
+          artifactsDir: join(testDir, 'artifacts'),
+          stateDir: join(testDir, 'state'),
+          logDir: join(testDir, 'logs'),
+          baseBranch: 'main',
+          docsDir: 'docs/',
+          config: minimalConfig,
+        });
       } finally {
         setSystemTime(); // restore the real clock
       }
@@ -8169,12 +8102,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-multi',
           nodes: [
             {
@@ -8190,15 +8123,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       expect(mockSendQueryDag.mock.calls.length).toBe(3);
     });
@@ -8223,12 +8156,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-prev-output',
           nodes: [
             {
@@ -8244,15 +8177,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       expect(mockSendQueryDag.mock.calls.length).toBe(2);
       const promptIter1 = mockSendQueryDag.mock.calls[0][0] as string;
@@ -8288,12 +8221,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-prev-clean',
           nodes: [
             {
@@ -8309,15 +8242,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       expect(mockSendQueryDag.mock.calls.length).toBe(2);
       const promptIter2 = mockSendQueryDag.mock.calls[1][0] as string;
@@ -8346,12 +8279,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform1 = createMockPlatform();
       const freshRun = makeWorkflowRun('resume-prev-fresh-run');
 
-      await executeDagWorkflow(
-        mockDeps1,
-        platform1,
-        'conv-dag',
-        testDir,
-        {
+      await executeDagWorkflow({
+        deps: mockDeps1,
+        platform: platform1,
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'interactive-loop-resume-prev-output',
           nodes: [
             {
@@ -8369,16 +8302,16 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             },
           ],
         },
-        freshRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowRun: freshRun,
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // First iteration of a fresh interactive loop: $LOOP_PREV_OUTPUT empty;
       // $LOOP_USER_INPUT empty (no user has spoken yet).
@@ -8418,12 +8351,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         },
       });
 
-      await executeDagWorkflow(
-        mockDeps2,
-        platform2,
-        'conv-dag',
-        testDir,
-        {
+      await executeDagWorkflow({
+        deps: mockDeps2,
+        platform: platform2,
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'interactive-loop-resume-prev-output',
           nodes: [
             {
@@ -8441,16 +8374,16 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             },
           ],
         },
-        resumedRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowRun: resumedRun,
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // Second executeDagWorkflow call started a fresh sendQuery generator (mock
       // call index 1 across the two runs). The resumed iteration must NOT carry
@@ -8479,12 +8412,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-max',
           nodes: [
             {
@@ -8500,15 +8433,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // Should have called sendQuery exactly 2 times (max_iterations)
       expect(mockSendQueryDag.mock.calls.length).toBe(2);
@@ -8537,12 +8470,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-xml-tag',
           nodes: [
             {
@@ -8558,15 +8491,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // 3 iterations run, signal found on iteration 3 → completed, NOT failed
       expect(mockSendQueryDag.mock.calls.length).toBe(3);
@@ -8613,12 +8546,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-output',
           nodes: [
             {
@@ -8640,15 +8573,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // Loop ran 2 iterations + downstream ran once = 3 calls
       expect(mockSendQueryDag.mock.calls.length).toBe(3);
@@ -8670,12 +8603,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-fresh',
           nodes: [
             {
@@ -8691,15 +8624,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // Both calls should have undefined resumeSessionId (fresh context)
       expect(mockSendQueryDag.mock.calls.length).toBe(2);
@@ -8725,12 +8658,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-stateful',
           nodes: [
             {
@@ -8746,15 +8679,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       expect(mockSendQueryDag.mock.calls.length).toBe(2);
       // First call: fresh (iteration 1 always fresh)
@@ -8788,12 +8721,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-until-bash-only');
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-until-bash-only',
           nodes: [
             {
@@ -8810,15 +8743,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       expect(calls).toBe(2);
       expect((await readFile(counterFile, 'utf8')).trim()).toBe('2');
@@ -8855,22 +8788,22 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         ],
       });
 
-      await executeDagWorkflow(
-        createMockDeps(store),
-        createMockPlatform(),
-        'conv-dag',
-        testDir,
-        ready(workflow),
-        makeWorkflowRun('loop-required-output-ref'),
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+      await executeDagWorkflow({
+        deps: createMockDeps(store),
+        platform: createMockPlatform(),
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: ready(workflow),
+        workflowRun: makeWorkflowRun('loop-required-output-ref'),
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       const failed = store.createWorkflowEvent.mock.calls
         .map(([event]) => event)
@@ -8896,12 +8829,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-large-until-bash');
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-large-until-bash',
           nodes: [
             {
@@ -8924,15 +8857,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
+        workflowProvider: 'claude',
+        workflowModel: undefined,
         artifactsDir,
-        join(testDir, 'state'),
+        stateDir: join(testDir, 'state'),
         logDir,
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       expect(calls).toBe(1);
       expect(
@@ -8966,12 +8899,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-stray-sentinel');
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-stray-sentinel',
           nodes: [
             {
@@ -8987,15 +8920,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // Two iterations, not one — the sentinel was inert.
       expect(calls).toBe(2);
@@ -9020,12 +8953,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-shortcircuit');
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-shortcircuit',
           nodes: [
             {
@@ -9044,15 +8977,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       expect(calls).toBe(1);
       let sentinelExists = true;
@@ -9089,12 +9022,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-until-field');
 
-      const result = await executeDagWorkflow(
-        mockDeps,
+      const result = await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-until-field',
           nodes: [
             {
@@ -9111,15 +9044,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // false, false, true -> exactly three iterations.
       expect(calls).toBe(3);
@@ -9136,12 +9069,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-of-passthrough');
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-of-passthrough',
           nodes: [
             {
@@ -9153,15 +9086,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // Before #2563 the parse transform dropped output_format for loop nodes, so
       // the schema never reached sendQuery at all.
@@ -9181,12 +9114,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-strict-bool');
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-strict-bool',
           nodes: [
             {
@@ -9198,15 +9131,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // Enforced provider -> zero reasks, fails on the first attempt.
       expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -9234,12 +9167,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-reask-recover');
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-reask-recover',
           nodes: [
             {
@@ -9252,15 +9185,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'pi',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        { ...minimalConfig, assistant: 'pi' }
-      );
+        workflowProvider: 'pi',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: { ...minimalConfig, assistant: 'pi' },
+      });
 
       expect(mockSendQueryDag.mock.calls.length).toBe(2);
       const events = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
@@ -9308,12 +9241,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-reask-threading');
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-reask-threading',
           nodes: [
             {
@@ -9331,15 +9264,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'pi',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        { ...minimalConfig, assistant: 'pi' }
-      );
+        workflowProvider: 'pi',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: { ...minimalConfig, assistant: 'pi' },
+      });
 
       // 1: fresh (iteration 1 always is). 2: threads from iteration 1's session.
       // 3: the reask, deliberately fresh. 4: MUST thread from attempt 0's session,
@@ -9376,12 +9309,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-reask-iter1');
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-reask-iter1',
           nodes: [
             {
@@ -9394,15 +9327,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'pi',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        { ...minimalConfig, assistant: 'pi' }
-      );
+        workflowProvider: 'pi',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: { ...minimalConfig, assistant: 'pi' },
+      });
 
       expect(sessions[0]).toBeUndefined(); // iteration 1, attempt 0 — always fresh
       expect(sessions[1]).toBeUndefined(); // the reask — deliberately fresh
@@ -9435,12 +9368,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-reask-crossnode');
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-reask-crossnode',
           nodes: [
             {
@@ -9460,15 +9393,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'pi',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        { ...minimalConfig, assistant: 'pi' }
-      );
+        workflowProvider: 'pi',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: { ...minimalConfig, assistant: 'pi' },
+      });
 
       // The third call is the downstream node; it must inherit the loop's conversation.
       expect(sessions[2]).toBe('loop-conv');
@@ -9485,12 +9418,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-reask-exhausted');
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-reask-exhausted',
           nodes: [
             {
@@ -9503,15 +9436,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'pi',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        { ...minimalConfig, assistant: 'pi' }
-      );
+        workflowProvider: 'pi',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: { ...minimalConfig, assistant: 'pi' },
+      });
 
       // Original + 3 reasks, then fail — the loop does NOT keep iterating on a
       // broken completion channel until max_iterations.
@@ -9553,12 +9486,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         },
       });
 
-      const result = await executeDagWorkflow(
-        mockDeps,
+      const result = await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'finalize-declared-fields',
           nodes: [
             {
@@ -9585,15 +9518,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // Declared-but-absent optional resolves to empty (shell-quoted by the
       // bash-escaped substitution path), not a failed consumer.
@@ -9618,12 +9551,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-inline-sentinel');
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-inline-sentinel',
           nodes: [
             {
@@ -9641,15 +9574,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // `done` stays false, so only the prose sentinel can have ended this.
       expect(calls).toBe(1);
@@ -9673,12 +9606,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-signal-in-payload');
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-signal-in-payload',
           nodes: [
             {
@@ -9696,15 +9629,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // `done` stays false, so only the signal can have ended it.
       expect(calls).toBe(1);
@@ -9723,12 +9656,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('loop-downstream-field');
 
-      const result = await executeDagWorkflow(
-        mockDeps,
+      const result = await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-downstream-field',
           nodes: [
             {
@@ -9747,15 +9680,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // Shell-quoted by the bash-escaped substitution path, as any $node.output.field is.
       expect(result).toContain("note='shipped'");
@@ -9771,12 +9704,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-strip',
           nodes: [
             {
@@ -9787,15 +9720,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // In batch mode, accumulated clean output is sent
       const sendCalls = (platform.sendMessage as Mock<IWorkflowPlatform['sendMessage']>).mock.calls;
@@ -9828,12 +9761,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-cancel',
           nodes: [
             {
@@ -9849,15 +9782,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // Should have only done 1 iteration (cancelled before iteration 2)
       expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -9872,12 +9805,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-ai-error',
           nodes: [
             {
@@ -9893,15 +9826,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // Should have run exactly 1 iteration (failed on first)
       expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -9922,12 +9855,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-plain-signal',
           nodes: [
             {
@@ -9943,15 +9876,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // Should complete on first iteration (plain signal on own line)
       expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -9974,12 +9907,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'dag-loop-false-positive',
           nodes: [
             {
@@ -9990,15 +9923,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // Should have run max_iterations times (NOT detected as complete)
       expect(mockSendQueryDag.mock.calls.length).toBe(2);
@@ -10026,12 +9959,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'interactive-loop-test',
           nodes: [
             {
@@ -10049,15 +9982,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // Should have called sendQuery exactly once (paused after iteration 1)
       expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -10091,12 +10024,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const mockDeps = createMockDeps();
       const platform = createMockPlatform();
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'interactive-loop-bash-gate',
           nodes: [
             {
@@ -10114,16 +10047,16 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             },
           ],
         },
-        makeWorkflowRun('loop-bash-gate'),
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowRun: makeWorkflowRun('loop-bash-gate'),
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       expectLoopGateEvidence(
         mockDeps.store,
@@ -10147,12 +10080,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const mockDeps = createMockDeps();
       const platform = createMockPlatform();
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'interactive-loop-field-gate',
           nodes: [
             {
@@ -10171,16 +10104,16 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             },
           ],
         },
-        makeWorkflowRun('loop-field-gate'),
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowRun: makeWorkflowRun('loop-field-gate'),
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       expectLoopGateEvidence(
         mockDeps.store,
@@ -10204,12 +10137,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const mockDeps = createMockDeps();
       const platform = createMockPlatform();
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'interactive-loop-unmet-gate',
           nodes: [
             {
@@ -10229,16 +10162,16 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
             },
           ],
         },
-        makeWorkflowRun('loop-unmet-gate'),
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowRun: makeWorkflowRun('loop-unmet-gate'),
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       expectLoopGateEvidence(
         mockDeps.store,
@@ -10261,12 +10194,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'interactive-loop-signal',
           nodes: [
             {
@@ -10284,15 +10217,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // On first iteration (fresh start, no user input), the loop MUST pause
       // at the gate even if the AI emits the completion signal. The user hasn't
@@ -10344,12 +10277,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         },
       });
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'interactive-loop-resume-signal',
           nodes: [
             {
@@ -10367,15 +10300,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // On resume with user input, the AI processes the approval and emits the
       // completion signal. The loop exits immediately without pausing at the gate.
@@ -10409,12 +10342,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         },
       });
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'interactive-loop-resume',
           nodes: [
             {
@@ -10432,15 +10365,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // Should have called sendQuery once (starting from iteration 2, completed immediately)
       expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -10462,12 +10395,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun('signal-completes-run');
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'signal-completes-test',
           nodes: [
             {
@@ -10486,15 +10419,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // No gate: the node completed autonomously on the signal.
       const pauseCalls = (
@@ -10543,12 +10476,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         },
       });
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'finalize-on-approve',
           nodes: [
             {
@@ -10566,15 +10499,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // No new iteration ran — the node finalized from the persisted output.
       expect(mockSendQueryDag.mock.calls.length).toBe(0);
@@ -10639,22 +10572,22 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         },
       ];
       const pausingDeps = createMockDeps();
-      await executeDagWorkflow(
-        pausingDeps,
-        createMockPlatform(),
-        'conv-dag',
-        testDir,
-        { name: 'finalize-struct-pause', nodes: loopNodes },
-        makeWorkflowRun('finalize-struct-pause-run'),
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+      await executeDagWorkflow({
+        deps: pausingDeps,
+        platform: createMockPlatform(),
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: { name: 'finalize-struct-pause', nodes: loopNodes },
+        workflowRun: makeWorkflowRun('finalize-struct-pause-run'),
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
       const pauseCalls = (
         pausingDeps.store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>
       ).mock.calls;
@@ -10673,28 +10606,28 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         yield { type: 'result', sessionId: 'never' };
       });
       const resumingDeps = createMockDeps();
-      await executeDagWorkflow(
-        resumingDeps,
-        createMockPlatform(),
-        'conv-dag',
-        testDir,
-        { name: 'finalize-struct-resume', nodes: loopNodes },
-        makeWorkflowRun('finalize-struct-resume-run', {
+      await executeDagWorkflow({
+        deps: resumingDeps,
+        platform: createMockPlatform(),
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: { name: 'finalize-struct-resume', nodes: loopNodes },
+        workflowRun: makeWorkflowRun('finalize-struct-resume-run', {
           metadata: {
             approval: { ...approval },
             loop_user_input: 'Approved',
             loop_feedback_given: false,
           },
         }),
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
       expect(mockSendQueryDag.mock.calls.length).toBe(0);
       const completed = (
         resumingDeps.store.createWorkflowEvent as Mock<
@@ -10733,12 +10666,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         },
       });
 
-      await executeDagWorkflow(
-        mockDeps,
-        createMockPlatform(),
-        'conv-dag',
-        testDir,
-        {
+      await executeDagWorkflow({
+        deps: mockDeps,
+        platform: createMockPlatform(),
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'finalize-on-approve',
           nodes: [
             {
@@ -10756,15 +10689,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       expect(mockSendQueryDag.mock.calls.length).toBe(0);
       const eventCalls = (
@@ -10807,12 +10740,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         },
       });
 
-      await executeDagWorkflow(
-        mockDeps,
-        createMockPlatform(),
-        'conv-dag',
-        testDir,
-        {
+      await executeDagWorkflow({
+        deps: mockDeps,
+        platform: createMockPlatform(),
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'finalize-invalid-tokens',
           nodes: [
             {
@@ -10830,15 +10763,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       const warnCalls = mockLogFn.mock.calls.filter(
         (call: unknown[]) => call[1] === 'dag_loop.signaled_tokens_invalid_ignored'
@@ -10892,12 +10825,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         },
       });
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'feedback-iterates',
           nodes: [
             {
@@ -10915,15 +10848,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // Feedback ⇒ a fresh iteration ran with $LOOP_USER_INPUT substituted.
       expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -10979,12 +10912,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         },
       });
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'nonsignaled-iterates',
           nodes: [
             {
@@ -11002,15 +10935,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // Nothing to finalize — a normal resumed iteration ran.
       expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -11040,12 +10973,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         },
       });
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'legacy-loop-resume',
           nodes: [
             {
@@ -11063,15 +10996,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // A real iteration ran (no zero-duration finalize short-circuit).
       expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -11100,12 +11033,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'loop-iteration-err',
           nodes: [
             {
@@ -11121,15 +11054,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // Should fail after one iteration rather than burning through max_iterations
       expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -11182,12 +11115,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'loop-success-stop-seq-test',
           nodes: [
             {
@@ -11203,15 +11136,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
       const failedEvents = eventCalls.filter((call: unknown[]) => {
@@ -11231,12 +11164,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'non-interactive-loop',
           nodes: [
             {
@@ -11252,15 +11185,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // pauseWorkflowRun should never be called for non-interactive loops
       const pauseCalls = (
@@ -11315,12 +11248,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'loop-cmd-read-once',
           nodes: [
             {
@@ -11336,15 +11269,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // Both iterations ran — the mid-run deletion did not break iteration 2.
       expect(mockSendQueryDag.mock.calls.length).toBe(2);
@@ -11381,12 +11314,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'loop-cmd-missing',
           nodes: [
             {
@@ -11402,15 +11335,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // sendQuery must never have been invoked — load failed pre-iteration.
       expect(mockSendQueryDag.mock.calls.length).toBe(0);
@@ -11449,12 +11382,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'loop-cmd-empty',
           nodes: [
             {
@@ -11470,15 +11403,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       expect(mockSendQueryDag.mock.calls.length).toBe(0);
       const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
@@ -11503,12 +11436,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'loop-cmd-unsafe',
           nodes: [
             {
@@ -11524,15 +11457,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       expect(mockSendQueryDag.mock.calls.length).toBe(0);
       const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
@@ -11576,12 +11509,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'loop-cmd-subst',
           nodes: [
             {
@@ -11597,15 +11530,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       expect(mockSendQueryDag.mock.calls.length).toBe(2);
       const promptIter1 = mockSendQueryDag.mock.calls[0][0] as string;
@@ -11660,22 +11593,22 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
         ],
       };
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        gatedWorkflow,
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: gatedWorkflow,
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // Invocation 1 paused at the gate and persisted the loaded body.
       const pauseCalls = (
@@ -11707,22 +11640,22 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const store2 = createMockStore();
       const mockDeps2 = createMockDeps(store2);
 
-      await executeDagWorkflow(
-        mockDeps2,
+      await executeDagWorkflow({
+        deps: mockDeps2,
         platform,
-        'conv-dag',
-        testDir,
-        gatedWorkflow,
-        resumedRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: gatedWorkflow,
+        workflowRun: resumedRun,
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       // The resumed iteration ran from the snapshot: original body, user
       // feedback substituted, no trace of the tampered content, no failure
@@ -11794,22 +11727,22 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       )?.workflow;
       expect(originalWorkflow).toBeDefined();
 
-      await executeDagWorkflow(
-        firstDeps,
+      await executeDagWorkflow({
+        deps: firstDeps,
         platform,
-        'conv-dag',
-        testDir,
-        ready(originalWorkflow!),
-        makeWorkflowRun(),
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: ready(originalWorkflow!),
+        workflowRun: makeWorkflowRun(),
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       const pauseCalls = (
         firstDeps.store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>
@@ -11834,22 +11767,22 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       expect(rediscoveredWorkflow).toBeDefined();
       mockSendQueryDag.mockClear();
       const freshStore = createMockStore();
-      await executeDagWorkflow(
-        createMockDeps(freshStore),
+      await executeDagWorkflow({
+        deps: createMockDeps(freshStore),
         platform,
-        'conv-dag',
-        testDir,
-        ready(rediscoveredWorkflow!),
-        makeWorkflowRun('fresh-invalid-command-run'),
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: ready(rediscoveredWorkflow!),
+        workflowRun: makeWorkflowRun('fresh-invalid-command-run'),
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
       expect(mockSendQueryDag).not.toHaveBeenCalled();
       const freshFailures = (
         freshStore.createWorkflowEvent as ReturnType<typeof mock>
@@ -11867,22 +11800,22 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       });
 
       mockSendQueryDag.mockClear();
-      await executeDagWorkflow(
-        createMockDeps(createMockStore()),
+      await executeDagWorkflow({
+        deps: createMockDeps(createMockStore()),
         platform,
-        'conv-dag',
-        testDir,
-        ready(rediscoveredWorkflow!),
-        resumedRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: ready(rediscoveredWorkflow!),
+        workflowRun: resumedRun,
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       const resumedPrompt = mockSendQueryDag.mock.calls[0]?.[0] as string;
       expect(resumedPrompt).toContain('ORIGINAL materialized command.');
@@ -11900,25 +11833,25 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       loop[COMPILED_LOOP_COMMAND] = {} as CompiledLoopCommand;
       const store = createMockStore();
 
-      await executeDagWorkflow(
-        createMockDeps(store),
-        createMockPlatform(),
-        'conv-dag',
-        testDir,
-        {
+      await executeDagWorkflow({
+        deps: createMockDeps(store),
+        platform: createMockPlatform(),
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'malformed-compiled-command-workflow',
           nodes: [{ id: 'repeat', kind: 'loop', loop }],
         },
-        makeWorkflowRun('malformed-compiled-command-run'),
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowRun: makeWorkflowRun('malformed-compiled-command-run'),
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       expect(mockSendQueryDag).not.toHaveBeenCalled();
       const failures = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls.filter(
@@ -11971,22 +11904,22 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       expect(workflow).toBeDefined();
       const store = createMockStore();
 
-      await executeDagWorkflow(
-        createMockDeps(store),
-        createMockPlatform(),
-        'conv-dag',
-        testDir,
-        ready(workflow!),
-        makeWorkflowRun('empty-included-loop-run'),
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+      await executeDagWorkflow({
+        deps: createMockDeps(store),
+        platform: createMockPlatform(),
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: ready(workflow!),
+        workflowRun: makeWorkflowRun('empty-included-loop-run'),
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       expect(mockSendQueryDag).not.toHaveBeenCalled();
       const failures = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls.filter(
@@ -12017,12 +11950,12 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'loop-cmd-exhaust',
           nodes: [
             {
@@ -12038,15 +11971,15 @@ describe('executeDagWorkflow -- resume with priorCompletedNodes', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       expect(mockSendQueryDag.mock.calls.length).toBe(2);
       const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
@@ -12111,12 +12044,12 @@ describe('executeDagWorkflow -- always_run resume opt-out', () => {
 
     const priorCompletedNodes = new Map([['producer', { output: 'cached stale output' }]]);
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-always-run',
-      testDir,
-      {
+      conversationId: 'conv-always-run',
+      cwd: testDir,
+      workflow: {
         name: 'always-run-producer',
         nodes: [
           {
@@ -12134,18 +12067,16 @@ describe('executeDagWorkflow -- always_run resume opt-out', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
 
     // Producer re-runs (instead of being skipped) AND consumer runs => 2 sendQuery calls
     expect(mockSendQueryDag.mock.calls.length).toBe(2);
@@ -12180,12 +12111,12 @@ describe('executeDagWorkflow -- always_run resume opt-out', () => {
 
     const priorCompletedNodes = new Map([['producer', { output: largeOutput }]]);
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-always-run-large',
-      testDir,
-      {
+      conversationId: 'conv-always-run-large',
+      cwd: testDir,
+      workflow: {
         name: 'always-run-producer-large',
         nodes: [
           {
@@ -12203,18 +12134,16 @@ describe('executeDagWorkflow -- always_run resume opt-out', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
+      workflowProvider: 'claude',
+      workflowModel: undefined,
       artifactsDir,
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const resetEvent = eventCalls.find(
@@ -12251,12 +12180,12 @@ describe('executeDagWorkflow -- always_run resume opt-out', () => {
       ['cached', { output: 'cached output' }],
     ]);
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-mixed',
-      testDir,
-      {
+      conversationId: 'conv-mixed',
+      cwd: testDir,
+      workflow: {
         name: 'mixed',
         nodes: [
           {
@@ -12269,18 +12198,16 @@ describe('executeDagWorkflow -- always_run resume opt-out', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
 
     // Only producer re-runs; cached node stays skipped
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -12315,12 +12242,12 @@ describe('executeDagWorkflow -- always_run resume opt-out', () => {
 
     const priorCompletedNodes = new Map([['producer', { output: 'STALE_CACHED_VALUE' }]]);
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-fresh-output',
-      testDir,
-      {
+      conversationId: 'conv-fresh-output',
+      cwd: testDir,
+      workflow: {
         name: 'always-run-fresh',
         nodes: [
           {
@@ -12338,18 +12265,16 @@ describe('executeDagWorkflow -- always_run resume opt-out', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
 
     // Consumer's prompt should contain the fresh producer output, not the stale cached value
     const consumerPrompt = seenPrompts[1];
@@ -12423,12 +12348,12 @@ describe('executeDagWorkflow -- prior-success cache invalidated by dep re-execut
       ['consumer', { output: 'STALE_CACHED_CONSUMER' }],
     ]);
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-2402-always-run',
-      testDir,
-      {
+      conversationId: 'conv-2402-always-run',
+      cwd: testDir,
+      workflow: {
         name: 'stale-cache-always-run',
         nodes: [
           {
@@ -12446,18 +12371,16 @@ describe('executeDagWorkflow -- prior-success cache invalidated by dep re-execut
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
 
     // Producer re-runs (always_run) AND consumer re-runs (cache invalidated by dep) —
     // before the fix, consumer was skipped and only 1 sendQuery call happened.
@@ -12522,12 +12445,12 @@ describe('executeDagWorkflow -- prior-success cache invalidated by dep re-execut
       ['consumer', { output: 'cached consumer output' }],
     ]);
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-2402-identical',
-      testDir,
-      {
+      conversationId: 'conv-2402-identical',
+      cwd: testDir,
+      workflow: {
         name: 'stale-cache-identical',
         nodes: [
           {
@@ -12545,18 +12468,16 @@ describe('executeDagWorkflow -- prior-success cache invalidated by dep re-execut
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
 
     // Producer re-runs (always_run) with output identical to its prior snapshot;
     // consumer stays cached because the comparison found no diff. A regression that
@@ -12603,12 +12524,12 @@ describe('executeDagWorkflow -- prior-success cache invalidated by dep re-execut
       ['consumer', { output: 'stale consumer output' }],
     ]);
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-2402-uncached-dep',
-      testDir,
-      {
+      conversationId: 'conv-2402-uncached-dep',
+      cwd: testDir,
+      workflow: {
         name: 'stale-cache-uncached-dep',
         nodes: [
           { id: 'producer', kind: 'agent', source: { kind: 'command', name: 'producer' } },
@@ -12621,18 +12542,16 @@ describe('executeDagWorkflow -- prior-success cache invalidated by dep re-execut
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
 
     // Producer ran fresh + consumer was invalidated and re-ran = 2 sendQuery calls.
     expect(queryCount).toBe(2);
@@ -12669,12 +12588,12 @@ describe('executeDagWorkflow -- prior-success cache invalidated by dep re-execut
       ['consumer', { output: largeOutput }],
     ]);
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-2402-large-invalidated',
-      testDir,
-      {
+      conversationId: 'conv-2402-large-invalidated',
+      cwd: testDir,
+      workflow: {
         name: 'stale-cache-large-invalidated',
         nodes: [
           { id: 'producer', kind: 'agent', source: { kind: 'command', name: 'producer' } },
@@ -12687,18 +12606,16 @@ describe('executeDagWorkflow -- prior-success cache invalidated by dep re-execut
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
+      workflowProvider: 'claude',
+      workflowModel: undefined,
       artifactsDir,
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
 
     expect(queryCount).toBe(2);
 
@@ -12773,12 +12690,12 @@ describe('executeDagWorkflow -- prior-success cache invalidated by dep re-execut
       ['consumer', { output: 'STALE_CACHED_CONSUMER' }],
     ]);
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-2402-fresh-failed-dep',
-      testDir,
-      {
+      conversationId: 'conv-2402-fresh-failed-dep',
+      cwd: testDir,
+      workflow: {
         name: 'stale-cache-fresh-failed-dep',
         nodes: [
           { id: 'producer', kind: 'agent', source: { kind: 'command', name: 'producer' } },
@@ -12798,18 +12715,16 @@ describe('executeDagWorkflow -- prior-success cache invalidated by dep re-execut
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
 
     // Producer failed (1 sendQuery attempt) + consumer was invalidated by the
     // failed-dep arm and re-ran = 2 sendQuery calls in total. A regression that
@@ -12885,12 +12800,12 @@ describe('executeDagWorkflow -- prior-success cache invalidated by dep re-execut
       ['consumer', { output: 'STALE_CACHED_CONSUMER' }],
     ]);
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-2705-r1-cached-dep-fresh-fail',
-      testDir,
-      {
+      conversationId: 'conv-2705-r1-cached-dep-fresh-fail',
+      cwd: testDir,
+      workflow: {
         name: 'stale-cache-cached-dep-fresh-fail',
         nodes: [
           {
@@ -12909,18 +12824,16 @@ describe('executeDagWorkflow -- prior-success cache invalidated by dep re-execut
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
 
     // Producer's failed attempt (1) + consumer invalidated and re-ran (1) = 2. A
     // regression that judges a previously-cached dep by value alone leaves consumer
@@ -12986,12 +12899,12 @@ describe('executeDagWorkflow -- prior-success cache invalidated by dep re-execut
       ['consumer', { output: 'cached consumer', structuredOutput: { stale: true } }],
     ]);
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-2402-structured',
-      testDir,
-      {
+      conversationId: 'conv-2402-structured',
+      cwd: testDir,
+      workflow: {
         name: 'stale-cache-structured',
         nodes: [
           // always_run forces the producer re-execution that surfaces case 3.
@@ -13010,18 +12923,16 @@ describe('executeDagWorkflow -- prior-success cache invalidated by dep re-execut
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
 
     // Producer re-ran (always_run) + consumer was invalidated (text-stable but
     // structured-output differs) = 2 sendQuery calls.
@@ -13080,12 +12991,12 @@ describe('executeDagWorkflow -- prior-success cache invalidated by dep re-execut
       ['consumer', { output: 'STALE consumer output' }],
     ]);
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-2402-multi-dep',
-      testDir,
-      {
+      conversationId: 'conv-2402-multi-dep',
+      cwd: testDir,
+      workflow: {
         name: 'stale-cache-multi-dep',
         nodes: [
           // always_run forces producer to re-execute this resume (case 2 fires).
@@ -13107,18 +13018,16 @@ describe('executeDagWorkflow -- prior-success cache invalidated by dep re-execut
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
 
     // Exactly two queries: producer re-runs (always_run), consumer re-runs
     // (cache invalidated). Side is skipped via the pre-populate prior-success arm,
@@ -13219,25 +13128,25 @@ describe('executeDagWorkflow -- break after result (no hang on subprocess exit)'
 
     // Should complete promptly (not hang for 30 min)
     const result = await Promise.race([
-      executeDagWorkflow(
-        mockDeps,
+      executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'break-test',
           nodes: [{ id: 'n1', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      ).then(() => 'completed'),
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      }).then(() => 'completed'),
       new Promise<string>((_, reject) =>
         setTimeout(() => reject(new Error('Timed out — break after result not working')), 5000)
       ),
@@ -13259,12 +13168,12 @@ describe('executeDagWorkflow -- break after result (no hang on subprocess exit)'
     const workflowRun = makeWorkflowRun();
 
     const result = await Promise.race([
-      executeDagWorkflow(
-        mockDeps,
+      executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'loop-break-test',
           nodes: [
             {
@@ -13280,15 +13189,15 @@ describe('executeDagWorkflow -- break after result (no hang on subprocess exit)'
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      ).then(() => 'completed'),
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      }).then(() => 'completed'),
       new Promise<string>((_, reject) =>
         setTimeout(() => reject(new Error('Timed out — break after result not working')), 5000)
       ),
@@ -13347,12 +13256,12 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    const result = await executeDagWorkflow(
-      mockDeps,
+    const result = await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'linear-dag',
         nodes: [
           { id: 'step1', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } },
@@ -13365,15 +13274,15 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(result).toBe('Final summary text');
   });
@@ -13397,12 +13306,12 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'empty-dag',
         nodes: [
           {
@@ -13414,15 +13323,15 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const nodeFailedEvents = eventCalls.filter(
@@ -13474,12 +13383,12 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'structured-only-dag',
         nodes: [
           {
@@ -13491,15 +13400,15 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const nodeFailedEvents = eventCalls.filter(
@@ -13536,12 +13445,12 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'idle-timeout-no-output',
         nodes: [
           {
@@ -13557,15 +13466,15 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const nodeFailedEvents = eventCalls.filter(
@@ -13608,12 +13517,12 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const realSetTimeout = globalThis.setTimeout;
     globalThis.setTimeout = ((fn: () => void) => realSetTimeout(fn, 1)) as typeof setTimeout;
     try {
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'loop-idle-timeout-no-output',
           nodes: [
             {
@@ -13630,15 +13539,15 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       expect(mockSendQueryDag).toHaveBeenCalledTimes(2);
       const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
@@ -13693,12 +13602,12 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const realSetTimeout = globalThis.setTimeout;
     globalThis.setTimeout = ((fn: () => void) => realSetTimeout(fn, 1)) as typeof setTimeout;
     try {
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-dag',
-        testDir,
-        {
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: {
           name: 'structured-loop-idle-timeout',
           nodes: [
             {
@@ -13720,15 +13629,15 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       expect(mockSendQueryDag).toHaveBeenCalledTimes(1);
       const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
@@ -13762,12 +13671,12 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'outfmt-missing',
         nodes: [
           {
@@ -13784,15 +13693,15 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const failed = eventCalls.filter(
@@ -13816,12 +13725,12 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'outfmt-invalid',
         nodes: [
           {
@@ -13838,15 +13747,15 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const failed = eventCalls.filter(
@@ -13872,12 +13781,12 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'when-badref',
         nodes: [
           {
@@ -13902,15 +13811,15 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const runmeFailed = eventCalls.find(
@@ -13930,12 +13839,12 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'when-object-field',
         nodes: [
           {
@@ -13955,15 +13864,15 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const runmeEvents = eventCalls.filter(
@@ -14005,12 +13914,12 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'reask-recover',
         nodes: [
           {
@@ -14028,15 +13937,15 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
         ],
       },
       workflowRun,
-      'pi',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      { ...minimalConfig, assistant: 'pi' }
-    );
+      workflowProvider: 'pi',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: { ...minimalConfig, assistant: 'pi' },
+    });
 
     // sendQuery ran twice (original + 1 reask); node completed, not failed.
     expect(mockSendQueryDag.mock.calls.length).toBe(2);
@@ -14088,12 +13997,12 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'three-node-fold',
         nodes: [
           { id: 'a', kind: 'agent', source: { kind: 'inline', prompt: 'a' } },
@@ -14102,15 +14011,15 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(runUsageWrites(mockDeps.store)).toEqual([
       {
@@ -14151,12 +14060,12 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'reask-partial-cache',
         nodes: [
           {
@@ -14174,15 +14083,15 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
         ],
       },
       workflowRun,
-      'pi',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      { ...minimalConfig, assistant: 'pi' }
-    );
+      workflowProvider: 'pi',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: { ...minimalConfig, assistant: 'pi' },
+    });
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const completed = eventCalls.filter(
@@ -14230,12 +14139,12 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
 
     const store = createMockStore();
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-dag',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'reask-nan-cost',
         nodes: [
           {
@@ -14252,16 +14161,16 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
           },
         ],
       },
-      makeWorkflowRun(),
-      'pi',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      { ...minimalConfig, assistant: 'pi' }
-    );
+      workflowRun: makeWorkflowRun(),
+      workflowProvider: 'pi',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: { ...minimalConfig, assistant: 'pi' },
+    });
 
     expect(runUsageWrites(store)).toEqual([{ total_cost_usd: 0.01 }]);
     expect(
@@ -14282,12 +14191,12 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'reask-exhaust',
         nodes: [
           {
@@ -14305,15 +14214,15 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
         ],
       },
       workflowRun,
-      'pi',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      { ...minimalConfig, assistant: 'pi' }
-    );
+      workflowProvider: 'pi',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: { ...minimalConfig, assistant: 'pi' },
+    });
 
     // 1 initial + 3 reasks = 4 sendQuery calls, then fail-fast.
     expect(mockSendQueryDag.mock.calls.length).toBe(4);
@@ -14339,12 +14248,12 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'enforced-no-reask',
         nodes: [
           {
@@ -14362,15 +14271,15 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
@@ -14395,12 +14304,12 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'reask-missing',
         nodes: [
           {
@@ -14418,15 +14327,15 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
         ],
       },
       workflowRun,
-      'pi',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      { ...minimalConfig, assistant: 'pi' }
-    );
+      workflowProvider: 'pi',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: { ...minimalConfig, assistant: 'pi' },
+    });
 
     expect(mockSendQueryDag.mock.calls.length).toBe(2);
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
@@ -14458,12 +14367,12 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'reask-idle',
         nodes: [
           {
@@ -14482,15 +14391,15 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
         ],
       },
       workflowRun,
-      'pi',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      { ...minimalConfig, assistant: 'pi' }
-    );
+      workflowProvider: 'pi',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: { ...minimalConfig, assistant: 'pi' },
+    });
 
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
@@ -14525,12 +14434,12 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'idle-timeout-with-output',
         nodes: [
           {
@@ -14543,15 +14452,15 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const nodeFailedEvents = eventCalls.filter(
@@ -14577,12 +14486,12 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'unknown-provider-dag',
         nodes: [
           {
@@ -14594,15 +14503,15 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(store.failWorkflowRun).toHaveBeenCalled();
     // The "unknown provider" detail surfaces on the node_failed event; the
@@ -14625,12 +14534,12 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'fail-msg-test',
         nodes: [
           {
@@ -14642,15 +14551,15 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(store.failWorkflowRun).toHaveBeenCalled();
     const failCall = (store.failWorkflowRun as ReturnType<typeof mock>).mock.calls[0];
@@ -14676,12 +14585,12 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    const result = await executeDagWorkflow(
-      mockDeps,
+    const result = await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'fanin-dag',
         nodes: [
           { id: 'a', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } },
@@ -14695,15 +14604,15 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // Only 'c' is terminal (no node depends on it); 'a' and 'b' are not terminal
     expect(result).toBe('C final output');
@@ -14749,12 +14658,12 @@ describe('executeDagWorkflow -- cancel node', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'cancel-test',
         nodes: [
           { id: 'check', kind: 'exec', runtime: 'sh', script: 'echo blocked' },
@@ -14762,15 +14671,15 @@ describe('executeDagWorkflow -- cancel node', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // cancelWorkflowRun should have been called
     expect(store.cancelWorkflowRun.mock.calls.length).toBe(1);
@@ -14793,12 +14702,12 @@ describe('executeDagWorkflow -- cancel node', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'cancel-skip-test',
         nodes: [
           { id: 'check', kind: 'exec', runtime: 'sh', script: 'echo ok' },
@@ -14812,15 +14721,15 @@ describe('executeDagWorkflow -- cancel node', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // cancelWorkflowRun should NOT have been called (when: condition is false)
     if (store.cancelWorkflowRun && typeof store.cancelWorkflowRun === 'function') {
@@ -14879,12 +14788,12 @@ describe('executeDagWorkflow -- credit exhaustion', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun('credit-exhaustion-run');
 
-    await executeDagWorkflow(
+    await executeDagWorkflow({
       deps,
       platform,
-      'conv-credit',
-      testDir,
-      {
+      conversationId: 'conv-credit',
+      cwd: testDir,
+      workflow: {
         name: 'credit-test',
         nodes: [
           {
@@ -14895,15 +14804,15 @@ describe('executeDagWorkflow -- credit exhaustion', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // node_failed (not node_completed) must have been stored
     const events = (
@@ -14933,12 +14842,12 @@ describe('executeDagWorkflow -- credit exhaustion', () => {
     });
     const store = createMockStore();
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-credit',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-credit',
+      cwd: testDir,
+      workflow: {
         name: 'credit-resume-test',
         nodes: [
           {
@@ -14948,15 +14857,15 @@ describe('executeDagWorkflow -- credit exhaustion', () => {
           },
         ],
       },
-      makeWorkflowRun('credit-resume-run'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      {
+      workflowRun: makeWorkflowRun('credit-resume-run'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: {
         ...minimalConfig,
         workflows: {
           autoResumeOnQuotaReset: true,
@@ -14964,8 +14873,8 @@ describe('executeDagWorkflow -- credit exhaustion', () => {
           quotaMaxAttempts: 1,
           quotaDeadlineMs: 3_600_000,
         },
-      }
-    );
+      },
+    });
 
     const failRun = store.failWorkflowRun as Mock<IWorkflowStore['failWorkflowRun']>;
     expect(failRun).toHaveBeenCalledTimes(1);
@@ -14998,12 +14907,12 @@ describe('executeDagWorkflow -- credit exhaustion', () => {
     });
     const store = createMockStore();
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-credit',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-credit',
+      cwd: testDir,
+      workflow: {
         name: 'credit-resume-test',
         nodes: [
           {
@@ -15013,23 +14922,23 @@ describe('executeDagWorkflow -- credit exhaustion', () => {
           },
         ],
       },
-      makeWorkflowRun('credit-resume-run'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      {
+      workflowRun: makeWorkflowRun('credit-resume-run'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: {
         ...minimalConfig,
         workflows: {
           autoResumeOnQuotaReset: true,
           quotaMaxAttempts: 1,
           quotaDeadlineMs: 3_600_000,
         },
-      }
-    );
+      },
+    });
 
     const failRun = store.failWorkflowRun as Mock<IWorkflowStore['failWorkflowRun']>;
     expect(failRun).toHaveBeenCalledTimes(1);
@@ -15056,12 +14965,12 @@ describe('executeDagWorkflow -- credit exhaustion', () => {
     });
     const store = createMockStore();
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-credit',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-credit',
+      cwd: testDir,
+      workflow: {
         name: 'container-credit-resume-test',
         nodes: [
           {
@@ -15071,15 +14980,15 @@ describe('executeDagWorkflow -- credit exhaustion', () => {
           },
         ],
       },
-      makeWorkflowRun('container-credit-resume-run'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      {
+      workflowRun: makeWorkflowRun('container-credit-resume-run'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: {
         ...minimalConfig,
         workflows: {
           autoResumeOnQuotaReset: true,
@@ -15088,15 +14997,8 @@ describe('executeDagWorkflow -- credit exhaustion', () => {
           quotaDeadlineMs: 3_600_000,
         },
       },
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      { kind: 'container', containerId: 'container-1' }
-    );
+      execContext: { kind: 'container', containerId: 'container-1' },
+    });
 
     const failRun = store.failWorkflowRun as Mock<IWorkflowStore['failWorkflowRun']>;
     expect(failRun.mock.calls[0]?.[2]).toBeUndefined();
@@ -15125,25 +15027,25 @@ describe('executeDagWorkflow -- durable wait node', () => {
   it('persists a future wait and returns without invoking a provider', async () => {
     const store = createMockStore();
     const deps = createMockDeps(store);
-    await executeDagWorkflow(
+    await executeDagWorkflow({
       deps,
-      createMockPlatform(),
-      'conv-wait',
-      testDir,
-      {
+      platform: createMockPlatform(),
+      conversationId: 'conv-wait',
+      cwd: testDir,
+      workflow: {
         name: 'wait-test',
         nodes: [{ id: 'delay', kind: 'wait', wait: { duration_ms: 60_000 } }],
       },
-      makeWorkflowRun(),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun(),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
     expect(store.pauseWorkflowRunForWait).toHaveBeenCalledTimes(1);
     const context = (store.pauseWorkflowRunForWait as ReturnType<typeof mock>).mock.calls[0]?.[1];
     expect(context).toMatchObject({ nodeId: 'delay', kind: 'time' });
@@ -15154,25 +15056,25 @@ describe('executeDagWorkflow -- durable wait node', () => {
     const store = createMockStore();
     const resumeAt = '2099-08-24T11:00:00.000Z';
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-wait-input',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-wait-input',
+      cwd: testDir,
+      workflow: {
         name: 'wait-input-test',
         nodes: [{ id: 'delay', kind: 'wait', wait: { until: '$INPUTS.resume_at' } }],
       },
-      makeWorkflowRun('wait-input', { metadata: { inputs: { resume_at: resumeAt } } }),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('wait-input', { metadata: { inputs: { resume_at: resumeAt } } }),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(store.pauseWorkflowRunForWait).toHaveBeenCalledWith(
       'wait-input',
@@ -15184,12 +15086,12 @@ describe('executeDagWorkflow -- durable wait node', () => {
   it('resolves a child workflow input embedded in an event name', async () => {
     const store = createMockStore();
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-wait-input',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-wait-input',
+      cwd: testDir,
+      workflow: {
         name: 'wait-event-input-test',
         nodes: [
           {
@@ -15199,16 +15101,18 @@ describe('executeDagWorkflow -- durable wait node', () => {
           },
         ],
       },
-      makeWorkflowRun('wait-event-input', { metadata: { inputs: { channel: 'prod' } } }),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('wait-event-input', {
+        metadata: { inputs: { channel: 'prod' } },
+      }),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(store.pauseWorkflowRunForWait).toHaveBeenCalledWith(
       'wait-event-input',
@@ -15232,27 +15136,27 @@ describe('executeDagWorkflow -- durable wait node', () => {
         },
       },
     });
-    await executeDagWorkflow(
+    await executeDagWorkflow({
       deps,
-      createMockPlatform(),
-      'conv-wait',
-      testDir,
-      {
+      platform: createMockPlatform(),
+      conversationId: 'conv-wait',
+      cwd: testDir,
+      workflow: {
         name: 'wait-expiry-test',
         nodes: [
           { id: 'ci', kind: 'wait', wait: { event: 'checks.complete', deadline_ms: 60_000 } },
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
     expect(store.pauseWorkflowRunForWait).not.toHaveBeenCalled();
     expect(store.clearWorkflowWaitContext).toHaveBeenCalledWith(
       'wait-resume',
@@ -15274,25 +15178,25 @@ describe('executeDagWorkflow -- durable wait node', () => {
       resumeAt: '2099-08-24T11:00:00.000Z',
     };
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-wait',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-wait',
+      cwd: testDir,
+      workflow: {
         name: 'wait-early-resume-test',
         nodes: [{ id: 'delay', kind: 'wait', wait: { duration_ms: 60_000 } }],
       },
-      makeWorkflowRun('wait-early-resume', { metadata: { wait: persisted } }),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('wait-early-resume', { metadata: { wait: persisted } }),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(store.pauseWorkflowRunForWait).toHaveBeenCalledWith('wait-early-resume', persisted, {
       kind: 'continued',
@@ -15308,25 +15212,25 @@ describe('executeDagWorkflow -- durable wait node', () => {
     });
     store.getWorkflowRunStatus = mock(async () => (pauseAttempted ? 'cancelled' : 'running'));
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-wait-cancelled',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-wait-cancelled',
+      cwd: testDir,
+      workflow: {
         name: 'wait-cancelled-race',
         nodes: [{ id: 'delay', kind: 'wait', wait: { duration_ms: 60_000 } }],
       },
-      makeWorkflowRun('wait-cancelled'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('wait-cancelled'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const events = store.createWorkflowEvent.mock.calls.map(call => call[0].event_type);
     expect(events).not.toContain('node_failed');
@@ -15372,12 +15276,12 @@ describe('executeDagWorkflow -- approval node', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-approval',
-      testDir,
-      {
+      conversationId: 'conv-approval',
+      cwd: testDir,
+      workflow: {
         name: 'approval-test',
         nodes: [
           {
@@ -15397,15 +15301,15 @@ describe('executeDagWorkflow -- approval node', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // AI should NOT have been called (fresh approval just pauses)
     expect(mockSendQueryDag.mock.calls.length).toBe(0);
@@ -15430,12 +15334,12 @@ describe('executeDagWorkflow -- approval node', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-approval',
-      testDir,
-      {
+      conversationId: 'conv-approval',
+      cwd: testDir,
+      workflow: {
         name: 'approval-no-capture',
         nodes: [
           {
@@ -15449,15 +15353,15 @@ describe('executeDagWorkflow -- approval node', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // GateNode.captureResponse is a required boolean (#2486) — an undeclared
     // capture_response resolves to false, not undefined.
@@ -15497,12 +15401,12 @@ describe('executeDagWorkflow -- approval node', () => {
       },
     });
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-approval',
-      testDir,
-      {
+      conversationId: 'conv-approval',
+      cwd: testDir,
+      workflow: {
         name: 'approval-reject-resume',
         nodes: [
           {
@@ -15522,15 +15426,15 @@ describe('executeDagWorkflow -- approval node', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // AI should have been called once (on_reject prompt ran)
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -15568,12 +15472,12 @@ describe('executeDagWorkflow -- approval node', () => {
       },
     });
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-approval',
-      testDir,
-      {
+      conversationId: 'conv-approval',
+      cwd: testDir,
+      workflow: {
         name: 'approval-no-poison',
         nodes: [
           {
@@ -15593,15 +15497,15 @@ describe('executeDagWorkflow -- approval node', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // The on_reject synthetic node must NOT produce a node_completed event with
     // step_name equal to the approval gate's own ID ('review'). If it did, a
@@ -15642,12 +15546,12 @@ describe('executeDagWorkflow -- approval node', () => {
       },
     });
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-approval',
-      testDir,
-      {
+      conversationId: 'conv-approval',
+      cwd: testDir,
+      workflow: {
         name: 'approval-exhausted',
         nodes: [
           {
@@ -15664,15 +15568,15 @@ describe('executeDagWorkflow -- approval node', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // AI should NOT have been called (max attempts reached, straight to cancel)
     expect(mockSendQueryDag.mock.calls.length).toBe(0);
@@ -15710,12 +15614,12 @@ describe('executeDagWorkflow -- approval node', () => {
       },
     });
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-approval',
-      testDir,
-      {
+      conversationId: 'conv-approval',
+      cwd: testDir,
+      workflow: {
         name: 'approval-max1',
         nodes: [
           {
@@ -15732,15 +15636,15 @@ describe('executeDagWorkflow -- approval node', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // Should cancel immediately, no AI call
     expect(mockSendQueryDag.mock.calls.length).toBe(0);
@@ -15772,12 +15676,12 @@ describe('executeDagWorkflow -- approval node', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun('approval-sub-run');
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-approval-sub',
-      testDir,
-      {
+      conversationId: 'conv-approval-sub',
+      cwd: testDir,
+      workflow: {
         name: 'approval-sub-test',
         nodes: [
           {
@@ -15806,15 +15710,15 @@ describe('executeDagWorkflow -- approval node', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // gather-context AI call ran once; approval node does NOT call AI
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -15894,29 +15798,29 @@ describe('executeDagWorkflow -- env var injection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'dag-env-test',
         nodes: [{ id: 'task', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      {
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: {
         ...minimalConfig,
         envVars: { MY_SECRET: 'abc123', ANTHROPIC_API_KEY: 'acting-user-secret' },
         protectedEnvKeys: ['ANTHROPIC_API_KEY'],
-      }
-    );
+      },
+    });
 
     expect(mockSendQueryDag.mock.calls.length).toBeGreaterThan(0);
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
@@ -15932,25 +15836,25 @@ describe('executeDagWorkflow -- env var injection', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'dag-no-env',
         nodes: [{ id: 'task', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      { ...minimalConfig, envVars: {} }
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: { ...minimalConfig, envVars: {} },
+    });
 
     expect(mockSendQueryDag.mock.calls.length).toBeGreaterThan(0);
     const optionsArg = mockSendQueryDag.mock.calls[0]?.[3] as Record<string, unknown> | undefined;
@@ -16008,12 +15912,12 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'budget-test',
         nodes: [
           {
@@ -16025,15 +15929,15 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(
       (store.failWorkflowRun as Mock<(id: string, msg: string) => Promise<void>>).mock.calls.length
@@ -16066,12 +15970,12 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'budget-msg-test',
         nodes: [
           { id: 'ok', kind: 'agent', source: { kind: 'inline', prompt: 'do work first' } },
@@ -16085,15 +15989,15 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
     const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
@@ -16122,25 +16026,25 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'err-exec-test',
         nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // The node_failed event should carry the subtype and SDK errors detail
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
@@ -16194,25 +16098,25 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'success-stop-seq-test',
         nodes: [{ id: 'classify', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const nodeFailedEvents = eventCalls.filter(
@@ -16229,26 +16133,26 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'workflow-effort-test',
         nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
         effort: 'high',
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(mockSendQueryDag.mock.calls.length).toBeGreaterThan(0);
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
@@ -16261,12 +16165,12 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'node-effort-override-test',
         nodes: [
           {
@@ -16279,15 +16183,15 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
         effort: 'low',
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(mockSendQueryDag.mock.calls.length).toBeGreaterThan(0);
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
@@ -16309,12 +16213,12 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'codex-claude-opts-test',
         nodes: [
           {
@@ -16327,15 +16231,15 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
         ],
       },
       workflowRun,
-      'codex',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      { ...minimalConfig, assistant: 'codex' }
-    );
+      workflowProvider: 'codex',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: { ...minimalConfig, assistant: 'codex' },
+    });
 
     const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
     const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
@@ -16359,26 +16263,26 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'codex-workflow-effort-test',
         nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
         effort: 'xhigh',
       },
       workflowRun,
-      'codex',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      { ...minimalConfig, assistant: 'codex' }
-    );
+      workflowProvider: 'codex',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: { ...minimalConfig, assistant: 'codex' },
+    });
 
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
     const nodeConfig = optionsArg?.nodeConfig as Record<string, unknown>;
@@ -16401,12 +16305,12 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      loaderBypassingWorkflow({
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: loaderBypassingWorkflow({
         name: 'codex-node-effort-beats-deprecated-test',
         nodes: [
           {
@@ -16419,15 +16323,15 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
         modelReasoningEffort: 'high',
       }),
       workflowRun,
-      'codex',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      { ...minimalConfig, assistant: 'codex' }
-    );
+      workflowProvider: 'codex',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: { ...minimalConfig, assistant: 'codex' },
+    });
 
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
     const nodeConfig = optionsArg?.nodeConfig as Record<string, unknown>;
@@ -16444,12 +16348,12 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'codex-workflow-options-test',
         nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
         // #2556: the loader translates `modelReasoningEffort:` into `effort:`,
@@ -16459,15 +16363,15 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
         webSearchMode: 'live',
       },
       workflowRun,
-      'codex',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      { ...minimalConfig, assistant: 'codex' }
-    );
+      workflowProvider: 'codex',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: { ...minimalConfig, assistant: 'codex' },
+    });
 
     expect(mockSendQueryDag.mock.calls.length).toBeGreaterThan(0);
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
@@ -16492,12 +16396,12 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
       },
     });
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'codex-workflow-beats-preset-test',
         nodes: [
           {
@@ -16510,20 +16414,16 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
         effort: 'xhigh',
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      aiProfile
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      aiProfile,
+    });
 
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
     const nodeConfig = optionsArg?.nodeConfig as Record<string, unknown>;
@@ -16547,12 +16447,12 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
       },
     });
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      loaderBypassingWorkflow({
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: loaderBypassingWorkflow({
         name: 'mixed-provider-preset-effort-test',
         nodes: [
           {
@@ -16568,20 +16468,16 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
         modelReasoningEffort: 'high',
       }),
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      aiProfile
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      aiProfile,
+    });
 
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
     const nodeConfig = optionsArg?.nodeConfig as Record<string, unknown>;
@@ -16595,26 +16491,26 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'codex-options-on-claude-test',
         nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
         webSearchMode: 'live',
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
     const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
@@ -16642,27 +16538,27 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      loaderBypassingWorkflow({
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: loaderBypassingWorkflow({
         name: 'codex-effort-telemetry-test',
         nodes: [{ id: 'step1', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
         effort: 'max',
         modelReasoningEffort: 'low',
       }),
       workflowRun,
-      'codex',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      { ...minimalConfig, assistant: 'codex' }
-    );
+      workflowProvider: 'codex',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: { ...minimalConfig, assistant: 'codex' },
+    });
 
     const optionsArg = mockSendQueryDag.mock.calls[0][3] as Record<string, unknown>;
     const nodeConfig = optionsArg?.nodeConfig as Record<string, unknown>;
@@ -16689,12 +16585,12 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
       },
     });
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'codex-workflow-node-resolves-to-claude-test',
         nodes: [
           {
@@ -16707,20 +16603,16 @@ describe('executeDagWorkflow -- Claude SDK advanced options', () => {
         webSearchMode: 'live',
       },
       workflowRun,
-      'codex',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      aiProfile
-    );
+      workflowProvider: 'codex',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      aiProfile,
+    });
 
     expect(mockGetAgentProviderDag.mock.calls[0][0]).toBe('claude');
 
@@ -16774,25 +16666,25 @@ describe('executeDagWorkflow -- cost tracking', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'dag-cost',
         nodes: [{ id: 'step', kind: 'agent', source: { kind: 'inline', prompt: 'Do thing.' } }],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(runUsageWrites(store)).toEqual([{ total_cost_usd: 0.0042 }]);
     // Exactly one writer: completeWorkflowRun keeps node_counts, not usage (#2469).
@@ -16817,12 +16709,12 @@ describe('executeDagWorkflow -- cost tracking', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'dag-cost-multi',
         nodes: [
           { id: 'step1', kind: 'agent', source: { kind: 'inline', prompt: 'Step 1.' } },
@@ -16835,15 +16727,15 @@ describe('executeDagWorkflow -- cost tracking', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(runUsageWrites(store)).toEqual([{ total_cost_usd: 0.002 }]);
   });
@@ -16859,25 +16751,25 @@ describe('executeDagWorkflow -- cost tracking', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'dag-no-cost',
         nodes: [{ id: 'step', kind: 'agent', source: { kind: 'inline', prompt: 'Do thing.' } }],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // A zero must stay ABSENT, not written as 0 — a bash-only workflow reading as a
     // free AI run is the misleading shape the `> 0` guards exist to prevent.
@@ -16914,12 +16806,12 @@ describe('executeDagWorkflow -- cost tracking', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'dag-loop-cost',
         nodes: [
           {
@@ -16930,15 +16822,15 @@ describe('executeDagWorkflow -- cost tracking', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // The final NaN is omitted without erasing the first three iterations.
     expect(runUsageWrites(store)).toEqual([{ total_cost_usd: 0.004 }]);
@@ -17003,12 +16895,12 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
     const store = createMockStore();
     const mockDeps = createMockDeps(store);
 
-    await executeDagWorkflow(
-      mockDeps,
-      createMockPlatform(),
-      'conv-usage',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: mockDeps,
+      platform: createMockPlatform(),
+      conversationId: 'conv-usage',
+      cwd: testDir,
+      workflow: {
         name: 'usage-on-failure',
         nodes: [
           { id: 'spend', kind: 'agent', source: { kind: 'inline', prompt: 'Burn some tokens.' } },
@@ -17021,16 +16913,16 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
           },
         ],
       },
-      makeWorkflowRun(),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun(),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(store.failWorkflowRun).toHaveBeenCalled();
     expect(store.completeWorkflowRun).not.toHaveBeenCalled();
@@ -17077,12 +16969,12 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
     const logDir = join(testDir, 'logs');
     const workflowRun = makeWorkflowRun('spend-transcript-run');
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-spend',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-spend',
+      cwd: testDir,
+      workflow: {
         name: 'spend-transcript',
         nodes: [
           { id: 'a', kind: 'agent', source: { kind: 'inline', prompt: 'Cheap work.' } },
@@ -17095,15 +16987,15 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
       logDir,
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const rows = await readTranscript(logDir, workflowRun.id);
 
@@ -17166,25 +17058,25 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
     const workflowRun = makeWorkflowRun('cancel-transcript-run');
 
     try {
-      await executeDagWorkflow(
-        createMockDeps(store),
-        createMockPlatform(),
-        'conv-cancel',
-        testDir,
-        {
+      await executeDagWorkflow({
+        deps: createMockDeps(store),
+        platform: createMockPlatform(),
+        conversationId: 'conv-cancel',
+        cwd: testDir,
+        workflow: {
           name: 'cancel-transcript',
           nodes: [{ id: 'only', kind: 'agent', source: { kind: 'inline', prompt: 'Work.' } }],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
         logDir,
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
     } finally {
       setSystemTime(); // restore the real clock
     }
@@ -17225,12 +17117,12 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
     const workflowRun = makeWorkflowRun('cancel-throw-run');
 
     try {
-      await executeDagWorkflow(
-        createMockDeps(store),
-        createMockPlatform(),
-        'conv-cancel-throw',
-        testDir,
-        {
+      await executeDagWorkflow({
+        deps: createMockDeps(store),
+        platform: createMockPlatform(),
+        conversationId: 'conv-cancel-throw',
+        cwd: testDir,
+        workflow: {
           name: 'cancel-throw',
           nodes: [
             {
@@ -17242,15 +17134,15 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
         logDir,
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
     } finally {
       setSystemTime();
     }
@@ -17291,27 +17183,27 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
     );
     const mockDeps = createMockDeps(store);
 
-    await executeDagWorkflow(
-      mockDeps,
-      createMockPlatform(),
-      'conv-usage',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: mockDeps,
+      platform: createMockPlatform(),
+      conversationId: 'conv-usage',
+      cwd: testDir,
+      workflow: {
         name: 'usage-on-cancel',
         nodes: [
           { id: 'spend', kind: 'agent', source: { kind: 'inline', prompt: 'Burn some tokens.' } },
         ],
       },
-      makeWorkflowRun(),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun(),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(store.completeWorkflowRun).not.toHaveBeenCalled();
     expect(store.failWorkflowRun).not.toHaveBeenCalled();
@@ -17344,12 +17236,12 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
     );
     const mockDeps = createMockDeps(store);
 
-    await executeDagWorkflow(
-      mockDeps,
-      createMockPlatform(),
-      'conv-usage',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: mockDeps,
+      platform: createMockPlatform(),
+      conversationId: 'conv-usage',
+      cwd: testDir,
+      workflow: {
         name: 'usage-on-pause',
         nodes: [
           { id: 'analyze', kind: 'agent', source: { kind: 'inline', prompt: 'Analyze.' } },
@@ -17364,16 +17256,16 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
           },
         ],
       },
-      makeWorkflowRun(),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun(),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(store.pauseWorkflowRun).toHaveBeenCalled();
     expect(store.completeWorkflowRun).not.toHaveBeenCalled();
@@ -17406,12 +17298,12 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
     const store = createMockStore();
     const mockDeps = createMockDeps(store);
 
-    await executeDagWorkflow(
-      mockDeps,
-      createMockPlatform(),
-      'conv-usage',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: mockDeps,
+      platform: createMockPlatform(),
+      conversationId: 'conv-usage',
+      cwd: testDir,
+      workflow: {
         name: 'usage-nan-cost',
         nodes: [
           { id: 'good', kind: 'agent', source: { kind: 'inline', prompt: 'Spend normally.' } },
@@ -17423,16 +17315,16 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
           },
         ],
       },
-      makeWorkflowRun(),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun(),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // The healthy node's spend survives; only the broken node's contribution is dropped.
     // Tokens are unaffected — both nodes reported finite ones.
@@ -17470,27 +17362,27 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
     );
     const mockDeps = createMockDeps(store);
 
-    await executeDagWorkflow(
-      mockDeps,
-      createMockPlatform(),
-      'conv-usage',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: mockDeps,
+      platform: createMockPlatform(),
+      conversationId: 'conv-usage',
+      cwd: testDir,
+      workflow: {
         name: 'usage-write-fails',
         nodes: [
           { id: 'spend', kind: 'agent', source: { kind: 'inline', prompt: 'Burn some tokens.' } },
         ],
       },
-      makeWorkflowRun(),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun(),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // The run still completes normally — the usage figure is simply absent, and every
     // reader type-guards that. Absent is safe; plausible-and-wrong is the failure mode.
@@ -17575,12 +17467,12 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
     });
 
     await expect(
-      executeDagWorkflow(
-        createMockDeps(store),
+      executeDagWorkflow({
+        deps: createMockDeps(store),
         platform,
-        'conv-usage',
-        testDir,
-        {
+        conversationId: 'conv-usage',
+        cwd: testDir,
+        workflow: {
           name: 'usage-on-throw',
           returns: 'spend',
           outcome_field: 'green',
@@ -17598,16 +17490,16 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
             { id: 'stop', kind: 'halt', reason: 'platform is gone' },
           ],
         },
-        makeWorkflowRun(),
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      )
+        workflowRun: makeWorkflowRun(),
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      })
     ).rejects.toThrow(/authentication\/permission/i);
 
     // Neither terminal writer ran — the throw skipped them both — yet the spend survived.
@@ -17678,22 +17570,22 @@ describe('executeDagWorkflow -- script nodes', () => {
       runtime: 'bun',
     };
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-script',
-      testDir,
-      { name: 'script-inline-bun-test', nodes: [scriptNode] },
+      conversationId: 'conv-script',
+      cwd: testDir,
+      workflow: { name: 'script-inline-bun-test', nodes: [scriptNode] },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // Script node should NOT invoke AI client
     expect(mockSendQueryDag.mock.calls.length).toBe(0);
@@ -17723,22 +17615,22 @@ describe('executeDagWorkflow -- script nodes', () => {
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-script',
-      testDir,
-      { name: 'script-subst-test', nodes },
+      conversationId: 'conv-script',
+      cwd: testDir,
+      workflow: { name: 'script-subst-test', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // AI client called for the downstream AI node
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -17762,22 +17654,22 @@ describe('executeDagWorkflow -- script nodes', () => {
       runtime: 'uv',
     };
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-script-uv',
-      testDir,
-      { name: 'script-inline-uv-test', nodes: [scriptNode] },
+      conversationId: 'conv-script-uv',
+      cwd: testDir,
+      workflow: { name: 'script-inline-uv-test', nodes: [scriptNode] },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // Script node should NOT invoke AI client
     expect(mockSendQueryDag.mock.calls.length).toBe(0);
@@ -17804,22 +17696,22 @@ describe('executeDagWorkflow -- script nodes', () => {
       runtime: 'bun',
     };
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-named',
-      testDir,
-      { name: 'named-script-test', nodes: [scriptNode] },
+      conversationId: 'conv-named',
+      cwd: testDir,
+      workflow: { name: 'named-script-test', nodes: [scriptNode] },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(mockSendQueryDag.mock.calls.length).toBe(0);
   });
@@ -17840,22 +17732,22 @@ describe('executeDagWorkflow -- script nodes', () => {
       runtime: 'bun',
     };
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-fail',
-      testDir,
-      { name: 'script-fail-test', nodes: [scriptNode] },
+      conversationId: 'conv-fail',
+      cwd: testDir,
+      workflow: { name: 'script-fail-test', nodes: [scriptNode] },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
     const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
@@ -17884,22 +17776,22 @@ describe('executeDagWorkflow -- script nodes', () => {
       runtime: 'bun',
     };
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-1389s',
-      testDir,
-      { name: 'script-1389', nodes: [scriptNode] },
+      conversationId: 'conv-1389s',
+      cwd: testDir,
+      workflow: { name: 'script-1389', nodes: [scriptNode] },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const eventCalls = (mockDeps.store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const failedEvent = eventCalls.find(
@@ -17938,22 +17830,22 @@ describe('executeDagWorkflow -- script nodes', () => {
       timeout: 500,
     };
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-timeout',
-      testDir,
-      { name: 'script-timeout-test', nodes: [scriptNode] },
+      conversationId: 'conv-timeout',
+      cwd: testDir,
+      workflow: { name: 'script-timeout-test', nodes: [scriptNode] },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
     const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
@@ -17979,22 +17871,22 @@ describe('executeDagWorkflow -- script nodes', () => {
       runtime: 'bun',
     };
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-stderr',
-      testDir,
-      { name: 'script-stderr-test', nodes: [scriptNode] },
+      conversationId: 'conv-stderr',
+      cwd: testDir,
+      workflow: { name: 'script-stderr-test', nodes: [scriptNode] },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
     const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
@@ -18035,22 +17927,22 @@ describe('executeDagWorkflow -- script nodes', () => {
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-subst',
-      testDir,
-      { name: 'script-subst-vars', nodes },
+      conversationId: 'conv-subst',
+      cwd: testDir,
+      workflow: { name: 'script-subst-vars', nodes },
       workflowRun,
-      'claude',
-      undefined,
+      workflowProvider: 'claude',
+      workflowModel: undefined,
       artifactsDir,
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // The downstream AI node should have received the substituted output
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -18103,22 +17995,22 @@ describe('executeDagWorkflow -- script nodes', () => {
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-statedir',
-      testDir,
-      { name: 'state-dir-env', nodes },
+      conversationId: 'conv-statedir',
+      cwd: testDir,
+      workflow: { name: 'state-dir-env', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
       stateDir,
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
     const prompt = mockSendQueryDag.mock.calls[0][0] as string;
@@ -18166,22 +18058,22 @@ describe('executeDagWorkflow -- script nodes', () => {
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-wfid',
-      testDir,
-      { name: 'workflow-id-env', nodes },
+      conversationId: 'conv-wfid',
+      cwd: testDir,
+      workflow: { name: 'workflow-id-env', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
     const prompt = mockSendQueryDag.mock.calls[0][0] as string;
@@ -18206,22 +18098,22 @@ describe('executeDagWorkflow -- script nodes', () => {
       runtime: 'bun',
     };
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-notfound',
-      testDir,
-      { name: 'script-notfound-test', nodes: [scriptNode] },
+      conversationId: 'conv-notfound',
+      cwd: testDir,
+      workflow: { name: 'script-notfound-test', nodes: [scriptNode] },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
     const messages = sendMessage.mock.calls.map((call: unknown[]) => call[1] as string);
@@ -18250,22 +18142,22 @@ describe('executeDagWorkflow -- script nodes', () => {
       runtime: 'bun',
     };
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-env-leak',
-      testDir,
-      { name: 'env-leak-test', nodes: [scriptNode] },
+      conversationId: 'conv-env-leak',
+      cwd: testDir,
+      workflow: { name: 'env-leak-test', nodes: [scriptNode] },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // The node output should be "CLEAN" — the repo .env was not loaded
     const eventCalls = (mockDeps.store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
@@ -18286,25 +18178,25 @@ describe('executeDagWorkflow -- script nodes', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun('script-env-run-id');
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-script-env',
-      testDir,
-      {
+      conversationId: 'conv-script-env',
+      cwd: testDir,
+      workflow: {
         name: 'script-env-test',
         nodes: [{ id: 'inline-bun', kind: 'exec', script: 'console.log("ok")', runtime: 'bun' }],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      { ...minimalConfig, envVars: { MY_SECRET: 'abc123' } }
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: { ...minimalConfig, envVars: { MY_SECRET: 'abc123' } },
+    });
 
     expect(execSpy).toHaveBeenCalledWith(
       'bun',
@@ -18464,12 +18356,12 @@ describe('executeDagWorkflow -- MCP failure filtering', () => {
     });
 
     const platform = createMockPlatform();
-    await executeDagWorkflow(
-      createMockDeps(),
+    await executeDagWorkflow({
+      deps: createMockDeps(),
       platform,
-      'conv-mcp-filter',
-      testDir,
-      {
+      conversationId: 'conv-mcp-filter',
+      cwd: testDir,
+      workflow: {
         name: 'mcp-filter-test',
         nodes: [
           {
@@ -18480,16 +18372,16 @@ describe('executeDagWorkflow -- MCP failure filtering', () => {
           },
         ],
       },
-      makeWorkflowRun(),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun(),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
     return platform;
   }
 
@@ -18620,29 +18512,27 @@ describe('executeDagWorkflow -- authored run outcome (#2618)', () => {
       priorCompletedNodes?: Map<string, PersistedNodeOutput>;
     } = {}
   ): Promise<void> => {
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-outcome',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-outcome',
+      cwd: testDir,
+      workflow: {
         name: 'authored-outcome',
         nodes,
         ...(options.declared === false ? {} : { returns: 'result', outcome_field: 'green' }),
       },
-      options.workflowRun ?? makeWorkflowRun('authored-outcome-run'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      options.priorCompletedNodes
-    );
+      workflowRun: options.workflowRun ?? makeWorkflowRun('authored-outcome-run'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes: options.priorCompletedNodes,
+    });
   };
 
   beforeEach(async () => {
@@ -18895,25 +18785,25 @@ describe('executeDagWorkflow -- final status derivation', () => {
   it('a failed-only DAG delegates its terminal event to failWorkflowRun', async () => {
     const mockStore = createMockStore();
 
-    await executeDagWorkflow(
-      createMockDeps(mockStore),
-      createMockPlatform(),
-      'conv-status',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(mockStore),
+      platform: createMockPlatform(),
+      conversationId: 'conv-status',
+      cwd: testDir,
+      workflow: {
         name: 'status-test',
         nodes: [{ id: 'fail', kind: 'exec', runtime: 'sh', script: 'exit 1' } as ExecNode],
       },
-      makeWorkflowRun('dag-status-failed-only'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('dag-status-failed-only'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(mockStore.failWorkflowRun).toHaveBeenCalledTimes(1);
     expect(mockStore.createWorkflowEvent).not.toHaveBeenCalledWith(
@@ -18932,22 +18822,22 @@ describe('executeDagWorkflow -- final status derivation', () => {
       { id: 'fail', kind: 'exec', runtime: 'sh', script: 'exit 1' } as ExecNode,
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-status',
-      testDir,
-      { name: 'status-test', nodes },
+      conversationId: 'conv-status',
+      cwd: testDir,
+      workflow: { name: 'status-test', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect((mockStore.failWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(1);
     expect((mockStore.completeWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(0);
@@ -18980,22 +18870,22 @@ describe('executeDagWorkflow -- final status derivation', () => {
       { id: 'fail', kind: 'exec', runtime: 'sh', script: 'exit 1' } as ExecNode,
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-status',
-      testDir,
-      { name: 'status-test-multi', nodes },
+      conversationId: 'conv-status',
+      cwd: testDir,
+      workflow: { name: 'status-test-multi', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect((mockStore.failWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(1);
     expect((mockStore.completeWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(0);
@@ -19033,22 +18923,22 @@ describe('executeDagWorkflow -- final status derivation', () => {
       } as ExecNode,
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-status',
-      testDir,
-      { name: 'status-test-skip', nodes },
+      conversationId: 'conv-status',
+      cwd: testDir,
+      workflow: { name: 'status-test-skip', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect((mockStore.failWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(1);
     expect((mockStore.completeWorkflowRun as ReturnType<typeof mock>).mock.calls.length).toBe(0);
@@ -19098,29 +18988,27 @@ describe('executeDagWorkflow -- evidence gate (#2230)', () => {
       { id: 'work', kind: 'exec', runtime: 'sh', script: 'echo done' } as ExecNode,
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
-      opts.platform,
-      'conv-evidence',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: mockDeps,
+      platform: opts.platform,
+      conversationId: 'conv-evidence',
+      cwd: testDir,
+      workflow: {
         name: 'evidence-test',
         nodes,
         ...(opts.evidencePolicy ? { evidence_policy: opts.evidencePolicy } : {}),
       },
       workflowRun,
-      'claude',
-      undefined,
+      workflowProvider: 'claude',
+      workflowModel: undefined,
       artifactsDir,
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      opts.priorCompletedNodes
-    );
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes: opts.priorCompletedNodes,
+    });
   }
 
   it('required: true + missing evidence.json -> failWorkflowRun with explicit reason, never completed', async () => {
@@ -19353,13 +19241,13 @@ describe('provider resolution -- regression for #1610', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-provider',
-      testDir,
+      conversationId: 'conv-provider',
+      cwd: testDir,
       // Node has model: opus[1m] but NO provider: — must inherit workflowProvider
-      {
+      workflow: {
         name: 'provider-regression',
         nodes: [
           {
@@ -19371,15 +19259,16 @@ describe('provider resolution -- regression for #1610', () => {
         ],
       },
       workflowRun,
-      'codex', // workflowProvider (simulates defaultAssistant: codex)
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      { ...minimalConfig, assistant: 'codex' }
-    );
+      // Simulates defaultAssistant: codex.
+      workflowProvider: 'codex',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: { ...minimalConfig, assistant: 'codex' },
+    });
 
     // getAgentProvider must have been called with 'codex', not 'claude'
     expect(mockGetAgentProviderDag).toHaveBeenCalledWith('codex');
@@ -19392,13 +19281,13 @@ describe('provider resolution -- regression for #1610', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-provider',
-      testDir,
+      conversationId: 'conv-provider',
+      cwd: testDir,
       // Node has both model: opus[1m] AND provider: claude
-      {
+      workflow: {
         name: 'provider-explicit',
         nodes: [
           {
@@ -19411,15 +19300,15 @@ describe('provider resolution -- regression for #1610', () => {
         ],
       },
       workflowRun,
-      'codex', // workflowProvider
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      { ...minimalConfig, assistant: 'codex' }
-    );
+      workflowProvider: 'codex',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: { ...minimalConfig, assistant: 'codex' },
+    });
 
     // getAgentProvider must have been called with 'claude'
     expect(mockGetAgentProviderDag).toHaveBeenCalledWith('claude');
@@ -19505,12 +19394,12 @@ describe('executeDagWorkflow -- typed artifacts (output_type)', () => {
   });
 
   it('node with output_type writes nodes/<id>.md + .meta.json with the declared type', async () => {
-    await executeDagWorkflow(
-      createMockDeps(),
-      createMockPlatform(),
-      'conv-dag',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(),
+      platform: createMockPlatform(),
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'typed-test',
         nodes: [
           {
@@ -19521,16 +19410,16 @@ describe('executeDagWorkflow -- typed artifacts (output_type)', () => {
           },
         ],
       },
-      makeWorkflowRun(),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun(),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const body = await readFile(join(testDir, 'artifacts', 'nodes', 'planner.md'), 'utf8');
     expect(body).toBe('AI response');
@@ -19549,12 +19438,12 @@ describe('executeDagWorkflow -- typed artifacts (output_type)', () => {
   });
 
   it('bash node with output_type writes a sidecar with no sessionId', async () => {
-    await executeDagWorkflow(
-      createMockDeps(),
-      createMockPlatform(),
-      'conv-dag',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(),
+      platform: createMockPlatform(),
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'bash-typed',
         nodes: [
           {
@@ -19566,16 +19455,16 @@ describe('executeDagWorkflow -- typed artifacts (output_type)', () => {
           },
         ],
       },
-      makeWorkflowRun(),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun(),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const body = await readFile(join(testDir, 'artifacts', 'nodes', 'metrics.md'), 'utf8');
     expect(body).toContain('result-data');
@@ -19597,12 +19486,12 @@ describe('executeDagWorkflow -- typed artifacts (output_type)', () => {
     await writeFile(join(artifactsDir, 'nodes'), 'not a directory', 'utf8');
 
     // Resolves without throwing — the best-effort catch swallows the write failure.
-    await executeDagWorkflow(
-      createMockDeps(),
-      createMockPlatform(),
-      'conv-dag',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(),
+      platform: createMockPlatform(),
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'typed-fail',
         nodes: [
           {
@@ -19613,41 +19502,41 @@ describe('executeDagWorkflow -- typed artifacts (output_type)', () => {
           },
         ],
       },
-      makeWorkflowRun(),
-      'claude',
-      undefined,
+      workflowRun: makeWorkflowRun(),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
       artifactsDir,
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // The node executed despite the artifact write being impossible.
     expect(mockSendQueryDag.mock.calls.length).toBeGreaterThan(0);
   });
 
   it('node without output_type writes no sidecar artifact', async () => {
-    await executeDagWorkflow(
-      createMockDeps(),
-      createMockPlatform(),
-      'conv-dag',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(),
+      platform: createMockPlatform(),
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'untyped-test',
         nodes: [{ id: 'planner', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
       },
-      makeWorkflowRun(),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun(),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     let wrote = true;
     try {
@@ -19693,12 +19582,12 @@ describe('executeDagWorkflow -- persist_session', () => {
     const store = createMockStore();
     const mockDeps = createMockDeps(store);
 
-    await executeDagWorkflow(
-      mockDeps,
-      createMockPlatform(),
-      'conv-dag',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: mockDeps,
+      platform: createMockPlatform(),
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'persist-test',
         nodes: [
           {
@@ -19709,16 +19598,16 @@ describe('executeDagWorkflow -- persist_session', () => {
           },
         ],
       },
-      makeWorkflowRun(),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun(),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const getMock = store.getWorkflowNodeSession as Mock<typeof store.getWorkflowNodeSession>;
     const upsertMock = store.upsertWorkflowNodeSession as Mock<
@@ -19758,12 +19647,12 @@ describe('executeDagWorkflow -- persist_session', () => {
     });
     const mockDeps = createMockDeps(store);
 
-    await executeDagWorkflow(
-      mockDeps,
-      createMockPlatform(),
-      'conv-dag',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: mockDeps,
+      platform: createMockPlatform(),
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'persist-test',
         nodes: [
           {
@@ -19774,16 +19663,16 @@ describe('executeDagWorkflow -- persist_session', () => {
           },
         ],
       },
-      makeWorkflowRun(),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun(),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(mockSendQueryDag.mock.calls[0][2]).toBe('prior-session-id');
     // A warm resume (resumed not false) runs the node exactly once — never replayed.
@@ -19824,12 +19713,12 @@ describe('executeDagWorkflow -- persist_session', () => {
       yield { type: 'result', sessionId: 'cold-id', resumed: false };
     });
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'persist-test',
         nodes: [
           {
@@ -19840,16 +19729,16 @@ describe('executeDagWorkflow -- persist_session', () => {
           },
         ],
       },
-      makeWorkflowRun(),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun(),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // Ran exactly once — a cold resume is NOT replayed (the cold run is already fresh).
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -19904,12 +19793,12 @@ describe('executeDagWorkflow -- persist_session', () => {
     armColdResume(store);
     const platform = createMockPlatform();
 
-    await executeDagWorkflow(
-      createMockDeps(store),
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'persist-test',
         nodes: [
           {
@@ -19920,23 +19809,17 @@ describe('executeDagWorkflow -- persist_session', () => {
           },
         ],
       },
-      makeWorkflowRun(),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      scopeDir
-    );
+      workflowRun: makeWorkflowRun(),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      scopeArtifactsDir: scopeDir,
+    });
 
     const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
     const messages = sendMessage.mock.calls.map(c => String(c[1]));
@@ -19967,12 +19850,12 @@ describe('executeDagWorkflow -- persist_session', () => {
     armColdResume(store);
     const platform = createMockPlatform();
 
-    await executeDagWorkflow(
-      createMockDeps(store),
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'persist-test',
         nodes: [
           {
@@ -19983,23 +19866,17 @@ describe('executeDagWorkflow -- persist_session', () => {
           },
         ],
       },
-      makeWorkflowRun(),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      scopeDir
-    );
+      workflowRun: makeWorkflowRun(),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      scopeArtifactsDir: scopeDir,
+    });
 
     const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
     const messages = sendMessage.mock.calls.map(c => String(c[1]));
@@ -20012,12 +19889,12 @@ describe('executeDagWorkflow -- persist_session', () => {
     armColdResume(store);
     const platform = createMockPlatform();
 
-    await executeDagWorkflow(
-      createMockDeps(store),
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'persist-test',
         nodes: [
           {
@@ -20028,23 +19905,17 @@ describe('executeDagWorkflow -- persist_session', () => {
           },
         ],
       },
-      makeWorkflowRun(),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      join(testDir, 'scope-artifacts-never-created')
-    );
+      workflowRun: makeWorkflowRun(),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      scopeArtifactsDir: join(testDir, 'scope-artifacts-never-created'),
+    });
 
     const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
     const messages = sendMessage.mock.calls.map(c => String(c[1]));
@@ -20055,12 +19926,12 @@ describe('executeDagWorkflow -- persist_session', () => {
   it('persist node with output_type mirrors its typed sidecar into the scope dir', async () => {
     const scopeDir = join(testDir, 'scope-artifacts');
 
-    await executeDagWorkflow(
-      createMockDeps(),
-      createMockPlatform(),
-      'conv-dag',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(),
+      platform: createMockPlatform(),
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'persist-test',
         nodes: [
           {
@@ -20072,23 +19943,17 @@ describe('executeDagWorkflow -- persist_session', () => {
           },
         ],
       },
-      makeWorkflowRun(),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      scopeDir
-    );
+      workflowRun: makeWorkflowRun(),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      scopeArtifactsDir: scopeDir,
+    });
 
     // Written to BOTH the per-run dir and the durable scope dir.
     const runCopy = await readFile(join(testDir, 'artifacts', 'nodes', 'planner.md'), 'utf8');
@@ -20108,12 +19973,12 @@ describe('executeDagWorkflow -- persist_session', () => {
   it('non-persist node with output_type does NOT mirror into the scope dir', async () => {
     const scopeDir = join(testDir, 'scope-artifacts');
 
-    await executeDagWorkflow(
-      createMockDeps(),
-      createMockPlatform(),
-      'conv-dag',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(),
+      platform: createMockPlatform(),
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'persist-test',
         // scope dir present (another node opted in), but THIS node doesn't persist.
         nodes: [
@@ -20125,23 +19990,17 @@ describe('executeDagWorkflow -- persist_session', () => {
           },
         ],
       },
-      makeWorkflowRun(),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      scopeDir
-    );
+      workflowRun: makeWorkflowRun(),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      scopeArtifactsDir: scopeDir,
+    });
 
     // Run-dir sidecar exists; the scope dir stays untouched.
     const runCopy = await readFile(join(testDir, 'artifacts', 'nodes', 'planner.md'), 'utf8');
@@ -20161,12 +20020,12 @@ describe('executeDagWorkflow -- persist_session', () => {
     await mkdir(scopeDir, { recursive: true });
     await writeFile(join(scopeDir, 'nodes'), 'not a directory', 'utf8');
 
-    await executeDagWorkflow(
-      createMockDeps(),
-      createMockPlatform(),
-      'conv-dag',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(),
+      platform: createMockPlatform(),
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'persist-test',
         nodes: [
           {
@@ -20178,23 +20037,17 @@ describe('executeDagWorkflow -- persist_session', () => {
           },
         ],
       },
-      makeWorkflowRun(),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      scopeDir
-    );
+      workflowRun: makeWorkflowRun(),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      scopeArtifactsDir: scopeDir,
+    });
 
     // Node ran and the run-dir sidecar was still written (mirror is best-effort).
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -20210,12 +20063,12 @@ describe('executeDagWorkflow -- persist_session', () => {
     const store = createMockStore();
     const mockDeps = createMockDeps(store);
 
-    await executeDagWorkflow(
-      mockDeps,
-      createMockPlatform(),
-      'conv-dag',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: mockDeps,
+      platform: createMockPlatform(),
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'persist-test',
         nodes: [
           {
@@ -20226,16 +20079,16 @@ describe('executeDagWorkflow -- persist_session', () => {
           },
         ],
       },
-      makeWorkflowRun(),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun(),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const upsertMock = store.upsertWorkflowNodeSession as Mock<
       typeof store.upsertWorkflowNodeSession
@@ -20258,25 +20111,25 @@ describe('executeDagWorkflow -- persist_session', () => {
     const store = createMockStore();
     const mockDeps = createMockDeps(store);
 
-    await executeDagWorkflow(
-      mockDeps,
-      createMockPlatform(),
-      'conv-dag',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: mockDeps,
+      platform: createMockPlatform(),
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'no-persist',
         nodes: [{ id: 'planner', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
       },
-      makeWorkflowRun(),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun(),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(store.getWorkflowNodeSession).not.toHaveBeenCalled();
     expect(store.upsertWorkflowNodeSession).not.toHaveBeenCalled();
@@ -20287,12 +20140,12 @@ describe('executeDagWorkflow -- persist_session', () => {
     const store = createMockStore();
     const mockDeps = createMockDeps(store);
 
-    await executeDagWorkflow(
-      mockDeps,
-      createMockPlatform(),
-      'conv-dag',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: mockDeps,
+      platform: createMockPlatform(),
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'wf-default-on',
         nodes: [
           {
@@ -20304,16 +20157,16 @@ describe('executeDagWorkflow -- persist_session', () => {
         ],
         persist_sessions: true,
       },
-      makeWorkflowRun(),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun(),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(store.getWorkflowNodeSession).not.toHaveBeenCalled();
     expect(store.upsertWorkflowNodeSession).not.toHaveBeenCalled();
@@ -20333,12 +20186,12 @@ describe('executeDagWorkflow -- persist_session', () => {
     });
     const mockDeps = createMockDeps(store);
 
-    await executeDagWorkflow(
-      mockDeps,
-      createMockPlatform(),
-      'conv-dag',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: mockDeps,
+      platform: createMockPlatform(),
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'persist-test',
         nodes: [
           {
@@ -20350,16 +20203,16 @@ describe('executeDagWorkflow -- persist_session', () => {
           },
         ],
       },
-      makeWorkflowRun(),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun(),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(store.getWorkflowNodeSession).not.toHaveBeenCalled();
     expect(mockSendQueryDag.mock.calls[0][2]).toBeUndefined();
@@ -20381,12 +20234,12 @@ describe('executeDagWorkflow -- persist_session', () => {
     const mockDeps = createMockDeps(store);
     const platform = createMockPlatform();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'persist-test',
         nodes: [
           {
@@ -20397,16 +20250,16 @@ describe('executeDagWorkflow -- persist_session', () => {
           },
         ],
       },
-      makeWorkflowRun(),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun(),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // executeDagWorkflow catches per-node errors and emits a failure message.
     const sendMessage = platform.sendMessage as ReturnType<typeof mock>;
@@ -20420,26 +20273,26 @@ describe('executeDagWorkflow -- persist_session', () => {
     const store = createMockStore();
     const mockDeps = createMockDeps(store);
 
-    await executeDagWorkflow(
-      mockDeps,
-      createMockPlatform(),
-      'conv-dag',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: mockDeps,
+      platform: createMockPlatform(),
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'wf-inherit',
         nodes: [{ id: 'planner', kind: 'agent', source: { kind: 'command', name: 'my-cmd' } }],
         persist_sessions: true,
       },
-      makeWorkflowRun(),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun(),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(store.getWorkflowNodeSession).toHaveBeenCalledWith({
       workflow_name: 'wf-inherit',
@@ -20468,12 +20321,12 @@ describe('executeDagWorkflow -- persist_session', () => {
     const mockDeps = createMockDeps(store);
     const platform = createMockPlatform();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'persist-test',
         nodes: [
           {
@@ -20484,16 +20337,16 @@ describe('executeDagWorkflow -- persist_session', () => {
           },
         ],
       },
-      makeWorkflowRun(),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun(),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // Lookup threw → node still runs, with no resume session.
     expect(mockSendQueryDag.mock.calls[0][2]).toBeUndefined();
@@ -20515,12 +20368,12 @@ describe('executeDagWorkflow -- persist_session', () => {
     const mockDeps = createMockDeps(store);
     const platform = createMockPlatform();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-dag',
-      testDir,
-      {
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'persist-test',
         nodes: [
           {
@@ -20531,16 +20384,16 @@ describe('executeDagWorkflow -- persist_session', () => {
           },
         ],
       },
-      makeWorkflowRun(),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun(),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // Upsert threw, but the node executed (sendQuery ran) and the user was warned —
     // the failure did not abort the node.
@@ -20587,26 +20440,23 @@ describe('executeDagWorkflow -- completion telemetry', () => {
   });
 
   async function runDag(workflow: { name: string; nodes: DagNode[] }): Promise<void> {
-    await executeDagWorkflow(
-      createMockDeps(createMockStore()),
-      createMockPlatform(),
-      'conv-dag',
-      testDir,
+    await executeDagWorkflow({
+      deps: createMockDeps(createMockStore()),
+      platform: createMockPlatform(),
+      conversationId: 'conv-dag',
+      cwd: testDir,
       workflow,
-      makeWorkflowRun(),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      undefined,
-      'bundled'
-    );
+      workflowRun: makeWorkflowRun(),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      source: 'bundled',
+    });
   }
 
   it('emits outcome=completed with node counts and the threaded source on success', async () => {
@@ -20833,22 +20683,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    const result = await executeDagWorkflow(
-      mockDeps,
+    const result = await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg',
-      testDir,
-      { name: 'dag-loopgroup-done', nodes },
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: { name: 'dag-loopgroup-done', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // Two iterations: iter 1 (no signal) → iter 2 (DONE signal) → complete.
     expect(callCount).toBe(2);
@@ -20898,22 +20748,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
     if (!expanded) throw new Error('expected expanded workflow');
 
     const store = createMockStore();
-    const result = await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-lg',
-      testDir,
-      ready(expanded),
-      makeWorkflowRun('dag-loopgroup-included'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+    const result = await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: ready(expanded),
+      workflowRun: makeWorkflowRun('dag-loopgroup-included'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(callCount).toBe(2);
     expect(result).toContain('iteration 2\nDONE');
@@ -20969,22 +20819,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
     if (!expanded) throw new Error('expected expanded workflow');
 
     const artifactsDir = join(testDir, 'artifacts');
-    await executeDagWorkflow(
-      createMockDeps(createMockStore()),
-      createMockPlatform(),
-      'conv-lg',
-      testDir,
-      ready(expanded),
-      makeWorkflowRun('dag-loopgroup-typed-included'),
-      'claude',
-      undefined,
+    await executeDagWorkflow({
+      deps: createMockDeps(createMockStore()),
+      platform: createMockPlatform(),
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: ready(expanded),
+      workflowRun: makeWorkflowRun('dag-loopgroup-typed-included'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
       artifactsDir,
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(callCount).toBe(3);
     const artifacts = (await readNodeArtifacts(artifactsDir)).sort(
@@ -21028,12 +20878,12 @@ describe('executeDagWorkflow -- loop_group node', () => {
     });
 
     const artifactsDir = join(testDir, 'artifacts');
-    await executeDagWorkflow(
-      createMockDeps(createMockStore()),
-      createMockPlatform(),
-      'conv-lg',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(createMockStore()),
+      platform: createMockPlatform(),
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: {
         name: 'nested-typed-loop-group',
         nodes: [
           {
@@ -21066,16 +20916,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
           },
         ],
       },
-      makeWorkflowRun('dag-nested-loopgroup-typed'),
-      'claude',
-      undefined,
+      workflowRun: makeWorkflowRun('dag-nested-loopgroup-typed'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
       artifactsDir,
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(callCount).toBe(2);
     const artifacts = (await readNodeArtifacts(artifactsDir)).sort(
@@ -21126,22 +20976,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       yield { type: 'result', sessionId: 'typed-resume-1' };
     });
     const firstDeps = createMockDeps(createMockStore());
-    await executeDagWorkflow(
-      firstDeps,
-      createMockPlatform(),
-      'conv-lg',
-      testDir,
+    await executeDagWorkflow({
+      deps: firstDeps,
+      platform: createMockPlatform(),
+      conversationId: 'conv-lg',
+      cwd: testDir,
       workflow,
-      makeWorkflowRun('dag-loopgroup-typed-resume'),
-      'claude',
-      undefined,
+      workflowRun: makeWorkflowRun('dag-loopgroup-typed-resume'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
       artifactsDir,
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const beforeResume = await readNodeArtifacts(artifactsDir);
     expect(beforeResume).toHaveLength(1);
@@ -21154,13 +21004,13 @@ describe('executeDagWorkflow -- loop_group node', () => {
       yield { type: 'assistant', content: 'iteration 2 final DONE' };
       yield { type: 'result', sessionId: 'typed-resume-2' };
     });
-    await executeDagWorkflow(
-      createMockDeps(createMockStore()),
-      createMockPlatform(),
-      'conv-lg',
-      testDir,
+    await executeDagWorkflow({
+      deps: createMockDeps(createMockStore()),
+      platform: createMockPlatform(),
+      conversationId: 'conv-lg',
+      cwd: testDir,
       workflow,
-      makeWorkflowRun('dag-loopgroup-typed-resume', {
+      workflowRun: makeWorkflowRun('dag-loopgroup-typed-resume', {
         metadata: {
           approval: {
             type: 'interactive_loop',
@@ -21173,15 +21023,15 @@ describe('executeDagWorkflow -- loop_group node', () => {
           loop_user_input: 'continue',
         },
       }),
-      'claude',
-      undefined,
+      workflowProvider: 'claude',
+      workflowModel: undefined,
       artifactsDir,
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const afterResume = (await readNodeArtifacts(artifactsDir)).sort(
       (left, right) =>
@@ -21319,22 +21169,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
     let result: Awaited<ReturnType<typeof executeDagWorkflow>>;
     try {
       store = createMockStore();
-      result = await executeDagWorkflow(
-        createMockDeps(store),
-        createMockPlatform(),
-        'conv-lg',
-        testDir,
-        ready(expanded),
-        makeWorkflowRun('dag-nested-loopgroup-included-prev'),
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+      result = await executeDagWorkflow({
+        deps: createMockDeps(store),
+        platform: createMockPlatform(),
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: ready(expanded),
+        workflowRun: makeWorkflowRun('dag-nested-loopgroup-included-prev'),
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
     } finally {
       execSpy.mockRestore();
     }
@@ -21413,22 +21263,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
     if (!expanded) throw new Error('expected expanded workflow');
 
     const store = createMockStore();
-    const result = await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-lg',
-      testDir,
-      ready(expanded),
-      makeWorkflowRun('dag-included-untilbash-shellsafe'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+    const result = await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: ready(expanded),
+      workflowRun: makeWorkflowRun('dag-included-untilbash-shellsafe'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // The gate's quoted comparisons parsed correctly: the loop completed via until_bash
     // on its second iteration only after reading BOTH the included body's previous
@@ -21486,22 +21336,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg',
-      testDir,
-      { name: 'dag-loopgroup-cmd', nodes },
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: { name: 'dag-loopgroup-cmd', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // The command file's body (not a YAML inline prompt) reached the AI.
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -21563,22 +21413,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
         },
       ];
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-lg-userinput',
-        testDir,
-        { name: 'lg-userinput-script', nodes },
+        conversationId: 'conv-lg-userinput',
+        cwd: testDir,
+        workflow: { name: 'lg-userinput-script', nodes },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       const scriptCall = execSpy.mock.calls.find(
         c => (c[0] as string) === 'bun' && (c[1] as string[]).includes('-e')
@@ -21644,22 +21494,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
         },
       ];
 
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-lg-userinput-bash',
-        testDir,
-        { name: 'lg-userinput-bash', nodes },
+        conversationId: 'conv-lg-userinput-bash',
+        cwd: testDir,
+        workflow: { name: 'lg-userinput-bash', nodes },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
 
       const bashCall = execSpy.mock.calls.find(
         c => (c[0] as string) === git.resolveBashPath() && (c[1] as string[])[0] === '-c'
@@ -21706,22 +21556,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    const result = await executeDagWorkflow(
-      mockDeps,
+    const result = await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg',
-      testDir,
-      { name: 'dag-loopgroup-maxiter', nodes },
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: { name: 'dag-loopgroup-maxiter', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // The negated prose does not complete the group, so it exhausts max_iterations.
     expect(callCount).toBe(2);
@@ -21784,22 +21634,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    const result = await executeDagWorkflow(
-      mockDeps,
+    const result = await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg',
-      testDir,
-      { name: 'lg-multinode', nodes },
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: { name: 'lg-multinode', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // 2 iterations (review called once per iteration); DONE on iteration 2.
     expect(reviewCalls).toBe(2);
@@ -21846,22 +21696,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg-spill',
-      testDir,
-      { name: 'lg-spill-overwrite', nodes },
+      conversationId: 'conv-lg-spill',
+      cwd: testDir,
+      workflow: { name: 'lg-spill-overwrite', nodes },
       workflowRun,
-      'claude',
-      undefined,
+      workflowProvider: 'claude',
+      workflowModel: undefined,
       artifactsDir,
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect((await readFile(counterFile, 'utf8')).trim()).toBe('2');
 
@@ -21932,22 +21782,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg',
-      testDir,
-      { name: 'lg-loopprev', nodes },
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: { name: 'lg-loopprev', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // Iteration 1 prompt: $LOOP_PREV resolved to '' (no prior iteration).
     expect(callCount).toBeGreaterThanOrEqual(1);
@@ -22006,22 +21856,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
-      createMockPlatform(),
-      'conv-lg',
-      testDir,
-      { name: 'lg-binding-loopprev', nodes },
+    await executeDagWorkflow({
+      deps: mockDeps,
+      platform: createMockPlatform(),
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: { name: 'lg-binding-loopprev', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const consumeRows = (
       mockDeps.store.createWorkflowEvent as Mock<
@@ -22049,12 +21899,12 @@ describe('executeDagWorkflow -- loop_group node', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun('lg-large-loopprev');
 
-    const result = await executeDagWorkflow(
-      mockDeps,
+    const result = await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg',
-      testDir,
-      {
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: {
         name: 'lg-large-loopprev',
         nodes: [
           {
@@ -22082,15 +21932,15 @@ describe('executeDagWorkflow -- loop_group node', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
+      workflowProvider: 'claude',
+      workflowModel: undefined,
       artifactsDir,
-      join(testDir, 'state'),
+      stateDir: join(testDir, 'state'),
       logDir,
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(result).toContain('33000');
     expect(
@@ -22138,22 +21988,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    const result = await executeDagWorkflow(
-      mockDeps,
+    const result = await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg',
-      testDir,
-      { name: 'lg-untilbash', nodes },
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: { name: 'lg-untilbash', nodes },
       workflowRun,
-      'claude',
-      undefined,
+      workflowProvider: 'claude',
+      workflowModel: undefined,
       artifactsDir,
-      join(testDir, 'state'),
+      stateDir: join(testDir, 'state'),
       logDir,
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(result).toBe(largeOutput);
     expect(
@@ -22191,22 +22041,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       ],
     });
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-lg',
-      testDir,
-      ready(workflow),
-      makeWorkflowRun('group-required-output-ref'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: ready(workflow),
+      workflowRun: makeWorkflowRun('group-required-output-ref'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const failed = store.createWorkflowEvent.mock.calls
       .map(([event]) => event)
@@ -22251,22 +22101,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    const result = await executeDagWorkflow(
-      mockDeps,
+    const result = await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg',
-      testDir,
-      { name: 'lg-single', nodes },
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: { name: 'lg-single', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // Single iteration, completed immediately.
     expect(calls).toBe(1);
@@ -22311,22 +22161,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    const result = await executeDagWorkflow(
-      mockDeps,
+    const result = await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg',
-      testDir,
-      { name: 'lg-body-fail', nodes },
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: { name: 'lg-body-fail', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // Fail-fast: exactly ONE iteration ran — no burn-to-max_iterations.
     expect(calls).toBe(1);
@@ -22386,22 +22236,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    const result = await executeDagWorkflow(
-      mockDeps,
+    const result = await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg',
-      testDir,
-      { name: 'lg-outer-dep', nodes },
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: { name: 'lg-outer-dep', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // The body prompt received the outer node's output (seeded into the scoped map).
     expect(receivedPrompt).toContain('setup-context-123');
@@ -22698,22 +22548,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg',
-      testDir,
-      { name: 'lg-nested-prev', nodes },
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: { name: 'lg-nested-prev', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // Two inner iterations ran within the single outer iteration.
     expect(capturedPrompts.length).toBe(2);
@@ -22795,12 +22645,12 @@ describe('executeDagWorkflow -- loop_group node', () => {
       yield { type: 'result', sessionId: `loop-prev-when-${calls}` };
     });
 
-    const result = await executeDagWorkflow(
-      createMockDeps(),
-      createMockPlatform(),
-      'conv-loop-prev-when',
-      testDir,
-      {
+    const result = await executeDagWorkflow({
+      deps: createMockDeps(),
+      platform: createMockPlatform(),
+      conversationId: 'conv-loop-prev-when',
+      cwd: testDir,
+      workflow: {
         name: 'loop-prev-when',
         nodes: [
           {
@@ -22830,16 +22680,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
           },
         ],
       },
-      makeWorkflowRun('loop-prev-when'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('loop-prev-when'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(calls).toBe(3);
     expect(result).toContain('guarded');
@@ -23067,22 +22917,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    const result = await executeDagWorkflow(
-      mockDeps,
+    const result = await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg',
-      testDir,
-      { name: 'lg-multiterminal', nodes },
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: { name: 'lg-multiterminal', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // Both parallel terminal nodes ran on the completing iteration (iter 1).
     expect(aCalls).toBeGreaterThanOrEqual(1);
@@ -23127,22 +22977,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    const result = await executeDagWorkflow(
-      mockDeps,
+    const result = await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg',
-      testDir,
-      { name: 'lg-fresh', nodes },
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: { name: 'lg-fresh', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(calls).toBe(2);
     expect(result).toContain('final');
@@ -23190,22 +23040,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    const result = await executeDagWorkflow(
-      mockDeps,
+    const result = await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg',
-      testDir,
-      { name: 'lg-cancel', nodes },
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: { name: 'lg-cancel', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // Only iteration 1 ran before cancellation halted the loop. The run did not complete
     // (no DONE) → outer DAG sees no terminal output.
@@ -23253,22 +23103,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    const result = await executeDagWorkflow(
-      mockDeps,
+    const result = await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg',
-      testDir,
-      { name: 'lg-or', nodes },
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: { name: 'lg-or', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // Signal completed on iteration 1.
     expect(calls).toBe(1);
@@ -23317,22 +23167,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    const result = await executeDagWorkflow(
-      mockDeps,
+    const result = await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg',
-      testDir,
-      { name: 'lg-single-shot', nodes },
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: { name: 'lg-single-shot', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(calls).toBe(1);
     expect(result).toContain('one-shot');
@@ -23396,22 +23246,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    const result = await executeDagWorkflow(
-      mockDeps,
+    const result = await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg',
-      testDir,
-      { name: 'lg-nested', nodes },
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: { name: 'lg-nested', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // Inner ran (1 call), then outer review ran (1 call) emitting OUTER_DONE → outer completes.
     expect(calls).toBe(2);
@@ -23454,22 +23304,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg',
-      testDir,
-      { name: 'lg-interactive', nodes },
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: { name: 'lg-interactive', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // One AI call (iteration 1), then paused.
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -23497,12 +23347,12 @@ describe('executeDagWorkflow -- loop_group node', () => {
     const mockDeps = createMockDeps();
     const platform = createMockPlatform();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg',
-      testDir,
-      {
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: {
         name: 'lg-bash-gate',
         nodes: [
           {
@@ -23528,16 +23378,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
           },
         ],
       },
-      makeWorkflowRun('lg-bash-gate'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('lg-bash-gate'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expectLoopGateEvidence(
       mockDeps.store,
@@ -23585,22 +23435,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg',
-      testDir,
-      { name: 'lg-signal-gate', nodes },
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: { name: 'lg-signal-gate', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const pauseCalls = (mockDeps.store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>)
       .mock.calls;
@@ -23655,22 +23505,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg',
-      testDir,
-      { name: 'lg-signal-completes', nodes },
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: { name: 'lg-signal-completes', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const pauseCalls = (mockDeps.store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>)
       .mock.calls;
@@ -23738,22 +23588,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg',
-      testDir,
-      { name: 'lg-finalize', nodes },
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: { name: 'lg-finalize', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // No body iteration ran — the group finalized from the persisted output.
     expect(mockSendQueryDag.mock.calls.length).toBe(0);
@@ -23820,22 +23670,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
     };
 
     const pausingDeps = createMockDeps();
-    await executeDagWorkflow(
-      pausingDeps,
-      createMockPlatform(),
-      'conv-lg',
-      testDir,
+    await executeDagWorkflow({
+      deps: pausingDeps,
+      platform: createMockPlatform(),
+      conversationId: 'conv-lg',
+      cwd: testDir,
       workflow,
-      makeWorkflowRun('lg-struct-pause'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('lg-struct-pause'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
     const pauseCalls = (
       pausingDeps.store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>
     ).mock.calls;
@@ -23849,28 +23699,28 @@ describe('executeDagWorkflow -- loop_group node', () => {
       yield { type: 'result', sessionId: 'never' };
     });
     const resumingDeps = createMockDeps();
-    await executeDagWorkflow(
-      resumingDeps,
-      createMockPlatform(),
-      'conv-lg',
-      testDir,
+    await executeDagWorkflow({
+      deps: resumingDeps,
+      platform: createMockPlatform(),
+      conversationId: 'conv-lg',
+      cwd: testDir,
       workflow,
-      makeWorkflowRun('lg-struct-resume', {
+      workflowRun: makeWorkflowRun('lg-struct-resume', {
         metadata: {
           approval: { ...approval },
           loop_user_input: 'Approved',
           loop_feedback_given: false,
         },
       }),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
     expect(mockSendQueryDag.mock.calls.length).toBe(0);
     const eventCalls2 = (
       resumingDeps.store.createWorkflowEvent as Mock<
@@ -23935,22 +23785,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       ] as DagNode[],
     };
 
-    await executeDagWorkflow(
-      mockDeps1,
-      platform1,
-      'conv-lg',
-      testDir,
+    await executeDagWorkflow({
+      deps: mockDeps1,
+      platform: platform1,
+      conversationId: 'conv-lg',
+      cwd: testDir,
       workflow,
-      freshRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: freshRun,
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
     // Call 1 paused at iteration 1, persisting the body's session cursor so a
     // fresh_context: false resume can continue the same conversation.
     expect(mockSendQueryDag.mock.calls.length).toBe(1);
@@ -23984,22 +23834,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     });
 
-    await executeDagWorkflow(
-      mockDeps2,
-      platform2,
-      'conv-lg',
-      testDir,
+    await executeDagWorkflow({
+      deps: mockDeps2,
+      platform: platform2,
+      conversationId: 'conv-lg',
+      cwd: testDir,
       workflow,
-      resumedRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: resumedRun,
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // Resumed iteration (iteration 2) ran once more and completed via APPROVED.
     expect(mockSendQueryDag.mock.calls.length).toBe(2);
@@ -24058,22 +23908,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
         },
       ] as DagNode[],
     };
-    await executeDagWorkflow(
-      mockDeps1,
-      createMockPlatform(),
-      'conv-lg',
-      testDir,
+    await executeDagWorkflow({
+      deps: mockDeps1,
+      platform: createMockPlatform(),
+      conversationId: 'conv-lg',
+      cwd: testDir,
       workflow,
-      makeWorkflowRun('lg-prev-fresh'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('lg-prev-fresh'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // Iteration 1 prompt: $LOOP_PREV resolved to '' (no prior iteration in this process).
     const iter1Prompt = mockSendQueryDag.mock.calls[0][0] as string;
@@ -24088,13 +23938,13 @@ describe('executeDagWorkflow -- loop_group node', () => {
       yield { type: 'assistant', content: 'final\nAPPROVED' };
       yield { type: 'result', sessionId: 'lg-prev-sess-2' };
     });
-    await executeDagWorkflow(
-      createMockDeps(),
-      createMockPlatform(),
-      'conv-lg',
-      testDir,
+    await executeDagWorkflow({
+      deps: createMockDeps(),
+      platform: createMockPlatform(),
+      conversationId: 'conv-lg',
+      cwd: testDir,
       workflow,
-      makeWorkflowRun('lg-prev-resume', {
+      workflowRun: makeWorkflowRun('lg-prev-resume', {
         metadata: {
           approval: {
             type: 'interactive_loop',
@@ -24106,18 +23956,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
           loop_user_input: 'ok',
         },
       }),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
 
     // Resumed iteration 2: $LOOP_PREV resolves to the real persisted iteration-1 output.
     const resumePrompt = mockSendQueryDag.mock.calls[1][0] as string;
@@ -24185,13 +24033,13 @@ describe('executeDagWorkflow -- loop_group node', () => {
       yield { type: 'result', sessionId: 'lg-declared-fields-sess' };
     });
 
-    await executeDagWorkflow(
-      mockDeps,
-      createMockPlatform(),
-      'conv-lg-declared-fields',
-      testDir,
+    await executeDagWorkflow({
+      deps: mockDeps,
+      platform: createMockPlatform(),
+      conversationId: 'conv-lg-declared-fields',
+      cwd: testDir,
       workflow,
-      makeWorkflowRun('lg-resume-declared-fields', {
+      workflowRun: makeWorkflowRun('lg-resume-declared-fields', {
         metadata: {
           approval: {
             type: 'interactive_loop',
@@ -24202,18 +24050,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
           loop_user_input: '',
         },
       }),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
 
     // The undeclared `extra` field must fail loudly (not-in-schema) on the resumed
     // iteration — exactly as it would fail an in-process iteration — instead of
@@ -24268,22 +24114,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       ] as DagNode[],
     };
 
-    await executeDagWorkflow(
-      createMockDeps(freshStore),
-      createMockPlatform(),
-      'conv-lg-large',
-      testDir,
-      freshWorkflow,
-      makeWorkflowRun('lg-prev-large-fresh'),
-      'claude',
-      undefined,
+    await executeDagWorkflow({
+      deps: createMockDeps(freshStore),
+      platform: createMockPlatform(),
+      conversationId: 'conv-lg-large',
+      cwd: testDir,
+      workflow: freshWorkflow,
+      workflowRun: makeWorkflowRun('lg-prev-large-fresh'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
       artifactsDir,
-      join(testDir, 'state'),
+      stateDir: join(testDir, 'state'),
       logDir,
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const freshEventCalls = (freshStore.createWorkflowEvent as ReturnType<typeof mock>).mock.calls;
     const bodyEvent = freshEventCalls.find(
@@ -24335,13 +24181,13 @@ describe('executeDagWorkflow -- loop_group node', () => {
         },
       ] as DagNode[],
     };
-    const result = await executeDagWorkflow(
-      createMockDeps(createMockStore()),
-      createMockPlatform(),
-      'conv-lg-large-resume',
-      testDir,
-      resumedWorkflow,
-      makeWorkflowRun('lg-prev-large-resume', {
+    const result = await executeDagWorkflow({
+      deps: createMockDeps(createMockStore()),
+      platform: createMockPlatform(),
+      conversationId: 'conv-lg-large-resume',
+      cwd: testDir,
+      workflow: resumedWorkflow,
+      workflowRun: makeWorkflowRun('lg-prev-large-resume', {
         metadata: {
           approval: {
             type: 'interactive_loop',
@@ -24352,18 +24198,16 @@ describe('executeDagWorkflow -- loop_group node', () => {
           loop_user_input: '',
         },
       }),
-      'claude',
-      undefined,
+      workflowProvider: 'claude',
+      workflowModel: undefined,
       artifactsDir,
-      join(testDir, 'state'),
+      stateDir: join(testDir, 'state'),
       logDir,
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
 
     // The resumed body script measured $LOOP_PREV.work.output's length as the FULL
     // padding size — proving the real spilled bytes (not a truncated preview) survived
@@ -24412,22 +24256,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg',
-      testDir,
-      { name: 'lg-cost', nodes },
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: { name: 'lg-cost', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(calls).toBe(2);
     // 0.01 + 0.02 = 0.03 accumulated across the group's 2 iterations.
@@ -24502,22 +24346,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg',
-      testDir,
-      { name: 'lg-tokens', nodes },
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: { name: 'lg-tokens', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(calls).toBe(2);
     // The group sums tokens across iterations into its result; the outer runLayers
@@ -24601,22 +24445,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       yield { type: 'result', sessionId: 'lg-dbl-sess-1', tokens: { input: 100, output: 10 } };
     });
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-lg',
-      testDir,
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-lg',
+      cwd: testDir,
       workflow,
-      makeWorkflowRun('lg-finalize-tokens-run'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('lg-finalize-tokens-run'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const pauseCalls = (store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>).mock
       .calls;
@@ -24630,28 +24474,28 @@ describe('executeDagWorkflow -- loop_group node', () => {
     });
     const aiCallsBeforeResume = mockSendQueryDag.mock.calls.length;
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-lg',
-      testDir,
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-lg',
+      cwd: testDir,
       workflow,
-      makeWorkflowRun('lg-finalize-tokens-run', {
+      workflowRun: makeWorkflowRun('lg-finalize-tokens-run', {
         metadata: {
           approval: pauseCalls[0][1],
           loop_user_input: '',
           loop_feedback_given: false,
         },
       }),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // Finalized from the persisted output — no body iteration re-ran.
     expect(mockSendQueryDag.mock.calls.length).toBe(aiCallsBeforeResume);
@@ -24707,22 +24551,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
-      createMockPlatform(),
-      'conv-lg-no-usage',
-      testDir,
-      { name: 'lg-no-usage', nodes },
-      makeWorkflowRun('lg-no-usage-run'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+    await executeDagWorkflow({
+      deps: mockDeps,
+      platform: createMockPlatform(),
+      conversationId: 'conv-lg-no-usage',
+      cwd: testDir,
+      workflow: { name: 'lg-no-usage', nodes },
+      workflowRun: makeWorkflowRun('lg-no-usage-run'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls as Array<
       [{ event_type: string; step_name: string; data?: Record<string, unknown> }]
@@ -24773,22 +24617,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg',
-      testDir,
-      { name: 'lg-session-thread', nodes },
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: { name: 'lg-session-thread', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(mockSendQueryDag.mock.calls.length).toBe(2);
     // Iteration 1: always fresh.
@@ -24830,22 +24674,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg',
-      testDir,
-      { name: 'lg-session-fresh', nodes },
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: { name: 'lg-session-fresh', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(mockSendQueryDag.mock.calls.length).toBe(2);
     expect(mockSendQueryDag.mock.calls[0][2]).toBeUndefined();
@@ -24901,22 +24745,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    const result = await executeDagWorkflow(
-      mockDeps,
+    const result = await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg',
-      testDir,
-      { name: 'lg-when', nodes },
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: { name: 'lg-when', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // gate ran twice (both iterations); work ran once (iteration 2 only).
     expect(gateCalls).toBe(2);
@@ -24968,22 +24812,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    const result = await executeDagWorkflow(
-      mockDeps,
+    const result = await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg',
-      testDir,
-      { name: 'lg-multi-fail', nodes },
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: { name: 'lg-multi-fail', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // Only implement's single (failing) call ran — verify was skipped, no iteration 2.
     expect(calls).toBe(1);
@@ -25036,22 +24880,22 @@ describe('executeDagWorkflow -- loop_group node', () => {
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg',
-      testDir,
-      { name: 'lg-artifact', nodes },
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: { name: 'lg-artifact', nodes },
       workflowRun,
-      'claude',
-      undefined,
+      workflowProvider: 'claude',
+      workflowModel: undefined,
       artifactsDir,
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(calls).toBe(2);
     // The sidecar artifact carries the final iteration's terminal output.
@@ -25140,22 +24984,22 @@ describe('executeDagWorkflow -- loop_group body step_name namespacing (#2090)', 
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg',
-      testDir,
-      { name: 'lg-ns', nodes },
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: { name: 'lg-ns', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(calls).toBe(2);
 
@@ -25239,22 +25083,22 @@ describe('executeDagWorkflow -- loop_group body step_name namespacing (#2090)', 
       },
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg',
-      testDir,
-      { name: 'lg-nested-ns', nodes },
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: { name: 'lg-nested-ns', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(calls).toBe(2);
 
@@ -25290,12 +25134,12 @@ describe('executeDagWorkflow -- loop_group body step_name namespacing (#2090)', 
     });
 
     try {
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-lg',
-        testDir,
-        {
+        conversationId: 'conv-lg',
+        cwd: testDir,
+        workflow: {
           name: 'lg-emit-raw',
           nodes: [
             {
@@ -25319,15 +25163,15 @@ describe('executeDagWorkflow -- loop_group body step_name namespacing (#2090)', 
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
     } finally {
       unsubscribe();
     }
@@ -25398,25 +25242,23 @@ describe('executeDagWorkflow -- loop_group body step_name namespacing (#2090)', 
       yield { type: 'result', sessionId: `s-${calls}` };
     });
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-lg',
-      testDir,
-      { name: 'lg-resume', nodes },
+      conversationId: 'conv-lg',
+      cwd: testDir,
+      workflow: { name: 'lg-resume', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
 
     // Only `finalize` executes: the loop_group `fixer` was skipped as a unit (body never
     // re-ran), and the namespaced `fixer.work` key skipped nothing at the top level.
@@ -25461,34 +25303,24 @@ describe('executeDagWorkflow -- addressable session resume', () => {
     priorCompletedNodes?: Map<string, PersistedNodeOutput>,
     priorNodeSessions?: readonly WorkflowRunNodeSession[]
   ): Promise<MockWorkflowStore> {
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-addressable',
-      testDir,
-      { name: 'addressable', nodes },
-      makeWorkflowRun('addressable-run'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-addressable',
+      cwd: testDir,
+      workflow: { name: 'addressable', nodes },
+      workflowRun: makeWorkflowRun('addressable-run'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
       priorCompletedNodes,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      priorNodeSessions
-    );
+      priorNodeSessions,
+    });
     return store;
   }
 
@@ -26090,22 +25922,22 @@ describe('executeDagWorkflow -- provider-boundary session threading (#1992)', ()
   ): Promise<WorkflowDeps> {
     const mockDeps = createMockDeps();
     const platform = createMockPlatform();
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
       conversationId,
-      testDir,
+      cwd: testDir,
       workflow,
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
     return mockDeps;
   }
 
@@ -26708,25 +26540,23 @@ describe('executeDagWorkflow -- flattened include expansion', () => {
     output: string | undefined;
   }> {
     const mockDeps = createMockDeps();
-    const output = await executeDagWorkflow(
-      mockDeps,
-      createMockPlatform(),
-      'conv-inc',
-      testDir,
-      { name: 'gated-parent', nodes },
-      makeWorkflowRun(runId, { workflow_name: 'gated-parent' }),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+    const output = await executeDagWorkflow({
+      deps: mockDeps,
+      platform: createMockPlatform(),
+      conversationId: 'conv-inc',
+      cwd: testDir,
+      workflow: { name: 'gated-parent', nodes },
+      workflowRun: makeWorkflowRun(runId, { workflow_name: 'gated-parent' }),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
     return { events: eventList(mockDeps), output };
   }
 
@@ -26933,22 +26763,22 @@ describe('executeDagWorkflow -- flattened include expansion', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun('inc-run-id', { workflow_name: 'inc-parent' });
 
-    const terminalOutput = await executeDagWorkflow(
-      mockDeps,
+    const terminalOutput = await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-inc',
-      testDir,
-      { name: 'inc-parent', nodes: expandedParentNodes() },
+      conversationId: 'conv-inc',
+      cwd: testDir,
+      workflow: { name: 'inc-parent', nodes: expandedParentNodes() },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const events = eventList(mockDeps);
     const completedStepNames = events
@@ -26974,25 +26804,23 @@ describe('executeDagWorkflow -- flattened include expansion', () => {
     // Prior run completed the namespaced entry node inc__a.
     const prior = new Map([['inc__a', { output: 'AAA' }]]);
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-inc',
-      testDir,
-      { name: 'inc-parent', nodes: expandedParentNodes() },
+      conversationId: 'conv-inc',
+      cwd: testDir,
+      workflow: { name: 'inc-parent', nodes: expandedParentNodes() },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      prior
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes: prior,
+    });
 
     const events = eventList(mockDeps);
     // inc__a skipped as prior-success (its namespaced id matched the persisted map).
@@ -27013,25 +26841,23 @@ describe('executeDagWorkflow -- flattened include expansion', () => {
 
     const prior = new Map([['inc__a', { output: 'AAA' }]]);
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-inc',
-      testDir,
-      { name: 'inc-parent', nodes: expandedParentNodes(true) },
+      conversationId: 'conv-inc',
+      cwd: testDir,
+      workflow: { name: 'inc-parent', nodes: expandedParentNodes(true) },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      prior
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes: prior,
+    });
 
     const events = eventList(mockDeps);
     // always_run survived inlining: inc__a is force-reset (re-executed), not skipped.
@@ -27086,25 +26912,23 @@ describe('executeDagWorkflow -- unexpanded include node fail-fast guard', () => 
     const includeNode = dagNodeSchema.parse({ id: 'inc', include: 'some-block' }) as DagNode;
     const prior = new Map([['inc', { output: 'stale prior output' }]]);
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-inc-guard',
-      testDir,
-      { name: 'inc-guard', nodes: [includeNode] },
+      conversationId: 'conv-inc-guard',
+      cwd: testDir,
+      workflow: { name: 'inc-guard', nodes: [includeNode] },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      prior
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes: prior,
+    });
 
     const evs = events(mockDeps);
     const failed = evs.find(e => e.event_type === 'node_failed' && e.step_name === 'inc');
@@ -27131,24 +26955,24 @@ describe('executeDagWorkflow -- unexpanded include node fail-fast guard', () => 
       }),
     ];
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-inc-guard',
-      testDir,
+      conversationId: 'conv-inc-guard',
+      cwd: testDir,
       // Deliberately includes an unexpanded include directive — the test exercises the
       // `when:` guard firing BEFORE the executor would ever need to resolve it.
-      { name: 'inc-guard', nodes: nodes as DagNode[] },
+      workflow: { name: 'inc-guard', nodes: nodes as DagNode[] },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const evs = events(mockDeps);
     const failed = evs.find(e => e.event_type === 'node_failed' && e.step_name === 'inc');
@@ -27221,22 +27045,22 @@ describe('executeDagWorkflow -- approval node inside an included block', () => {
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun('inc-approval-run', { workflow_name: 'apparent' });
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-inc-approval',
-      testDir,
-      { name: 'apparent', nodes: expanded.nodes as DagNode[] },
+      conversationId: 'conv-inc-approval',
+      cwd: testDir,
+      workflow: { name: 'apparent', nodes: expanded.nodes as DagNode[] },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const pauseCalls = (store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>).mock
       .calls;
@@ -27455,24 +27279,24 @@ describe('subprocess credential redaction', () => {
     );
 
     try {
-      await executeDagWorkflow(
-        createMockDeps(store),
+      await executeDagWorkflow({
+        deps: createMockDeps(store),
         platform,
-        workflowRun.conversation_id,
-        testDir,
-        {
+        conversationId: workflowRun.conversation_id,
+        cwd: testDir,
+        workflow: {
           name: workflowRun.workflow_name,
           nodes: [{ id: 'fail', kind: 'exec', runtime: 'sh', script: 'exit 1' }],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
         logDir,
-        'main',
-        'docs/',
-        {
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: {
           ...minimalConfig,
           // Secret-suffixed keys redact automatically; BASE_BRANCH is the visible control.
           envVars: {
@@ -27485,15 +27309,8 @@ describe('subprocess credential redaction', () => {
           protectedEnvKeys: ['OPENAI_API_KEY', 'CUSTOM_AUTH', 'DATABASE_URL'],
           protectedCredentialValues: [fileDeliveredSecret],
         },
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        execContext
-      );
+        execContext,
+      });
 
       expect(execSpy).toHaveBeenCalledTimes(1);
       const dockerArgs = execSpy.mock.calls[0]?.[1] as string[];
@@ -27582,30 +27399,30 @@ describe('subprocess credential redaction', () => {
     );
 
     try {
-      await executeDagWorkflow(
-        createMockDeps(store),
+      await executeDagWorkflow({
+        deps: createMockDeps(store),
         platform,
-        workflowRun.conversation_id,
-        testDir,
-        {
+        conversationId: workflowRun.conversation_id,
+        cwd: testDir,
+        workflow: {
           name: workflowRun.workflow_name,
           nodes: [{ id: 'fail', kind: 'exec', runtime: 'sh', script: 'exit 1' }],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'host-artifacts'),
-        join(testDir, 'host-state'),
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'host-artifacts'),
+        stateDir: join(testDir, 'host-state'),
         logDir,
-        'main',
-        'docs/',
-        {
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: {
           ...minimalConfig,
           envVars: { CODEX_HOME: '/run/codex-home', BASE_BRANCH: 'main' },
           protectedEnvKeys: ['CODEX_HOME'],
           protectedCredentialValues: [protectedSecret],
-        }
-      );
+        },
+      });
 
       expect(execSpy).toHaveBeenCalledTimes(1);
       expect(execSpy.mock.calls[0]?.[0]).not.toBe('docker');
@@ -27659,12 +27476,12 @@ describe('subprocess credential redaction', () => {
     });
     const store = createMockStore();
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      workflowRun.conversation_id,
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: workflowRun.conversation_id,
+      cwd: testDir,
+      workflow: {
         name: workflowRun.workflow_name,
         nodes: [
           {
@@ -27677,14 +27494,14 @@ describe('subprocess credential redaction', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'success-redaction-artifacts'),
-      join(testDir, 'success-redaction-state'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'success-redaction-artifacts'),
+      stateDir: join(testDir, 'success-redaction-state'),
       logDir,
-      'main',
-      'docs/',
-      {
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: {
         ...minimalConfig,
         envVars: {
           OPENAI_API_KEY: suffixNamedSecret,
@@ -27692,8 +27509,8 @@ describe('subprocess credential redaction', () => {
           BASE_BRANCH: 'main',
         },
         protectedCredentialValues: [explicitlyProtectedSecret],
-      }
-    );
+      },
+    });
 
     const transcriptText = await readFile(join(logDir, `${workflowRun.id}.jsonl`), 'utf-8');
     expect(transcriptText).not.toContain(suffixNamedSecret);
@@ -27740,22 +27557,22 @@ describe('retained exec output', () => {
     const logDir = join(testDir, `${runId}-logs`);
     const store = createMockStore();
     const workflowRun = makeWorkflowRun(runId);
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-retained',
-      testDir,
-      { name: runId, nodes },
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-retained',
+      cwd: testDir,
+      workflow: { name: runId, nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, `${runId}-artifacts`),
-      join(testDir, `${runId}-state`),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, `${runId}-artifacts`),
+      stateDir: join(testDir, `${runId}-state`),
       logDir,
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
     return { logDir, rows: await readTranscript(logDir, workflowRun.id), store };
   };
 
@@ -27873,12 +27690,12 @@ describe('retained exec output', () => {
     });
     const workflowRun = makeWorkflowRun('retain-until-bash');
 
-    await executeDagWorkflow(
-      createMockDeps(),
-      createMockPlatform(),
-      'conv-retained-probe',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(),
+      platform: createMockPlatform(),
+      conversationId: 'conv-retained-probe',
+      cwd: testDir,
+      workflow: {
         name: 'retain-until-bash',
         nodes: [
           {
@@ -27895,15 +27712,15 @@ describe('retained exec output', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'until-bash-artifacts'),
-      join(testDir, 'until-bash-state'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'until-bash-artifacts'),
+      stateDir: join(testDir, 'until-bash-state'),
       logDir,
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const rows = await readTranscript(logDir, workflowRun.id);
     const probeRows = rows.filter(candidate => candidate.type === 'exec_output');
@@ -27949,12 +27766,12 @@ describe('retained exec output', () => {
     const counterPath = join(testDir, 'group-iterations');
     const workflowRun = makeWorkflowRun('retain-group-probe');
 
-    await executeDagWorkflow(
-      createMockDeps(),
-      createMockPlatform(),
-      'conv-group-probe',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(),
+      platform: createMockPlatform(),
+      conversationId: 'conv-group-probe',
+      cwd: testDir,
+      workflow: {
         name: 'retain-group-probe',
         nodes: [
           {
@@ -27973,15 +27790,15 @@ describe('retained exec output', () => {
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'group-probe-artifacts'),
-      join(testDir, 'group-probe-state'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'group-probe-artifacts'),
+      stateDir: join(testDir, 'group-probe-state'),
       logDir,
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const rows = await readTranscript(logDir, workflowRun.id);
     const probeRows = rows.filter(
@@ -28063,31 +27880,32 @@ describe('executeDagWorkflow -- container write-back gate', () => {
     );
     store.claimWriteback = mock(() => Promise.resolve({ claimed: opts.claimed ?? true }));
     const deps = createMockDeps(store);
-    await executeDagWorkflow(
+    await executeDagWorkflow({
       deps,
-      createMockPlatform(),
-      'conv-wb',
-      wbTestDir,
-      { name: 'wb', nodes: [{ id: 'a', kind: 'exec', runtime: 'sh', script: 'echo hi' }] },
-      makeWorkflowRun('wb-run'),
-      'claude',
-      undefined,
-      join(wbTestDir, 'artifacts'),
-      join(wbTestDir, 'state'),
-      join(wbTestDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      new Map([['a', { output: 'out' }]]), // pre-completed → node skipped, DAG reaches the gate
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      CONTAINER_EXEC,
-      { envId: 'env-x', writeBack: opts.writeBack ?? 'approve', backend: opts.backend }
-    );
+      platform: createMockPlatform(),
+      conversationId: 'conv-wb',
+      cwd: wbTestDir,
+      workflow: {
+        name: 'wb',
+        nodes: [{ id: 'a', kind: 'exec', runtime: 'sh', script: 'echo hi' }],
+      },
+      workflowRun: makeWorkflowRun('wb-run'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(wbTestDir, 'artifacts'),
+      stateDir: join(wbTestDir, 'state'),
+      logDir: join(wbTestDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes: new Map([['a', { output: 'out' }]]),
+      execContext: CONTAINER_EXEC,
+      containerCtx: {
+        envId: 'env-x',
+        writeBack: opts.writeBack ?? 'approve',
+        backend: opts.backend,
+      },
+    });
     return store;
   }
 
@@ -28247,31 +28065,28 @@ describe('executeDagWorkflow -- container write-back gate', () => {
     );
     store.claimWriteback = mock(() => Promise.resolve({ claimed: true }));
     try {
-      await executeDagWorkflow(
-        createMockDeps(store),
-        createMockPlatform(),
-        'conv-wb',
-        wbTestDir,
-        { name: 'wb', nodes: [{ id: 'a', kind: 'exec', runtime: 'sh', script: 'echo hi' }] },
-        makeWorkflowRun('wb-run'),
-        'claude',
-        undefined,
-        join(wbTestDir, 'artifacts'),
-        join(wbTestDir, 'state'),
-        join(wbTestDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig,
-        undefined,
-        undefined,
-        new Map([['a', { output: 'out' }]]),
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        CONTAINER_EXEC,
-        { envId: 'env-x', writeBack: 'approve', backend }
-      );
+      await executeDagWorkflow({
+        deps: createMockDeps(store),
+        platform: createMockPlatform(),
+        conversationId: 'conv-wb',
+        cwd: wbTestDir,
+        workflow: {
+          name: 'wb',
+          nodes: [{ id: 'a', kind: 'exec', runtime: 'sh', script: 'echo hi' }],
+        },
+        workflowRun: makeWorkflowRun('wb-run'),
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(wbTestDir, 'artifacts'),
+        stateDir: join(wbTestDir, 'state'),
+        logDir: join(wbTestDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+        priorCompletedNodes: new Map([['a', { output: 'out' }]]),
+        execContext: CONTAINER_EXEC,
+        containerCtx: { envId: 'env-x', writeBack: 'approve', backend },
+      });
     } catch {
       threw = true;
     }
@@ -28313,31 +28128,28 @@ describe('executeDagWorkflow -- container write-back gate', () => {
     backend: ReturnType<typeof makeWritebackBackend>,
     writeBack: 'approve' | 'auto'
   ): Promise<void> {
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-wb',
-      wbTestDir,
-      { name: 'wb', nodes: [{ id: 'a', kind: 'exec', runtime: 'sh', script: 'echo hi' }] },
-      makeWorkflowRun('wb-run'),
-      'claude',
-      undefined,
-      join(wbTestDir, 'artifacts'),
-      join(wbTestDir, 'state'),
-      join(wbTestDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      new Map([['a', { output: 'out' }]]),
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      CONTAINER_EXEC,
-      { envId: 'env-x', writeBack, backend }
-    );
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-wb',
+      cwd: wbTestDir,
+      workflow: {
+        name: 'wb',
+        nodes: [{ id: 'a', kind: 'exec', runtime: 'sh', script: 'echo hi' }],
+      },
+      workflowRun: makeWorkflowRun('wb-run'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(wbTestDir, 'artifacts'),
+      stateDir: join(wbTestDir, 'state'),
+      logDir: join(wbTestDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes: new Map([['a', { output: 'out' }]]),
+      execContext: CONTAINER_EXEC,
+      containerCtx: { envId: 'env-x', writeBack, backend },
+    });
   }
 
   // N1/item-2 — an apply-throw in APPROVE mode leaves the run with pending_writeback set
@@ -28530,12 +28342,12 @@ describe('executeDagWorkflow -- gate pause vs external transition (#1123)', () =
     });
 
     try {
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-pause-race',
-        testDir,
-        {
+        conversationId: 'conv-pause-race',
+        cwd: testDir,
+        workflow: {
           name: 'pause-race-approval',
           nodes: [
             {
@@ -28549,15 +28361,15 @@ describe('executeDagWorkflow -- gate pause vs external transition (#1123)', () =
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
     } finally {
       unsubscribe();
     }
@@ -28592,12 +28404,12 @@ describe('executeDagWorkflow -- gate pause vs external transition (#1123)', () =
     });
 
     try {
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-pause-race-loop',
-        testDir,
-        {
+        conversationId: 'conv-pause-race-loop',
+        cwd: testDir,
+        workflow: {
           name: 'pause-race-loop',
           nodes: [
             {
@@ -28615,15 +28427,15 @@ describe('executeDagWorkflow -- gate pause vs external transition (#1123)', () =
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
     } finally {
       unsubscribe();
     }
@@ -28664,39 +28476,30 @@ describe('executeDagWorkflow -- gate pause vs external transition (#1123)', () =
     });
 
     try {
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-pause-race-child',
-        testDir,
-        {
+        conversationId: 'conv-pause-race-child',
+        cwd: testDir,
+        workflow: {
           name: 'pause-race-child',
           nodes: [{ id: 'sub', kind: 'workflow', workflow: 'child-wf' } as DagNode],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        async () => {
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+        runChildWorkflow: async () => {
           throw new Error(
             'runChildWorkflow should not be called — an existing paused child was found'
           );
-        }
-      );
+        },
+      });
     } finally {
       unsubscribe();
     }
@@ -28741,12 +28544,12 @@ describe('executeDagWorkflow -- gate pause vs external transition (#1123)', () =
       const mockDeps = createMockDeps(store);
       const platform = createMockPlatform();
       const workflowRun = makeWorkflowRun();
-      await executeDagWorkflow(
-        mockDeps,
+      await executeDagWorkflow({
+        deps: mockDeps,
         platform,
-        'conv-subrun-contract',
-        testDir,
-        {
+        conversationId: 'conv-subrun-contract',
+        cwd: testDir,
+        workflow: {
           name: 'subrun-contract',
           nodes: [
             {
@@ -28758,27 +28561,18 @@ describe('executeDagWorkflow -- gate pause vs external transition (#1123)', () =
           ],
         },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        async () => {
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+        runChildWorkflow: async () => {
           throw new Error('runChildWorkflow should not be called — a completed child exists');
-        }
-      );
+        },
+      });
       return platform;
     };
 
@@ -28899,12 +28693,12 @@ describe('executeDagWorkflow -- gate pause vs external transition (#1123)', () =
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-pause-genuine-failure',
-      testDir,
-      {
+      conversationId: 'conv-pause-genuine-failure',
+      cwd: testDir,
+      workflow: {
         name: 'pause-genuine-failure',
         nodes: [
           {
@@ -28918,15 +28712,15 @@ describe('executeDagWorkflow -- gate pause vs external transition (#1123)', () =
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const events = (
       store.createWorkflowEvent as Mock<IWorkflowStore['createWorkflowEvent']>
@@ -29063,28 +28857,24 @@ describe('executeDagWorkflow -- a workflow runs as authored, standalone or compo
       loadConfig: mock<WorkflowDeps['loadConfig']>(async _cwd => collapseConfig),
     };
 
-    await executeDagWorkflow(
+    await executeDagWorkflow({
       deps,
-      createMockPlatform(),
-      'conv-collapse',
-      testDir,
-      ready(workflow),
-      makeWorkflowRun(`collapse-${runName}`, { workflow_name: runName }),
+      platform: createMockPlatform(),
+      conversationId: 'conv-collapse',
+      cwd: testDir,
+      workflow: ready(workflow),
+      workflowRun: makeWorkflowRun(`collapse-${runName}`, { workflow_name: runName }),
       workflowProvider,
       workflowModel,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      collapseConfig,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: collapseConfig,
       aiProfile,
-      workflowPreset
-    );
+      workflowPreset,
+    });
 
     const result = new Map<string, EffectiveConfig>();
     for (const { provider, options: queryOptions } of seen) {
@@ -29317,22 +29107,22 @@ describe('executeDagWorkflow -- composed-workflow run-time boundaries', () => {
   ): Promise<void> {
     const { workflows, errors } = expandWorkflowIncludes(new Map(defs.map(d => [d.name, d])));
     expect(errors).toEqual([]);
-    await executeDagWorkflow(
+    await executeDagWorkflow({
       deps,
-      createMockPlatform(),
-      'conv-dag',
-      testDir,
-      ready(workflows.get(runName)!),
-      makeWorkflowRun(`comp-${runName}`, { workflow_name: runName }),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      platform: createMockPlatform(),
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: ready(workflows.get(runName)!),
+      workflowRun: makeWorkflowRun(`comp-${runName}`, { workflow_name: runName }),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
   }
 
   it('AC7 — a composed block entry starts a fresh session even after a same-provider node', async () => {
@@ -29460,22 +29250,28 @@ describe('executeDagWorkflow -- composed-workflow run-time boundaries', () => {
       ])
     );
     expect(errors).toEqual([]);
-    await executeDagWorkflow(
+    await executeDagWorkflow({
       deps,
-      createMockPlatform(),
-      'conv-dag',
-      testDir,
-      ready(workflows.get('env-parent')!),
-      makeWorkflowRun('comp-env', { workflow_name: 'env-parent', user_message: 'real-args' }),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      { ...minimalConfig, envVars: { INPUTS_PLAN: 'from-project-env', ARGUMENTS: 'hijacked' } }
-    );
+      platform: createMockPlatform(),
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: ready(workflows.get('env-parent')!),
+      workflowRun: makeWorkflowRun('comp-env', {
+        workflow_name: 'env-parent',
+        user_message: 'real-args',
+      }),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: {
+        ...minimalConfig,
+        envVars: { INPUTS_PLAN: 'from-project-env', ARGUMENTS: 'hijacked' },
+      },
+    });
 
     const output = nodeOutputOf(store, 'inc__run');
     expect(output).toBe('from-with|real-args');
@@ -29530,22 +29326,22 @@ describe('executeDagWorkflow -- systemPrompt and agents are runtime substitution
     nodes: unknown[],
     run = makeWorkflowRun('aicfg-run')
   ): Promise<SendQueryOptions[]> {
-    await executeDagWorkflow(
-      createMockDeps(),
-      createMockPlatform(),
-      'conv-dag',
-      testDir,
-      { name: 'aicfg', nodes: nodes.map(n => dagNodeSchema.parse(n) as DagNode) },
-      run,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+    await executeDagWorkflow({
+      deps: createMockDeps(),
+      platform: createMockPlatform(),
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: { name: 'aicfg', nodes: nodes.map(n => dagNodeSchema.parse(n) as DagNode) },
+      workflowRun: run,
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
     return mockSendQueryDag.mock.calls.map(call => {
       const options = call[3];
       if (!options) throw new Error('Expected provider query options');
@@ -29583,22 +29379,22 @@ describe('executeDagWorkflow -- systemPrompt and agents are runtime substitution
       prompt: 'go',
       systemPrompt: 'dir=$ARTIFACTS_DIR',
     }) as DagNode;
-    await executeDagWorkflow(
-      createMockDeps(),
-      createMockPlatform(),
-      'conv-dag',
-      testDir,
-      { name: 'aicfg2', nodes: [definition] },
-      makeWorkflowRun('aicfg-run-2'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+    await executeDagWorkflow({
+      deps: createMockDeps(),
+      platform: createMockPlatform(),
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: { name: 'aicfg2', nodes: [definition] },
+      workflowRun: makeWorkflowRun('aicfg-run-2'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
     expect(definition.systemPrompt).toBe('dir=$ARTIFACTS_DIR');
   });
 
@@ -29631,22 +29427,22 @@ describe('executeDagWorkflow -- systemPrompt and agents are runtime substitution
       ])
     );
     expect(errors).toEqual([]);
-    await executeDagWorkflow(
-      createMockDeps(),
-      createMockPlatform(),
-      'conv-dag',
-      testDir,
-      ready(workflows.get('sp-parent')!),
-      makeWorkflowRun('sp-composed'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+    await executeDagWorkflow({
+      deps: createMockDeps(),
+      platform: createMockPlatform(),
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: ready(workflows.get('sp-parent')!),
+      workflowRun: makeWorkflowRun('sp-composed'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
     expect(mockSendQueryDag.mock.calls.at(-1)?.[3]?.systemPrompt).toBe('mode=strict');
   });
 });
@@ -29736,25 +29532,23 @@ describe('executeDagWorkflow -- composition governance survives the collapse', (
       loadConfig: mock<WorkflowDeps['loadConfig']>(async _cwd => minimalConfig),
     };
 
-    await executeDagWorkflow(
+    await executeDagWorkflow({
       deps,
-      createMockPlatform(),
-      'conv-gov',
-      testDir,
-      ready(workflows.get('resume-parent')!),
-      makeWorkflowRun('gov-resume', { workflow_name: 'resume-parent' }),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      prior
-    );
+      platform: createMockPlatform(),
+      conversationId: 'conv-gov',
+      cwd: testDir,
+      workflow: ready(workflows.get('resume-parent')!),
+      workflowRun: makeWorkflowRun('gov-resume', { workflow_name: 'resume-parent' }),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes: prior,
+    });
 
     const events = store.createWorkflowEvent.mock.calls.map(call => call[0]);
     expect(
@@ -29792,22 +29586,22 @@ describe('executeDagWorkflow -- composition governance survives the collapse', (
 
     const store = createMockStore();
     const runId = 'gov-gate-run';
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-gov',
-      testDir,
-      ready(workflows.get('gate-parent')!),
-      makeWorkflowRun(runId, { workflow_name: 'gate-parent' }),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-gov',
+      cwd: testDir,
+      workflow: ready(workflows.get('gate-parent')!),
+      workflowRun: makeWorkflowRun(runId, { workflow_name: 'gate-parent' }),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const pauseCalls = store.pauseWorkflowRun.mock.calls;
     expect(pauseCalls.length).toBe(1);
@@ -29871,29 +29665,25 @@ describe('executeDagWorkflow -- a workflow-level provider/model conflict is repo
     expect(errors).toEqual([]);
 
     const platform = createMockPlatform();
-    await executeDagWorkflow(
-      createMockDeps(),
+    await executeDagWorkflow({
+      deps: createMockDeps(),
       platform,
-      'conv-conflict',
-      testDir,
-      ready(workflows.get('conflict')!),
-      makeWorkflowRun('conflict-run', { workflow_name: 'conflict' }),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      buildAiProfile('claude', {
+      conversationId: 'conv-conflict',
+      cwd: testDir,
+      workflow: ready(workflows.get('conflict')!),
+      workflowRun: makeWorkflowRun('conflict-run', { workflow_name: 'conflict' }),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      aiProfile: buildAiProfile('claude', {
         repoTiers: { large: { provider: 'codex', model: 'gpt-5.6-sol' } },
-      })
-    );
+      }),
+    });
 
     const conflictMessages = platform.sendMessage.mock.calls
       .map(c => c[1])
@@ -30176,25 +29966,25 @@ describe('TokenUsage axis seam guard', () => {
     const store = createMockStore();
     const logDir = join(testDir, 'logs');
     const workflowRun = makeWorkflowRun(`axis-seam-run-${outcome}`);
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-dag',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: {
         name: 'axis-seam',
         nodes: [{ id: 'step', kind: 'agent', source: { kind: 'inline', prompt: 'Do thing.' } }],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
       logDir,
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
     return { store, runId: workflowRun.id, logDir };
   }
 
@@ -30307,22 +30097,22 @@ describe('TokenUsage axis seam guard', () => {
       },
     ];
     const pausingDeps = createMockDeps();
-    await executeDagWorkflow(
-      pausingDeps,
-      createMockPlatform(),
-      'conv-dag',
-      testDir,
-      { name: 'axis-loop-pause', nodes: loopNodes },
-      makeWorkflowRun('axis-loop-pause-run'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+    await executeDagWorkflow({
+      deps: pausingDeps,
+      platform: createMockPlatform(),
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: { name: 'axis-loop-pause', nodes: loopNodes },
+      workflowRun: makeWorkflowRun('axis-loop-pause-run'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
     const pauseCalls = (
       pausingDeps.store.pauseWorkflowRun as Mock<IWorkflowStore['pauseWorkflowRun']>
     ).mock.calls;
@@ -30341,13 +30131,13 @@ describe('TokenUsage axis seam guard', () => {
       yield { type: 'result', sessionId: 'never' };
     });
     const resumingDeps = createMockDeps();
-    await executeDagWorkflow(
-      resumingDeps,
-      createMockPlatform(),
-      'conv-dag',
-      testDir,
-      { name: 'axis-loop-resume', nodes: loopNodes },
-      makeWorkflowRun('axis-loop-resume-run', {
+    await executeDagWorkflow({
+      deps: resumingDeps,
+      platform: createMockPlatform(),
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: { name: 'axis-loop-resume', nodes: loopNodes },
+      workflowRun: makeWorkflowRun('axis-loop-resume-run', {
         metadata: {
           approval: {
             type: 'interactive_loop',
@@ -30363,15 +30153,15 @@ describe('TokenUsage axis seam guard', () => {
           loop_feedback_given: false,
         },
       }),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
     expect(mockSendQueryDag.mock.calls.length).toBe(0);
     expectSeamCarriesAxes(
       'loop gate (read)',
@@ -30448,25 +30238,23 @@ describe('value transport (#2637): persistence, resume, and node-local bindings'
     workflowRunOverrides?: Partial<WorkflowRun>
   ): Promise<{ events: PersistedEvent[]; store: MockWorkflowStore }> {
     const store = createMockStore();
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-2637',
-      testDir,
-      ready(workflow),
-      makeWorkflowRun(runId, workflowRunOverrides),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-2637',
+      cwd: testDir,
+      workflow: ready(workflow),
+      workflowRun: makeWorkflowRun(runId, workflowRunOverrides),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
     const events = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls.map(
       (call: unknown[]) => call[0] as PersistedEvent
     );
@@ -30961,22 +30749,22 @@ describe('value transport (#2637): persistence, resume, and node-local bindings'
       }),
     ];
 
-    const result = await executeDagWorkflow(
-      createMockDeps(),
-      createMockPlatform(),
-      'conv-lg-binding',
-      testDir,
-      { name: 'lg-binding-completed', nodes: nodes as DagNode[] },
-      makeWorkflowRun('lg-binding-completed'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+    const result = await executeDagWorkflow({
+      deps: createMockDeps(),
+      platform: createMockPlatform(),
+      conversationId: 'conv-lg-binding',
+      cwd: testDir,
+      workflow: { name: 'lg-binding-completed', nodes: nodes as DagNode[] },
+      workflowRun: makeWorkflowRun('lg-binding-completed'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // The group's real whole-ref output resolved — the `if_skipped` default never fired.
     expect(result).toBe('CORRECTIONS_APPLIED');
@@ -31008,22 +30796,22 @@ describe('value transport (#2637): persistence, resume, and node-local bindings'
       }),
     ];
 
-    const result = await executeDagWorkflow(
-      createMockDeps(),
-      createMockPlatform(),
-      'conv-lg-binding',
-      testDir,
-      { name: 'lg-binding-skipped', nodes: nodes as DagNode[] },
-      makeWorkflowRun('lg-binding-skipped'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+    const result = await executeDagWorkflow({
+      deps: createMockDeps(),
+      platform: createMockPlatform(),
+      conversationId: 'conv-lg-binding',
+      cwd: testDir,
+      workflow: { name: 'lg-binding-skipped', nodes: nodes as DagNode[] },
+      workflowRun: makeWorkflowRun('lg-binding-skipped'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // The group never ran — the binding took its declared default, unchanged by #2696.
     expect(result).toBe('NO_CORRECTIONS_RAN');
@@ -31063,22 +30851,22 @@ describe('value transport (#2637): persistence, resume, and node-local bindings'
     ];
 
     const platform = createMockPlatform();
-    await executeDagWorkflow(
-      createMockDeps(),
+    await executeDagWorkflow({
+      deps: createMockDeps(),
       platform,
-      'conv-lg-binding',
-      testDir,
-      { name: 'lg-binding-failed', nodes: nodes as DagNode[] },
-      makeWorkflowRun('lg-binding-failed'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      conversationId: 'conv-lg-binding',
+      cwd: testDir,
+      workflow: { name: 'lg-binding-failed', nodes: nodes as DagNode[] },
+      workflowRun: makeWorkflowRun('lg-binding-failed'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // gate-ready's body never executed — no public-write consequence from a failed group.
     expect(await Bun.file(markerPath).exists()).toBe(false);
@@ -31127,22 +30915,22 @@ describe('value transport (#2637): persistence, resume, and node-local bindings'
     ];
 
     const platform = createMockPlatform();
-    await executeDagWorkflow(
-      createMockDeps(),
+    await executeDagWorkflow({
+      deps: createMockDeps(),
       platform,
-      'conv-lg-binding-plain',
-      testDir,
-      { name: 'lg-binding-plain-with-failed', nodes: nodes as DagNode[] },
-      makeWorkflowRun('lg-binding-plain-with-failed'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      conversationId: 'conv-lg-binding-plain',
+      cwd: testDir,
+      workflow: { name: 'lg-binding-plain-with-failed', nodes: nodes as DagNode[] },
+      workflowRun: makeWorkflowRun('lg-binding-plain-with-failed'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // gate-ready's body never executed — no public-write consequence from a failed group.
     expect(await Bun.file(markerPath).exists()).toBe(false);
@@ -31371,22 +31159,22 @@ describe('#2707 step 3: gate-terminated loop_group pause escalation', () => {
     const store = createEscalationStore('run-escalation-1');
     const platform = createMockPlatform();
 
-    await executeDagWorkflow(
-      createMockDeps(store),
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
       platform,
-      'conv-dag',
-      testDir,
-      ready(gateTerminatedLoopGroupWorkflow()),
-      makeWorkflowRun('run-escalation-1'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: ready(gateTerminatedLoopGroupWorkflow()),
+      workflowRun: makeWorkflowRun('run-escalation-1'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     // Only 'work' ran once — proves the loop did NOT barrel through remaining
     // iterations re-running the body every time the gate re-paused.
@@ -31413,22 +31201,22 @@ describe('#2707 step 3: gate-terminated loop_group pause escalation', () => {
     const deps = createMockDeps(store);
     const platform = createMockPlatform();
 
-    await executeDagWorkflow(
+    await executeDagWorkflow({
       deps,
       platform,
-      'conv-dag',
-      testDir,
-      ready(waitTerminatedLoopGroupWorkflow()),
-      makeWorkflowRun('run-wait-escalation'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: ready(waitTerminatedLoopGroupWorkflow()),
+      workflowRun: makeWorkflowRun('run-wait-escalation'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const paused = store.getState();
     expect(paused.status).toBe('paused');
@@ -31448,22 +31236,22 @@ describe('#2707 step 3: gate-terminated loop_group pause escalation', () => {
     });
     const resumedStore = createEscalationStore('run-wait-escalation');
 
-    await executeDagWorkflow(
-      createMockDeps(resumedStore),
+    await executeDagWorkflow({
+      deps: createMockDeps(resumedStore),
       platform,
-      'conv-dag',
-      testDir,
-      ready(waitTerminatedLoopGroupWorkflow()),
-      resumeRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: ready(waitTerminatedLoopGroupWorkflow()),
+      workflowRun: resumeRun,
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(resumedStore.completeWorkflowRun).toHaveBeenCalledTimes(1);
     expect(resumedStore.pauseWorkflowRunForWait).not.toHaveBeenCalled();
@@ -31483,22 +31271,22 @@ describe('#2707 step 3: gate-terminated loop_group pause escalation', () => {
     };
     const store = createEscalationStore('run-repeating-wait');
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-dag',
-      testDir,
-      ready(repeatingWaitTerminatedLoopGroupWorkflow()),
-      makeWorkflowRun('run-repeating-wait', { metadata: { wait: expiredWait } }),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: ready(repeatingWaitTerminatedLoopGroupWorkflow()),
+      workflowRun: makeWorkflowRun('run-repeating-wait', { metadata: { wait: expiredWait } }),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(store.getState().status).toBe('paused');
     expect(store.pauseWorkflowRunForWait).toHaveBeenCalledTimes(1);
@@ -31533,25 +31321,25 @@ describe('#2707 step 3: gate-terminated loop_group pause escalation', () => {
     };
     const store = createEscalationStore('run-included-missing-probe');
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-dag',
-      testDir,
-      ready(workflow),
-      makeWorkflowRun('run-included-missing-probe', { metadata: { wait: expiredWait } }),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      new Map()
-    );
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: ready(workflow),
+      workflowRun: makeWorkflowRun('run-included-missing-probe', {
+        metadata: { wait: expiredWait },
+      }),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes: new Map(),
+    });
 
     expect(store.completeWorkflowRun).not.toHaveBeenCalled();
     expect(store.failWorkflowRun).toHaveBeenCalledTimes(1);
@@ -31585,25 +31373,25 @@ describe('#2707 step 3: gate-terminated loop_group pause escalation', () => {
     ]);
     const store = createEscalationStore('run-included-restored-probe');
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-dag',
-      testDir,
-      ready(workflow),
-      makeWorkflowRun('run-included-restored-probe', { metadata: { wait: expiredWait } }),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: ready(workflow),
+      workflowRun: makeWorkflowRun('run-included-restored-probe', {
+        metadata: { wait: expiredWait },
+      }),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
 
     expect(await Bun.file(markerPath).exists()).toBe(true);
     expect(store.completeWorkflowRun).not.toHaveBeenCalled();
@@ -31638,25 +31426,25 @@ describe('#2707 step 3: gate-terminated loop_group pause escalation', () => {
     ]);
     const store = createEscalationStore('run-included-double-quoted-probe');
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-dag',
-      testDir,
-      ready(workflow),
-      makeWorkflowRun('run-included-double-quoted-probe', { metadata: { wait: expiredWait } }),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: ready(workflow),
+      workflowRun: makeWorkflowRun('run-included-double-quoted-probe', {
+        metadata: { wait: expiredWait },
+      }),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
 
     expect(await Bun.file(markerPath).exists()).toBe(true);
     expect(store.completeWorkflowRun).toHaveBeenCalledTimes(1);
@@ -31669,22 +31457,22 @@ describe('#2707 step 3: gate-terminated loop_group pause escalation', () => {
       signaledAt: new Date().toISOString(),
     }));
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-dag',
-      testDir,
-      ready(eventWaitTerminatedLoopGroupWorkflow()),
-      makeWorkflowRun('run-immediate-signal'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: ready(eventWaitTerminatedLoopGroupWorkflow()),
+      workflowRun: makeWorkflowRun('run-immediate-signal'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(store.pauseWorkflowRunForWait).toHaveBeenCalledTimes(1);
     expect(store.getState().metadata.wait).toMatchObject({
@@ -31727,25 +31515,23 @@ describe('#2707 step 3: gate-terminated loop_group pause escalation', () => {
       },
     });
 
-    await executeDagWorkflow(
-      createMockDeps(store),
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
       platform,
-      'conv-dag',
-      testDir,
-      ready(gateTerminatedLoopGroupWorkflow()),
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: ready(gateTerminatedLoopGroupWorkflow()),
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
 
     // No fresh iteration ran — the resumed iteration's completion was decided
     // from the reconstructed data, not by re-running the body.
@@ -31795,25 +31581,23 @@ describe('#2707 step 3: gate-terminated loop_group pause escalation', () => {
       },
     });
 
-    await executeDagWorkflow(
-      createMockDeps(store),
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
       platform,
-      'conv-dag',
-      testDir,
-      ready(gateTerminatedLoopGroupWorkflow()),
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: ready(gateTerminatedLoopGroupWorkflow()),
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
 
     // A genuinely fresh iteration 2 ran (the "revise" decision did not satisfy
     // until_bash), seeded with the human's feedback via the ordinary $LOOP_PREV
@@ -31884,25 +31668,23 @@ describe('#2707 step 3: gate-terminated loop_group pause escalation', () => {
       ],
     };
 
-    await executeDagWorkflow(
-      createMockDeps(store),
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
       platform,
-      'conv-dag',
-      testDir,
-      ready(outerRefWorkflow),
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: ready(outerRefWorkflow),
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
 
     // No fresh iteration ran — the outer ref resolved correctly on resume, so
     // until_bash saw both halves satisfied and completed without re-running the body.
@@ -31973,25 +31755,23 @@ describe('#2707 step 3: gate-terminated loop_group pause escalation', () => {
       ],
     };
 
-    await executeDagWorkflow(
-      createMockDeps(store),
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
       platform,
-      'conv-dag',
-      testDir,
-      ready(talkativeProbeWorkflow),
+      conversationId: 'conv-dag',
+      cwd: testDir,
+      workflow: ready(talkativeProbeWorkflow),
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
       logDir,
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      priorCompletedNodes
-    );
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      priorCompletedNodes,
+    });
 
     // Zero provider calls means no fresh iteration ran, so the single retained row
     // below can only have come from the resume branch's probe — not the ordinary
@@ -32056,22 +31836,22 @@ describe('#2707 step 3: gate-terminated loop_group pause escalation', () => {
 
     // Must not throw — the fallthrough path is a normal, tolerated outcome.
     await expect(
-      executeDagWorkflow(
-        createMockDeps(store),
+      executeDagWorkflow({
+        deps: createMockDeps(store),
         platform,
-        'conv-dag',
-        testDir,
-        ready(singleIterationWorkflow),
-        makeWorkflowRun('run-escalation-4'),
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      )
+        conversationId: 'conv-dag',
+        cwd: testDir,
+        workflow: ready(singleIterationWorkflow),
+        workflowRun: makeWorkflowRun('run-escalation-4'),
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      })
     ).resolves.toBeUndefined();
 
     // The escalation was attempted and correctly observed the lost race.
@@ -32149,12 +31929,12 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun('compose-run-id');
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-compose',
-      testDir,
-      {
+      conversationId: 'conv-compose',
+      cwd: testDir,
+      workflow: {
         name: 'compose-parent',
         nodes: [
           {
@@ -32174,15 +31954,15 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
         ],
       },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const events = eventsOf(mockDeps.store);
     // One audit snapshot BEFORE any instance schedules.
@@ -32221,12 +32001,12 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
     );
     const store = createMockStore();
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-compose',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-compose',
+      cwd: testDir,
+      workflow: {
         name: 'compose-parent',
         nodes: [
           { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a"]'` },
@@ -32239,16 +32019,16 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
           },
         ],
       },
-      makeWorkflowRun('compose-return-id'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('compose-return-id'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const wrapper = eventsOf(store).find(
       event => event.event_type === 'node_completed' && event.step_name === 'fan'
@@ -32265,12 +32045,12 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
       new Error('disk full')
     );
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-compose',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-compose',
+      cwd: testDir,
+      workflow: {
         name: 'compose-parent',
         nodes: [
           { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a"]'` },
@@ -32283,16 +32063,16 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
           },
         ],
       },
-      makeWorkflowRun('compose-snapshot-fail-id'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('compose-snapshot-fail-id'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(eventsOf(store).some(event => /__work$/.test(event.step_name))).toBe(false);
     expect(
@@ -32329,12 +32109,12 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
       costUsd: 0,
     });
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-compose',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-compose',
+      cwd: testDir,
+      workflow: {
         name: 'compose-parent',
         nodes: [
           { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["changed"]'` },
@@ -32347,16 +32127,16 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
           },
         ],
       },
-      makeWorkflowRun('compose-partial-resume-id'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('compose-partial-resume-id'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const events = eventsOf(store);
     expect(
@@ -32386,12 +32166,12 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
       costUsd: 0,
     });
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-compose',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-compose',
+      cwd: testDir,
+      workflow: {
         name: 'compose-parent',
         nodes: [
           { id: 'list', kind: 'exec', runtime: 'sh', script: 'echo not-json' },
@@ -32404,16 +32184,16 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
           },
         ],
       },
-      makeWorkflowRun('compose-malformed-drift-id'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('compose-malformed-drift-id'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const wrapper = eventsOf(store).find(
       event => event.event_type === 'node_completed' && event.step_name === 'fan'
@@ -32444,12 +32224,12 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
       costUsd: 0,
     });
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-compose',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-compose',
+      cwd: testDir,
+      workflow: {
         name: 'compose-parent',
         nodes: [
           { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a"]'` },
@@ -32470,16 +32250,16 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
           },
         ],
       },
-      makeWorkflowRun('compose-frozen-inputs-id'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('compose-frozen-inputs-id'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const wrapper = eventsOf(store).find(
       event => event.event_type === 'node_completed' && event.step_name === 'fan'
@@ -32500,12 +32280,12 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
       costUsd: 0,
     });
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-compose',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-compose',
+      cwd: testDir,
+      workflow: {
         name: 'compose-parent',
         nodes: [
           { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a"]'` },
@@ -32518,16 +32298,16 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
           },
         ],
       },
-      makeWorkflowRun('compose-ambiguous-id'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('compose-ambiguous-id'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(eventsOf(store).some(event => /__work$/.test(event.step_name))).toBe(false);
     expect(
@@ -32563,12 +32343,12 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
     }));
     const store = createMockStore();
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-compose',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-compose',
+      cwd: testDir,
+      workflow: {
         name: 'compose-parent',
         nodes: [
           { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a"]'` },
@@ -32581,26 +32361,18 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
           },
         ],
       },
-      makeWorkflowRun('compose-child-id'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      { kind: 'host' },
-      undefined,
-      runChildWorkflow
-    );
+      workflowRun: makeWorkflowRun('compose-child-id'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      execContext: { kind: 'host' },
+      runChildWorkflow,
+    });
 
     expect(runChildWorkflow).toHaveBeenCalledTimes(1);
     const wrapper = eventsOf(store).find(
@@ -32648,12 +32420,12 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
       async _parentRunId => childRuns
     );
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-compose-child-loop',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-compose-child-loop',
+      cwd: testDir,
+      workflow: {
         name: 'compose-parent-child-loop',
         nodes: [
           {
@@ -32685,26 +32457,18 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
           },
         ],
       },
-      makeWorkflowRun('compose-child-loop-id'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      { kind: 'host' },
-      undefined,
-      runChildWorkflow
-    );
+      workflowRun: makeWorkflowRun('compose-child-loop-id'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      execContext: { kind: 'host' },
+      runChildWorkflow,
+    });
 
     expect(runChildWorkflow).toHaveBeenCalledTimes(2);
     const ownedNodeIds = runChildWorkflow.mock.calls.map(([args]) => args.nodeId);
@@ -32758,12 +32522,12 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
       async _parentRunId => childRuns
     );
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-compose-child-fan-loop',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-compose-child-fan-loop',
+      cwd: testDir,
+      workflow: {
         name: 'compose-parent-child-fan-loop',
         nodes: [
           {
@@ -32795,26 +32559,18 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
           },
         ],
       },
-      makeWorkflowRun('compose-child-fan-loop-id'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      { kind: 'host' },
-      undefined,
-      runChildWorkflow
-    );
+      workflowRun: makeWorkflowRun('compose-child-fan-loop-id'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+      execContext: { kind: 'host' },
+      runChildWorkflow,
+    });
 
     expect(runChildWorkflow).toHaveBeenCalledTimes(2);
     const ownedNodeIds = runChildWorkflow.mock.calls.map(([args]) => args.nodeId);
@@ -32843,12 +32599,12 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
       return { persisted: true };
     });
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-compose-claim',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-compose-claim',
+      cwd: testDir,
+      workflow: {
         name: 'compose-parent-claim',
         nodes: [
           { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a","b"]'` },
@@ -32861,16 +32617,16 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
           },
         ],
       },
-      makeWorkflowRun('compose-claim-id'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('compose-claim-id'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(claimCount).toBe(2);
     expect(await readFile(join(testDir, '.compose-claimed-items'), 'utf8')).toBe('a\n');
@@ -32923,12 +32679,12 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
       return { persisted: true };
     });
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-compose-sibling-pause',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-compose-sibling-pause',
+      cwd: testDir,
+      workflow: {
         name: 'compose-parent-sibling-pause',
         nodes: [
           { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a","b"]'` },
@@ -32941,16 +32697,16 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
           },
         ],
       },
-      makeWorkflowRun('compose-sibling-pause-id'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('compose-sibling-pause-id'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(claimCount).toBe(2);
     expect(await readFile(join(testDir, '.compose-paused-first'), 'utf8')).toBe('a\n');
@@ -33024,12 +32780,12 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
       return { persisted: true };
     });
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-compose-paused-nested',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-compose-paused-nested',
+      cwd: testDir,
+      workflow: {
         name: 'compose-parent-paused-nested',
         nodes: [
           { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a","b"]'` },
@@ -33042,16 +32798,16 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
           },
         ],
       },
-      makeWorkflowRun('compose-paused-nested-id'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('compose-paused-nested-id'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(claimCount).toBe(3);
     expect(await readFile(join(testDir, '.compose-paused-nested'), 'utf8')).toBe('x\n');
@@ -33105,12 +32861,12 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
     claimCount = 0;
     (store.createWorkflowEvent as Mock<IWorkflowStore['createWorkflowEvent']>).mockClear();
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-compose-paused-nested',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-compose-paused-nested',
+      cwd: testDir,
+      workflow: {
         name: 'compose-parent-paused-nested',
         nodes: [
           { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a","b"]'` },
@@ -33123,16 +32879,16 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
           },
         ],
       },
-      makeWorkflowRun('compose-paused-nested-id'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('compose-paused-nested-id'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(claimCount).toBe(2);
     expect(await readFile(join(testDir, '.compose-paused-nested'), 'utf8')).toBe('x\nx\n');
@@ -33183,12 +32939,12 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
       return { persisted: true };
     });
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-compose-paused-loop',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-compose-paused-loop',
+      cwd: testDir,
+      workflow: {
         name: 'compose-parent-paused-loop',
         nodes: [
           { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a","b"]'` },
@@ -33201,16 +32957,16 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
           },
         ],
       },
-      makeWorkflowRun('compose-paused-loop-id'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('compose-paused-loop-id'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(claimCount).toBe(2);
     expect(await readFile(join(testDir, '.compose-paused-loop-first'), 'utf8')).toBe('a\n');
@@ -33283,12 +33039,12 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
       return { persisted: true };
     });
 
-    await executeDagWorkflow(
-      createMockDeps(store),
-      createMockPlatform(),
-      'conv-compose-cancelled-nested',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: createMockDeps(store),
+      platform: createMockPlatform(),
+      conversationId: 'conv-compose-cancelled-nested',
+      cwd: testDir,
+      workflow: {
         name: 'compose-parent-cancelled-nested',
         nodes: [
           { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a"]'` },
@@ -33301,16 +33057,16 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
           },
         ],
       },
-      makeWorkflowRun('compose-cancelled-nested-id'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('compose-cancelled-nested-id'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     expect(await readFile(join(testDir, '.compose-cancelled-nested-first'), 'utf8')).toBe('x\n');
     await expect(
@@ -33336,12 +33092,12 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
     const mockDeps = createMockDeps();
     const platform = createMockPlatform();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-compose',
-      testDir,
-      {
+      conversationId: 'conv-compose',
+      cwd: testDir,
+      workflow: {
         name: 'compose-parent',
         nodes: [
           { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '[]'` },
@@ -33354,16 +33110,16 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
           },
         ],
       },
-      makeWorkflowRun('compose-empty-id'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('compose-empty-id'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const wrapper = eventsOf(mockDeps.store).find(
       e => e.event_type === 'node_completed' && e.step_name === 'fan'
@@ -33396,12 +33152,12 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
     const mockDeps = createMockDeps();
     const platform = createMockPlatform();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-compose',
-      testDir,
-      {
+      conversationId: 'conv-compose',
+      cwd: testDir,
+      workflow: {
         name: 'compose-parent',
         nodes: [
           { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a"]'` },
@@ -33414,16 +33170,16 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
           },
         ],
       },
-      makeWorkflowRun('compose-gate-id'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('compose-gate-id'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const failed = eventsOf(mockDeps.store).find(
       e => e.event_type === 'node_failed' && e.step_name === 'fan'
@@ -33450,12 +33206,12 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
     const mockDeps = createMockDeps();
     const platform = createMockPlatform();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-compose',
-      testDir,
-      {
+      conversationId: 'conv-compose',
+      cwd: testDir,
+      workflow: {
         name: 'compose-parent',
         nodes: [
           { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a", "b"]'` },
@@ -33468,16 +33224,16 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
           },
         ],
       },
-      makeWorkflowRun('compose-checkout-id'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('compose-checkout-id'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const failed = eventsOf(mockDeps.store).find(
       e => e.event_type === 'node_failed' && e.step_name === 'fan'
@@ -33495,12 +33251,12 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
     const mockDeps = createMockDeps();
     const platform = createMockPlatform();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-compose',
-      testDir,
-      {
+      conversationId: 'conv-compose',
+      cwd: testDir,
+      workflow: {
         name: 'compose-parent',
         nodes: [
           { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '["a", "b"]'` },
@@ -33513,16 +33269,16 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
           },
         ],
       },
-      makeWorkflowRun('compose-fail-id'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('compose-fail-id'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const failed = eventsOf(mockDeps.store).find(
       e => e.event_type === 'node_failed' && e.step_name === 'fan'
@@ -33545,12 +33301,12 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
     const mockDeps = createMockDeps();
     const platform = createMockPlatform();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-compose',
-      testDir,
-      {
+      conversationId: 'conv-compose',
+      cwd: testDir,
+      workflow: {
         name: 'compose-parent',
         nodes: [
           {
@@ -33568,16 +33324,16 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
           },
         ],
       },
-      makeWorkflowRun('compose-partial-id'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('compose-partial-id'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const wrapper = eventsOf(mockDeps.store).find(
       e => e.event_type === 'node_completed' && e.step_name === 'fan'
@@ -33620,12 +33376,12 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
     const mockDeps = createMockDeps(storeOverride);
     const platform = createMockPlatform();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-compose',
-      testDir,
-      {
+      conversationId: 'conv-compose',
+      cwd: testDir,
+      workflow: {
         name: 'compose-parent',
         nodes: [
           { id: 'list', kind: 'exec', runtime: 'sh', script: `echo '${JSON.stringify(items)}'` },
@@ -33639,16 +33395,16 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
           },
         ],
       },
-      makeWorkflowRun('compose-resume-id'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('compose-resume-id'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const wrapper = eventsOf(storeOverride).find(
       e => e.event_type === 'node_completed' && e.step_name === 'fan'
@@ -33703,12 +33459,12 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
     const mockDeps = createMockDeps();
     const platform = createMockPlatform();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-compose-nested',
-      testDir,
-      {
+      conversationId: 'conv-compose-nested',
+      cwd: testDir,
+      workflow: {
         name: 'compose-parent-nested',
         nodes: [
           {
@@ -33727,16 +33483,16 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
           },
         ],
       },
-      makeWorkflowRun('compose-nested-id'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('compose-nested-id'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const events = eventsOf(mockDeps.store);
     expect(events.some(e => String(e.data.error ?? '').includes('failed to compose'))).toBe(false);
@@ -33783,12 +33539,12 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
     );
 
     const mockDeps = createMockDeps();
-    await executeDagWorkflow(
-      mockDeps,
-      createMockPlatform(),
-      'conv-compose-nested-gate',
-      testDir,
-      {
+    await executeDagWorkflow({
+      deps: mockDeps,
+      platform: createMockPlatform(),
+      conversationId: 'conv-compose-nested-gate',
+      cwd: testDir,
+      workflow: {
         name: 'compose-parent-nested-gate',
         nodes: [
           {
@@ -33806,16 +33562,16 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
           },
         ],
       },
-      makeWorkflowRun('compose-nested-gate-id'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('compose-nested-gate-id'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const events = eventsOf(mockDeps.store);
     expect(events.some(event => event.event_type === 'fan_out_instances')).toBe(false);
@@ -33860,12 +33616,12 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
     const mockDeps = createMockDeps(storeOverride);
     const platform = createMockPlatform();
 
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-compose-loop',
-      testDir,
-      {
+      conversationId: 'conv-compose-loop',
+      cwd: testDir,
+      workflow: {
         name: 'compose-parent-loop',
         nodes: [
           {
@@ -33893,16 +33649,16 @@ describe('executeDagWorkflow -- composed fan-out (include + fan_out, #2512)', ()
           },
         ],
       },
-      makeWorkflowRun('compose-loop-id'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowRun: makeWorkflowRun('compose-loop-id'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const events = eventsOf(mockDeps.store);
     // The instance actually executed in BOTH iterations under iteration-scoped names.
@@ -33959,22 +33715,22 @@ describe('executeDagWorkflow -- node-level mutates_checkout: false (#2771)', () 
       script,
       ...(declareReadOnly ? { mutates_checkout: false as const } : {}),
     };
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-mc',
-      testDir,
-      { name: 'mc-test', nodes: [bashNode] },
+      conversationId: 'conv-mc',
+      cwd: testDir,
+      workflow: { name: 'mc-test', nodes: [bashNode] },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
     return mockDeps;
   };
 
@@ -34072,22 +33828,22 @@ describe('executeDagWorkflow -- node-level mutates_checkout: false (#2771)', () 
       },
       { id: 'mutator', kind: 'exec', runtime: 'sh', script: 'touch sibling.txt' },
     ];
-    await executeDagWorkflow(
-      mockDeps,
+    await executeDagWorkflow({
+      deps: mockDeps,
       platform,
-      'conv-mc',
-      testDir,
-      { name: 'mc-test', nodes },
+      conversationId: 'conv-mc',
+      cwd: testDir,
+      workflow: { name: 'mc-test', nodes },
       workflowRun,
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
     expect(nodeFailedError(mockDeps, 'guarded')).toBeUndefined();
   });
 
@@ -34141,22 +33897,22 @@ describe('executeDagWorkflow -- side effects survive a failed terminal write', (
       if ('runId' in event && event.runId === workflowRun.id) emitted.push(event.type);
     });
     try {
-      return await executeDagWorkflow(
-        createMockDeps(store),
+      return await executeDagWorkflow({
+        deps: createMockDeps(store),
         platform,
-        'conv-terminal-order',
-        testDir,
-        { name: 'terminal-order', nodes },
+        conversationId: 'conv-terminal-order',
+        cwd: testDir,
+        workflow: { name: 'terminal-order', nodes },
         workflowRun,
-        'claude',
-        undefined,
-        join(testDir, 'artifacts'),
-        join(testDir, 'state'),
-        join(testDir, 'logs'),
-        'main',
-        'docs/',
-        minimalConfig
-      );
+        workflowProvider: 'claude',
+        workflowModel: undefined,
+        artifactsDir: join(testDir, 'artifacts'),
+        stateDir: join(testDir, 'state'),
+        logDir: join(testDir, 'logs'),
+        baseBranch: 'main',
+        docsDir: 'docs/',
+        config: minimalConfig,
+      });
     } finally {
       unsubscribe();
     }

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -9634,6 +9634,77 @@ async function buildColdResumeRecoveryPointer(
   }
 }
 
+type ClaimedWorkPausePolicy = 'finish_through_parent_pause';
+
+/** Run-level values the caller supplies verbatim to the DAG boundary. */
+interface RunInputs {
+  deps: WorkflowDeps;
+  platform: IWorkflowPlatform;
+  conversationId: string;
+  /** The workspace nodes ACT on: provider turns, subprocesses, git, output files. */
+  cwd: string;
+  /**
+   * Injected closure that starts a child sub-run for a `workflow:` node (#2121
+   * Phase 2). Undefined when the caller (e.g. a unit test) doesn't wire it — a
+   * `workflow:` node then fails fast rather than silently no-op'ing. Forwarded
+   * into loop_group body contexts too, though a `workflow:` node inside a
+   * loop_group body is rejected at load time.
+   */
+  runChildWorkflow?: RunChildWorkflowFn;
+  workflowRun: WorkflowRun;
+  config: WorkflowConfig;
+  workflowProvider: string;
+  workflowModel: string | undefined;
+  aiProfile?: ResolvedAiProfile;
+  workflowPreset?: ModelAliasPreset;
+  artifactsDir: string;
+  /**
+   * `$STATE_DIR` — the per-PROJECT cross-run state directory (#2200), shared by
+   * every workflow in the project and pre-created by the executor. A run-level
+   * invariant like `artifactsDir`; forwarded unchanged into loop_group bodies.
+   */
+  stateDir: string;
+  logDir: string;
+  baseBranch: string;
+  docsDir: string;
+  configuredCommandFolder?: string;
+  issueContext?: string;
+}
+
+/** Run-level values derived exactly once at the DAG boundary, never supplied by callers. */
+interface RunDerived {
+  /**
+   * The roots nodes READ executable source from — command files and named scripts.
+   *
+   * REQUIRED and concrete: normalized once at the DAG boundary so no leaf lookup can be
+   * reached without them. They were optional at first, and an omitted argument at any one
+   * of six call sites silently recreated the original source/target bug — the resolver
+   * would fall back to `cwd` and look for the workflow's own files inside the workspace it
+   * was executing against. Public discovery helpers keep their live-source defaults; this
+   * internal path does not.
+   */
+  workflowSourceRoots: WorkflowSourceRoots;
+  /** Where nodes in these layers execute (host, or the container in Phase B). Threaded
+   *  into every AI turn's SendQueryOptions and every deterministic subprocess. */
+  execContext: ExecutionContext;
+  /** Workflow name — used for persist_session keying + telemetry. */
+  workflowName: string;
+  workflowLevelOptions: WorkflowLevelOptions;
+  /** Cross-run session-persistence scope key (DB conversation UUID), or undefined to skip. */
+  persistScopeKey: string | undefined;
+  /** Workflow-level default for per-node `persist_session` (opt-in). */
+  workflowPersistSessions: boolean;
+  /**
+   * Stable cross-invocation artifact scope dir (`scopes/<workflow>/<scope>/`), or
+   * undefined when the workflow doesn't use session persistence. When set,
+   * persistence-participating nodes with `output_type` mirror their typed sidecars
+   * here, and a cold session resume points the user at the prior invocation's
+   * artifacts by reference (#1846). Always undefined for loop_group bodies
+   * (which also run with `persistScopeKey: undefined`).
+   */
+  scopeArtifactsDir: string | undefined;
+}
+
 /**
  * Shared context for {@link runLayers}. Bundles the run-level invariants (deps, platform,
  * run record, resolved provider/model/options, paths, config) together with the per-subgraph
@@ -9649,72 +9720,7 @@ async function buildColdResumeRecoveryPointer(
  * executeLoopNode / executeApprovalNode. Body lifecycle rows additionally carry `iteration`
  * in `data`. The in-process emitter payloads stay raw (unprefixed) — see #2090.
  */
-type ClaimedWorkPausePolicy = 'finish_through_parent_pause';
-
-interface RunLayersContext {
-  // --- run-level invariants (shared by top-level DAG and loop_group body) ---
-  deps: WorkflowDeps;
-  platform: IWorkflowPlatform;
-  conversationId: string;
-  /** The workspace nodes ACT on: provider turns, subprocesses, git, output files. */
-  cwd: string;
-  /**
-   * The roots nodes READ executable source from — command files and named scripts.
-   *
-   * REQUIRED and concrete: normalized once at the DAG boundary so no leaf lookup can be
-   * reached without them. They were optional at first, and an omitted argument at any one
-   * of six call sites silently recreated the original source/target bug — the resolver
-   * would fall back to `cwd` and look for the workflow's own files inside the workspace it
-   * was executing against. Public discovery helpers keep their live-source defaults; this
-   * internal path does not.
-   */
-  workflowSourceRoots: WorkflowSourceRoots;
-  /**
-   * Injected closure that starts a child sub-run for a `workflow:` node (#2121
-   * Phase 2). Undefined when the caller (e.g. a unit test) doesn't wire it — a
-   * `workflow:` node then fails fast rather than silently no-op'ing. Forwarded
-   * into loop_group body contexts too, though a `workflow:` node inside a
-   * loop_group body is rejected at load time.
-   */
-  runChildWorkflow?: RunChildWorkflowFn;
-  /** Where nodes in these layers execute (host, or the container in Phase B). Threaded
-   *  into every AI turn's SendQueryOptions and every deterministic subprocess. */
-  execContext: ExecutionContext;
-  workflowRun: WorkflowRun;
-  /** Workflow name — used for persist_session keying + telemetry. */
-  workflowName: string;
-  config: WorkflowConfig;
-  workflowProvider: string;
-  workflowModel: string | undefined;
-  workflowLevelOptions: WorkflowLevelOptions;
-  aiProfile?: ResolvedAiProfile;
-  workflowPreset?: ModelAliasPreset;
-  artifactsDir: string;
-  /**
-   * `$STATE_DIR` — the per-PROJECT cross-run state directory (#2200), shared by
-   * every workflow in the project and pre-created by the executor. A run-level
-   * invariant like `artifactsDir`; forwarded unchanged into loop_group bodies.
-   */
-  stateDir: string;
-  logDir: string;
-  baseBranch: string;
-  docsDir: string;
-  configuredCommandFolder?: string;
-  issueContext?: string;
-  /** Cross-run session-persistence scope key (DB conversation UUID), or undefined to skip. */
-  persistScopeKey: string | undefined;
-  /** Workflow-level default for per-node `persist_session` (opt-in). */
-  workflowPersistSessions: boolean;
-  /**
-   * Stable cross-invocation artifact scope dir (`scopes/<workflow>/<scope>/`), or
-   * undefined when the workflow doesn't use session persistence. When set,
-   * persistence-participating nodes with `output_type` mirror their typed sidecars
-   * here, and a cold session resume points the user at the prior invocation's
-   * artifacts by reference (#1846). Always undefined for loop_group bodies
-   * (which also run with `persistScopeKey: undefined`).
-   */
-  scopeArtifactsDir: string | undefined;
-
+interface RunLayersContext extends RunInputs, RunDerived {
   // --- per-subgraph mutable state (varies between top-level DAG and loop_group body) ---
   /** Pre-computed topological layers (caller builds once — body shape is static). runLayers walks ONLY these; there is deliberately no flat node list here. */
   layers: DagNode[][];
@@ -11508,15 +11514,8 @@ async function raiseWriteBackGate(
   await safeSendMessage(platform, conversationId, message, { workflowId: runId });
 }
 
-/**
- * Execute a complete DAG workflow.
- * Called from executeWorkflow() in executor.ts.
- */
-export async function executeDagWorkflow(
-  deps: WorkflowDeps,
-  platform: IWorkflowPlatform,
-  conversationId: string,
-  cwd: string,
+/** Inputs accepted by {@link executeDagWorkflow}. */
+export interface ExecuteDagWorkflowOptions extends RunInputs {
   workflow: {
     name: string;
     nodes: readonly DagNode[];
@@ -11531,58 +11530,76 @@ export async function executeDagWorkflow(
     returns?: string;
     /** Required boolean property on `returns:` that authors the durable run outcome. */
     outcome_field?: string;
-  } & WorkflowLevelOptions,
-  workflowRun: WorkflowRun,
-  workflowProvider: string,
-  workflowModel: string | undefined,
-  artifactsDir: string,
-  stateDir: string,
-  logDir: string,
-  baseBranch: string,
-  docsDir: string,
-  config: WorkflowConfig,
-  configuredCommandFolder?: string,
-  issueContext?: string,
-  priorCompletedNodes?: Map<string, PersistedNodeOutput>,
+  } & WorkflowLevelOptions;
+  priorCompletedNodes?: Map<string, PersistedNodeOutput>;
   /** Discovery source — telemetry only (custom-vs-default + name redaction). */
-  source?: WorkflowSource,
-  aiProfile?: ResolvedAiProfile,
-  workflowPreset?: ModelAliasPreset,
+  source?: WorkflowSource;
   /**
    * Stable cross-invocation artifact scope dir (`scopes/<workflow>/<scope>/`),
    * resolved by executor.ts when the workflow uses session persistence (#1846).
    * Undefined otherwise — no mirroring, no cold-resume pointer.
    */
-  scopeArtifactsDir?: string,
+  scopeArtifactsDir?: string;
   /**
    * Execution context for this run (host by default; the container backend
    * threads a container context in Phase B). Threaded onto every node's
    * `RunLayersContext` so provider turns and subprocesses exec in the right place.
    */
-  execContext: ExecutionContext = { kind: 'host' },
+  execContext?: ExecutionContext;
   /**
    * Container run context (Phase C): the write-back backend port + env id + policy.
    * Present only for container runs. Drives suspend-on-pause and the engine-level
    * write-back gate that runs after the last node before the run completes.
    */
-  containerCtx?: ContainerRunContext,
-  /**
-   * Injected closure that starts a child sub-run for a `workflow:` node (#2121
-   * Phase 2). executor.ts is the sole caller and passes it; other callers (unit
-   * tests) may omit it, in which case a `workflow:` node fails fast.
-   */
-  runChildWorkflow?: RunChildWorkflowFn,
+  containerCtx?: ContainerRunContext;
   /** Cumulative usage restored on resume, from prior completion AND failure events. */
-  priorUsage?: PriorRunUsage,
+  priorUsage?: PriorRunUsage;
   /** Private run-scoped handles restored before a cold resume transitions to running. */
-  priorNodeSessions?: readonly WorkflowRunNodeSession[],
+  priorNodeSessions?: readonly WorkflowRunNodeSession[];
   /**
    * Roots this run's commands and scripts are read from. Undefined here means the caller
    * has no capture (an in-process caller with a hand-built definition); the boundary below
    * normalizes it to live roots ONCE so nothing downstream has to.
    */
-  workflowSourceRoots?: WorkflowSourceRoots
+  workflowSourceRoots?: WorkflowSourceRoots;
+}
+
+/**
+ * Execute a complete DAG workflow.
+ * Called from executeWorkflow() in executor.ts.
+ */
+export async function executeDagWorkflow(
+  options: ExecuteDagWorkflowOptions
 ): Promise<string | undefined> {
+  const {
+    deps,
+    platform,
+    conversationId,
+    cwd,
+    workflow,
+    workflowRun,
+    workflowProvider,
+    workflowModel,
+    artifactsDir,
+    stateDir,
+    logDir,
+    baseBranch,
+    docsDir,
+    config,
+    configuredCommandFolder,
+    issueContext,
+    priorCompletedNodes,
+    source,
+    aiProfile,
+    workflowPreset,
+    scopeArtifactsDir,
+    execContext = { kind: 'host' },
+    containerCtx,
+    runChildWorkflow,
+    priorUsage,
+    priorNodeSessions,
+    workflowSourceRoots,
+  } = options;
   const dagStartTime = Date.now();
 
   // Container capability fail-fast: before ANY node runs (and before any
@@ -11770,7 +11787,9 @@ export async function executeDagWorkflow(
   // Run the topological layers. runLayers mutates the context's mutable fields in place
   // (nodeOutputs, lastSequentialSession, usage accumulators); we read them back below
   // for the terminal tally. stepNamePrefix is '' for the top-level DAG so node event
-  // step_names are the raw node ids (identical to pre-refactor behavior).
+  // step_names are the raw node ids (identical to pre-refactor behavior). Fields stay
+  // explicit because spreading options would also copy executor-only state into this
+  // context without an excess-property check.
   const runCtx: RunLayersContext = {
     deps,
     platform,
@@ -11780,7 +11799,6 @@ export async function executeDagWorkflow(
     runChildWorkflow,
     workflowRun,
     workflowName: workflow.name,
-    // Normalized once, here. Everything below takes concrete roots.
     workflowSourceRoots: workflowSourceRoots ?? liveSourceRoots(cwd),
     config,
     workflowProvider,

--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -421,7 +421,7 @@ describe('executeWorkflow', () => {
       );
       // Guard passed → DAG entered (mocked no-op) → run completes.
       expect(mockExecuteDagWorkflow).toHaveBeenCalledTimes(1);
-      expect(mockExecuteDagWorkflow.mock.calls[0]?.[24]).toEqual({
+      expect(mockExecuteDagWorkflow.mock.calls[0]?.[0].priorUsage).toEqual({
         tokens: { input: 40, output: 4 },
         costUsd: 0.5,
       });
@@ -875,9 +875,9 @@ describe('executeWorkflow', () => {
         }
       );
 
-      expect(mockExecuteDagWorkflow.mock.calls[0]?.[6]).toBe('pi');
-      expect(mockExecuteDagWorkflow.mock.calls[0]?.[7]).toBe('openai/gpt-5.6');
-      const profile = mockExecuteDagWorkflow.mock.calls[0]?.[18];
+      expect(mockExecuteDagWorkflow.mock.calls[0]?.[0].workflowProvider).toBe('pi');
+      expect(mockExecuteDagWorkflow.mock.calls[0]?.[0].workflowModel).toBe('openai/gpt-5.6');
+      const profile = mockExecuteDagWorkflow.mock.calls[0]?.[0].aiProfile;
       expect(profile?.aliases.large).toEqual({ provider: 'pi', model: 'openai/gpt-5.6' });
       expect(profile?.aliases.small?.provider).toBe('claude');
       expect(profile?.aliases.medium?.provider).toBe('claude');
@@ -924,7 +924,7 @@ describe('executeWorkflow', () => {
           metadata: expect.objectContaining({ model_bindings: expect.any(Object) }),
         })
       );
-      expect(mockExecuteDagWorkflow.mock.calls[0]?.[6]).toBe('codex');
+      expect(mockExecuteDagWorkflow.mock.calls[0]?.[0].workflowProvider).toBe('codex');
     });
 
     // #2872 — `run --detach` writes the row before it forks, so `Started` names a
@@ -1076,8 +1076,8 @@ describe('executeWorkflow', () => {
         'db-conv-1',
         { preCreatedRun, priorCompletedNodes: new Map() }
       );
-      expect(mockExecuteDagWorkflow.mock.calls[0]?.[6]).toBe('pi');
-      expect(mockExecuteDagWorkflow.mock.calls[0]?.[7]).toBe('openai/gpt-5.6');
+      expect(mockExecuteDagWorkflow.mock.calls[0]?.[0].workflowProvider).toBe('pi');
+      expect(mockExecuteDagWorkflow.mock.calls[0]?.[0].workflowModel).toBe('openai/gpt-5.6');
 
       await expect(
         executeWorkflow(
@@ -1336,8 +1336,8 @@ describe('executeWorkflow', () => {
       ]);
 
       const concurrent = mockExecuteDagWorkflow.mock.calls.slice(0, 2).map(call => ({
-        provider: call[6],
-        model: call[7],
+        provider: call[0].workflowProvider,
+        model: call[0].workflowModel,
       }));
       expect(concurrent).toContainEqual({ provider: 'pi', model: 'openai/gpt-5.6' });
       expect(concurrent).toContainEqual({ provider: 'codex', model: 'gpt-5.6-sol' });
@@ -1352,9 +1352,9 @@ describe('executeWorkflow', () => {
         'db-c'
       );
       const cleanCall = mockExecuteDagWorkflow.mock.calls[2];
-      expect(cleanCall?.[6]).toBe('claude');
-      expect(cleanCall?.[7]).not.toBe('openai/gpt-5.6');
-      expect(cleanCall?.[7]).not.toBe('gpt-5.6-sol');
+      expect(cleanCall?.[0].workflowProvider).toBe('claude');
+      expect(cleanCall?.[0].workflowModel).not.toBe('openai/gpt-5.6');
+      expect(cleanCall?.[0].workflowModel).not.toBe('gpt-5.6-sol');
     });
   });
 
@@ -1424,9 +1424,9 @@ describe('executeWorkflow', () => {
       );
 
       expect(sealRunConfig).toHaveBeenCalledTimes(1);
-      expect(mockExecuteDagWorkflow.mock.calls[0]?.[6]).toBe('pi');
-      expect(mockExecuteDagWorkflow.mock.calls[0]?.[7]).toBe('openai/gpt-5.6');
-      expect(mockExecuteDagWorkflow.mock.calls[0]?.[13]).toMatchObject({
+      expect(mockExecuteDagWorkflow.mock.calls[0]?.[0].workflowProvider).toBe('pi');
+      expect(mockExecuteDagWorkflow.mock.calls[0]?.[0].workflowModel).toBe('openai/gpt-5.6');
+      expect(mockExecuteDagWorkflow.mock.calls[0]?.[0].config).toMatchObject({
         assistant: 'pi',
         envVars: {
           REPO_ONLY: 'kept',
@@ -1471,8 +1471,8 @@ describe('executeWorkflow', () => {
       );
 
       expect(unsealRunConfig).toHaveBeenCalledWith(sealedMetadata);
-      expect(mockExecuteDagWorkflow.mock.calls[0]?.[12]).toBe('handbook');
-      expect(mockExecuteDagWorkflow.mock.calls[0]?.[13]).toMatchObject({
+      expect(mockExecuteDagWorkflow.mock.calls[0]?.[0].docsDir).toBe('handbook');
+      expect(mockExecuteDagWorkflow.mock.calls[0]?.[0].config).toMatchObject({
         envVars: { RUN_ONLY: 'restored' },
       });
     });
@@ -1540,9 +1540,9 @@ describe('executeWorkflow', () => {
       ]);
 
       const concurrent = mockExecuteDagWorkflow.mock.calls.slice(0, 2).map(call => ({
-        provider: call[6],
-        model: call[7],
-        marker: (call[13] as WorkflowConfig | undefined)?.envVars?.RUN_MARKER,
+        provider: call[0].workflowProvider,
+        model: call[0].workflowModel,
+        marker: call[0].config.envVars?.RUN_MARKER,
       }));
       expect(concurrent).toContainEqual({
         provider: 'pi',
@@ -1566,9 +1566,9 @@ describe('executeWorkflow', () => {
         'clean',
         'db-clean'
       );
-      const cleanConfig = mockExecuteDagWorkflow.mock.calls[2]?.[13] as WorkflowConfig | undefined;
+      const cleanConfig = mockExecuteDagWorkflow.mock.calls[2]?.[0].config;
       expect(cleanConfig?.envVars?.RUN_MARKER).toBeUndefined();
-      expect(mockExecuteDagWorkflow.mock.calls[2]?.[6]).toBe('claude');
+      expect(mockExecuteDagWorkflow.mock.calls[2]?.[0].workflowProvider).toBe('claude');
     });
   });
 
@@ -1902,8 +1902,7 @@ describe('executeWorkflow', () => {
         'db-conv-1'
       );
       expect(mockExecuteDagWorkflow).toHaveBeenCalledTimes(1);
-      // docsDir is arg index 11 (0-indexed) of executeDagWorkflow
-      const docsDir = mockExecuteDagWorkflow.mock.calls[0]?.[12];
+      const docsDir = mockExecuteDagWorkflow.mock.calls[0]?.[0].docsDir;
       expect(docsDir).toBe('docs/');
     });
 
@@ -1934,7 +1933,7 @@ describe('executeWorkflow', () => {
         'db-conv-1'
       );
       expect(mockExecuteDagWorkflow).toHaveBeenCalledTimes(1);
-      const docsDir = mockExecuteDagWorkflow.mock.calls[0]?.[12];
+      const docsDir = mockExecuteDagWorkflow.mock.calls[0]?.[0].docsDir;
       expect(docsDir).toBe('packages/docs-web/src/content/docs');
     });
   });
@@ -1963,7 +1962,7 @@ describe('executeWorkflow', () => {
       );
 
       expect(mockGetDefaultBranch).not.toHaveBeenCalled();
-      expect(mockExecuteDagWorkflow.mock.calls[0]?.[11]).toBe('develop');
+      expect(mockExecuteDagWorkflow.mock.calls[0]?.[0].baseBranch).toBe('develop');
     });
 
     it('prefers repo config baseBranch over caller-provided baseBranch', async () => {
@@ -1989,7 +1988,7 @@ describe('executeWorkflow', () => {
       );
 
       expect(mockGetDefaultBranch).not.toHaveBeenCalled();
-      expect(mockExecuteDagWorkflow.mock.calls[0]?.[11]).toBe('main');
+      expect(mockExecuteDagWorkflow.mock.calls[0]?.[0].baseBranch).toBe('main');
     });
 
     it('prefers baseOverride over repo config baseBranch', async () => {
@@ -2020,7 +2019,7 @@ describe('executeWorkflow', () => {
       );
 
       expect(mockGetDefaultBranch).not.toHaveBeenCalled();
-      expect(mockExecuteDagWorkflow.mock.calls[0]?.[11]).toBe('epic/foo');
+      expect(mockExecuteDagWorkflow.mock.calls[0]?.[0].baseBranch).toBe('epic/foo');
     });
 
     it('falls back to git auto-detection when config and caller branch are unset', async () => {
@@ -2037,7 +2036,7 @@ describe('executeWorkflow', () => {
       );
 
       expect(mockGetDefaultBranch).toHaveBeenCalledWith('/tmp/worktree');
-      expect(mockExecuteDagWorkflow.mock.calls[0]?.[11]).toBe('main');
+      expect(mockExecuteDagWorkflow.mock.calls[0]?.[0].baseBranch).toBe('main');
     });
 
     it('skips git auto-detection for a folder-kind codebase, no ERROR/WARN spam (#2159)', async () => {
@@ -2067,7 +2066,7 @@ describe('executeWorkflow', () => {
       // benign auto-detect WARN is never emitted and $BASE_BRANCH resolves to
       // empty (unresolved-but-not-referenced).
       expect(mockGetDefaultBranch).not.toHaveBeenCalled();
-      expect(mockExecuteDagWorkflow.mock.calls[0]?.[11]).toBe('');
+      expect(mockExecuteDagWorkflow.mock.calls[0]?.[0].baseBranch).toBe('');
       const warnedAutoDetect = (mockLogFn.mock.calls as unknown[][]).some(
         args => args[1] === 'workflow.base_branch_auto_detect_failed'
       );
@@ -2098,7 +2097,7 @@ describe('executeWorkflow', () => {
       );
 
       expect(mockGetDefaultBranch).toHaveBeenCalledWith('/tmp/worktree');
-      expect(mockExecuteDagWorkflow.mock.calls[0]?.[11]).toBe('main');
+      expect(mockExecuteDagWorkflow.mock.calls[0]?.[0].baseBranch).toBe('main');
     });
   });
 
@@ -2146,11 +2145,7 @@ describe('executeWorkflow', () => {
         'db-conv-1',
         { preCreatedRun: resumed, priorCompletedNodes }
       );
-      // dag-executor receives the priorCompletedNodes map at arg index 15.
-      // dag-executor signature: deps, platform, conversationId, cwd, workflow,
-      // workflowRun, provider, model, artifactsDir, logDir, baseBranch,
-      // docsDir, config, configuredCommandFolder, issueContext, priorCompletedNodes
-      const passedPriors = mockExecuteDagWorkflow.mock.calls[0]?.[16] as
+      const passedPriors = mockExecuteDagWorkflow.mock.calls[0]?.[0].priorCompletedNodes as
         | Map<string, { output: string }>
         | undefined;
       expect(passedPriors).toBe(priorCompletedNodes);
@@ -2237,11 +2232,11 @@ describe('executeWorkflow', () => {
       );
 
       const dagCall = mockExecuteDagWorkflow.mock.calls[0];
-      expect(dagCall?.[16]).toBe(completedNodeOutputs);
+      expect(dagCall?.[0].priorCompletedNodes).toBe(completedNodeOutputs);
       // Both usage axes travel as one `priorUsage` bundle (#2469) — cost is restored
       // across resume exactly like tokens, so a resumed run's total never regresses.
-      expect(dagCall?.[24]).toEqual({ tokens, costUsd });
-      expect(dagCall?.[25]).toEqual(hydrated.priorNodeSessions);
+      expect(dagCall?.[0].priorUsage).toEqual({ tokens, costUsd });
+      expect(dagCall?.[0].priorNodeSessions).toEqual(hydrated.priorNodeSessions);
       expect(store.createWorkflowRun).not.toHaveBeenCalled();
     });
   });
@@ -2322,7 +2317,7 @@ describe('executeWorkflow', () => {
       // unregistered-cwd project (`_cwd/tmp`, #2200); scope = workflow name +
       // conversation UUID ('conv-1' from the createWorkflowRun mock;
       // getScopeArtifactsPath is mocked to `${root}/scopes/${wf}/${scope}`).
-      const scopeArg = mockExecuteDagWorkflow.mock.calls[0]?.[20] as string | undefined;
+      const scopeArg = mockExecuteDagWorkflow.mock.calls[0]?.[0].scopeArtifactsDir;
       expect(scopeArg).toBe(
         wsPath('_cwd', 'tmp', 'artifacts', 'scopes', 'test-workflow', 'conv-1')
       );
@@ -2340,7 +2335,7 @@ describe('executeWorkflow', () => {
         'test message',
         'db-conv-1'
       );
-      const scopeArg = mockExecuteDagWorkflow.mock.calls[0]?.[20] as string | undefined;
+      const scopeArg = mockExecuteDagWorkflow.mock.calls[0]?.[0].scopeArtifactsDir;
       expect(scopeArg).toBeUndefined();
     });
   });
@@ -2405,8 +2400,7 @@ describe('executeWorkflow', () => {
       // DB env vars should have been fetched for the codebaseId
       expect(store.getCodebaseEnvVars).toHaveBeenCalledWith('codebase-1');
 
-      // The config passed to executeDagWorkflow (arg index 12) should have merged envVars
-      const configArg = mockExecuteDagWorkflow.mock.calls[0]?.[13] as WorkflowConfig | undefined;
+      const configArg = mockExecuteDagWorkflow.mock.calls[0]?.[0].config;
       expect(configArg?.envVars).toEqual({ FILE_KEY: 'file_val', DB_KEY: 'db_val' });
     });
 
@@ -2510,7 +2504,7 @@ describe('executeWorkflow', () => {
         'db-c1',
         { codebaseId: 'codebase-1', userId: 'u-1' }
       );
-      const configArg = mockExecuteDagWorkflow.mock.calls[0]?.[13] as WorkflowConfig | undefined;
+      const configArg = mockExecuteDagWorkflow.mock.calls[0]?.[0].config;
       expect(configArg?.envVars).toMatchObject({
         DATABASE_URL: 'db_val',
         BASE_BRANCH: 'reserved-db-secret',
@@ -2560,7 +2554,7 @@ describe('executeWorkflow', () => {
         { codebaseId: 'codebase-1', userId: 'u-1' }
       );
 
-      const configArg = mockExecuteDagWorkflow.mock.calls[0]?.[13] as WorkflowConfig | undefined;
+      const configArg = mockExecuteDagWorkflow.mock.calls[0]?.[0].config;
       expect(configArg?.envVars).toMatchObject({
         GH_TOKEN: 'user-token',
         GITHUB_TOKEN: 'user-token',
@@ -2630,7 +2624,7 @@ describe('executeWorkflow', () => {
           })
         ).resolves.toBeDefined();
 
-        const configArg = mockExecuteDagWorkflow.mock.calls[0]?.[13] as WorkflowConfig | undefined;
+        const configArg = mockExecuteDagWorkflow.mock.calls[0]?.[0].config;
         expect(await readFile(firstFile, 'utf8')).toBe(credentialValue);
         expect(configArg?.envVars).not.toHaveProperty('CODEX_HOME');
         expect(configArg?.protectedCredentialValues).toEqual([credentialValue]);
@@ -2666,7 +2660,7 @@ describe('executeWorkflow', () => {
       );
 
       expect(getUserProviderEnv).toHaveBeenCalledWith('persisted-user', expect.any(String));
-      const configArg = mockExecuteDagWorkflow.mock.calls[0]?.[13] as WorkflowConfig | undefined;
+      const configArg = mockExecuteDagWorkflow.mock.calls[0]?.[0].config;
       expect(configArg?.protectedCredentialValues).toEqual(['persisted-user-token']);
     });
   });
@@ -3350,7 +3344,7 @@ describe('telemetry wiring', () => {
     expect(mockCaptureWorkflowCompleted).not.toHaveBeenCalled();
   });
 
-  it('threads source through to executeDagWorkflow (arg index 16)', async () => {
+  it('threads source through to executeDagWorkflow', async () => {
     const store = makeStore();
     const deps = makeDeps(store);
 
@@ -3367,7 +3361,7 @@ describe('telemetry wiring', () => {
       }
     );
 
-    expect(mockExecuteDagWorkflow.mock.calls[0]?.[17]).toBe('bundled');
+    expect(mockExecuteDagWorkflow.mock.calls[0]?.[0].source).toBe('bundled');
   });
 
   it('resolves top-level workflow tier refs before calling the DAG executor', async () => {
@@ -3397,16 +3391,16 @@ describe('telemetry wiring', () => {
       'db-conv-1'
     );
 
-    expect(mockExecuteDagWorkflow.mock.calls[0]?.[6]).toBe('codex');
-    expect(mockExecuteDagWorkflow.mock.calls[0]?.[7]).toBe('gpt-5.5');
-    expect(mockExecuteDagWorkflow.mock.calls[0]?.[18]).toEqual(
+    expect(mockExecuteDagWorkflow.mock.calls[0]?.[0].workflowProvider).toBe('codex');
+    expect(mockExecuteDagWorkflow.mock.calls[0]?.[0].workflowModel).toBe('gpt-5.5');
+    expect(mockExecuteDagWorkflow.mock.calls[0]?.[0].aiProfile).toEqual(
       expect.objectContaining({
         aliases: expect.objectContaining({
           large: { provider: 'codex', model: 'gpt-5.5', effort: 'high' },
         }),
       })
     );
-    expect(mockExecuteDagWorkflow.mock.calls[0]?.[19]).toEqual({
+    expect(mockExecuteDagWorkflow.mock.calls[0]?.[0].workflowPreset).toEqual({
       provider: 'codex',
       model: 'gpt-5.5',
       effort: 'high',
@@ -3447,8 +3441,8 @@ describe('telemetry wiring', () => {
 
     expect(getUserAiPrefs).toHaveBeenCalledWith('user-1');
     // User tier wins over the config tier for the same key.
-    expect(mockExecuteDagWorkflow.mock.calls[0]?.[6]).toBe('codex');
-    expect(mockExecuteDagWorkflow.mock.calls[0]?.[7]).toBe('gpt-5.5');
+    expect(mockExecuteDagWorkflow.mock.calls[0]?.[0].workflowProvider).toBe('codex');
+    expect(mockExecuteDagWorkflow.mock.calls[0]?.[0].workflowModel).toBe('gpt-5.5');
   });
 
   it('does not consult per-user AI prefs without a userId (solo unchanged)', async () => {
@@ -3490,7 +3484,7 @@ describe('telemetry wiring', () => {
     );
 
     // Config default is claude → built-in tier defaults resolve 'large'.
-    expect(mockExecuteDagWorkflow.mock.calls[0]?.[6]).toBe('claude');
+    expect(mockExecuteDagWorkflow.mock.calls[0]?.[0].workflowProvider).toBe('claude');
   });
 
   it('structurally invalid stored prefs degrade to config-only (run still starts)', async () => {
@@ -3514,7 +3508,7 @@ describe('telemetry wiring', () => {
       { userId: 'user-1' }
     );
 
-    expect(mockExecuteDagWorkflow.mock.calls[0]?.[6]).toBe('claude');
+    expect(mockExecuteDagWorkflow.mock.calls[0]?.[0].workflowProvider).toBe('claude');
   });
 
   it("per-user default provider rebases tier defaults for the run's profile", async () => {
@@ -3537,7 +3531,7 @@ describe('telemetry wiring', () => {
 
     // No tiers configured anywhere → built-in tier defaults follow the
     // user's default provider, not the install config's.
-    expect(mockExecuteDagWorkflow.mock.calls[0]?.[6]).toBe('codex');
+    expect(mockExecuteDagWorkflow.mock.calls[0]?.[0].workflowProvider).toBe('codex');
   });
 
   it('passes undefined source when the caller does not supply one', async () => {
@@ -3554,7 +3548,7 @@ describe('telemetry wiring', () => {
       'db-conv-1'
     );
 
-    expect(mockExecuteDagWorkflow.mock.calls[0]?.[17]).toBeUndefined();
+    expect(mockExecuteDagWorkflow.mock.calls[0]?.[0].source).toBeUndefined();
   });
 });
 

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -3042,15 +3042,15 @@ export async function executeWorkflow(
     // encloses only the DAG: a child sub-run spawned from a node re-enters
     // `executeWorkflow` and scopes its own (absent) adoption.
     const dagSummary = await runWithAdoptedRunDir(adoptedRunDir, () =>
-      executeDagWorkflow(
+      executeDagWorkflow({
         deps,
         platform,
         conversationId,
         cwd,
-        { ...workflow, nodes: telemetryNodes },
-        runForDag,
-        resolvedProvider,
-        resolvedModel,
+        workflow: { ...workflow, nodes: telemetryNodes },
+        workflowRun: runForDag,
+        workflowProvider: resolvedProvider,
+        workflowModel: resolvedModel,
         artifactsDir,
         stateDir,
         logDir,
@@ -3059,7 +3059,7 @@ export async function executeWorkflow(
         config,
         configuredCommandFolder,
         issueContext,
-        dagPriorCompletedNodes,
+        priorCompletedNodes: dagPriorCompletedNodes,
         source,
         aiProfile,
         workflowPreset,
@@ -3070,7 +3070,7 @@ export async function executeWorkflow(
         // import cycle) so a `workflow:` node can spawn a governed child run in-process.
         // Also captures the per-child isolation resolver (slice 2, PR-A) so an
         // `isolation: 'worktree'` child gets its own worktree cwd.
-        (childArgs: RunChildWorkflowArgs): Promise<ChildWorkflowOutcome> =>
+        runChildWorkflow: (childArgs: RunChildWorkflowArgs): Promise<ChildWorkflowOutcome> =>
           runChildWorkflow(
             deps,
             platform,
@@ -3079,13 +3079,13 @@ export async function executeWorkflow(
             effectiveRunConfig,
             resolveChildIsolation
           ),
-        dagPriorUsage,
+        priorUsage: dagPriorUsage,
         priorNodeSessions,
         // Container runs resolve from the capture like every other run: it is bind-mounted
         // read-only at the SAME absolute path inside the container, so one source-roots
         // value means the same thing on both sides of the boundary.
-        workflowSourceRoots
-      )
+        workflowSourceRoots,
+      })
     );
 
     // executeDagWorkflow throws on fatal errors; check DB status for result

--- a/packages/workflows/src/script-node-deps.test.ts
+++ b/packages/workflows/src/script-node-deps.test.ts
@@ -281,22 +281,14 @@ describe('script node deps field — command construction', () => {
       deps: ['httpx', 'beautifulsoup4'],
     };
 
-    await executeDagWorkflow({
-      deps: createMockDeps(),
-      platform: createMockPlatform(),
-      conversationId: 'conv-deps',
-      cwd: testDir,
-      workflow: { name: 'deps-test', nodes: [node] },
-      workflowRun: makeWorkflowRun('deps-run-1'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(),
+        cwd: testDir,
+        workflow: { name: 'deps-test', nodes: [node] },
+        workflowRun: makeWorkflowRun('deps-run-1'),
+      })
+    );
 
     const calls = mockExecFileAsync.mock.calls;
     const scriptCall = calls.find(c => (c[0] as string) === 'uv');
@@ -322,22 +314,14 @@ describe('script node deps field — command construction', () => {
       runtime: 'uv',
     };
 
-    await executeDagWorkflow({
-      deps: createMockDeps(),
-      platform: createMockPlatform(),
-      conversationId: 'conv-deps',
-      cwd: testDir,
-      workflow: { name: 'deps-test', nodes: [node] },
-      workflowRun: makeWorkflowRun('deps-run-2'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(),
+        cwd: testDir,
+        workflow: { name: 'deps-test', nodes: [node] },
+        workflowRun: makeWorkflowRun('deps-run-2'),
+      })
+    );
 
     const calls = mockExecFileAsync.mock.calls;
     const scriptCall = calls.find(c => (c[0] as string) === 'uv');
@@ -356,22 +340,14 @@ describe('script node deps field — command construction', () => {
       deps: [],
     };
 
-    await executeDagWorkflow({
-      deps: createMockDeps(),
-      platform: createMockPlatform(),
-      conversationId: 'conv-deps',
-      cwd: testDir,
-      workflow: { name: 'deps-test', nodes: [node] },
-      workflowRun: makeWorkflowRun('deps-run-3'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(),
+        cwd: testDir,
+        workflow: { name: 'deps-test', nodes: [node] },
+        workflowRun: makeWorkflowRun('deps-run-3'),
+      })
+    );
 
     const calls = mockExecFileAsync.mock.calls;
     const scriptCall = calls.find(c => (c[0] as string) === 'uv');
@@ -390,22 +366,14 @@ describe('script node deps field — command construction', () => {
       deps: ['zod', 'node-fetch'],
     };
 
-    await executeDagWorkflow({
-      deps: createMockDeps(),
-      platform: createMockPlatform(),
-      conversationId: 'conv-deps',
-      cwd: testDir,
-      workflow: { name: 'deps-test', nodes: [node] },
-      workflowRun: makeWorkflowRun('deps-run-4'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(),
+        cwd: testDir,
+        workflow: { name: 'deps-test', nodes: [node] },
+        workflowRun: makeWorkflowRun('deps-run-4'),
+      })
+    );
 
     const calls = mockExecFileAsync.mock.calls;
     const scriptCall = calls.find(c => (c[0] as string) === 'bun');
@@ -426,22 +394,14 @@ describe('script node deps field — command construction', () => {
       runtime: 'bun',
     };
 
-    await executeDagWorkflow({
-      deps: createMockDeps(),
-      platform: createMockPlatform(),
-      conversationId: 'conv-deps',
-      cwd: testDir,
-      workflow: { name: 'deps-test', nodes: [node] },
-      workflowRun: makeWorkflowRun('deps-run-5'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(),
+        cwd: testDir,
+        workflow: { name: 'deps-test', nodes: [node] },
+        workflowRun: makeWorkflowRun('deps-run-5'),
+      })
+    );
 
     const calls = mockExecFileAsync.mock.calls;
     const scriptCall = calls.find(c => (c[0] as string) === 'bun');
@@ -466,22 +426,14 @@ describe('script node deps field — command construction', () => {
       deps: ['httpx'],
     };
 
-    await executeDagWorkflow({
-      deps: createMockDeps(),
-      platform: createMockPlatform(),
-      conversationId: 'conv-deps',
-      cwd: testDir,
-      workflow: { name: 'deps-test', nodes: [node] },
-      workflowRun: makeWorkflowRun('deps-run-6'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(),
+        cwd: testDir,
+        workflow: { name: 'deps-test', nodes: [node] },
+        workflowRun: makeWorkflowRun('deps-run-6'),
+      })
+    );
 
     const calls = mockExecFileAsync.mock.calls;
     const scriptCall = calls.find(c => (c[0] as string) === 'uv');
@@ -513,22 +465,14 @@ describe('script node deps field — command construction', () => {
       runtime: 'uv',
     };
 
-    await executeDagWorkflow({
-      deps: createMockDeps(),
-      platform: createMockPlatform(),
-      conversationId: 'conv-deps',
-      cwd: testDir,
-      workflow: { name: 'deps-test', nodes: [node] },
-      workflowRun: makeWorkflowRun('deps-run-7'),
-      workflowProvider: 'claude',
-      workflowModel: undefined,
-      artifactsDir: join(testDir, 'artifacts'),
-      stateDir: join(testDir, 'state'),
-      logDir: join(testDir, 'logs'),
-      baseBranch: 'main',
-      docsDir: 'docs/',
-      config: minimalConfig,
-    });
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(),
+        cwd: testDir,
+        workflow: { name: 'deps-test', nodes: [node] },
+        workflowRun: makeWorkflowRun('deps-run-7'),
+      })
+    );
 
     const calls = mockExecFileAsync.mock.calls;
     const scriptCall = calls.find(c => (c[0] as string) === 'uv');

--- a/packages/workflows/src/script-node-deps.test.ts
+++ b/packages/workflows/src/script-node-deps.test.ts
@@ -251,22 +251,22 @@ describe('script node deps field — command construction', () => {
       deps: ['httpx', 'beautifulsoup4'],
     };
 
-    await executeDagWorkflow(
-      createMockDeps(),
-      createMockPlatform(),
-      'conv-deps',
-      testDir,
-      { name: 'deps-test', nodes: [node] },
-      makeWorkflowRun('deps-run-1'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+    await executeDagWorkflow({
+      deps: createMockDeps(),
+      platform: createMockPlatform(),
+      conversationId: 'conv-deps',
+      cwd: testDir,
+      workflow: { name: 'deps-test', nodes: [node] },
+      workflowRun: makeWorkflowRun('deps-run-1'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const calls = mockExecFileAsync.mock.calls;
     const scriptCall = calls.find(c => (c[0] as string) === 'uv');
@@ -292,22 +292,22 @@ describe('script node deps field — command construction', () => {
       runtime: 'uv',
     };
 
-    await executeDagWorkflow(
-      createMockDeps(),
-      createMockPlatform(),
-      'conv-deps',
-      testDir,
-      { name: 'deps-test', nodes: [node] },
-      makeWorkflowRun('deps-run-2'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+    await executeDagWorkflow({
+      deps: createMockDeps(),
+      platform: createMockPlatform(),
+      conversationId: 'conv-deps',
+      cwd: testDir,
+      workflow: { name: 'deps-test', nodes: [node] },
+      workflowRun: makeWorkflowRun('deps-run-2'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const calls = mockExecFileAsync.mock.calls;
     const scriptCall = calls.find(c => (c[0] as string) === 'uv');
@@ -326,22 +326,22 @@ describe('script node deps field — command construction', () => {
       deps: [],
     };
 
-    await executeDagWorkflow(
-      createMockDeps(),
-      createMockPlatform(),
-      'conv-deps',
-      testDir,
-      { name: 'deps-test', nodes: [node] },
-      makeWorkflowRun('deps-run-3'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+    await executeDagWorkflow({
+      deps: createMockDeps(),
+      platform: createMockPlatform(),
+      conversationId: 'conv-deps',
+      cwd: testDir,
+      workflow: { name: 'deps-test', nodes: [node] },
+      workflowRun: makeWorkflowRun('deps-run-3'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const calls = mockExecFileAsync.mock.calls;
     const scriptCall = calls.find(c => (c[0] as string) === 'uv');
@@ -360,22 +360,22 @@ describe('script node deps field — command construction', () => {
       deps: ['zod', 'node-fetch'],
     };
 
-    await executeDagWorkflow(
-      createMockDeps(),
-      createMockPlatform(),
-      'conv-deps',
-      testDir,
-      { name: 'deps-test', nodes: [node] },
-      makeWorkflowRun('deps-run-4'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+    await executeDagWorkflow({
+      deps: createMockDeps(),
+      platform: createMockPlatform(),
+      conversationId: 'conv-deps',
+      cwd: testDir,
+      workflow: { name: 'deps-test', nodes: [node] },
+      workflowRun: makeWorkflowRun('deps-run-4'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const calls = mockExecFileAsync.mock.calls;
     const scriptCall = calls.find(c => (c[0] as string) === 'bun');
@@ -396,22 +396,22 @@ describe('script node deps field — command construction', () => {
       runtime: 'bun',
     };
 
-    await executeDagWorkflow(
-      createMockDeps(),
-      createMockPlatform(),
-      'conv-deps',
-      testDir,
-      { name: 'deps-test', nodes: [node] },
-      makeWorkflowRun('deps-run-5'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+    await executeDagWorkflow({
+      deps: createMockDeps(),
+      platform: createMockPlatform(),
+      conversationId: 'conv-deps',
+      cwd: testDir,
+      workflow: { name: 'deps-test', nodes: [node] },
+      workflowRun: makeWorkflowRun('deps-run-5'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const calls = mockExecFileAsync.mock.calls;
     const scriptCall = calls.find(c => (c[0] as string) === 'bun');
@@ -436,22 +436,22 @@ describe('script node deps field — command construction', () => {
       deps: ['httpx'],
     };
 
-    await executeDagWorkflow(
-      createMockDeps(),
-      createMockPlatform(),
-      'conv-deps',
-      testDir,
-      { name: 'deps-test', nodes: [node] },
-      makeWorkflowRun('deps-run-6'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+    await executeDagWorkflow({
+      deps: createMockDeps(),
+      platform: createMockPlatform(),
+      conversationId: 'conv-deps',
+      cwd: testDir,
+      workflow: { name: 'deps-test', nodes: [node] },
+      workflowRun: makeWorkflowRun('deps-run-6'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const calls = mockExecFileAsync.mock.calls;
     const scriptCall = calls.find(c => (c[0] as string) === 'uv');
@@ -483,22 +483,22 @@ describe('script node deps field — command construction', () => {
       runtime: 'uv',
     };
 
-    await executeDagWorkflow(
-      createMockDeps(),
-      createMockPlatform(),
-      'conv-deps',
-      testDir,
-      { name: 'deps-test', nodes: [node] },
-      makeWorkflowRun('deps-run-7'),
-      'claude',
-      undefined,
-      join(testDir, 'artifacts'),
-      join(testDir, 'state'),
-      join(testDir, 'logs'),
-      'main',
-      'docs/',
-      minimalConfig
-    );
+    await executeDagWorkflow({
+      deps: createMockDeps(),
+      platform: createMockPlatform(),
+      conversationId: 'conv-deps',
+      cwd: testDir,
+      workflow: { name: 'deps-test', nodes: [node] },
+      workflowRun: makeWorkflowRun('deps-run-7'),
+      workflowProvider: 'claude',
+      workflowModel: undefined,
+      artifactsDir: join(testDir, 'artifacts'),
+      stateDir: join(testDir, 'state'),
+      logDir: join(testDir, 'logs'),
+      baseBranch: 'main',
+      docsDir: 'docs/',
+      config: minimalConfig,
+    });
 
     const calls = mockExecFileAsync.mock.calls;
     const scriptCall = calls.find(c => (c[0] as string) === 'uv');

--- a/packages/workflows/src/script-node-deps.test.ts
+++ b/packages/workflows/src/script-node-deps.test.ts
@@ -45,7 +45,7 @@ mock.module('@archon/paths', () => ({
 }));
 
 // --- Imports (after all mock.module calls) ---
-import { executeDagWorkflow } from './dag-executor';
+import { executeDagWorkflow, type ExecuteDagWorkflowOptions } from './dag-executor';
 import type { ExecNode, WorkflowRun } from './schemas';
 import type { WorkflowDeps, IWorkflowPlatform, WorkflowConfig } from './deps';
 import type { IWorkflowStore } from './store';
@@ -219,6 +219,36 @@ const minimalConfig: WorkflowConfig = {
   commands: {},
   defaults: { loadDefaultCommands: false, loadDefaultWorkflows: false },
 };
+
+/**
+ * `deps`, `cwd`, `workflow`, and `workflowRun` carry each test's own fixtures, so every call
+ * supplies them; the run directories derive from `cwd` the way every call site built them.
+ */
+type DagOptionsOverrides = Partial<ExecuteDagWorkflowOptions> &
+  Pick<ExecuteDagWorkflowOptions, 'deps' | 'cwd' | 'workflow' | 'workflowRun'>;
+
+/**
+ * Options for a direct `executeDagWorkflow` call, built from only what a test varies. The
+ * defaults are the exact values these tests used to spell out at every call site. They are
+ * this file's own fixtures — `dag-executor.test.ts` has a builder of the same shape over its
+ * own mocks, and the two do not have to agree.
+ */
+function dagOptions(overrides: DagOptionsOverrides): ExecuteDagWorkflowOptions {
+  const { cwd } = overrides;
+  return {
+    platform: createMockPlatform(),
+    conversationId: 'conv-deps',
+    workflowProvider: 'claude',
+    workflowModel: undefined,
+    artifactsDir: join(cwd, 'artifacts'),
+    stateDir: join(cwd, 'state'),
+    logDir: join(cwd, 'logs'),
+    baseBranch: 'main',
+    docsDir: 'docs/',
+    config: minimalConfig,
+    ...overrides,
+  };
+}
 
 describe('script node deps field — command construction', () => {
   let testDir: string;


### PR DESCRIPTION
## Problem and outcome

`executeDagWorkflow` accepted 27 positional arguments, making call sites and mock assertions fragile when run state changes. This PR is PR-B of the #2302 series: it moves the DAG boundary to one named options object while preserving execution behavior.

- **Outcome:** Callers pass named DAG execution inputs, and tests assert named fields instead of tuple indexes.
- **Invariant:** `workflowModel` remains a required `string | undefined` option; DAG-derived state stays distinct from caller-supplied inputs.
- **Scope boundary:** This does not change workflow behavior, provider/model resolution, or the PR-A run-context work already merged in #3039.

## Review guidance

- **Feedback requested:** Confirm the input/derived boundary is correct and that no DAG execution values were lost or made optional.
- **Start here:** `packages/workflows/src/dag-executor.ts:9639` — the split between caller inputs, DAG-derived values, and mutable per-subgraph state.
- **Review order:** Review commit `902572031` for the type and production caller, then `311d1710d` for the mechanical direct-test-call migration and mock assertions, then `b76bc6931` for the options contract test.
- **Lower-attention areas:** `dag-executor.test.ts` and `script-node-deps.test.ts` are mechanical conversions of 442 direct calls; an AST comparison verified each retained argument and every call includes `workflowModel`.
- **Known risk or uncertainty:** None.

## Solution

`RunInputs` now owns the values supplied to the DAG boundary, while `RunDerived` holds the concrete run-layer values, including boundary normalizations. `RunLayersContext` combines those types with its per-subgraph mutable state. The exported `ExecuteDagWorkflowOptions` extends the input contract with the workflow and optional boundary inputs needed by callers.

`executeWorkflow` now calls `executeDagWorkflow` with named options. The executor locally destructures those options and explicitly builds its run context, normalizing boundary values before adding mutable subgraph state. Direct test calls and executor mocks use the same field names.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | DAG execution values were passed by position. | The same values are passed by descriptive option names. |
| **Failure behavior** | Positional argument ordering could be misread at call sites. | TypeScript rejects positional calls and rejects a missing required `workflowModel`. |

## Architecture

```mermaid
flowchart LR
  E[executeWorkflow] --> O[ExecuteDagWorkflowOptions]
  O --> I[RunInputs]
  O --> D[Boundary-derived values]
  I --> C[RunLayersContext]
  D --> C
  C --> R[runLayers]
```

### Changed seams

| Boundary or contract | Change | Evidence |
|---|---|---|
| `executeWorkflow` → `executeDagWorkflow` | One named options object replaces 27 positional arguments. | `packages/workflows/src/executor.ts:3045` |
| DAG boundary → `runLayers` | Caller inputs and derived context are separately typed before mutable subgraph state is added. | `packages/workflows/src/dag-executor.ts:9639` |
| Executor tests → DAG mock | Assertions select named options fields rather than numeric call indexes. | `packages/workflows/src/executor.test.ts` |

## Validation

- `bun install --frozen-lockfile` — passed; lockfile unchanged.
- `cd packages/workflows && bun x tsc --noEmit` — passed.
- `cd packages/workflows && bun test src/dag-executor.test.ts` — 703 passed, 0 failed.
- `cd packages/workflows && bun test src/executor.test.ts` — 136 passed, 0 failed.
- `cd packages/workflows && bun test src/script-node-deps.test.ts` — 7 passed, 0 failed.
- `cd packages/workflows && bun test src/executor-preamble.test.ts` — 7 passed, 0 failed.
- `bun run validate` — passed, including generated artifacts, type checks, lint, formatting, installer tests, package tests, and script tests.
- Temporary positional-transposition proof: TypeScript rejected the restored 14-argument call with `TS2554: Expected 1 arguments, but got 14`; reverted before validation.
- Temporary required-field proof: TypeScript rejected a production options object without `workflowModel` with `TS2345` because the property is required; reverted before validation.
- `git diff --check origin/dev...HEAD` — passed.
- **Not verified:** Nothing material; validation covers the type contract and existing DAG behavior.

## Links

- Relates to #2302
- Depends on #3039

## Follow-up: test call sites now pass only what they vary

Operator-directed simplification pass on the reviewed change. The 1:1 codemod was faithful
but left every test call spelling out all fourteen named options, so the conversion read as
the fields a test does not care about rather than as the run it configures. Net effect on the
two test files was only −180 lines, and 439 of the retained lines were `workflowModel: undefined`.

**The builder.** `dagOptions(overrides)` is test scaffolding, private to each test file — not
an engine export and not on any production path. It returns `ExecuteDagWorkflowOptions`, takes
`deps`, `cwd`, `workflow`, and `workflowRun` as required (they carry each test's own fixtures),
and defaults the rest. Each of the two files owns its own builder over its own mocks; the two
carry different values for `conversationId`, `config`, and `platform`, and neither has to agree
with the other for either to stay correct.

**Where the defaults came from.** They are not invented. Every call site's property values were
extracted with the TypeScript parser and tallied, and each default is the expression that
tally showed the call sites already passing — `'claude'`, `undefined`, `'main'`, `'docs/'`,
`minimalConfig`, `createMockPlatform()`, `'conv-dag'` (`'conv-deps'` in the smaller file). The
three run directories are derived from the call's own `cwd`, which is how every site built them.

**How the conversion was made.** An AST codemod, run once from a scratch directory and not
committed. It drops a property only when that property's exact source text equals the default
the builder would produce for that same call site, and never when the property carries a
comment; everything else is emitted verbatim, including the nested `loop_group` and
`compose_fan_out` fixtures. A hand pass over 34,000 lines is the transposition risk this
series exists to remove.

**Equivalence evidence.** A second pass re-parsed the rewritten files, recomputed each site's
`defaults + overrides`, and compared it against the property→expression map captured from the
same site before the rewrite, matching on AST shape so prettier's reflow and trailing commas
cannot mask a difference. All 442 sites matched with zero mismatches. The comparison was seen
red first: changing one builder default from `'docs/'` to `'docs'` reported 435 mismatches.

| | Before this pass | After |
|---|---|---|
| `dag-executor.test.ts` | 34,020 lines | 31,312 lines (**−2,708**) |
| `script-node-deps.test.ts` | 513 lines | 487 lines (**−26**) |
| `workflowModel: undefined` lines | 439 | 3 (two builder defaults, one contract fixture) |

Suite counts and assertion counts are identical on both sides, which is the behavioural half of
the equivalence claim:

- `dag-executor.test.ts` — 703 pass / 0 fail / 2078 `expect()` before and after.
- `script-node-deps.test.ts` — 7 pass / 0 fail / 36 `expect()` before and after.
- `executor.test.ts` — 136 pass / 0 fail / 319 `expect()`; untouched by this pass. Its named-field
  mock assertions read the options object the production caller builds, which the builder has no
  business in.

Unchanged by this pass: the production signature, `ExecuteDagWorkflowOptions`, and the decision
that `workflowModel` stays a required `string | undefined`. The builder supplying it as a default
does not weaken that guard, whose audience is production callers rather than tests. The
options-contract test still spells the full shape out and still holds the positional call under
`@ts-expect-error`. `cd packages/workflows && bun x tsc --noEmit` and `bun run validate` are both
green on the pushed head; `validate` ran the three suites at 703 / 136 / 7.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined workflow execution interfaces with clearly named options.
  * Organized workflow run inputs and derived execution details into consistent structures.
  * Preserved existing workflow execution behavior and results.

* **Tests**
  * Updated workflow execution tests for the new options-based interface.
  * Maintained coverage across configuration, resuming runs, paths, environments, telemetry, and workflow execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
