### PR TITLE
test(cli): isolate outside-git registry lookup

### DIFF
--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -4,14 +4,15 @@
  * Note: These tests focus on argument parsing logic.
  * Full integration tests would require mocking the database and commands.
  */
-import { describe, it, expect, beforeAll } from 'bun:test';
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { parseArgs } from 'util';
 import { cliArgOptions } from './args';
 import * as git from '@archon/git';
+import { SqliteAdapter } from '@archon/core/db/adapters/sqlite';
 import { removeTempTree } from '@archon/paths/test-utils';
 import { spawnSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join, relative } from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -1046,6 +1047,27 @@ describe('main catch --json error envelope', () => {
 });
 
 describe('pre-dispatch gates --json error envelope', () => {
+  let outsideGitRoot = '';
+  let outsideGitCwd: string;
+  let outsideGitDefaultHome: string;
+  let outsideGitArchonHome: string;
+
+  afterAll(async () => {
+    if (outsideGitRoot) await removeTempTree(outsideGitRoot);
+  });
+
+  beforeAll(async () => {
+    outsideGitRoot = mkdtempSync(join(tmpdir(), 'archon-cli-no-git-'));
+    outsideGitCwd = join(outsideGitRoot, 'project');
+    outsideGitDefaultHome = join(outsideGitRoot, 'default-home');
+    outsideGitArchonHome = join(outsideGitRoot, 'archon-home');
+    mkdirSync(outsideGitCwd);
+    mkdirSync(outsideGitDefaultHome);
+
+    const registry = new SqliteAdapter(join(outsideGitArchonHome, 'archon.db'));
+    await registry.close();
+  });
+
   it('emits { ok: false } on stdout when --cwd does not exist', () => {
     const { status, envelope } = spawnJsonError([
       'workflow',
@@ -1062,11 +1084,22 @@ describe('pre-dispatch gates --json error envelope', () => {
   });
 
   it('emits { ok: false } on stdout when outside a git repository', () => {
-    const { status, envelope } = spawnJsonError(['workflow', 'list', '--json', '--cwd', tmpdir()]);
+    const { status, envelope } = spawnJsonError(
+      ['workflow', 'list', '--json', '--cwd', outsideGitCwd],
+      {
+        ARCHON_HOME: outsideGitArchonHome,
+        DATABASE_URL: '',
+        ARCHON_DOCKER: '',
+        WORKSPACE_PATH: '',
+        HOME: outsideGitDefaultHome,
+        USERPROFILE: outsideGitDefaultHome,
+      }
+    );
 
     expect(status).toBe(1);
     expect(envelope).not.toThrow();
     expect(envelope()).toMatchObject({ ok: false });
+    expect(existsSync(join(outsideGitDefaultHome, '.archon', 'archon.db'))).toBe(false);
   });
 
   it('emits { ok: false } on stdout for an unknown command instead of usage text', () => {


### PR DESCRIPTION
## Problem and outcome

The outside-git JSON-envelope test launched the full CLI without a test-owned Archon home. Its timed body could initialize the operator's SQLite registry, mixing schema startup into the assertion and potentially mutating developer state.

- **Outcome:** The test now uses a tracked scratch non-git directory, fake OS home, and prebuilt empty Archon registry.
- **Invariant:** It still exercises the real CLI subprocess, registered-folder lookup, exit status, JSON parsing, and `{ ok: false }` envelope.
- **Scope boundary:** Production CLI and folder-project behavior are unchanged; this does not attempt the broader test audit in #2982.
- **Root cause:** The child inherited the default `ARCHON_HOME`, so the no-git lookup could create the full SQLite registry inside the timed test body.

## Review guidance

- **Feedback requested:** Test isolation and whether the fixture still proves the real outside-git behavior.
- **Start here:** `packages/cli/src/cli.test.ts` — the setup creates and closes the scratch registry before the timed invocation.
- **Review order:** Review the single-file diff, then the reproduction and validation evidence below.
- **Lower-attention areas:** None.
- **Known risk or uncertainty:** Windows CI evidence is pending on this PR.

## Solution

One suite-owned scratch root now contains the non-git cwd, fake default home, and separate `ARCHON_HOME`. Setup creates and closes an empty SQLite registry before the test runs. The child receives explicit SQLite/non-Docker environment values, and the assertion proves the fake default home remains untouched.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | The test could initialize the default/operator registry. | All registry state is created under the test-owned scratch root. |
| **Failure behavior** | SQLite schema creation and host state could consume the test timeout. | Schema creation occurs in setup; the timed body measures the real outside-git lookup and envelope. |

## Validation

- Focused target — passed, including the default-home untouched assertion.
- 25 local reruns under Bun's unchanged 5-second default — 25 passed; target bodies were 213–241 ms.
- Mutation proof — disabling the JSON failure path made the target fail at JSON parsing; restoring it returned green.
- Registered-folder integration — 3 passed.
- `bun --filter @archon/cli test` — passed.
- `bun run validate` — passed, including generated checks, type checks, lint, formatting, installer tests, package tests, and script tests.
- **Not verified:** Windows CI; this PR supplies the branch and checks needed for that evidence.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Security / permissions / data | The test no longer reads or writes the operator registry. | Scratch `HOME`, `USERPROFILE`, and `ARCHON_HOME`; post-run absence assertion. |
| Observability | The test body no longer includes hidden schema initialization. | Prebuilt registry plus repeated focused timings. |

## Links

- Related #2982


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI error handling when commands are run outside a Git repository.
  * Prevented unintended database files from being created in the default home directory during error scenarios.
* **Tests**
  * Added isolated test environments to improve reliability and prevent filesystem or environment state from affecting results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->