### PR TITLE
test(adapters): exercise production fork detection

### DIFF
--- a/packages/adapters/src/community/forge/gitea/adapter.test.ts
+++ b/packages/adapters/src/community/forge/gitea/adapter.test.ts
@@ -113,6 +113,7 @@ mock.module('@archon/core', () => ({
 }));
 
 import { GiteaAdapter } from './adapter';
+import type { WebhookEvent } from './types';
 import { ConversationLockManager } from '@archon/core';
 
 // Create a mock lock manager that immediately executes handlers
@@ -655,7 +656,7 @@ describe('GiteaAdapter', () => {
               repo: { full_name: headRepoFullName },
             };
 
-      return JSON.stringify({
+      const event = {
         action: 'created',
         issue: {
           number: 42,
@@ -684,7 +685,9 @@ describe('GiteaAdapter', () => {
           default_branch: 'main',
         },
         sender: { login: 'user123' },
-      });
+      } satisfies WebhookEvent;
+
+      return JSON.stringify(event);
     }
 
     async function expectForkVerdict(

--- a/packages/adapters/src/community/forge/gitea/adapter.test.ts
+++ b/packages/adapters/src/community/forge/gitea/adapter.test.ts
@@ -5,6 +5,8 @@
  * database modules to avoid test pollution issues with Bun's mock.module.
  */
 import { describe, test, expect, mock, spyOn, beforeEach, afterEach } from 'bun:test';
+import { createHmac } from 'node:crypto';
+import type { Codebase, Conversation } from '@archon/core';
 
 // Mock @archon/paths to suppress noisy logger output during tests
 const mockLogger = {
@@ -46,9 +48,13 @@ const mockFindOrCreateUserByPlatformIdentity = mock(
 mock.module('@archon/core/db/users', () => ({
   findOrCreateUserByPlatformIdentity: mockFindOrCreateUserByPlatformIdentity,
 }));
-const mockGetOrCreateConversation = mock(async () => {
-  throw new Error('DB not mocked in tests');
-});
+const mockGetOrCreateConversation = mock(
+  async (): Promise<
+    Pick<Conversation, 'id' | 'codebase_id' | 'platform_type' | 'platform_conversation_id'>
+  > => {
+    throw new Error('DB not mocked in tests');
+  }
+);
 const mockUpdateConversation = mock(async () => {
   throw new Error('DB not mocked in tests');
 });
@@ -59,7 +65,9 @@ mock.module('@archon/core/db/conversations', () => ({
   getConversation: mockGetConversation,
 }));
 
-const mockFindCodebaseByRepoUrl = mock(async () => null);
+const mockFindCodebaseByRepoUrl = mock(
+  async (): Promise<Pick<Codebase, 'id' | 'repository_url' | 'default_cwd' | 'name'> | null> => null
+);
 const mockCreateCodebase = mock(async () => {
   throw new Error('DB not mocked in tests');
 });
@@ -637,25 +645,97 @@ describe('GiteaAdapter', () => {
   });
 
   describe('fork detection logic', () => {
-    test('should detect same-repo PR when head and base repos match', () => {
-      const headRepoFullName = 'owner/repo';
-      const baseRepoFullName = 'owner/repo';
-      const isForkPR = headRepoFullName !== baseRepoFullName;
-      expect(isForkPR).toBe(false);
+    function createPullRequestCommentPayload(headRepoFullName?: string): string {
+      const head =
+        headRepoFullName === undefined
+          ? { ref: 'feature-branch', sha: 'abc123def456' }
+          : {
+              ref: 'feature-branch',
+              sha: 'abc123def456',
+              repo: { full_name: headRepoFullName },
+            };
+
+      return JSON.stringify({
+        action: 'created',
+        issue: {
+          number: 42,
+          title: 'Test PR',
+          body: 'Description',
+          user: { login: 'user123' },
+          labels: [],
+          state: 'open',
+          pull_request: {},
+        },
+        pull_request: {
+          number: 42,
+          title: 'Test PR',
+          body: 'Description',
+          user: { login: 'user123' },
+          state: 'open',
+          head,
+          base: { repo: { full_name: 'testuser/testrepo' } },
+        },
+        comment: { body: '@archon review this', user: { login: 'user123' } },
+        repository: {
+          owner: { login: 'testuser' },
+          name: 'testrepo',
+          full_name: 'testuser/testrepo',
+          html_url: 'https://gitea.example.com/testuser/testrepo',
+          default_branch: 'main',
+        },
+        sender: { login: 'user123' },
+      });
+    }
+
+    async function expectForkVerdict(
+      headRepoFullName: string | undefined,
+      expected: boolean
+    ): Promise<void> {
+      mockGetOrCreateConversation.mockResolvedValueOnce({
+        id: 'conv-test-uuid',
+        codebase_id: 'codebase-test-uuid',
+        platform_type: 'gitea',
+        platform_conversation_id: 'testuser/testrepo!42',
+      });
+      mockFindCodebaseByRepoUrl.mockResolvedValueOnce({
+        id: 'codebase-test-uuid',
+        repository_url: 'https://gitea.example.com/testuser/testrepo',
+        default_cwd: '/tmp/test-workspaces/testuser/testrepo/source',
+        name: 'testrepo',
+      });
+      mockHandleMessage.mockClear();
+      const fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response('[]', { status: 200 })
+      );
+      const payload = createPullRequestCommentPayload(headRepoFullName);
+      const signature = createHmac('sha256', 'fake-webhook-secret').update(payload).digest('hex');
+
+      try {
+        await adapter.handleWebhook(payload, signature);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+
+      expect(mockHandleMessage).toHaveBeenCalledWith(
+        expect.anything(),
+        'testuser/testrepo!42',
+        expect.anything(),
+        expect.objectContaining({
+          isolationHints: expect.objectContaining({ isForkPR: expected }),
+        })
+      );
+    }
+
+    test('should detect same-repo PR when head and base repos match', async () => {
+      await expectForkVerdict('testuser/testrepo', false);
     });
 
-    test('should detect fork PR when head and base repos differ', () => {
-      const headRepoFullName = 'contributor/repo';
-      const baseRepoFullName = 'owner/repo';
-      const isForkPR = headRepoFullName !== baseRepoFullName;
-      expect(isForkPR).toBe(true);
+    test('should detect fork PR when head and base repos differ', async () => {
+      await expectForkVerdict('contributor/testrepo', true);
     });
 
-    test('should detect fork PR when head.repo is undefined (deleted fork)', () => {
-      const headRepoFullName: string | undefined = undefined;
-      const baseRepoFullName = 'owner/repo';
-      const isForkPR = headRepoFullName !== baseRepoFullName;
-      expect(isForkPR).toBe(true);
+    test('should detect fork PR when head.repo is undefined (deleted fork)', async () => {
+      await expectForkVerdict(undefined, true);
     });
   });
 

--- a/packages/adapters/src/forge/github/adapter.test.ts
+++ b/packages/adapters/src/forge/github/adapter.test.ts
@@ -160,6 +160,7 @@ mock.module('@archon/git', () => ({
 }));
 
 import { GitHubAdapter } from './adapter';
+import type { WebhookEvent } from './types';
 import { ConversationLockManager } from '@archon/core';
 // Namespace import so the dedup tests can spyOn(core, 'handleMessage') — the
 // orchestrator entry point the adapter calls after webhook setup succeeds.
@@ -1116,7 +1117,7 @@ describe('GitHubAdapter', () => {
 
   describe('fork detection logic', () => {
     function createPullRequestCommentPayload(): string {
-      return JSON.stringify({
+      const event = {
         action: 'created',
         issue: {
           number: 42,
@@ -1136,7 +1137,9 @@ describe('GitHubAdapter', () => {
           default_branch: 'main',
         },
         sender: { login: 'user123' },
-      });
+      } satisfies WebhookEvent;
+
+      return JSON.stringify(event);
     }
 
     async function expectForkVerdict(

--- a/packages/adapters/src/forge/github/adapter.test.ts
+++ b/packages/adapters/src/forge/github/adapter.test.ts
@@ -31,7 +31,7 @@ import {
   beforeEach,
   afterEach,
 } from 'bun:test';
-import { randomUUID } from 'node:crypto';
+import { createHmac, randomUUID } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -1115,50 +1115,81 @@ describe('GitHubAdapter', () => {
   });
 
   describe('fork detection logic', () => {
-    /**
-     * Tests for the fork detection comparison logic used in handleWebhook.
-     * The actual logic: isForkPR = headRepoFullName !== baseRepoFullName
-     * This logic determines whether a PR uses the actual branch (same-repo)
-     * or a synthetic pr-N-review branch (fork).
-     */
+    function createPullRequestCommentPayload(): string {
+      return JSON.stringify({
+        action: 'created',
+        issue: {
+          number: 42,
+          title: 'Test PR',
+          body: 'Description',
+          user: { login: 'user123' },
+          labels: [],
+          state: 'open',
+          pull_request: { url: 'https://api.github.com/repos/testuser/testrepo/pulls/42' },
+        },
+        comment: { body: '@archon review this', user: { login: 'user123' } },
+        repository: {
+          owner: { login: 'testuser' },
+          name: 'testrepo',
+          full_name: 'testuser/testrepo',
+          html_url: 'https://github.com/testuser/testrepo',
+          default_branch: 'main',
+        },
+        sender: { login: 'user123' },
+      });
+    }
 
-    test('should detect same-repo PR when head and base repos match', () => {
-      // Simulates same-repo PR where contributor has push access
-      const headRepoFullName = 'owner/repo';
-      const baseRepoFullName = 'owner/repo';
-      const isForkPR = headRepoFullName !== baseRepoFullName;
+    async function expectForkVerdict(
+      headRepoFullName: string | undefined,
+      expected: boolean
+    ): Promise<void> {
+      handleMessageSpy.mockClear();
+      const { pullsGet } = installOctokitStubs(adapter);
+      pullsGet.mockResolvedValueOnce({
+        data: {
+          head: {
+            ref: 'feature-branch',
+            sha: 'abc123def456',
+            repo: headRepoFullName === undefined ? null : { full_name: headRepoFullName },
+          },
+          base: { repo: { full_name: 'testuser/testrepo' } },
+        },
+      });
+      const payload = createPullRequestCommentPayload();
+      const signature =
+        'sha256=' + createHmac('sha256', 'fake-webhook-secret').update(payload).digest('hex');
 
-      expect(isForkPR).toBe(false);
+      await adapter.handleWebhook(payload, signature);
+
+      expect(pullsGet).toHaveBeenCalledWith({
+        owner: 'testuser',
+        repo: 'testrepo',
+        pull_number: 42,
+      });
+      expect(handleMessageSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        'testuser/testrepo#42',
+        expect.anything(),
+        expect.objectContaining({
+          isolationHints: expect.objectContaining({ isForkPR: expected }),
+        })
+      );
+    }
+
+    test('should detect same-repo PR when head and base repos match', async () => {
+      await expectForkVerdict('testuser/testrepo', false);
     });
 
-    test('should detect fork PR when head and base repos differ', () => {
-      // Simulates fork PR where head is from a different repo
-      const headRepoFullName = 'contributor/repo';
-      const baseRepoFullName = 'owner/repo';
-      const isForkPR = headRepoFullName !== baseRepoFullName;
-
-      expect(isForkPR).toBe(true);
+    test('should detect fork PR when head and base repos differ', async () => {
+      await expectForkVerdict('contributor/testrepo', true);
     });
 
-    test('should detect fork PR when head.repo is null (deleted fork)', () => {
-      // When a fork is deleted after a PR was opened, head.repo becomes null
-      // The optional chaining (?.) returns undefined, and undefined !== 'owner/repo' is true
-      const headRepoFullName: string | undefined = undefined; // Simulates prData.head.repo?.full_name
-      const baseRepoFullName = 'owner/repo';
-      const isForkPR = headRepoFullName !== baseRepoFullName;
-
-      // Correctly treated as fork - can't push to deleted repo anyway
-      expect(isForkPR).toBe(true);
+    test('should detect fork PR when head.repo is null (deleted fork)', async () => {
+      await expectForkVerdict(undefined, true);
     });
 
-    test('should handle case sensitivity correctly', () => {
-      // GitHub full_names are case-sensitive in the API response
-      const headRepoFullName = 'Owner/Repo';
-      const baseRepoFullName = 'owner/repo';
-      const isForkPR = headRepoFullName !== baseRepoFullName;
-
-      // Different casing = different repos (fork detection)
-      expect(isForkPR).toBe(true);
+    test('should handle case sensitivity correctly', async () => {
+      await expectForkVerdict('TestUser/TestRepo', true);
     });
   });
 


### PR DESCRIPTION
## Problem and outcome

The GitHub and Gitea fork-detection suites compared test-local literals, so a regression in the adapters' production rule would still pass the tests that claimed to cover it. The suites now drive each adapter's webhook path and assert the verdict delivered to the downstream message handler.

- **Outcome:** Fork detection is exercised through `handleWebhook` for every existing scenario.
- **Invariant:** Production fork-detection behavior is unchanged; same-repository, different-repository, and deleted-head cases retain coverage (including GitHub's case-sensitive-name case).
- **Scope boundary:** Only adapter tests and their typed fixtures/mock return values changed; production code and TypeScript-project membership did not.
- **Root cause:** The former tests computed and asserted an independent literal comparison instead of observing the adapter's production result.

## Review guidance

- **Feedback requested:** Verify that the new assertions reach the production fork-detection boundary without broadening adapter behavior.
- **Start here:** `packages/adapters/src/forge/github/adapter.test.ts:1119` -- the helper submits a signed webhook, stubs the PR lookup, and checks the resulting `isForkPR` isolation hint.
- **Review order:** Review the GitHub helper and four cases, then the equivalent Gitea payload path at `packages/adapters/src/community/forge/gitea/adapter.test.ts:649` and its three cases.
- **Known risk or uncertainty:** The two files remain excluded from the adapters TypeScript project. Temporarily including them produced 56 pre-existing errors elsewhere, with no TS2367 or errors in the rewritten blocks; that mechanical typing work remains scoped to #2407.

## Solution

Each suite now sends a representative signed pull-request comment webhook through its existing adapter instance. The tests arrange the head and base repository identities where each adapter obtains them, then assert the `isForkPR` isolation hint passed to `handleMessage`. Gitea's existing database mocks were narrowed to the production-owned fields required by the resolved values, avoiding casts and error suppression.

## Validation

- `bun test src/forge/github/adapter.test.ts --test-name-pattern 'fork detection logic'` — 4 passed after restoring production — proves the GitHub production path reports all retained scenarios.
- `bun test src/community/forge/gitea/adapter.test.ts --test-name-pattern 'fork detection logic'` — 3 passed after restoring production — proves the Gitea production path reports all retained scenarios.
- Seen-red: temporarily inverted both production comparisons from `!==` to `===`; GitHub failed 4/4 and Gitea failed 3/3 at the downstream verdict assertions. Restored the exact comparisons immediately afterward.
- `bun run type-check && bun run test` in `packages/adapters` — passed; the full GitHub and Gitea files reported 73 and 48 passing tests respectively.
- `bun run validate` — passed on committed HEAD `c59ccd269`, including generated-artifact checks, API types, package type checks, lint, formatting, installer tests, and all tests.
- **Not verified:** Nothing material. A test-inclusive adapters type-check is intentionally deferred to #2407 because its 56 unrelated existing errors would make this focused behavior fix red; the diagnostic confirmed no TS2367 or rewritten-block error.

## Links

- Closes #3051

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded validation for forked pull request detection across GitHub and Gitea integrations.
  - Added coverage for webhook-based processing, signature verification, matching and differing repositories, and missing source repository details.
  - Improves confidence that pull request isolation is correctly identified in real webhook scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->