### PR TITLE
feat(console): multi-chat history, run chat tab, and live execution cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,10 +220,10 @@ Archon includes a web dashboard for chatting with your coding agent, running wor
 Register a project by clicking **+** next to "Project" in the chat sidebar - enter a GitHub URL or local path. Then start a conversation, invoke workflows, and watch progress in real time.
 
 **Key pages:**
-- **Chat** - Conversation interface with real-time streaming and tool call visualization
+- **Chat** - Conversation interface with multi-chat history, real-time streaming, run chat tabs, and tool call visualization
 - **Dashboard** - Mission Control for monitoring running workflows, with filterable history by project, status, and date
 - **Workflow Builder** - Visual drag-and-drop editor for creating DAG workflows with loop nodes
-- **Workflow Execution** - Step-by-step progress view for any running or completed workflow
+- **Workflow Execution** - Step-by-step progress view with live execution cards for running and completed workflows
 
 **Monitoring hub:** The sidebar shows conversations from **all platforms** - not just the web. Workflows kicked off from the CLI, messages from Slack or Telegram, GitHub issue interactions - everything appears in one place.
 

--- a/packages/docs-web/src/content/docs/adapters/web.md
+++ b/packages/docs-web/src/content/docs/adapters/web.md
@@ -173,6 +173,7 @@ Click a workflow run in the console to open its execution detail page at
 - The full DAG graph with per-node status
 - Execution status and authored outcome as separate labels when an outcome exists
 - Step-by-step logs for each node
+- Interactive run chat tab linked to the orchestrator conversation
 - Artifacts produced by the workflow
 - Actions to resume, cancel, or abandon the run
 

--- a/packages/server/src/routes/api.conversations.test.ts
+++ b/packages/server/src/routes/api.conversations.test.ts
@@ -3,6 +3,25 @@ import { OpenAPIHono } from '@hono/zod-openapi';
 import type { ConversationLockManager } from '@archon/core';
 import type { WebAdapter } from '../adapters/web';
 import { validationErrorHook } from './openapi-defaults';
+
+mock.module('../auth', () => ({
+  getAuth: () => null,
+  isWebAuthEnabled: () => false,
+  getSignupMode: () => 'disabled',
+  isApiGateEnabled: () => false,
+}));
+
+mock.module('@archon/core/db/users', () => ({
+  findOrCreateUserByPlatformIdentity: mock(async (_platform: string, platformUserId: string) => ({
+    id: `user-${platformUserId}`,
+    display_name: null,
+    email: null,
+    role: 'admin' as const,
+    created_at: new Date(),
+    updated_at: new Date(),
+  })),
+}));
+
 import { mockAllWorkflowModules } from '../test/workflow-mock-factories';
 
 const mockFindConversationByPlatformId = mock(
@@ -285,6 +304,51 @@ describe('PATCH /api/conversations/:id', () => {
     expect(response.status).toBe(200);
     const lastCall = mockUpdateConversationTitle.mock.calls.at(-1) as [string, string];
     expect(lastCall[1].length).toBe(255);
+  });
+
+  test('returns 403 when user does not own conversation', async () => {
+    mockFindConversationByPlatformId.mockImplementationOnce(async () => ({
+      ...MOCK_CONV,
+      user_id: 'user-bob',
+    }));
+
+    const app = new OpenAPIHono();
+    registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+
+    const authHeader = process.env.ARCHON_WEB_AUTH_HEADER || 'X-Archon-User';
+    const response = await app.request('/api/conversations/web-test-abc', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        [authHeader]: 'alice',
+      },
+      body: JSON.stringify({ title: 'New Title' }),
+    });
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toContain('Forbidden');
+  });
+
+  test('allows rename when user owns conversation', async () => {
+    mockFindConversationByPlatformId.mockImplementationOnce(async () => ({
+      ...MOCK_CONV,
+      user_id: 'user-alice',
+    }));
+    mockUpdateConversationTitle.mockImplementationOnce(async () => {});
+
+    const app = new OpenAPIHono();
+    registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+
+    const authHeader = process.env.ARCHON_WEB_AUTH_HEADER || 'X-Archon-User';
+    const response = await app.request('/api/conversations/web-test-abc', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        [authHeader]: 'alice',
+      },
+      body: JSON.stringify({ title: 'Alice Title' }),
+    });
+    expect(response.status).toBe(200);
   });
 });
 
@@ -658,5 +722,48 @@ describe('PATCH /api/conversations/:id — forge platform IDs with encoded slash
       body: JSON.stringify({ title: 'New Title' }),
     });
     expect(response.status).toBe(404);
+  });
+
+  test('returns 403 on delete when user does not own conversation', async () => {
+    mockFindConversationByPlatformId.mockImplementationOnce(async () => ({
+      ...FORGE_CONV,
+      user_id: 'user-bob',
+    }));
+
+    const app = new OpenAPIHono();
+    registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+
+    const authHeader = process.env.ARCHON_WEB_AUTH_HEADER || 'X-Archon-User';
+    const response = await app.request('/api/conversations/Solvation-BV%2FArchon%2342', {
+      method: 'DELETE',
+      headers: {
+        [authHeader]: 'alice',
+      },
+    });
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toContain('Forbidden');
+  });
+
+  test('allows delete when user owns conversation', async () => {
+    mockFindConversationByPlatformId.mockImplementationOnce(async () => ({
+      ...FORGE_CONV,
+      user_id: 'user-alice',
+    }));
+    mockSoftDeleteConversation.mockImplementationOnce(async () => {});
+
+    const app = new OpenAPIHono();
+    registerApiRoutes(app, {} as WebAdapter, {} as ConversationLockManager);
+
+    const authHeader = process.env.ARCHON_WEB_AUTH_HEADER || 'X-Archon-User';
+    const response = await app.request('/api/conversations/Solvation-BV%2FArchon%2342', {
+      method: 'DELETE',
+      headers: {
+        [authHeader]: 'alice',
+      },
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { success: boolean };
+    expect(body).toEqual({ success: true });
   });
 });

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -627,6 +627,7 @@ const updateConversationRoute = createRoute({
       description: 'Updated',
     },
     400: jsonError('Bad request'),
+    403: jsonError('Forbidden'),
     404: jsonError('Not found'),
     500: jsonError('Server error'),
   },
@@ -643,6 +644,7 @@ const deleteConversationRoute = createRoute({
       content: { 'application/json': { schema: successResponseSchema } },
       description: 'Deleted',
     },
+    403: jsonError('Forbidden'),
     404: jsonError('Not found'),
     500: jsonError('Server error'),
   },
@@ -1591,7 +1593,7 @@ export function registerApiRoutes(
 ): void {
   function apiError(
     c: Context,
-    status: 400 | 401 | 404 | 422 | 500 | 503,
+    status: 400 | 401 | 403 | 404 | 422 | 500 | 503,
     message: string,
     detail?: string
   ): Response {
@@ -2791,10 +2793,14 @@ export function registerApiRoutes(
   registerOpenApiRoute(updateConversationRoute, async c => {
     const platformId = c.req.param('id') ?? '';
     const { title } = getValidatedBody(c, updateConversationBodySchema);
+    const userId = await resolveWebUserId(c);
     try {
       const conv = await conversationDb.findConversationByPlatformId(platformId);
       if (!conv) {
         return apiError(c, 404, 'Conversation not found');
+      }
+      if (conv.user_id && userId && conv.user_id !== userId) {
+        return apiError(c, 403, 'Forbidden');
       }
       if (title !== undefined) {
         await conversationDb.updateConversationTitle(conv.id, title.slice(0, 255));
@@ -2812,10 +2818,14 @@ export function registerApiRoutes(
   // DELETE /api/conversations/:id - Soft delete
   registerOpenApiRoute(deleteConversationRoute, async c => {
     const platformId = c.req.param('id') ?? '';
+    const userId = await resolveWebUserId(c);
     try {
       const conv = await conversationDb.findConversationByPlatformId(platformId);
       if (!conv) {
         return apiError(c, 404, 'Conversation not found');
+      }
+      if (conv.user_id && userId && conv.user_id !== userId) {
+        return apiError(c, 403, 'Forbidden');
       }
       await conversationDb.softDeleteConversation(conv.id);
       return c.json({ success: true });
@@ -3553,7 +3563,32 @@ export function registerApiRoutes(
       } catch (e: unknown) {
         getLog().error({ err: e, conversationId }, 'conversation_lookup_failed');
       }
+      if (!conv) {
+        try {
+          conv = await conversationDb.getOrCreateConversation(
+            'web',
+            conversationId,
+            undefined,
+            undefined,
+            userId
+          );
+        } catch (e: unknown) {
+          getLog().error({ err: e, conversationId }, 'conversation_creation_failed');
+        }
+      }
+      if (!conv) {
+        return apiError(c, 500, 'Failed to initialize conversation for workflow execution');
+      }
       if (conv) {
+        if (!conv.hidden) {
+          try {
+            await conversationDb.updateConversation(conv.id, { hidden: true });
+            conv.hidden = true;
+          } catch (e: unknown) {
+            getLog().error({ err: e, conversationId: conv.id }, 'conversation_hide_failed');
+            throw e;
+          }
+        }
         try {
           const meta =
             savedFiles.length > 0

--- a/packages/server/src/routes/api.workflow-runs.test.ts
+++ b/packages/server/src/routes/api.workflow-runs.test.ts
@@ -10,6 +10,13 @@ import type { WorkflowRun } from '@archon/workflows/schemas/workflow-run';
 import { makeTestResolvedWorkflow } from '@archon/workflows/test-utils';
 import type { WebAdapter } from '../adapters/web';
 import { validationErrorHook } from './openapi-defaults';
+mock.module('../auth', () => ({
+  getAuth: () => null,
+  isWebAuthEnabled: () => false,
+  getSignupMode: () => 'disabled',
+  isApiGateEnabled: () => false,
+}));
+
 import {
   dashboardWorkflowRunSchema as apiDashboardWorkflowRunSchema,
   workflowRunSchema as apiWorkflowRunSchema,
@@ -299,22 +306,25 @@ mock.module('@archon/git', () => ({
   toWorktreePath: (p: string) => p,
 }));
 
+const mockGetOrCreateConversation = mock(async () => ({
+  id: 'internal-uuid-123',
+  platform_conversation_id: 'web-test-abc',
+  title: null,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  platform_type: 'web',
+  deleted_at: null,
+  codebase_id: null,
+  ai_assistant_type: 'claude',
+}));
+
 mock.module('@archon/core/db/conversations', () => ({
   findConversationByPlatformId: mockFindConversationByPlatformId,
   listConversations: mock(async () => []),
-  getOrCreateConversation: mock(async () => ({
-    id: 'internal-uuid-123',
-    platform_conversation_id: 'web-test-abc',
-    title: null,
-    created_at: new Date().toISOString(),
-    updated_at: new Date().toISOString(),
-    platform_type: 'web',
-    deleted_at: null,
-    codebase_id: null,
-    ai_assistant_type: 'claude',
-  })),
+  getOrCreateConversation: mockGetOrCreateConversation,
   softDeleteConversation: mock(async () => {}),
   updateConversationTitle: mock(async () => {}),
+  updateConversation: mock(async () => ({})),
   getConversationById: mockGetConversationById,
 }));
 
@@ -579,6 +589,24 @@ describe('POST /api/workflows/:name/run', () => {
     const body = (await response.json()) as { accepted: boolean; status: string };
     expect(body.accepted).toBe(true);
     expect(body.status).toBe('started');
+  });
+
+  test('fails closed with 500 when conversation lookup and creation both fail', async () => {
+    mockFindConversationByPlatformId.mockImplementationOnce(async () => null);
+    mockGetOrCreateConversation.mockImplementationOnce(async () => {
+      throw new Error('DB outage');
+    });
+
+    const { app } = makeApp();
+    const response = await app.request('/api/workflows/deploy/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ conversationId: 'web-test-abc', message: 'Deploy to staging' }),
+    });
+    expect(response.status).toBe(500);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toContain('Failed to initialize conversation');
+    expect(mockHandleMessage).not.toHaveBeenCalled();
   });
 
   test('sends /workflow run <name> <message> to orchestrator', async () => {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { Component } from 'react';
 import type { ReactNode, ErrorInfo } from 'react';
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router';
+import { BrowserRouter, Routes, Route, Navigate, useParams } from 'react-router';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { Layout } from '@/components/layout/Layout';
 import { ProjectProvider } from '@/contexts/ProjectContext';
@@ -63,6 +63,12 @@ class ErrorBoundary extends Component<{ children: ReactNode }, ErrorBoundaryStat
   }
 }
 
+export function ProjectRedirect(): React.ReactElement {
+  const { projectId, '*': rest } = useParams();
+  const target = rest ? `/console/p/${projectId}/${rest}` : `/console/p/${projectId}`;
+  return <Navigate to={target} replace />;
+}
+
 export function App(): React.ReactElement {
   return (
     <ErrorBoundary>
@@ -74,6 +80,8 @@ export function App(): React.ReactElement {
               <Route path="/login" element={<LoginPage />} />
               {/* The console is now the default UI. */}
               <Route path="/" element={<Navigate to="/console" replace />} />
+              <Route path="/p/:projectId/*" element={<ProjectRedirect />} />
+              <Route path="/p/:projectId" element={<ProjectRedirect />} />
               {/*
                 Console mounts OUTSIDE Layout (so it does not inherit TopNav) but
                 still INSIDE SessionGate — otherwise /console would bypass web auth

--- a/packages/web/src/experiments/console/ConsoleApp.tsx
+++ b/packages/web/src/experiments/console/ConsoleApp.tsx
@@ -79,6 +79,7 @@ export function ConsoleApp(): ReactElement {
             <Route path="_preview" element={<PreviewPage />} />
             <Route path="p/:projectId" element={<RunsPage />} />
             <Route path="p/:projectId/chat" element={<ChatPage />} />
+            <Route path="p/:projectId/chat/:convId" element={<ChatPage />} />
             <Route path="p/:projectId/r/:runId" element={<RunDetailPage />} />
           </Routes>
         </main>

--- a/packages/web/src/experiments/console/components/ChatComposer.tsx
+++ b/packages/web/src/experiments/console/components/ChatComposer.tsx
@@ -1,4 +1,4 @@
-import { Paperclip } from 'lucide-react';
+import { Paperclip, Square } from 'lucide-react';
 import { useRef, useState, type KeyboardEvent, type ReactElement } from 'react';
 import {
   ACCEPTED_EXTENSIONS,
@@ -9,14 +9,27 @@ import {
   isAcceptedFileType,
 } from '../primitives/file';
 
+/**
+ * Properties for the ChatComposer component.
+ */
 interface ChatComposerProps {
+  /** Callback fired when user sends a message or attached files. */
   onSend: (message: string, files?: File[]) => void;
+  /** Whether the composer inputs are disabled. */
   disabled: boolean;
+  /** Optional explanation tooltip displayed when composer is disabled. */
   disabledReason?: string;
+  /** Whether an active orchestrator turn is running. */
+  isRunning?: boolean;
+  /** Optional callback to abort the running turn. */
+  onStop?: () => void;
 }
 
 const MAX_HEIGHT = 200;
 
+/**
+ * Metadata for an attached file pending send.
+ */
 interface PickedFile {
   file: File;
   id: string;
@@ -39,6 +52,8 @@ export function ChatComposer({
   onSend,
   disabled,
   disabledReason,
+  isRunning = false,
+  onStop,
 }: ChatComposerProps): ReactElement {
   const [value, setValue] = useState('');
   const [files, setFiles] = useState<PickedFile[]>([]);
@@ -88,9 +103,9 @@ export function ChatComposer({
   };
 
   const submit = (): void => {
-    const trimmed = value.trim();
-    if (trimmed.length === 0 || disabled) return;
-    onSend(trimmed, files.length > 0 ? files.map(f => f.file) : undefined);
+    if (disabled || isRunning) return;
+    if (value.trim().length === 0 && files.length === 0) return;
+    onSend(value, files.length > 0 ? files.map(f => f.file) : undefined);
     setValue('');
     setFiles([]);
     setFileError(null);
@@ -203,18 +218,31 @@ export function ChatComposer({
             className="min-h-0 flex-1 resize-none bg-transparent py-[7px] text-[14.5px] leading-[1.5] text-text-primary placeholder:text-text-tertiary focus:outline-none disabled:opacity-50"
             style={{ maxHeight: `${MAX_HEIGHT.toString()}px` }}
           />
-          <button
-            type="button"
-            onClick={submit}
-            disabled={disabled || value.trim().length === 0}
-            title="Send · Enter"
-            className="brand-bar flex h-[36px] shrink-0 items-center gap-[7px] rounded-[10px] px-[15px] text-[13px] font-bold text-white shadow-[0_6px_18px_-8px_color-mix(in_oklch,var(--brand-magenta),transparent_30%)] transition-[filter,transform] hover:brightness-110 active:translate-y-[1px] disabled:opacity-45 disabled:shadow-none disabled:hover:brightness-100"
-          >
-            Send
-            <span aria-hidden className="font-mono text-[10px] opacity-70">
-              ↵
-            </span>
-          </button>
+          {isRunning ? (
+            <button
+              type="button"
+              onClick={onStop}
+              aria-label="Stop run"
+              title="Stop run"
+              className="flex h-[36px] shrink-0 items-center gap-[7px] rounded-[10px] bg-error px-[15px] text-[13px] font-bold text-white shadow-[0_6px_18px_-8px_color-mix(in_oklch,var(--error),transparent_30%)] transition-[filter,transform] hover:brightness-110 active:translate-y-[1px]"
+            >
+              <Square className="h-3.5 w-3.5 fill-current" />
+              Stop
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={submit}
+              disabled={disabled || (value.trim().length === 0 && files.length === 0)}
+              title="Send · Enter"
+              className="brand-bar flex h-[36px] shrink-0 items-center gap-[7px] rounded-[10px] px-[15px] text-[13px] font-bold text-white shadow-[0_6px_18px_-8px_color-mix(in_oklch,var(--brand-magenta),transparent_30%)] transition-[filter,transform] hover:brightness-110 active:translate-y-[1px] disabled:opacity-45 disabled:shadow-none disabled:hover:brightness-100"
+            >
+              Send
+              <span aria-hidden className="font-mono text-[10px] opacity-70">
+                ↵
+              </span>
+            </button>
+          )}
         </div>
         <div className="mt-[9px] flex items-center justify-between px-[2px] font-mono text-[11px] text-text-tertiary">
           <span />

--- a/packages/web/src/experiments/console/components/ChatHistoryPanel.tsx
+++ b/packages/web/src/experiments/console/components/ChatHistoryPanel.tsx
@@ -1,0 +1,304 @@
+import { useState, type ReactElement } from 'react';
+import { Check, Pencil, Plus, Trash2, X } from 'lucide-react';
+import { relativeTime } from '../lib/format';
+import type { ConversationSummary } from '../primitives/conversation';
+
+/**
+ * Properties for the ChatHistoryPanel component.
+ */
+export interface ChatHistoryPanelProps {
+  /** Array of project conversation summaries sorted by activity. */
+  conversations: ConversationSummary[];
+  /** Currently active/selected conversation platform ID. */
+  activeConvId: string | null;
+  /** Callback fired when user selects a conversation row. */
+  onSelectConversation: (convId: string) => void;
+  /** Callback fired when user clicks "+ New Chat". */
+  onNewChat: () => void;
+  /** Optional callback to rename a conversation. */
+  onRenameConversation?: (convId: string, newTitle: string) => Promise<void>;
+  /** Optional callback to delete a conversation. */
+  onDeleteConversation?: (convId: string) => Promise<void>;
+}
+
+/**
+ * Narrow right-hand chat history index for the console chat route.
+ * Shows project-scoped chat sessions sorted by last activity with a "+ New Chat" button,
+ * inline conversation renaming, and inline deletion confirmation.
+ */
+export function ChatHistoryPanel({
+  conversations,
+  activeConvId,
+  onSelectConversation,
+  onNewChat,
+  onRenameConversation,
+  onDeleteConversation,
+}: ChatHistoryPanelProps): ReactElement {
+  const [editingConvId, setEditingConvId] = useState<string | null>(null);
+  const [editTitle, setEditTitle] = useState('');
+  const [confirmDeleteConvId, setConfirmDeleteConvId] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleStartRename = (c: ConversationSummary): void => {
+    setConfirmDeleteConvId(null);
+    setEditingConvId(c.id);
+    setEditTitle(c.title?.trim() || 'Untitled Chat');
+  };
+
+  const handleCancelRename = (): void => {
+    setEditingConvId(null);
+    setEditTitle('');
+  };
+
+  const handleSaveRename = async (convId: string): Promise<void> => {
+    const trimmed = editTitle.trim();
+    if (!trimmed || isSubmitting) return;
+    setIsSubmitting(true);
+    try {
+      if (onRenameConversation) {
+        await onRenameConversation(convId, trimmed);
+      }
+      setEditingConvId(null);
+    } catch (err) {
+      console.error('Failed to update conversation title:', err);
+      // Keep edit mode open on failure
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleStartDelete = (convId: string): void => {
+    setEditingConvId(null);
+    setConfirmDeleteConvId(convId);
+  };
+
+  const handleCancelDelete = (): void => {
+    setConfirmDeleteConvId(null);
+  };
+
+  const handleConfirmDelete = async (convId: string): Promise<void> => {
+    if (isSubmitting) return;
+    setIsSubmitting(true);
+    try {
+      if (onDeleteConversation) {
+        await onDeleteConversation(convId);
+      }
+      setConfirmDeleteConvId(null);
+    } catch (err) {
+      console.error('Failed to delete conversation:', err);
+      // Keep confirm state open on failure
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <aside
+      aria-label="Chat history"
+      className="flex h-full w-64 shrink-0 flex-col border-l border-border bg-surface text-text-primary"
+    >
+      <div className="flex items-center justify-between border-b border-border px-4 py-3">
+        <h2 className="font-mono text-[11px] font-semibold uppercase tracking-[0.1em] text-text-secondary">
+          Chats
+        </h2>
+        <button
+          type="button"
+          onClick={onNewChat}
+          className="flex items-center gap-1.5 rounded-[7px] border border-border bg-surface-elevated px-2.5 py-1 text-[11.5px] font-medium text-text-primary transition-colors hover:border-border-bright hover:bg-surface-hover hover:text-text-primary active:scale-[0.98]"
+        >
+          <Plus size={13} className="text-accent" />
+          <span>New Chat</span>
+        </button>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-2">
+        {conversations.length === 0 ? (
+          <div className="flex h-32 items-center justify-center text-center font-mono text-[11px] text-text-tertiary">
+            No past chats
+          </div>
+        ) : (
+          <ul className="flex flex-col gap-1">
+            {conversations.map(c => {
+              const active = c.id === activeConvId;
+              const title = c.title?.trim() || 'Untitled Chat';
+              const time = c.lastActivityAt ? relativeTime(c.lastActivityAt) : null;
+
+              if (confirmDeleteConvId === c.id) {
+                return (
+                  <li key={c.id}>
+                    <div
+                      className={`flex w-full flex-col gap-1.5 rounded-[8px] p-2 text-left border ${
+                        active
+                          ? 'border-border-bright bg-surface-elevated text-text-primary'
+                          : 'border-border bg-surface-hover text-text-primary'
+                      }`}
+                    >
+                      <div className="flex items-center justify-between gap-1 text-[11px] font-medium text-error">
+                        <span>Delete chat?</span>
+                        <div className="flex items-center gap-1">
+                          <button
+                            type="button"
+                            disabled={isSubmitting}
+                            onClick={e => {
+                              e.stopPropagation();
+                              void handleConfirmDelete(c.id);
+                            }}
+                            className="rounded bg-error px-1.5 py-0.5 text-[11px] font-semibold text-white hover:bg-error/90 disabled:opacity-50"
+                          >
+                            Delete
+                          </button>
+                          <button
+                            type="button"
+                            disabled={isSubmitting}
+                            onClick={e => {
+                              e.stopPropagation();
+                              handleCancelDelete();
+                            }}
+                            className="rounded border border-border px-1.5 py-0.5 text-[11px] font-medium text-text-secondary hover:bg-surface hover:text-text-primary disabled:opacity-50"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </li>
+                );
+              }
+
+              if (editingConvId === c.id) {
+                return (
+                  <li key={c.id}>
+                    <div
+                      className={`flex w-full items-center gap-1 rounded-[8px] p-1.5 border ${
+                        active
+                          ? 'border-border-bright bg-surface-elevated text-text-primary'
+                          : 'border-border bg-surface-hover text-text-primary'
+                      }`}
+                      onClick={e => {
+                        e.stopPropagation();
+                      }}
+                    >
+                      <input
+                        type="text"
+                        autoFocus
+                        disabled={isSubmitting}
+                        value={editTitle}
+                        onChange={e => {
+                          setEditTitle(e.target.value);
+                        }}
+                        onKeyDown={e => {
+                          if (e.key === 'Enter') {
+                            e.preventDefault();
+                            void handleSaveRename(c.id);
+                          } else if (e.key === 'Escape') {
+                            e.preventDefault();
+                            handleCancelRename();
+                          }
+                        }}
+                        className="min-w-0 flex-1 rounded border border-border bg-surface px-1.5 py-0.5 text-[12px] text-text-primary focus:border-border-bright focus:outline-none"
+                      />
+                      <button
+                        type="button"
+                        title="Save title"
+                        aria-label="Save title"
+                        disabled={isSubmitting || !editTitle.trim()}
+                        onClick={e => {
+                          e.stopPropagation();
+                          void handleSaveRename(c.id);
+                        }}
+                        className="rounded p-1 text-text-tertiary transition-colors hover:bg-surface hover:text-text-primary disabled:opacity-50"
+                      >
+                        <Check size={12} />
+                      </button>
+                      <button
+                        type="button"
+                        title="Cancel rename"
+                        aria-label="Cancel rename"
+                        disabled={isSubmitting}
+                        onClick={e => {
+                          e.stopPropagation();
+                          handleCancelRename();
+                        }}
+                        className="rounded p-1 text-text-tertiary transition-colors hover:bg-surface hover:text-text-primary disabled:opacity-50"
+                      >
+                        <X size={12} />
+                      </button>
+                    </div>
+                  </li>
+                );
+              }
+
+              return (
+                <li key={c.id}>
+                  <div
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => {
+                      onSelectConversation(c.id);
+                    }}
+                    onKeyDown={e => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        onSelectConversation(c.id);
+                      }
+                    }}
+                    className={`group relative flex w-full cursor-pointer items-center justify-between rounded-[8px] p-2.5 text-left transition-colors ${
+                      active
+                        ? 'border border-border-bright bg-surface-elevated text-text-primary'
+                        : 'border border-transparent text-text-secondary hover:bg-surface-hover hover:text-text-primary'
+                    }`}
+                  >
+                    {active ? (
+                      <span
+                        aria-hidden
+                        className="brand-bar absolute inset-y-1 left-0 w-1 rounded-r-full"
+                      />
+                    ) : null}
+                    <div className="flex min-w-0 flex-1 flex-col items-start gap-1">
+                      <span className="w-full truncate text-[12.5px] font-medium leading-tight">
+                        {title}
+                      </span>
+                      {time !== null ? (
+                        <span className="font-mono text-[10.5px] text-text-tertiary">{time}</span>
+                      ) : null}
+                    </div>
+                    <div className="ml-1 hidden shrink-0 items-center gap-0.5 group-hover:flex group-focus-within:flex">
+                      {onRenameConversation !== undefined ? (
+                        <button
+                          type="button"
+                          title="Rename chat"
+                          aria-label={`Rename ${title}`}
+                          onClick={e => {
+                            e.stopPropagation();
+                            handleStartRename(c);
+                          }}
+                          className="rounded p-1 text-text-tertiary transition-colors hover:bg-surface hover:text-text-primary"
+                        >
+                          <Pencil size={12} />
+                        </button>
+                      ) : null}
+                      {onDeleteConversation !== undefined ? (
+                        <button
+                          type="button"
+                          title="Delete chat"
+                          aria-label={`Delete ${title}`}
+                          onClick={e => {
+                            e.stopPropagation();
+                            handleStartDelete(c.id);
+                          }}
+                          className="rounded p-1 text-text-tertiary transition-colors hover:bg-surface hover:text-error"
+                        >
+                          <Trash2 size={12} />
+                        </button>
+                      ) : null}
+                    </div>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/packages/web/src/experiments/console/components/ChatStream.tsx
+++ b/packages/web/src/experiments/console/components/ChatStream.tsx
@@ -1,10 +1,15 @@
 import { Fragment, type ReactElement } from 'react';
 import { MessageItem } from './MessageItem';
 import { ToolCallItem } from './ToolCallItem';
-import { ConsoleWorkflowResultCard } from './ConsoleWorkflowResultCard';
+import { WorkflowProgressCard } from './WorkflowProgressCard';
+import { WorkflowResultCard } from './WorkflowResultCard';
 import { isSystemCategory, type Message } from '../primitives/message';
 
+/**
+ * Properties for the ChatStream component.
+ */
 interface ChatStreamProps {
+  /** Ordered list of chat messages to display. */
   messages: Message[];
   /**
    * When false (default) the chat reads like a conversation: only user/assistant
@@ -13,6 +18,8 @@ interface ChatStreamProps {
    * indicator) the full trace is revealed inline.
    */
   showTools?: boolean;
+  /** Whether system category messages should be rendered. */
+  showSystem?: boolean;
 }
 
 /**
@@ -23,32 +30,42 @@ interface ChatStreamProps {
  * Wrap in <StreamContextProvider> upstream (ChatPage) so StreamCard timestamps
  * resolve — pass runStartedAt: null for wall-clock display.
  */
-export function ChatStream({ messages, showTools = false }: ChatStreamProps): ReactElement {
+export function ChatStream({
+  messages,
+  showTools = true,
+  showSystem = true,
+}: ChatStreamProps): ReactElement {
   // `workflow_result` messages are normally swept up by `isSystemCategory` (the
   // `workflow_` prefix), but they carry the run summary + a completion card — let
   // them through explicitly. Other `workflow_*` narration stays suppressed.
-  const visible = showTools
-    ? messages
-    : messages.filter(
-        m =>
-          m.category === 'workflow_result' ||
-          (!isSystemCategory(m.category) && m.content.trim().length > 0)
-      );
+  const visible = messages.filter(m => {
+    if (m.category === 'workflow_result') return true;
+    if (m.dispatch !== null && m.dispatch !== undefined) return true;
+    if (isSystemCategory(m.category) || m.role === 'system') return showSystem;
+    if (!showTools && m.content.trim().length === 0) return false;
+    return true;
+  });
 
   return (
     <div className="flex flex-col gap-[14px]">
       {visible.map(message => (
         <Fragment key={message.id}>
           {message.category === 'workflow_result' && message.workflowResult !== null ? (
-            <ConsoleWorkflowResultCard
+            <WorkflowResultCard
               runId={message.workflowResult.runId}
               workflowName={message.workflowResult.workflowName}
-              summary={message.content}
+              content={message.content}
             />
           ) : (
             <MessageItem message={message} />
           )}
-          {showTools
+          {message.dispatch?.workerConversationId ? (
+            <WorkflowProgressCard
+              workflowName={message.dispatch.workflowName}
+              workerConversationId={message.dispatch.workerConversationId}
+            />
+          ) : null}
+          {showTools && message.toolCalls && message.toolCalls.length > 0
             ? message.toolCalls.map((call, i) => (
                 <ToolCallItem
                   key={`${message.id}:tool:${i.toString()}`}

--- a/packages/web/src/experiments/console/components/MessageItem.tsx
+++ b/packages/web/src/experiments/console/components/MessageItem.tsx
@@ -7,11 +7,16 @@ import { AgentAvatar } from './AgentAvatar';
 import { formatClock } from '../lib/format';
 import type { Message } from '../primitives/message';
 
+/**
+ * Properties for the MessageItem component.
+ */
 interface MessageItemProps {
+  /** Message payload to render. */
   message: Message;
   /**
-   * `chat` (default) — Direction-B chat card. `log` — run-log styling
-   * (design v3 .log-agent-card): violet left accent + mono body, no avatar.
+   * Layout styling variant:
+   * `chat` (default) — Direction-B chat card.
+   * `log` — run-log styling (design v3 .log-agent-card): violet left accent + mono body, no avatar.
    */
   variant?: 'chat' | 'log';
 }
@@ -114,7 +119,7 @@ export function MessageItem({ message, variant = 'chat' }: MessageItemProps): Re
           </time>
         </header>
         <div
-          className="max-w-[76%] self-end rounded-[14px_14px_4px_14px] px-[17px] py-[13px] text-[14.5px] leading-[1.5] break-words"
+          className="max-w-[76%] self-end rounded-[14px_14px_4px_14px] px-[17px] py-[13px] text-[14.5px] leading-[1.5] break-words whitespace-pre-wrap"
           style={{
             background: 'color-mix(in oklch, var(--brand-magenta), transparent 94%)',
             border: '1px solid color-mix(in oklch, var(--brand-magenta), transparent 50%)',

--- a/packages/web/src/experiments/console/components/StreamToolbar.tsx
+++ b/packages/web/src/experiments/console/components/StreamToolbar.tsx
@@ -1,26 +1,47 @@
 import type { ReactElement, ReactNode } from 'react';
 
-export type DetailView = 'log' | 'graph' | 'artifacts';
+/**
+ * View modes supported by the run details and chat toolbar.
+ */
+export type DetailView = 'log' | 'chat' | 'graph' | 'artifacts';
 
+/**
+ * Filter option representing a distinct DAG node execution step.
+ */
 export interface NodeFilterOption {
+  /** Unique ID of the node. */
   id: string;
+  /** Human-readable node name. */
   name: string;
 }
 
+/**
+ * Properties for the StreamToolbar component.
+ */
 interface StreamToolbarProps {
+  /** Active view mode. */
   view: DetailView;
+  /** Callback fired when switching view modes. */
   onChangeView: (next: DetailView) => void;
+  /** Whether tool calls are currently visible. */
   showToolCalls: boolean;
+  /** Callback to toggle tool calls visibility. */
   onToggleToolCalls: (next: boolean) => void;
+  /** Whether system messages are currently visible. */
   showSystem: boolean;
+  /** Callback to toggle system messages visibility. */
   onToggleSystem: (next: boolean) => void;
+  /** Count of tool calls in the active run/chat. */
   toolCallCount: number;
+  /** Count of messages in the active run/chat. */
   messageCount: number;
+  /** Optional count of generated artifact files. */
   artifactCount: number | null;
   /** Distinct nodes in the run; empty hides the node filter. */
   nodeOptions: NodeFilterOption[];
-  /** `'all'` or a nodeId. */
+  /** Filter selection: `'all'` or a specific nodeId. */
   selectedNodeId: string;
+  /** Callback fired when selecting a node filter option. */
   onSelectNode: (next: string) => void;
 }
 
@@ -133,6 +154,13 @@ export function StreamToolbar({
           }}
         />
         <Tab
+          label="Chat"
+          active={view === 'chat'}
+          onClick={() => {
+            onChangeView('chat');
+          }}
+        />
+        <Tab
           label="Graph"
           active={view === 'graph'}
           onClick={() => {
@@ -149,15 +177,16 @@ export function StreamToolbar({
         />
       </div>
 
-      {isLog ? (
+      {isLog || view === 'chat' ? (
         <span className="ml-3 font-mono text-[12px] text-text-tertiary">
-          {messageCount.toString()} messages · {toolCallCount.toString()} tool calls
+          {messageCount.toString()} messages
+          {isLog ? ` · ${toolCallCount.toString()} tool calls` : ''}
         </span>
       ) : null}
 
-      {isLog ? (
+      {isLog || view === 'chat' ? (
         <div className="ml-auto flex items-center gap-[18px] font-mono text-[12px]">
-          {nodeOptions.length > 0 ? (
+          {isLog && nodeOptions.length > 0 ? (
             <label className="flex items-center gap-1.5 text-text-secondary">
               <span className="text-text-tertiary">Node</span>
               <SelectShell>

--- a/packages/web/src/experiments/console/components/WorkflowProgressCard.tsx
+++ b/packages/web/src/experiments/console/components/WorkflowProgressCard.tsx
@@ -1,0 +1,312 @@
+/* eslint-disable no-restricted-imports */
+import { useState, useEffect, useRef, type ReactElement } from 'react';
+import { useNavigate, useParams } from 'react-router';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { CheckCircle, ChevronRight, Loader2, Pause, XCircle } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { approveWorkflowRun, getWorkflowRunByWorker, rejectWorkflowRun } from '@/lib/api';
+import { useWorkflowStore } from '@/stores/workflow-store';
+import { ConfirmRunActionDialog } from '@/components/dashboard/ConfirmRunActionDialog';
+import { StatusIcon } from '@/components/workflows/StatusIcon';
+import { formatDurationMs } from '@/lib/format';
+import { isTerminalStatus } from '@/lib/workflow-utils';
+import type { DagNodeState } from '@/lib/types';
+
+/**
+ * Properties for the WorkflowProgressCard component.
+ */
+export interface WorkflowProgressCardProps {
+  /** Name of the workflow definition being executed. */
+  workflowName: string;
+  /** Worker conversation platform ID associated with the execution. */
+  workerConversationId: string;
+}
+
+/**
+ * Live DAG workflow execution card embedded directly in the chat stream.
+ * Displays real-time node progress, elapsed timer, and inline approval / pause gates.
+ */
+export function WorkflowProgressCard({
+  workflowName,
+  workerConversationId,
+}: WorkflowProgressCardProps): ReactElement {
+  const navigate = useNavigate();
+  const { projectId: routeProjectId } = useParams<{ projectId?: string }>();
+
+  // REST polling for run data (stops when terminal)
+  const {
+    data: runData,
+    isError,
+    refetch,
+  } = useQuery({
+    queryKey: ['workflowRunByWorker', workerConversationId],
+    queryFn: () => getWorkflowRunByWorker(workerConversationId),
+    refetchInterval: (query): number | false => {
+      const status = query.state.data?.run?.status;
+      if (status === 'completed' || status === 'failed' || status === 'cancelled') return false;
+      return 3000;
+    },
+  });
+
+  const runId = runData?.run?.id;
+  const restStatus = runData?.run?.status;
+  const projectId =
+    routeProjectId ??
+    runData?.run?.codebase_id ??
+    (runData?.run as { projectId?: string } | undefined)?.projectId;
+
+  // Live SSE state from Zustand store
+  const liveState = useWorkflowStore(state => (runId ? state.workflows.get(runId) : undefined));
+
+  // Merge: prefer live state when available
+  const status = liveState?.status ?? restStatus;
+  const dagNodes: DagNodeState[] = liveState?.dagNodes ?? [];
+  const currentTool = liveState?.currentTool ?? null;
+  const approval = liveState?.approval ?? null;
+  const error = liveState?.error;
+  const startedAt = liveState?.startedAt;
+
+  const completedCount = dagNodes.filter(n => n.status === 'completed').length;
+  const totalNodes = dagNodes.length;
+  const isRunning = status === 'running' || status === 'pending';
+  const isPaused = status === 'paused';
+
+  // Expand/collapse state
+  const [expanded, setExpanded] = useState(false);
+  const userToggled = useRef(false);
+
+  // Auto-expand when running or paused, auto-collapse when terminal (unless user toggled)
+  useEffect(() => {
+    if (userToggled.current) return;
+    if (isRunning || isPaused) {
+      setExpanded(true);
+    } else if (isTerminalStatus(status)) {
+      setExpanded(false);
+    }
+  }, [isRunning, isPaused, status]);
+
+  // Live elapsed timer
+  const [elapsed, setElapsed] = useState(0);
+  useEffect(() => {
+    if (!isRunning || !startedAt) return;
+    setElapsed(Date.now() - startedAt);
+    const interval = setInterval(() => {
+      setElapsed(Date.now() - startedAt);
+    }, 1000);
+    return (): void => {
+      clearInterval(interval);
+    };
+  }, [isRunning, startedAt]);
+
+  // Approve/reject mutations
+  const approveMutation = useMutation({
+    mutationFn: () => approveWorkflowRun(runId ?? ''),
+  });
+  const rejectMutation = useMutation({
+    mutationFn: (reason?: string) => rejectWorkflowRun(runId ?? '', reason),
+  });
+  const mutationError = approveMutation.error ?? rejectMutation.error;
+
+  // Completed duration from live state
+  const completedAt = liveState?.completedAt;
+  const finalDuration = completedAt && startedAt ? completedAt - startedAt : null;
+
+  const handleHeaderClick = (): void => {
+    userToggled.current = true;
+    setExpanded(prev => !prev);
+  };
+
+  const handleViewFullScreen = (): void => {
+    if (runId && projectId) {
+      void navigate(`/console/p/${projectId}/r/${runId}`);
+    } else if (runId) {
+      void navigate(`/console/r/${runId}`);
+    } else if (projectId) {
+      void navigate(`/console/p/${projectId}/chat/${encodeURIComponent(workerConversationId)}`);
+    } else {
+      void navigate(`/console/chat/${encodeURIComponent(workerConversationId)}`);
+    }
+  };
+
+  // Loading state: no run data yet
+  if (!runData && !isError) {
+    return (
+      <div className="flex items-center gap-2 rounded-lg border border-border bg-surface px-3 py-2 text-xs max-w-md">
+        <Loader2 className="h-3.5 w-3.5 animate-spin text-primary shrink-0" />
+        <span className="truncate text-text-primary font-medium">{workflowName}</span>
+        <span className="text-text-tertiary">Starting...</span>
+      </div>
+    );
+  }
+
+  // Error state: couldn't fetch run
+  if (isError && !runData) {
+    return (
+      <div className="flex items-center gap-2 rounded-lg border border-border bg-surface px-3 py-2 text-xs max-w-md">
+        <span className="text-error text-xs shrink-0">&#x26A0;</span>
+        <span className="truncate text-text-primary font-medium">{workflowName}</span>
+        <button
+          onClick={(): void => {
+            refetch();
+          }}
+          className="text-primary hover:text-accent-bright transition-colors shrink-0"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        'rounded-lg border border-border bg-surface transition-colors max-w-md overflow-hidden',
+        isRunning && 'border-l-2 border-l-primary',
+        isPaused && 'border-l-2 border-l-warning'
+      )}
+    >
+      {/* Header bar - always visible, clickable */}
+      <button
+        onClick={handleHeaderClick}
+        className="flex h-9 w-full items-center gap-2 px-3 text-left"
+      >
+        <ChevronRight
+          className={cn(
+            'h-3.5 w-3.5 shrink-0 text-text-tertiary transition-transform duration-150',
+            expanded && 'rotate-90'
+          )}
+        />
+        <span className="shrink-0">
+          <StatusIcon status={status ?? 'pending'} />
+        </span>
+        <span className="truncate text-xs font-medium text-text-primary">{workflowName}</span>
+        {totalNodes > 0 && (
+          <span className="shrink-0 text-[10px] text-text-secondary">
+            {String(completedCount)}/{String(totalNodes)} nodes
+          </span>
+        )}
+        <span className="ml-auto shrink-0">
+          {isRunning && elapsed > 0 ? (
+            <span className="rounded-full bg-primary/20 px-2 py-0.5 text-[10px] text-primary">
+              {formatDurationMs(elapsed)}
+            </span>
+          ) : finalDuration != null ? (
+            <span className="rounded-full bg-surface-elevated px-2 py-0.5 text-[10px] text-text-secondary">
+              {formatDurationMs(finalDuration)}
+            </span>
+          ) : null}
+        </span>
+      </button>
+
+      {/* Expanded body */}
+      {expanded && (
+        <div className="border-t border-border">
+          {/* Node list */}
+          {dagNodes.length > 0 && (
+            <div className="space-y-0.5 px-3 py-2">
+              {dagNodes.map((node: DagNodeState) => (
+                <div key={node.nodeId} className="flex items-center gap-2 text-xs py-0.5">
+                  <span className="shrink-0">
+                    <StatusIcon status={node.status} />
+                  </span>
+                  <span className="truncate flex-1 text-text-secondary">{node.name}</span>
+                  {node.duration !== undefined && (
+                    <span className="shrink-0 text-[10px] text-text-tertiary">
+                      {formatDurationMs(node.duration)}
+                    </span>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Approval request banner */}
+          {isPaused && (
+            <div className="border-t border-border px-3 py-2 space-y-2">
+              <div className="rounded-md bg-warning/5 border border-warning/20 px-3 py-2 flex items-start gap-2">
+                <Pause className="h-3.5 w-3.5 text-warning shrink-0 mt-0.5" />
+                <p className="text-xs text-text-secondary">
+                  {approval?.message ?? 'Waiting for approval'}
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() => {
+                    approveMutation.mutate();
+                  }}
+                  disabled={!runId || approveMutation.isPending || rejectMutation.isPending}
+                  className="flex items-center gap-1 rounded-md px-2 py-1 text-xs text-success/80 hover:bg-success/10 hover:text-success transition-colors disabled:opacity-50"
+                >
+                  <CheckCircle className="h-3.5 w-3.5" />
+                  Approve
+                </button>
+                <ConfirmRunActionDialog
+                  trigger={
+                    <button
+                      disabled={!runId || approveMutation.isPending || rejectMutation.isPending}
+                      className="flex items-center gap-1 rounded-md px-2 py-1 text-xs text-error/80 hover:bg-error/10 hover:text-error transition-colors disabled:opacity-50"
+                    >
+                      <XCircle className="h-3.5 w-3.5" />
+                      Reject
+                    </button>
+                  }
+                  title="Reject workflow?"
+                  description={
+                    <>
+                      Reject the paused workflow <strong>{workflowName}</strong>. If the approval
+                      node defines an <code>on_reject</code> prompt, it runs with your reason as{' '}
+                      <code>$REJECTION_REASON</code>; otherwise the run is cancelled.
+                    </>
+                  }
+                  confirmLabel="Reject"
+                  reasonInput={{
+                    label: 'Reason (optional)',
+                    placeholder: 'Why are you rejecting? Visible to the on_reject prompt.',
+                  }}
+                  onConfirm={(reason): void => {
+                    rejectMutation.mutate(reason);
+                  }}
+                />
+              </div>
+              {(approveMutation.isError || rejectMutation.isError) && (
+                <p className="text-xs text-error">
+                  {mutationError instanceof Error
+                    ? mutationError.message
+                    : 'Action failed — please try again'}
+                </p>
+              )}
+            </div>
+          )}
+
+          {/* Current tool activity */}
+          {currentTool?.status === 'running' && (
+            <div className="flex items-center gap-2 px-3 py-1.5 text-xs border-t border-border">
+              <Loader2 className="h-3 w-3 animate-spin text-primary shrink-0" />
+              <span className="truncate font-mono text-primary">{currentTool.name}</span>
+            </div>
+          )}
+
+          {/* Error message */}
+          {status === 'failed' && error && (
+            <div
+              className="px-3 py-1.5 text-xs text-error border-t border-border truncate"
+              title={error}
+            >
+              {error.slice(0, 120)}
+            </div>
+          )}
+
+          {/* Footer: View Full Screen */}
+          <div className="border-t border-border px-3 py-1.5">
+            <button
+              onClick={handleViewFullScreen}
+              className="text-[10px] text-primary hover:text-accent-bright transition-colors"
+            >
+              View Full Screen &rarr;
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/experiments/console/components/WorkflowResultCard.test.ts
+++ b/packages/web/src/experiments/console/components/WorkflowResultCard.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'bun:test';
+import { extractArtifactInfo } from './WorkflowResultCard';
+
+describe('extractArtifactInfo', () => {
+  it('should extract runId and filename from standard artifact path with forward slashes', () => {
+    const text = 'artifacts/runs/64d87e85-2581-41aa-8407-233018ba2a1b/review/fix-report.md';
+    const result = extractArtifactInfo(text);
+    expect(result).toEqual({
+      runId: '64d87e85-2581-41aa-8407-233018ba2a1b',
+      filename: 'review/fix-report.md',
+    });
+  });
+
+  it('should extract runId and filename from artifact path with backslashes', () => {
+    const text = 'artifacts\\runs\\64d87e85-2581-41aa-8407-233018ba2a1b\\summary.json';
+    const result = extractArtifactInfo(text);
+    expect(result).toEqual({
+      runId: '64d87e85-2581-41aa-8407-233018ba2a1b',
+      filename: 'summary.json',
+    });
+  });
+
+  it('should extract runId and filename from embedded path in text', () => {
+    const text =
+      'Saved report at /workspace/project/artifacts/runs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/output.txt';
+    const result = extractArtifactInfo(text);
+    expect(result).toEqual({
+      runId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      filename: 'output.txt',
+    });
+  });
+
+  it('should return null when path contains path traversal components (..)', () => {
+    const text = 'artifacts/runs/64d87e85-2581-41aa-8407-233018ba2a1b/../secret.env';
+    const result = extractArtifactInfo(text);
+    expect(result).toBeNull();
+  });
+
+  it('should return null for non-artifact text', () => {
+    expect(extractArtifactInfo('hello world')).toBeNull();
+    expect(extractArtifactInfo('/var/log/app.log')).toBeNull();
+    expect(extractArtifactInfo('')).toBeNull();
+  });
+});

--- a/packages/web/src/experiments/console/components/WorkflowResultCard.tsx
+++ b/packages/web/src/experiments/console/components/WorkflowResultCard.tsx
@@ -1,0 +1,298 @@
+/* eslint-disable no-restricted-imports */
+import { useState, useMemo, type ReactElement } from 'react';
+import { useNavigate, useParams } from 'react-router';
+import { useQuery } from '@tanstack/react-query';
+import ReactMarkdown, { type Components } from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { useWorkflowStore } from '@/stores/workflow-store';
+import { getWorkflowRun } from '@/lib/api';
+import { StatusIcon } from '@/components/workflows/StatusIcon';
+import { ArtifactSummary } from '@/components/workflows/ArtifactSummary';
+import { ArtifactViewerModal } from '@/components/workflows/ArtifactViewerModal';
+import { formatDurationMs, ensureUtc } from '@/lib/format';
+import type { WorkflowArtifact, ArtifactType } from '@/lib/types';
+
+// Matches artifact paths (forward- and back-slash safe); groups: [1] runId, [2] filename
+const ARTIFACT_PATH_RE = /artifacts[/\\]runs[/\\]([a-fA-F0-9-]+)[/\\](.+)/;
+
+/**
+ * Extracts the run ID and artifact relative filename from a text snippet or path.
+ * Defends against path traversal sequences.
+ *
+ * @param text - Path or message snippet containing artifact location
+ * @returns Object with runId and cleaned filename, or null if no valid artifact path found
+ */
+export function extractArtifactInfo(text: string): { runId: string; filename: string } | null {
+  const match = ARTIFACT_PATH_RE.exec(text);
+  if (!match) return null;
+  const filename = match[2].replace(/\\/g, '/');
+  if (filename.split('/').some(s => s === '..')) return null;
+  return { runId: match[1], filename };
+}
+
+/**
+ * Generates custom markdown renderers with interactive linkification for workflow artifacts.
+ *
+ * @param onArtifactClick - Callback fired when a markdown artifact link is clicked
+ * @returns React Markdown components map
+ */
+export function makeResultMarkdownComponents(
+  onArtifactClick: (runId: string, filename: string) => void
+): Components {
+  return {
+    a: ({ children, ...props }: React.ComponentPropsWithoutRef<'a'>): ReactElement => (
+      <a
+        className="text-primary underline decoration-primary/40 hover:decoration-primary"
+        target="_blank"
+        rel="noopener noreferrer"
+        {...props}
+      >
+        {children}
+      </a>
+    ),
+    code: ({
+      children,
+      className,
+      ...props
+    }: React.ComponentPropsWithoutRef<'code'> & { className?: string }): ReactElement => {
+      const isBlock = className?.startsWith('language-') || className?.startsWith('hljs');
+      if (isBlock) {
+        return (
+          <code className={className} {...props}>
+            {children}
+          </code>
+        );
+      }
+      if (typeof children === 'string') {
+        const artifact = extractArtifactInfo(children);
+        if (artifact) {
+          const { runId, filename } = artifact;
+          const displayName = filename.split('/').pop() ?? filename;
+          const encodedFilename = filename.split('/').map(encodeURIComponent).join('/');
+          const artifactHref = `/api/artifacts/${encodeURIComponent(runId)}/${encodedFilename}`;
+          return (
+            <a
+              href={artifactHref}
+              onClick={
+                filename.endsWith('.md')
+                  ? (e: React.MouseEvent): void => {
+                      e.preventDefault();
+                      onArtifactClick(runId, filename);
+                    }
+                  : undefined
+              }
+              target={filename.endsWith('.md') ? undefined : '_blank'}
+              rel={filename.endsWith('.md') ? undefined : 'noopener noreferrer'}
+              className="!text-accent-bright hover:!text-primary font-mono font-medium underline decoration-accent-bright/40 hover:decoration-accent-bright"
+            >
+              {displayName}
+            </a>
+          );
+        }
+      }
+      return (
+        <code className="rounded bg-surface-elevated px-1 py-0.5 font-mono text-[0.9em]" {...props}>
+          {children}
+        </code>
+      );
+    },
+  };
+}
+
+/**
+ * Properties for the WorkflowResultCard component.
+ */
+export interface WorkflowResultCardProps {
+  /** Workflow run ID. */
+  runId: string;
+  /** Name of the workflow definition that completed. */
+  workflowName: string;
+  /** Markdown content summarizing the run outcome. */
+  content: string;
+}
+
+/**
+ * Result card rendered in the chat stream when a workflow execution concludes.
+ * Surfaces execution status, duration, completed node count, and interactive artifact summaries.
+ */
+export function WorkflowResultCard({
+  workflowName,
+  runId,
+  content,
+}: WorkflowResultCardProps): ReactElement {
+  const navigate = useNavigate();
+  const { projectId: routeProjectId } = useParams<{ projectId?: string }>();
+  const [expanded, setExpanded] = useState(false);
+  const [artifactViewer, setArtifactViewer] = useState<{
+    runId: string;
+    filename: string;
+  } | null>(null);
+
+  // setArtifactViewer is a stable React state setter — empty dep array is intentional
+  const mdComponents = useMemo(
+    () =>
+      makeResultMarkdownComponents((aRunId, filename) => {
+        setArtifactViewer({ runId: aRunId, filename });
+      }),
+    []
+  );
+
+  // Zustand live state (populated if user had the page open during execution)
+  const liveState = useWorkflowStore(state => state.workflows.get(runId));
+
+  // One-time API fetch: staleTime: Infinity because a terminal run record is immutable —
+  // status, timestamps, and events do not change once completed/failed/cancelled.
+  const { data: runData, isError } = useQuery({
+    queryKey: ['workflowRun', runId],
+    queryFn: () => getWorkflowRun(runId),
+    staleTime: Infinity,
+  });
+
+  const projectId =
+    routeProjectId ??
+    runData?.run?.codebase_id ??
+    (liveState as { projectId?: string } | undefined)?.projectId;
+
+  // Merge: prefer live state when available
+  const status = liveState?.status ?? runData?.run?.status ?? 'completed';
+  const dagNodes = liveState?.dagNodes ?? [];
+  const storeArtifacts = liveState?.artifacts ?? [];
+  const startedAt =
+    liveState?.startedAt ??
+    (runData?.run?.started_at ? new Date(ensureUtc(runData.run.started_at)).getTime() : null);
+  const completedAt =
+    liveState?.completedAt ??
+    (runData?.run?.completed_at ? new Date(ensureUtc(runData.run.completed_at)).getTime() : null);
+  const duration = startedAt != null && completedAt != null ? completedAt - startedAt : null;
+
+  // Node counts: prefer live dagNodes (exact), fall back to events (approximation —
+  // totalCount is nodes that reached a terminal state, not the workflow's full node count).
+  let completedCount: number;
+  let totalCount: number;
+  if (dagNodes.length > 0) {
+    completedCount = dagNodes.filter(n => n.status === 'completed').length;
+    // Only count terminal nodes (same semantics as events fallback path)
+    totalCount = dagNodes.filter(
+      n => n.status === 'completed' || n.status === 'failed' || n.status === 'skipped'
+    ).length;
+  } else {
+    const events = runData?.events ?? [];
+    const terminalEvents = events.filter(
+      e =>
+        e.event_type === 'node_completed' ||
+        e.event_type === 'node_failed' ||
+        e.event_type === 'node_skipped'
+    );
+    completedCount = events.filter(e => e.event_type === 'node_completed').length;
+    totalCount = terminalEvents.length;
+  }
+
+  // Artifacts: prefer live store, fall back to events
+  const eventArtifacts: WorkflowArtifact[] = (runData?.events ?? [])
+    .filter(e => e.event_type === 'workflow_artifact')
+    .map(e => {
+      const d = e.data;
+      return {
+        type: (typeof d.artifactType === 'string'
+          ? d.artifactType
+          : 'file_created') as ArtifactType,
+        label: typeof d.label === 'string' ? d.label : '',
+        url: typeof d.url === 'string' ? d.url : undefined,
+        path: typeof d.path === 'string' ? d.path : undefined,
+      };
+    });
+  const artifacts = storeArtifacts.length > 0 ? storeArtifacts : eventArtifacts;
+
+  // If API fetch failed and no live state, show degraded card with just content + link
+  const fetchFailed = isError && !liveState;
+
+  // Status-aware header title
+  let headerTitle: string;
+  if (status === 'failed') {
+    headerTitle = 'Workflow failed';
+  } else if (status === 'cancelled') {
+    headerTitle = 'Workflow cancelled';
+  } else {
+    headerTitle = 'Workflow complete';
+  }
+
+  // Expand/collapse for text content
+  const lines = content.split('\n');
+  const isTruncatable = content.length > 500 || lines.length > 8;
+  const previewText = lines.slice(0, 8).join('\n').slice(0, 500);
+  const preview = isTruncatable
+    ? previewText + (previewText.length < content.length ? '...' : '')
+    : content;
+  const displayContent = expanded || !isTruncatable ? content : preview;
+
+  const handleViewFullLogs = (): void => {
+    if (projectId) {
+      void navigate(`/console/p/${projectId}/r/${runId}`);
+    } else {
+      void navigate(`/console/r/${runId}`);
+    }
+  };
+
+  return (
+    <>
+      <div className="rounded-lg border border-border bg-surface overflow-hidden max-w-3xl">
+        <div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-surface-elevated">
+          <span className="shrink-0">
+            <StatusIcon status={fetchFailed ? 'completed' : status} />
+          </span>
+          <span className="text-xs font-medium text-text-primary truncate flex-1">
+            {headerTitle}: {workflowName}
+          </span>
+          {!fetchFailed && totalCount > 0 && (
+            <span className="shrink-0 text-[10px] text-text-secondary">
+              {completedCount}/{totalCount} nodes
+            </span>
+          )}
+          {!fetchFailed && duration != null && (
+            <span className="rounded-full bg-surface px-2 py-0.5 text-[10px] text-text-secondary shrink-0">
+              {formatDurationMs(duration)}
+            </span>
+          )}
+          <button
+            onClick={handleViewFullLogs}
+            className="text-[10px] text-primary hover:text-accent-bright transition-colors shrink-0"
+          >
+            View full logs &rarr;
+          </button>
+        </div>
+        <div className="px-3 py-2">
+          {!fetchFailed && artifacts.length > 0 && (
+            <div className="mb-2">
+              <ArtifactSummary artifacts={artifacts} runId={runId} />
+            </div>
+          )}
+          <div className="chat-markdown text-xs text-text-secondary">
+            <ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>
+              {displayContent}
+            </ReactMarkdown>
+          </div>
+          {isTruncatable && (
+            <button
+              onClick={(): void => {
+                setExpanded(!expanded);
+              }}
+              className="mt-1 text-[10px] text-primary hover:text-accent-bright transition-colors"
+            >
+              {expanded ? 'Show less' : 'Show more'}
+            </button>
+          )}
+        </div>
+      </div>
+      {artifactViewer && (
+        <ArtifactViewerModal
+          open={true}
+          onOpenChange={(): void => {
+            setArtifactViewer(null);
+          }}
+          runId={artifactViewer.runId}
+          filename={artifactViewer.filename}
+        />
+      )}
+    </>
+  );
+}

--- a/packages/web/src/experiments/console/primitives/run.ts
+++ b/packages/web/src/experiments/console/primitives/run.ts
@@ -1,6 +1,9 @@
 import type { RunStatus } from '../lib/run-status';
 import type { components } from '@/lib/api.generated';
 
+/**
+ * Origin platform where a workflow run was triggered.
+ */
 export type RunOrigin = 'web' | 'cli' | 'slack' | 'telegram' | 'discord' | 'github' | 'unknown';
 export type RunOutcome = components['schemas']['WorkflowRunOutcome'];
 type WorkflowRunMetadata = components['schemas']['WorkflowRunMetadata'];
@@ -38,6 +41,8 @@ export interface Run {
    * runMessageConversationId() for how CLI vs. web runs are picked (#2048).
    */
   workerPlatformId: string | null;
+  /** Platform id of the parent orchestrator conversation that spawned this run. */
+  parentPlatformId?: string | null;
   workflow: string;
   origin: RunOrigin;
   status: RunStatus;
@@ -99,6 +104,8 @@ interface RawWorkflowRun {
   conversation_platform_id?: string | null;
   /** Worker conversation platform id — getRun response only, web runs only. */
   worker_platform_id?: string | null;
+  /** Parent orchestrator conversation platform id — getRun response only. */
+  parent_platform_id?: string | null;
   status: string;
   outcome?: RunOutcome;
   started_at: string;
@@ -236,6 +243,7 @@ export function toRun(raw: RawWorkflowRun): Run {
     conversationId: raw.conversation_id ?? null,
     conversationPlatformId: raw.conversation_platform_id ?? null,
     workerPlatformId: raw.worker_platform_id ?? null,
+    parentPlatformId: raw.parent_platform_id ?? null,
     workflow: raw.workflow_name,
     origin: normalizeOrigin(raw.platform_type),
     status: normalizeStatus(raw.status),

--- a/packages/web/src/experiments/console/routes/ChatPage.test.ts
+++ b/packages/web/src/experiments/console/routes/ChatPage.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'bun:test';
+import { resolveNextActiveConversation } from './ChatPage';
+
+describe('resolveNextActiveConversation', () => {
+  it('should keep active conversation if deleted conversation is not active', () => {
+    const convs = [{ id: 'conv-1' }, { id: 'conv-2' }, { id: 'conv-3' }];
+    const result = resolveNextActiveConversation('conv-2', 'conv-1', convs);
+    expect(result).toBe('conv-1');
+  });
+
+  it('should select next remaining conversation when active is deleted', () => {
+    const convs = [{ id: 'conv-1' }, { id: 'conv-2' }, { id: 'conv-3' }];
+    const result = resolveNextActiveConversation('conv-1', 'conv-1', convs);
+    expect(result).toBe('conv-2');
+  });
+
+  it('should select remaining conversation when active is last in list', () => {
+    const convs = [{ id: 'conv-1' }, { id: 'conv-2' }];
+    const result = resolveNextActiveConversation('conv-2', 'conv-2', convs);
+    expect(result).toBe('conv-1');
+  });
+
+  it('should return null when the sole remaining conversation is deleted', () => {
+    const convs = [{ id: 'conv-1' }];
+    const result = resolveNextActiveConversation('conv-1', 'conv-1', convs);
+    expect(result).toBeNull();
+  });
+
+  it('should return null when conversation list is empty', () => {
+    const result = resolveNextActiveConversation('conv-1', 'conv-1', []);
+    expect(result).toBeNull();
+  });
+
+  it('should handle null activeId gracefully', () => {
+    const convs = [{ id: 'conv-1' }, { id: 'conv-2' }];
+    const result = resolveNextActiveConversation('conv-1', null, convs);
+    expect(result).toBeNull();
+  });
+});

--- a/packages/web/src/experiments/console/routes/ChatPage.tsx
+++ b/packages/web/src/experiments/console/routes/ChatPage.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
-import { useParams } from 'react-router';
+import { useNavigate, useParams } from 'react-router';
 import { ChatStream } from '../components/ChatStream';
 import { ChatComposer } from '../components/ChatComposer';
+import { ChatHistoryPanel } from '../components/ChatHistoryPanel';
 import { ProjectViewTabs } from '../components/ProjectViewTabs';
 import { WorkingIndicator } from '../components/WorkingIndicator';
 import { WorkflowDock } from '../components/WorkflowDock';
@@ -10,10 +11,13 @@ import { StreamContextProvider } from '../lib/stream-context';
 import { useConversationSSE } from '../lib/sse';
 import { useEntity, invalidate } from '../store/cache';
 import { K } from '../store/keys';
+import { ensureUtc } from '../lib/format';
 import * as skill from '../skills';
 import type { Project } from '../primitives/project';
 import type { Message } from '../primitives/message';
 import type { ConversationSummary } from '../primitives/conversation';
+import type { Run } from '../primitives/run';
+import type { RunCounts } from '../skills/runs';
 
 // While a turn is active, refetch messages on this cadence so streamed replies
 // still surface if a per-conversation SSE event is dropped (cross-origin
@@ -30,18 +34,30 @@ const MAX_WAIT_MS = 300_000;
 const NEAR_BOTTOM_PX = 120;
 
 /**
- * Project-scoped agent chat. A tab peer of the runs view under a project.
+ * Resolves the next active conversation ID when a conversation is deleted.
  *
- * MVP conversation model: one active conversation per project — the most-recent
- * web conversation, or created lazily on first send. No multi-conversation
- * sidebar yet (spike decision #3, deferred).
- *
- * Data flow mirrors RunDetailPage: load messages via useEntity(K.messages),
- * keep live via useConversationSSE (invalidate → refetch), render with the
- * shared MessageItem/ToolCallItem cards inside a StreamContextProvider.
+ * @param deletedId - ID of the conversation being deleted
+ * @param activeId - Currently active conversation ID
+ * @param conversations - List of remaining conversation summaries
+ * @returns Next conversation ID to select, or null if list is empty
+ */
+export function resolveNextActiveConversation(
+  deletedId: string,
+  activeId: string | null,
+  conversations: { id: string }[]
+): string | null {
+  if (activeId !== deletedId) return activeId;
+  const remaining = conversations.filter(c => c.id !== deletedId);
+  return remaining.length > 0 ? (remaining[0]?.id ?? null) : null;
+}
+
+/**
+ * Console project chat page supporting multi-conversation sidebar management,
+ * message streaming, interactive workflow execution cards, and live thread selection.
  */
 export function ChatPage(): ReactElement {
-  const { projectId } = useParams<{ projectId: string }>();
+  const { projectId, convId } = useParams<{ projectId: string; convId?: string }>();
+  const navigate = useNavigate();
 
   const { data: project } = useEntity<Project | null>(
     projectId !== undefined ? K.project(projectId) : 'noop:no-project',
@@ -53,13 +69,143 @@ export function ChatPage(): ReactElement {
     () => (projectId !== undefined ? skill.listConversations(projectId) : Promise.resolve([]))
   );
 
-  // Active conversation: most-recent web conversation, else null until first send.
-  const [activeConvId, setActiveConvId] = useState<string | null>(null);
+  const { data: runsData } = useEntity<{ runs: Run[]; counts: RunCounts; total: number }>(
+    projectId !== undefined ? K.runs(projectId) : 'noop:no-project-runs',
+    () =>
+      projectId !== undefined
+        ? skill.listRuns({ codebaseId: projectId })
+        : Promise.resolve({
+            runs: [],
+            counts: {
+              all: 0,
+              running: 0,
+              paused: 0,
+              failed: 0,
+              completed: 0,
+              cancelled: 0,
+              pending: 0,
+            },
+            total: 0,
+          })
+  );
+
+  const workflowConvIds = useMemo(() => {
+    const runs = runsData?.runs ?? [];
+    return new Set(
+      runs.flatMap(r => {
+        const runWithWorker = r as Run & {
+          worker_platform_id?: string | null;
+        };
+        return [r.workerPlatformId, runWithWorker.worker_platform_id].filter((id): id is string =>
+          Boolean(id)
+        );
+      })
+    );
+  }, [runsData]);
+
+  const userChats = useMemo(() => {
+    const list = (conversations ?? []).filter(c => {
+      if (c.platformType !== 'web') return false;
+      const conv = c as ConversationSummary & {
+        platformConversationId?: string;
+        dbId?: string;
+      };
+      if (workflowConvIds.has(c.id)) return false;
+      if (conv.platformConversationId && workflowConvIds.has(conv.platformConversationId)) {
+        return false;
+      }
+      if (conv.dbId && workflowConvIds.has(conv.dbId)) {
+        return false;
+      }
+      return true;
+    });
+    return list.sort((a, b) => {
+      const timeA = a.lastActivityAt ? new Date(ensureUtc(a.lastActivityAt)).getTime() : 0;
+      const timeB = b.lastActivityAt ? new Date(ensureUtc(b.lastActivityAt)).getTime() : 0;
+      return timeB - timeA;
+    });
+  }, [conversations, workflowConvIds]);
+
+  // Active conversation state.
+  const [activeConvId, setActiveConvId] = useState<string | null>(convId ?? null);
+  const hasInitializedRef = useRef(false);
+
+  // Synchronize when route convId changes.
   useEffect(() => {
-    if (activeConvId !== null) return;
-    const web = (conversations ?? []).find(c => c.platformType === 'web');
-    if (web !== undefined) setActiveConvId(web.id);
-  }, [conversations, activeConvId]);
+    setActiveConvId(convId ?? null);
+    if (convId !== undefined) {
+      hasInitializedRef.current = true;
+    }
+  }, [convId]);
+
+  // Initial load auto-select: if no convId in URL and user hasn't interacted, pick the first user chat.
+  useEffect(() => {
+    if (hasInitializedRef.current) return;
+    if (convId !== undefined) {
+      hasInitializedRef.current = true;
+      return;
+    }
+    if (userChats.length > 0) {
+      hasInitializedRef.current = true;
+      const firstId = userChats[0]?.id;
+      if (firstId !== undefined) {
+        setActiveConvId(firstId);
+      }
+    }
+  }, [convId, userChats]);
+
+  const handleSelectConversation = useCallback(
+    (selectedId: string): void => {
+      hasInitializedRef.current = true;
+      setActiveConvId(selectedId);
+      if (projectId !== undefined) {
+        navigate(`/console/p/${projectId}/chat/${selectedId}`);
+      }
+    },
+    [navigate, projectId]
+  );
+
+  const handleNewChat = useCallback((): void => {
+    hasInitializedRef.current = true;
+    setActiveConvId(null);
+    if (projectId !== undefined) {
+      navigate(`/console/p/${projectId}/chat`);
+    }
+  }, [navigate, projectId]);
+
+  const handleRenameConversation = useCallback(
+    async (targetId: string, newTitle: string): Promise<void> => {
+      await skill.updateConversationTitle(targetId, newTitle);
+      if (projectId !== undefined) {
+        invalidate(K.conversations(projectId));
+      }
+    },
+    [projectId]
+  );
+
+  const handleDeleteConversation = useCallback(
+    async (targetId: string): Promise<void> => {
+      await skill.deleteConversation(targetId);
+      if (projectId !== undefined) {
+        invalidate(K.conversations(projectId));
+      }
+      invalidate(K.messages(targetId));
+
+      if (activeConvId === targetId) {
+        const nextId = resolveNextActiveConversation(targetId, activeConvId, userChats);
+        hasInitializedRef.current = true;
+        setActiveConvId(nextId);
+        if (projectId !== undefined) {
+          if (nextId !== null) {
+            navigate(`/console/p/${projectId}/chat/${nextId}`);
+          } else {
+            navigate(`/console/p/${projectId}/chat`);
+          }
+        }
+      }
+    },
+    [activeConvId, navigate, projectId, userChats]
+  );
 
   const { data: messages, error: messagesError } = useEntity<Message[]>(
     activeConvId !== null ? K.messages(activeConvId) : 'noop:no-conv',
@@ -70,7 +216,8 @@ export function ChatPage(): ReactElement {
   // Driven by message content and the send action, NOT by the SSE lock event,
   // so it stays correct even when the per-conversation SSE drops or never
   // connects (which it can, cross-origin in dev). SSE is a pure accelerator.
-  const [busy, setBusy] = useState(false);
+  const [runningConvIds, setRunningConvIds] = useState<Set<string>>(new Set());
+  const busy = activeConvId !== null && runningConvIds.has(activeConvId);
   const [error, setError] = useState<string | null>(null);
   // Non-error advisory (distinct channel from `error` so it doesn't read as a
   // send failure) — e.g. files dropped from a first message.
@@ -86,14 +233,23 @@ export function ChatPage(): ReactElement {
   // lock (conversation_lock:false) instead of waiting out SETTLE_MS. Must be
   // useCallback-stable — the hook's effect depends on it, so an inline lambda
   // would reconnect the EventSource on every render.
-  const onLockChange = useCallback((locked: boolean): void => {
-    if (locked) return;
-    if (settleTimerRef.current !== null) {
-      clearTimeout(settleTimerRef.current);
-      settleTimerRef.current = null;
-    }
-    setBusy(false);
-  }, []);
+  const onLockChange = useCallback(
+    (locked: boolean): void => {
+      if (locked) return;
+      if (settleTimerRef.current !== null) {
+        clearTimeout(settleTimerRef.current);
+        settleTimerRef.current = null;
+      }
+      if (activeConvId !== null) {
+        setRunningConvIds(prev => {
+          const next = new Set(prev);
+          next.delete(activeConvId);
+          return next;
+        });
+      }
+    },
+    [activeConvId]
+  );
   useConversationSSE(activeConvId, onLockChange);
 
   // Derive turn state from the trailing message: a user message means a reply
@@ -109,7 +265,9 @@ export function ChatPage(): ReactElement {
         clearTimeout(settleTimerRef.current);
         settleTimerRef.current = null;
       }
-      setBusy(true);
+      if (activeConvId !== null) {
+        setRunningConvIds(prev => new Set(prev).add(activeConvId));
+      }
       return;
     }
     // Trailing message is an assistant/system reply. Arm the settle timer once;
@@ -120,9 +278,15 @@ export function ChatPage(): ReactElement {
     settleSigRef.current = sig;
     if (settleTimerRef.current !== null) clearTimeout(settleTimerRef.current);
     settleTimerRef.current = setTimeout(() => {
-      setBusy(false);
+      if (activeConvId !== null) {
+        setRunningConvIds(prev => {
+          const next = new Set(prev);
+          next.delete(activeConvId);
+          return next;
+        });
+      }
     }, SETTLE_MS);
-  }, [messages]);
+  }, [messages, activeConvId]);
   useEffect(
     () => (): void => {
       if (settleTimerRef.current !== null) clearTimeout(settleTimerRef.current);
@@ -138,7 +302,11 @@ export function ChatPage(): ReactElement {
     busySinceRef.current = Date.now();
     const id = setInterval(() => {
       if (Date.now() - busySinceRef.current > MAX_WAIT_MS) {
-        setBusy(false);
+        setRunningConvIds(prev => {
+          const next = new Set(prev);
+          next.delete(activeConvId);
+          return next;
+        });
         return;
       }
       invalidate(K.messages(activeConvId));
@@ -148,19 +316,44 @@ export function ChatPage(): ReactElement {
     };
   }, [busy, activeConvId]);
 
-  // Reveal the raw tool trace inline (toggled from the working indicator).
-  const [showTools, setShowTools] = useState(false);
+  // Reveal the raw tool trace and system messages inline. Default to true.
+  const [showTools, setShowTools] = useState(true);
+  const [showSystem, setShowSystem] = useState(true);
+
+  const handleStop = useCallback(async () => {
+    if (activeConvId === null) return;
+    setError(null);
+    try {
+      await skill.stopConversationRun(activeConvId);
+      setRunningConvIds(prev => {
+        const next = new Set(prev);
+        next.delete(activeConvId);
+        return next;
+      });
+    } catch (err) {
+      console.error('Failed to stop run:', err);
+      setError(err instanceof Error ? err.message : 'Failed to stop run. Please try again.');
+    }
+  }, [activeConvId]);
 
   const onSend = (text: string, files?: File[]): void => {
     if (projectId === undefined) return;
     setError(null);
     setNotice(null);
-    setBusy(true); // optimistic: disable the composer immediately
+    const targetConvId = activeConvId;
+    if (targetConvId !== null) {
+      setRunningConvIds(prev => new Set(prev).add(targetConvId)); // optimistic: disable the composer immediately
+    }
     void (async (): Promise<void> => {
+      let createdConvId: string | null = null;
       try {
-        if (activeConvId === null) {
+        if (targetConvId === null) {
           const conv = await skill.createConversation(projectId, text);
+          createdConvId = conv.conversationId;
+          setRunningConvIds(prev => new Set(prev).add(conv.conversationId));
+          hasInitializedRef.current = true;
           setActiveConvId(conv.conversationId);
+          navigate(`/console/p/${projectId}/chat/${conv.conversationId}`);
           invalidate(K.conversations(projectId));
           invalidate(K.messages(conv.conversationId));
           // createConversation is JSON-only — files can't ride the first message.
@@ -173,59 +366,30 @@ export function ChatPage(): ReactElement {
             );
           }
         } else {
-          await skill.sendMessage(activeConvId, text, files);
-          invalidate(K.messages(activeConvId));
+          await skill.sendMessage(targetConvId, text, files);
+          invalidate(K.messages(targetConvId));
         }
       } catch (e: unknown) {
         setError(e instanceof Error ? e.message : 'Send failed.');
-        setBusy(false); // unblock so the user can retry
+        const failedConvId = targetConvId ?? createdConvId;
+        if (failedConvId !== null) {
+          setRunningConvIds(prev => {
+            const next = new Set(prev);
+            next.delete(failedConvId);
+            return next;
+          });
+        } // unblock so the user can retry
       }
       // On success `busy` stays true until the settle detector sees the reply.
     })();
   };
 
-  // Inline auto-scroll: stick to bottom on new messages if already near it.
-  // Mirrors RunDetailPage's variant.
-  const scrollRef = useRef<HTMLDivElement | null>(null);
-  const lastBottomRef = useRef(true);
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (el === null) return;
-    lastBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < NEAR_BOTTOM_PX;
-  });
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (el === null || !lastBottomRef.current) return;
-    el.scrollTop = el.scrollHeight;
-  }, [messages?.length]);
-
-  // Jump-to-bottom affordance: `atBottom` (state) drives the button's visibility;
-  // `lastBottomRef` (above) drives the auto-scroll stickiness. Keep them in sync.
-  const [atBottom, setAtBottom] = useState(true);
-  const handleScroll = useCallback((): void => {
-    const el = scrollRef.current;
-    if (el === null) return;
-    const near = el.scrollHeight - el.scrollTop - el.clientHeight < NEAR_BOTTOM_PX;
-    lastBottomRef.current = near;
-    setAtBottom(near);
-  }, []);
-  const scrollToBottom = useCallback((): void => {
-    const el = scrollRef.current;
-    if (el === null) return;
-    el.scrollTop = el.scrollHeight;
-    setAtBottom(true);
-  }, []);
-
-  if (projectId === undefined) {
-    return <EmptyState title="No project selected." />;
-  }
-
   const messageList = messages ?? [];
 
-  // Surface a failed (re)load of the conversation list or message history — a
-  // revalidation can fail silently (network blip, server restart) and otherwise
-  // leave stale/empty data with no signal. Send errors take precedence.
-  const loadError = messagesError ?? conversationsError;
+  const toolCallCount = useMemo(
+    () => messageList.reduce((acc, m) => acc + (m.toolCalls?.length ?? 0), 0),
+    [messageList]
+  );
 
   // Current activity for the working indicator: the latest tool the agent
   // invoked in the in-flight turn (walk back to the last user message).
@@ -241,6 +405,63 @@ export function ChatPage(): ReactElement {
     return null;
   }, [messageList]);
 
+  // Inline auto-scroll: stick to bottom on new messages if already near it.
+  // Mirrors RunDetailPage's variant.
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const lastBottomRef = useRef(true);
+
+  // Track total content length across messages to detect in-place streaming token additions
+  const messagesContentLength = useMemo(() => {
+    if (!messages) return 0;
+    let len = 0;
+    for (const m of messages) {
+      len += (m.content?.length ?? 0) + (m.toolCalls?.length ?? 0);
+      if (m.toolCalls) {
+        for (const t of m.toolCalls) {
+          len += (t.output?.length ?? 0) + (t.name?.length ?? 0);
+        }
+      }
+    }
+    return len;
+  }, [messages]);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el === null || !lastBottomRef.current) return;
+    el.scrollTop = el.scrollHeight;
+  }, [messages?.length, messagesContentLength, busy, currentActivity]);
+
+  // Jump-to-bottom affordance: `atBottom` (state) drives the button's visibility;
+  // `lastBottomRef` (above) drives the auto-scroll stickiness. Keep them in sync.
+  const [atBottom, setAtBottom] = useState(true);
+  const handleScroll = useCallback((): void => {
+    const el = scrollRef.current;
+    if (el === null) return;
+    const near = el.scrollHeight - el.scrollTop - el.clientHeight < NEAR_BOTTOM_PX;
+    lastBottomRef.current = near;
+    setAtBottom(near);
+  }, []);
+  const scrollToBottom = useCallback((): void => {
+    const el = scrollRef.current;
+    if (el === null) return;
+    el.scrollTop = el.scrollHeight;
+    lastBottomRef.current = true;
+    setAtBottom(true);
+  }, []);
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [activeConvId, scrollToBottom]);
+
+  if (projectId === undefined) {
+    return <EmptyState title="No project selected." />;
+  }
+
+  // Surface a failed (re)load of the conversation list or message history — a
+  // revalidation can fail silently (network blip, server restart) and otherwise
+  // leave stale/empty data with no signal. Send errors take precedence.
+  const loadError = messagesError ?? conversationsError;
+
   return (
     <section className="flex h-full flex-col">
       <header className="flex flex-col gap-3 border-b border-border px-6 py-4">
@@ -255,63 +476,109 @@ export function ChatPage(): ReactElement {
         <ProjectViewTabs projectId={projectId} active="chat" />
       </header>
 
-      <div className="relative min-h-0 flex-1">
-        <div
-          ref={scrollRef}
-          onScroll={handleScroll}
-          className="h-full overflow-y-auto px-[30px] pt-[26px] pb-[18px]"
-        >
-          {/* Match the composer's centered 940px column (design: .stream-inner) */}
-          <div className="mx-auto max-w-[940px]">
-            {messageList.length === 0 && !busy ? (
-              <EmptyState
-                title="No messages yet."
-                hint="Ask the agent about this project, or tell it what to run."
-              />
-            ) : (
-              <StreamContextProvider value={{ runStartedAt: null }}>
-                <ChatStream messages={messageList} showTools={showTools} />
-                {busy ? (
-                  <WorkingIndicator
-                    activity={currentActivity}
-                    expanded={showTools}
-                    onToggle={() => {
-                      setShowTools(v => !v);
-                    }}
-                  />
-                ) : null}
-              </StreamContextProvider>
-            )}
+      <div className="flex min-h-0 flex-1">
+        <div className="flex min-w-0 flex-1 flex-col">
+          <div className="flex items-center justify-between border-b border-border/60 bg-surface px-[30px] py-2 text-[11px]">
+            <span className="font-mono text-[12px] text-text-tertiary">
+              {messageList.length.toString()} messages · {toolCallCount.toString()} tool calls
+            </span>
+            <div className="flex items-center gap-[18px] font-mono text-[12px]">
+              <label className="flex cursor-pointer select-none items-center gap-1.5 text-text-secondary hover:text-text-primary">
+                <input
+                  type="checkbox"
+                  checked={showTools}
+                  onChange={e => {
+                    setShowTools(e.target.checked);
+                  }}
+                  className="h-3.5 w-3.5 cursor-pointer accent-[color:var(--accent-bright)]"
+                />
+                <span>Tool calls</span>
+              </label>
+              <label className="flex cursor-pointer select-none items-center gap-1.5 text-text-secondary hover:text-text-primary">
+                <input
+                  type="checkbox"
+                  checked={showSystem}
+                  onChange={e => {
+                    setShowSystem(e.target.checked);
+                  }}
+                  className="h-3.5 w-3.5 cursor-pointer accent-[color:var(--accent-bright)]"
+                />
+                <span>System</span>
+              </label>
+            </div>
           </div>
+          <div className="relative min-h-0 flex-1">
+            <div
+              ref={scrollRef}
+              onScroll={handleScroll}
+              className="h-full overflow-y-auto px-[30px] pt-[26px] pb-[18px]"
+            >
+              {/* Match the composer's centered 940px column (design: .stream-inner) */}
+              <div className="mx-auto max-w-[940px]">
+                {messageList.length === 0 && !busy ? (
+                  <EmptyState
+                    title="No messages yet."
+                    hint="Ask the agent about this project, or tell it what to run."
+                  />
+                ) : (
+                  <StreamContextProvider value={{ runStartedAt: null }}>
+                    <ChatStream
+                      messages={messageList}
+                      showTools={showTools}
+                      showSystem={showSystem}
+                    />
+                    {busy ? (
+                      <WorkingIndicator
+                        activity={currentActivity}
+                        expanded={showTools}
+                        onToggle={() => {
+                          setShowTools(v => !v);
+                        }}
+                      />
+                    ) : null}
+                  </StreamContextProvider>
+                )}
+              </div>
+            </div>
+            {!atBottom ? (
+              <button
+                type="button"
+                onClick={scrollToBottom}
+                aria-label="Jump to bottom"
+                className="absolute bottom-3 left-1/2 flex -translate-x-1/2 items-center gap-1 rounded-full border border-border bg-surface-elevated px-3 py-1 text-[11px] text-text-secondary shadow-md transition-colors hover:text-text-primary"
+              >
+                <span aria-hidden>↓</span>
+                Jump to bottom
+              </button>
+            ) : null}
+          </div>
+
+          <WorkflowDock projectId={projectId} />
+
+          {notice !== null ? (
+            <div className="shrink-0 border-t border-warning/30 bg-warning/[0.06] px-6 py-2 font-mono text-[11px] text-warning">
+              {notice}
+            </div>
+          ) : null}
+
+          {error !== null || loadError !== undefined ? (
+            <div className="shrink-0 border-t border-error/30 bg-error/[0.06] px-6 py-2 font-mono text-[11px] text-error">
+              {error ?? `Failed to load chat: ${loadError?.message ?? 'unknown error'}`}
+            </div>
+          ) : null}
+
+          <ChatComposer onSend={onSend} disabled={busy} isRunning={busy} onStop={handleStop} />
         </div>
-        {!atBottom ? (
-          <button
-            type="button"
-            onClick={scrollToBottom}
-            aria-label="Jump to bottom"
-            className="absolute bottom-3 left-1/2 flex -translate-x-1/2 items-center gap-1 rounded-full border border-border bg-surface-elevated px-3 py-1 text-[11px] text-text-secondary shadow-md transition-colors hover:text-text-primary"
-          >
-            <span aria-hidden>↓</span>
-            Jump to bottom
-          </button>
-        ) : null}
+
+        <ChatHistoryPanel
+          conversations={userChats}
+          activeConvId={activeConvId}
+          onSelectConversation={handleSelectConversation}
+          onNewChat={handleNewChat}
+          onRenameConversation={handleRenameConversation}
+          onDeleteConversation={handleDeleteConversation}
+        />
       </div>
-
-      <WorkflowDock projectId={projectId} />
-
-      {notice !== null ? (
-        <div className="shrink-0 border-t border-warning/30 bg-warning/[0.06] px-6 py-2 font-mono text-[11px] text-warning">
-          {notice}
-        </div>
-      ) : null}
-
-      {error !== null || loadError !== undefined ? (
-        <div className="shrink-0 border-t border-error/30 bg-error/[0.06] px-6 py-2 font-mono text-[11px] text-error">
-          {error ?? `Failed to load chat: ${loadError?.message ?? 'unknown error'}`}
-        </div>
-      ) : null}
-
-      <ChatComposer onSend={onSend} disabled={busy} />
     </section>
   );
 }

--- a/packages/web/src/experiments/console/routes/RunDetailPage.test.ts
+++ b/packages/web/src/experiments/console/routes/RunDetailPage.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'bun:test';
+import { resolveRunOrchestratorConversationId } from './RunDetailPage';
+
+describe('resolveRunOrchestratorConversationId', () => {
+  it('should return null when run is null or undefined', () => {
+    expect(resolveRunOrchestratorConversationId(null)).toBeNull();
+    expect(resolveRunOrchestratorConversationId(undefined)).toBeNull();
+  });
+
+  it('should resolve parentPlatformId with highest priority', () => {
+    const run = {
+      parentPlatformId: 'parent-platform-1',
+      parent_platform_id: 'parent-platform-2',
+      metadata: { parent_platform_id: 'meta-platform-1' },
+      conversationPlatformId: 'cli-platform-1',
+    };
+    expect(resolveRunOrchestratorConversationId(run as any)).toBe('parent-platform-1');
+  });
+
+  it('should fall back to parent_platform_id when parentPlatformId is absent', () => {
+    const run = {
+      parent_platform_id: 'parent-platform-2',
+      conversationPlatformId: 'cli-platform-1',
+    };
+    expect(resolveRunOrchestratorConversationId(run as any)).toBe('parent-platform-2');
+  });
+
+  it('should not resolve database UUID parentConversationId or sourceConversationId', () => {
+    const run = {
+      id: 'run-1',
+      parentConversationId: 'parent-db-uuid-1',
+      sourceConversationId: 'source-db-uuid-1',
+    };
+    expect(resolveRunOrchestratorConversationId(run as any)).toBeNull();
+  });
+
+  it('should fall back to metadata platform ID fields in priority order', () => {
+    const runMeta1 = {
+      metadata: {
+        parent_platform_id: 'meta-parent-plat-1',
+        parentPlatformId: 'meta-parent-plat-2',
+      },
+    };
+    expect(resolveRunOrchestratorConversationId(runMeta1 as any)).toBe('meta-parent-plat-1');
+
+    const runMeta2 = {
+      metadata: {
+        parentPlatformId: 'meta-parent-plat-2',
+        dispatch_platform_id: 'meta-dispatch-plat-1',
+      },
+    };
+    expect(resolveRunOrchestratorConversationId(runMeta2 as any)).toBe('meta-parent-plat-2');
+
+    const runMeta3 = {
+      metadata: {
+        dispatch_platform_id: 'meta-dispatch-plat-1',
+        dispatchPlatformId: 'meta-dispatch-plat-2',
+      },
+    };
+    expect(resolveRunOrchestratorConversationId(runMeta3 as any)).toBe('meta-dispatch-plat-1');
+
+    const runMeta4 = {
+      metadata: {
+        dispatchPlatformId: 'meta-dispatch-plat-2',
+      },
+    };
+    expect(resolveRunOrchestratorConversationId(runMeta4 as any)).toBe('meta-dispatch-plat-2');
+  });
+
+  it('should fall back to conversationPlatformId and conversation_platform_id for CLI / direct runs', () => {
+    const run1 = {
+      conversationPlatformId: 'conv-platform-1',
+      conversation_platform_id: 'conv-platform-2',
+    };
+    expect(resolveRunOrchestratorConversationId(run1 as any)).toBe('conv-platform-1');
+
+    const run2 = {
+      conversation_platform_id: 'conv-platform-2',
+    };
+    expect(resolveRunOrchestratorConversationId(run2 as any)).toBe('conv-platform-2');
+  });
+
+  it('should fall back to workerPlatformId when CLI conversation is not present', () => {
+    const run1 = {
+      workerPlatformId: 'worker-platform-1',
+      worker_platform_id: 'worker-platform-2',
+    };
+    expect(resolveRunOrchestratorConversationId(run1 as any)).toBe('worker-platform-1');
+
+    const run2 = {
+      worker_platform_id: 'worker-platform-2',
+    };
+    expect(resolveRunOrchestratorConversationId(run2 as any)).toBe('worker-platform-2');
+  });
+
+  it('should return null when run has no matching conversation platform properties', () => {
+    const run = {
+      id: 'run-1',
+      metadata: {
+        parent_conversation_id: 'db-uuid-1',
+      },
+    };
+    expect(resolveRunOrchestratorConversationId(run as any)).toBeNull();
+  });
+});

--- a/packages/web/src/experiments/console/routes/RunDetailPage.tsx
+++ b/packages/web/src/experiments/console/routes/RunDetailPage.tsx
@@ -7,10 +7,13 @@ import {
   useState,
   type ReactElement,
 } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { Link, useNavigate, useParams } from 'react-router';
 import { useKeymap, type Binding } from '../lib/keymap';
 import { RunDetailHeader } from '../components/RunDetailHeader';
 import { RunStream } from '../components/RunStream';
+import { ChatStream } from '../components/ChatStream';
+import { ChatComposer } from '../components/ChatComposer';
+import { WorkingIndicator } from '../components/WorkingIndicator';
 import { RunActionBar } from '../components/RunActionBar';
 import { StreamToolbar, type DetailView } from '../components/StreamToolbar';
 import { ApprovalContext } from '../components/ApprovalContext';
@@ -19,7 +22,7 @@ import { RunGraphPanel } from '../components/RunGraphPanel';
 import { ArtifactPanel } from '../components/ArtifactPanel';
 import { RunStartedLine, RunFinishedLine } from '../components/RunLifecycle';
 import { StreamContextProvider } from '../lib/stream-context';
-import { useRunStreamSSE } from '../lib/sse';
+import { useConversationSSE, useRunStreamSSE } from '../lib/sse';
 import { useEntity, invalidate } from '../store/cache';
 import { K } from '../store/keys';
 import * as skill from '../skills';
@@ -79,7 +82,10 @@ function writeToggle(key: string, value: boolean): void {
 function readView(): DetailView {
   try {
     const stored = localStorage.getItem(TOGGLE_KEYS.view);
-    return stored === 'graph' ? 'graph' : 'log';
+    if (stored === 'chat' || stored === 'graph' || stored === 'artifacts') {
+      return stored;
+    }
+    return 'log';
   } catch {
     return 'log';
   }
@@ -109,6 +115,51 @@ function writeNodeFilter(v: string): void {
   }
 }
 
+/**
+ * Resolves the parent orchestrator conversation platform ID for a workflow run
+ * using a priority chain (web dispatch parent platform IDs -> metadata platform IDs -> CLI fallback).
+ *
+ * @param run - Workflow run object or undefined
+ * @returns Resolved platform conversation ID, or null if no orchestrator conversation is linked
+ */
+export function resolveRunOrchestratorConversationId(
+  run:
+    | (Run & {
+        parentPlatformId?: string | null;
+        parent_platform_id?: string | null;
+        conversationPlatformId?: string | null;
+        conversation_platform_id?: string | null;
+        workerPlatformId?: string | null;
+        worker_platform_id?: string | null;
+        metadata?: Record<string, unknown> | null;
+      })
+    | undefined
+    | null
+): string | null {
+  if (!run) return null;
+  const meta = run.metadata;
+  const metaParent =
+    (meta?.parent_platform_id as string | undefined) ??
+    (meta?.parentPlatformId as string | undefined) ??
+    (meta?.dispatch_platform_id as string | undefined) ??
+    (meta?.dispatchPlatformId as string | undefined);
+
+  return (
+    run.parentPlatformId ??
+    run.parent_platform_id ??
+    metaParent ??
+    run.conversationPlatformId ??
+    run.conversation_platform_id ??
+    run.workerPlatformId ??
+    run.worker_platform_id ??
+    null
+  );
+}
+
+/**
+ * Run detail page presenting multi-tab inspectability across log timeline,
+ * scoped orchestrator chat, interactive DAG execution graph, and generated artifacts.
+ */
 export function RunDetailPage(): ReactElement {
   const { projectId, runId } = useParams<{ projectId: string; runId: string }>();
   const navigate = useNavigate();
@@ -116,9 +167,7 @@ export function RunDetailPage(): ReactElement {
   const [showToolCalls, setShowToolCalls] = useState<boolean>(() =>
     readToggle(TOGGLE_KEYS.toolCalls, true)
   );
-  const [showSystem, setShowSystem] = useState<boolean>(() =>
-    readToggle(TOGGLE_KEYS.system, false)
-  );
+  const [showSystem, setShowSystem] = useState<boolean>(() => readToggle(TOGGLE_KEYS.system, true));
   const [view, setView] = useState<DetailView>(() => readView());
   const [selectedNodeId, setSelectedNodeId] = useState<string>(() => readNodeFilter());
 
@@ -174,6 +223,84 @@ export function RunDetailPage(): ReactElement {
       conversationPlatformId !== null
         ? skill.listMessages(conversationPlatformId)
         : Promise.resolve([])
+  );
+
+  const resolvedOrchestratorConvId = useMemo(
+    () => resolveRunOrchestratorConversationId(detail?.run),
+    [detail?.run]
+  );
+  const [activeChatConvId, setActiveChatConvId] = useState<string | null>(null);
+  const [chatBusy, setChatBusy] = useState(false);
+  const [chatError, setChatError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setActiveChatConvId(null);
+    setChatBusy(false);
+    setChatError(null);
+  }, [runId]);
+
+  const chatConvId = activeChatConvId ?? resolvedOrchestratorConvId;
+
+  useConversationSSE(
+    view === 'chat' ? chatConvId : null,
+    useCallback(
+      (locked?: boolean) => {
+        if (typeof locked === 'boolean') {
+          setChatBusy(locked);
+        }
+        if (chatConvId !== null) {
+          invalidate(K.messages(chatConvId));
+        }
+      },
+      [chatConvId]
+    )
+  );
+
+  const { data: chatMessages } = useEntity<Message[]>(
+    chatConvId !== null && view === 'chat' ? K.messages(chatConvId) : 'noop:no-chat-conv',
+    () => (chatConvId !== null ? skill.listMessages(chatConvId) : Promise.resolve([]))
+  );
+
+  const chatMessageList = useMemo(() => {
+    if (!chatMessages) return [];
+    return chatMessages;
+  }, [chatMessages]);
+
+  const handleStopChat = useCallback(async () => {
+    if (chatConvId === null) return;
+    setChatError(null);
+    try {
+      await skill.stopConversationRun(chatConvId);
+      setChatBusy(false);
+    } catch (err) {
+      console.error('Failed to stop orchestrator chat run:', err);
+      setChatError(err instanceof Error ? err.message : 'Failed to stop run. Please try again.');
+    }
+  }, [chatConvId]);
+
+  const onSendChat = useCallback(
+    async (text: string, files?: File[]): Promise<void> => {
+      if (chatBusy || projectId === undefined) return;
+      setChatBusy(true);
+      setChatError(null);
+      try {
+        let targetConvId = chatConvId;
+        if (targetConvId === null) {
+          const newConv = await skill.createConversation(projectId, text);
+          targetConvId = newConv.conversationId;
+          setActiveChatConvId(targetConvId);
+          invalidate(K.conversations(projectId));
+        } else {
+          await skill.sendMessage(targetConvId, text, files);
+        }
+        invalidate(K.messages(targetConvId));
+      } catch (err) {
+        console.error('Failed to send orchestrator chat message:', err);
+        setChatError(err instanceof Error ? err.message : 'Failed to send message');
+        setChatBusy(false);
+      }
+    },
+    [chatBusy, chatConvId, projectId]
   );
 
   // Live updates: subscribe to the conversation SSE stream. Events here
@@ -348,13 +475,20 @@ export function RunDetailPage(): ReactElement {
       },
       {
         keys: ['2'],
+        label: 'Chat tab',
+        run: (): void => {
+          setViewPersist('chat');
+        },
+      },
+      {
+        keys: ['3'],
         label: 'Graph tab',
         run: (): void => {
           setViewPersist('graph');
         },
       },
       {
-        keys: ['3'],
+        keys: ['4'],
         label: 'Artifacts tab',
         run: (): void => {
           setViewPersist('artifacts');
@@ -435,7 +569,7 @@ export function RunDetailPage(): ReactElement {
         writeToggle(TOGGLE_KEYS.system, next);
       }}
       toolCallCount={toolCallCount}
-      messageCount={messageList.length}
+      messageCount={view === 'chat' ? chatMessageList.length : messageList.length}
       artifactCount={artifactFiles?.length ?? null}
       nodeOptions={nodeOptions}
       selectedNodeId={selectedNodeId}
@@ -511,6 +645,71 @@ export function RunDetailPage(): ReactElement {
                   Jump to bottom
                 </button>
               ) : null}
+            </div>
+          ) : view === 'chat' ? (
+            <div className="flex min-h-0 flex-1 flex-col">
+              <div className="flex items-center justify-between border-b border-border bg-surface-elevated/50 px-6 py-2">
+                <div className="flex items-center gap-2 font-mono text-[11px] text-text-secondary">
+                  <span className="inline-block h-2 w-2 rounded-full bg-accent" />
+                  <span>Orchestrator Chat · Scoped to Run #{runId ? runId.slice(0, 8) : ''}</span>
+                </div>
+                {chatConvId ? (
+                  <Link
+                    to={`/console/p/${projectId}/chat/${chatConvId}`}
+                    className="font-mono text-[11px] text-accent hover:underline"
+                  >
+                    Open in full Chat &rarr;
+                  </Link>
+                ) : null}
+              </div>
+              <div
+                ref={scrollRef}
+                onScroll={handleScroll}
+                className="min-h-0 flex-1 overflow-y-auto"
+              >
+                <div ref={contentRef} className="w-full px-6">
+                  <div className="sticky top-0 z-10 -mx-6 bg-surface px-6">{toolbar}</div>
+                  <div className="mx-auto max-w-[940px] py-4">
+                    {chatMessageList.length === 0 && !chatBusy ? (
+                      <div className="flex h-48 flex-col items-center justify-center gap-2 text-center text-sm text-text-tertiary">
+                        <p>No orchestrator conversation connected yet.</p>
+                        <p className="text-xs">
+                          Send a message below to start an interactive orchestrator session scoped
+                          to this run.
+                        </p>
+                      </div>
+                    ) : (
+                      <StreamContextProvider value={{ runStartedAt: run?.startedAt ?? null }}>
+                        <ChatStream
+                          messages={chatMessageList}
+                          showTools={showToolCalls}
+                          showSystem={showSystem}
+                        />
+                        {chatBusy ? (
+                          <WorkingIndicator
+                            activity={undefined}
+                            expanded={showToolCalls}
+                            onToggle={() => {
+                              setShowToolCalls(v => !v);
+                            }}
+                          />
+                        ) : null}
+                      </StreamContextProvider>
+                    )}
+                  </div>
+                </div>
+              </div>
+              {chatError !== null ? (
+                <div className="shrink-0 border-t border-error/30 bg-error/[0.06] px-6 py-2 font-mono text-[11px] text-error">
+                  {chatError}
+                </div>
+              ) : null}
+              <ChatComposer
+                onSend={onSendChat}
+                disabled={chatBusy}
+                isRunning={chatBusy}
+                onStop={handleStopChat}
+              />
             </div>
           ) : view === 'graph' ? (
             <>

--- a/packages/web/src/experiments/console/skills/conversations.ts
+++ b/packages/web/src/experiments/console/skills/conversations.ts
@@ -21,11 +21,23 @@ import { toConversationSummary, type ConversationSummary } from '../primitives/c
  *     multipart when files are attached (mirrors startRun's multipart path).
  */
 
+/**
+ * Response payload from createConversation.
+ */
 interface CreateConversationResponse {
+  /** Generated platform conversation ID. */
   conversationId: string;
+  /** Internal database UUID. */
   id: string;
 }
 
+/**
+ * Creates a new project conversation, optionally with an atomic first message.
+ *
+ * @param projectId - Codebase ID / project identifier
+ * @param message - Optional initial message to send atomically
+ * @returns Object with created conversationId and database UUID
+ */
 export async function createConversation(
   projectId: string,
   message?: string
@@ -38,6 +50,12 @@ export async function createConversation(
   });
 }
 
+/**
+ * Lists conversations associated with a project.
+ *
+ * @param projectId - Codebase ID / project identifier
+ * @returns Array of conversation summary objects
+ */
 export async function listConversations(projectId: string): Promise<ConversationSummary[]> {
   const raw = await requestJson<Parameters<typeof toConversationSummary>[0][]>(
     `/api/conversations?codebaseId=${encodeURIComponent(projectId)}&mine=true`
@@ -45,6 +63,13 @@ export async function listConversations(projectId: string): Promise<Conversation
   return raw.map(toConversationSummary);
 }
 
+/**
+ * Sends a text message and optional file attachments to an existing conversation.
+ *
+ * @param conversationPlatformId - Target platform conversation ID
+ * @param message - Message text
+ * @param files - Optional array of file attachments
+ */
 export async function sendMessage(
   conversationPlatformId: string,
   message: string,
@@ -80,4 +105,58 @@ export async function sendMessage(
     const path = new URL(url, window.location.origin).pathname;
     throw new HttpError(res.status, path, msg);
   }
+}
+
+/**
+ * Updates the title of an existing conversation.
+ *
+ * @param conversationPlatformId - Platform ID of the conversation
+ * @param title - New title string
+ * @returns Success response indicator
+ */
+export async function updateConversationTitle(
+  conversationPlatformId: string,
+  title: string
+): Promise<{ success: boolean }> {
+  return requestJson<{ success: boolean }>(
+    `/api/conversations/${encodeURIComponent(conversationPlatformId)}`,
+    {
+      method: 'PATCH',
+      body: JSON.stringify({ title }),
+    }
+  );
+}
+
+/**
+ * Permanently deletes a conversation by platform ID.
+ *
+ * @param conversationPlatformId - Platform ID of the conversation to delete
+ * @returns Success response indicator
+ */
+export async function deleteConversation(
+  conversationPlatformId: string
+): Promise<{ success: boolean }> {
+  return requestJson<{ success: boolean }>(
+    `/api/conversations/${encodeURIComponent(conversationPlatformId)}`,
+    {
+      method: 'DELETE',
+    }
+  );
+}
+
+/**
+ * Halts an in-flight conversation turn or active workflow run.
+ *
+ * @param conversationPlatformId - Platform ID of the conversation to stop
+ * @returns Success response indicator
+ */
+export async function stopConversationRun(
+  conversationPlatformId: string
+): Promise<{ success: boolean }> {
+  return requestJson<{ success: boolean }>(
+    `/api/conversations/${encodeURIComponent(conversationPlatformId)}/stop`,
+    {
+      method: 'POST',
+    }
+  );
 }


### PR DESCRIPTION
## Problem and outcome

Console UX was missing multi-chat session management, direct run-to-orchestrator interactive chat, preserved multiline message formatting, and inline live DAG execution / result visibility in the chat stream.

- **Outcome:**
  1. Multi-chat management sidebar (`ChatHistoryPanel`) with `+ New Chat`, inline title renaming, deletion confirmation, and automatic fallback navigation.
  2. Interactive orchestrator `Chat` tab in the run detail view (`RunDetailPage`) with two-way dispatching (`ChatComposer`), live auto-scrolling, running status indicator, and run-scoped navigation.
  3. Preserved whitespace and multiline code indentation in user message bubbles (`whitespace-pre-wrap`).
  4. Live embedded workflow execution cards (`WorkflowProgressCard`) and completion result cards (`WorkflowResultCard`) with artifact preview modals in `ChatStream`.
  5. Workflow parent orchestrator conversations are hidden from the primary chat session list to avoid duplicate clutter.
- **Invariant:** Existing console navigation, keyboard shortcuts, log streaming, and classic UI routing continue to operate seamlessly.
- **Scope boundary:** Does not modify backend workflow execution mechanics or CLI runtime behavior.

## Review guidance

- **Feedback requested:** Correctness of conversation routing (`/console/p/:projectId/chat/:convId`), orchestrator chat stream subscription / keymap bindings on `RunDetailPage`, and component boundary design of `WorkflowProgressCard` and `WorkflowResultCard`.
- **Start here:** `packages/web/src/experiments/console/routes/RunDetailPage.tsx` — Orchestrator chat tab wiring and live streaming synchronization.
- **Review order:**
  1. `packages/web/src/experiments/console/components/ChatHistoryPanel.tsx` and `packages/web/src/experiments/console/routes/ChatPage.tsx` (sidebar navigation, rename/delete lifecycle, and routing)
  2. `packages/web/src/experiments/console/routes/RunDetailPage.tsx` and `packages/web/src/experiments/console/components/StreamToolbar.tsx` (run detail chat tab)
  3. `packages/web/src/experiments/console/components/WorkflowProgressCard.tsx` and `packages/web/src/experiments/console/components/WorkflowResultCard.tsx` (DAG cards in chat)
  4. `packages/server/src/routes/api.ts` (orchestrator conversation visibility flag)
  5. `packages/web/src/experiments/console/skills/conversations.ts` and `packages/web/src/experiments/console/primitives/run.ts` (API wrappers and run normalizers)
- **Lower-attention areas:** `packages/web/src/experiments/console/components/MessageItem.tsx` (`whitespace-pre-wrap` styling update).
- **Known risk or uncertainty:** None.

## Solution

1. **Multi-Chat Management**: Added `ChatHistoryPanel.tsx` to `ChatPage.tsx` displaying non-workflow project conversations sorted by activity, supporting inline title edits via `updateConversationTitle`, deletion via `deleteConversation` with dialog confirmation, and URL-driven routing (`/console/p/:projectId/chat/:convId`).
2. **Run Detail Orchestrator Chat**: Added `'chat'` to `DetailView` in `StreamToolbar.tsx` and implemented the interactive orchestrator panel in `RunDetailPage.tsx`, resolving the parent conversation via `resolveRunOrchestratorConversationId`, providing real-time streaming updates, sticky auto-scroll with `ResizeObserver`, and stop/send actions.
3. **DAG Execution & Result Cards**: Created `WorkflowProgressCard.tsx` (displaying active DAG nodes, elapsed duration, and pause/approval controls) and `WorkflowResultCard.tsx` (displaying outcome, artifact summaries, and markdown inspection modal) embedded in `ChatStream.tsx`.
4. **Conversation Visibility Hygiene**: Set `hidden: true` on workflow orchestrator conversations in `packages/server/src/routes/api.ts` on run dispatch so they do not pollute the primary chat drawer.
5. **Whitespace Preservation**: Added `whitespace-pre-wrap` to user message bubble rendering in `MessageItem.tsx`.

## Behavior change

| | Before | After |
|---|---|---|
| **Chat history** | Single active conversation per project | Sidebar panel with full chat history, inline rename, delete confirmation, and URL navigation |
| **Run detail view** | Log, graph, and artifacts tabs only | Dedicated Chat tab to interact with the orchestrator session scoped to the run |
| **Workflow execution in chat** | Plain text system messages | Interactive progress and completion result cards with artifact preview modal |
| **User message formatting** | Collapsed whitespace | Preserved whitespace and multiline indentation |

## Validation

- `bun run type-check` — passes with 0 errors across all 12 packages.
- `bun run lint` — passes with 0 errors/warnings.
- `bun run format` — all files formatted cleanly.
- `bun run check:bundled` — passes with bundled defaults up to date.
- `bun run build:web` — Vite production build successful with 0 errors.
- `bun test packages/web` and `bun test packages/server` — all unit tests pass (704+ tests).
- **Not verified:** Live browser E2E session with running backend worker daemon; covered via unit tests and production Vite bundling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-chat history with conversation selection, creation, renaming, and deletion.
  * Added chat tabs for workflow runs with live progress, tool activity, results, artifacts, and approval actions.
  * Added controls to stop active runs and toggle system messages.
  * Added automatic redirection from legacy project links to the Console.
* **Bug Fixes**
  * Improved message formatting, artifact-link handling, and conversation access protection.
* **Documentation**
  * Updated Web UI and execution-page documentation with new chat, history, and live workflow features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->