### PR TITLE
fix(workflows): --supersedes skips output_root gate, stays metadata-only (#3064)

### DIFF
--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -10455,6 +10455,55 @@ describe('workflowRunCommand — supersedes run-id prefix resolution (#2990)', (
       expect.objectContaining({ adopted_from_run_id: supersededRunId })
     );
   });
+
+  it('refuses a non-terminal supersedes run in the detach pre-flight before forking', async () => {
+    const supersededRunId = '0b1ee8da-1111-2222-3333-444455556666';
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    const workflowDb = await import('@archon/core/db/workflows');
+    const paths = await import('@archon/paths');
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'assist', description: 'Help' })],
+      errors: [],
+    });
+    (paths.getArchonHome as ReturnType<typeof mock>).mockImplementationOnce(() => {
+      throw new Error('no home in test');
+    });
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce(null);
+    (codebaseDb.findCodebaseByPathPrefix as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'cb-1',
+      name: 'test/folder',
+      default_cwd: '/test/path',
+      kind: 'folder',
+    });
+    (workflowDb.findWorkflowRunsByIdPrefix as ReturnType<typeof mock>).mockResolvedValueOnce([
+      { id: supersededRunId },
+    ]);
+    // Argument-aware on purpose: the queued-value mocks are argument-blind, which
+    // would let terminality pass here even if it ran on the raw prefix.
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockImplementation(async (id: string) =>
+      id === supersededRunId ? { id: supersededRunId, status: 'running' } : null
+    );
+
+    const spawnSpy = spyOn(Bun, 'spawn');
+    try {
+      // The refusal names the resolved full id, so terminality is checked on the
+      // resolution, not on the raw prefix.
+      await expect(
+        workflowRunCommand('/test/path/subdir', 'assist', 'hello', {
+          detach: true,
+          supersedesRunId: '0b1ee8da',
+        })
+      ).rejects.toThrow(`Cannot supersede run '${supersededRunId}': it is still running.`);
+    } finally {
+      spawnSpy.mockRestore();
+    }
+
+    // The refusal reached the parent: no child was forked and no pending run row
+    // was left behind for a launch that cannot proceed (#2872).
+    expect(spawnSpy).not.toHaveBeenCalled();
+    expect(mockCreateWorkflowRun).not.toHaveBeenCalled();
+  });
 });
 
 describe('workflowWaitCommand', () => {

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -10210,6 +10210,253 @@ describe('workflowRunCommand — adopt lane source recapture (#2660/#2747)', () 
   });
 });
 
+describe('workflowRunCommand — supersedes run-id prefix resolution (#2990)', () => {
+  let consoleSpy: ReturnType<typeof spyOn>;
+
+  // The suites above leave queued mockOnce values and call history behind on the shared
+  // module mocks. Re-install the module-mock defaults so this describe starts from a
+  // clean queue and leaves one behind for the suites after it.
+  function resetSharedMocks(): void {
+    const discoverMock = require('@archon/workflows/workflow-discovery')
+      .discoverWorkflowsWithConfig as ReturnType<typeof mock>;
+    discoverMock.mockReset();
+    discoverMock.mockImplementation(() => Promise.resolve({ workflows: [], errors: [] }));
+    const codebaseDb = require('@archon/core/db/codebases');
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockReset();
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockImplementation(() =>
+      Promise.resolve(null)
+    );
+    (codebaseDb.findCodebaseByPathPrefix as ReturnType<typeof mock>).mockReset();
+    (codebaseDb.findCodebaseByPathPrefix as ReturnType<typeof mock>).mockImplementation(() =>
+      Promise.resolve(null)
+    );
+    const conversationDb = require('@archon/core/db/conversations');
+    (conversationDb.getOrCreateConversation as ReturnType<typeof mock>).mockReset();
+    (conversationDb.getOrCreateConversation as ReturnType<typeof mock>).mockImplementation(() =>
+      Promise.resolve({
+        id: 'conv-123',
+        platform_type: 'cli',
+        platform_conversation_id: 'cli-123',
+      })
+    );
+    (conversationDb.updateConversation as ReturnType<typeof mock>).mockReset();
+    (conversationDb.updateConversation as ReturnType<typeof mock>).mockImplementation(() =>
+      Promise.resolve(undefined)
+    );
+    const workflowDb = require('@archon/core/db/workflows');
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockReset();
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockImplementation(() =>
+      Promise.resolve(null)
+    );
+    (workflowDb.findWorkflowRunsByIdPrefix as ReturnType<typeof mock>).mockReset();
+    (workflowDb.findWorkflowRunsByIdPrefix as ReturnType<typeof mock>).mockImplementation(() =>
+      Promise.resolve([])
+    );
+    mockCreateWorkflowRun.mockReset();
+    mockCreateWorkflowRun.mockImplementation(
+      (data: { workflow_name: string; conversation_id: string }) =>
+        Promise.resolve({
+          id: 'run-detached-created',
+          workflow_name: data.workflow_name,
+          conversation_id: data.conversation_id,
+          status: 'pending',
+          working_path: null,
+          started_at: new Date(),
+          metadata: {},
+        })
+    );
+    const adoption = require('@archon/core/operations/workflow-adoption');
+    (adoption.resolveWorkflowAdoption as ReturnType<typeof mock>).mockReset();
+    (adoption.resolveWorkflowAdoption as ReturnType<typeof mock>).mockImplementation(() =>
+      Promise.reject(new Error('adoption not expected'))
+    );
+  }
+
+  beforeEach(() => {
+    consoleSpy = spyOn(console, 'log').mockImplementation(() => {});
+    resetSharedMocks();
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    resetSharedMocks();
+  });
+
+  function setupSupersedesMocks(): void {
+    const discoverMock = require('@archon/workflows/workflow-discovery')
+      .discoverWorkflowsWithConfig as ReturnType<typeof mock>;
+    discoverMock.mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'assist', description: 'Help' })],
+      errors: [],
+    });
+    const codebaseDb = require('@archon/core/db/codebases');
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'cb-sup',
+      name: 'test-repo',
+      default_cwd: '/test/path',
+      kind: 'repo',
+    });
+  }
+
+  it('supersedes a run from a unique short run-id prefix', async () => {
+    const supersededRunId = '0b1ee8da-1111-2222-3333-444455556666';
+    const workflowDb = await import('@archon/core/db/workflows');
+    setupSupersedesMocks();
+    (workflowDb.findWorkflowRunsByIdPrefix as ReturnType<typeof mock>).mockResolvedValueOnce([
+      { id: supersededRunId },
+    ]);
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: supersededRunId,
+      status: 'completed',
+    });
+
+    await workflowRunCommand('/test/path', 'assist', 'hello', {
+      supersedesRunId: '0b1ee8da',
+      noWorktree: true,
+    });
+
+    expect(workflowDb.findWorkflowRunsByIdPrefix).toHaveBeenCalledWith('0b1ee8da', 'cb-sup');
+    // The terminality check sees the resolved full id, not the typed prefix.
+    expect(workflowDb.getWorkflowRun).toHaveBeenCalledWith(supersededRunId);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`Superseding run ${supersededRunId}`)
+    );
+  });
+
+  it('rejects an ambiguous supersedes run prefix with its candidates', async () => {
+    const workflowDb = await import('@archon/core/db/workflows');
+    const adoption = await import('@archon/core/operations/workflow-adoption');
+    setupSupersedesMocks();
+    (workflowDb.findWorkflowRunsByIdPrefix as ReturnType<typeof mock>).mockResolvedValueOnce([
+      { id: '0b1ee8da-1111-2222-3333-444455556666' },
+      { id: '0b1ee8da-9999-8888-7777-666655554444' },
+    ]);
+
+    await expect(
+      workflowRunCommand('/test/path', 'assist', 'hello', {
+        supersedesRunId: '0b1ee8da',
+        noWorktree: true,
+      })
+    ).rejects.toThrow(
+      '0b1ee8da-1111-2222-3333-444455556666\n  0b1ee8da-9999-8888-7777-666655554444'
+    );
+    expect(workflowDb.getWorkflowRun).not.toHaveBeenCalled();
+    expect(adoption.resolveWorkflowAdoption).not.toHaveBeenCalled();
+  });
+
+  it('passes a full supersedes run id through unchanged', async () => {
+    const supersededRunId = '0b1ee8da-1111-2222-3333-444455556666';
+    const workflowDb = await import('@archon/core/db/workflows');
+    setupSupersedesMocks();
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: supersededRunId,
+      status: 'completed',
+    });
+
+    await workflowRunCommand('/test/path', 'assist', 'hello', {
+      supersedesRunId: supersededRunId,
+      noWorktree: true,
+    });
+
+    expect(workflowDb.findWorkflowRunsByIdPrefix).not.toHaveBeenCalled();
+    expect(workflowDb.getWorkflowRun).toHaveBeenCalledWith(supersededRunId);
+  });
+
+  it('keeps the unknown-id refusal for a prefix that matches nothing', async () => {
+    setupSupersedesMocks();
+
+    await expect(
+      workflowRunCommand('/test/path', 'assist', 'hello', {
+        supersedesRunId: 'deadbeef',
+        noWorktree: true,
+      })
+    ).rejects.toThrow("Cannot supersede: no workflow run 'deadbeef' exists.");
+  });
+
+  it('still refuses a supersedes run that is not terminal', async () => {
+    const supersededRunId = '0b1ee8da-1111-2222-3333-444455556666';
+    const workflowDb = await import('@archon/core/db/workflows');
+    setupSupersedesMocks();
+    (workflowDb.findWorkflowRunsByIdPrefix as ReturnType<typeof mock>).mockResolvedValueOnce([
+      { id: supersededRunId },
+    ]);
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: supersededRunId,
+      status: 'running',
+    });
+
+    await expect(
+      workflowRunCommand('/test/path', 'assist', 'hello', {
+        supersedesRunId: '0b1ee8da',
+        noWorktree: true,
+      })
+    ).rejects.toThrow(`Cannot supersede run '${supersededRunId}': it is still running.`);
+  });
+
+  it('resolves a supersedes run prefix before passing it to the detached child', async () => {
+    const supersededRunId = '0b1ee8da-1111-2222-3333-444455556666';
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    const workflowDb = await import('@archon/core/db/workflows');
+    const paths = await import('@archon/paths');
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'assist', description: 'Help' })],
+      errors: [],
+    });
+    (paths.getArchonHome as ReturnType<typeof mock>).mockImplementationOnce(() => {
+      throw new Error('no home in test');
+    });
+    // The detach pre-flight resolves the project the same way the adopt pre-flight
+    // does: a subdir cwd misses the exact default-cwd lookup, then the path-prefix
+    // lookup resolves the covering folder project.
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce(null);
+    (codebaseDb.findCodebaseByPathPrefix as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'cb-1',
+      name: 'test/folder',
+      default_cwd: '/test/path',
+      kind: 'folder',
+    });
+    (workflowDb.findWorkflowRunsByIdPrefix as ReturnType<typeof mock>).mockResolvedValueOnce([
+      { id: supersededRunId },
+    ]);
+    (workflowDb.getWorkflowRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: supersededRunId,
+      status: 'completed',
+    });
+
+    const child = createDetachedChildFixture();
+    const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(child.child);
+    const savedArgv = process.argv;
+    process.argv = ['bun', '/abs/cli.ts', 'workflow', 'run', 'assist', 'hello', '--detach'];
+
+    let spawnCmd: string[] = [];
+    // finishStartupWindow advances the 500 ms startup window on fake timers.
+    jest.useFakeTimers();
+    try {
+      const commandPromise = workflowRunCommand('/test/path/subdir', 'assist', 'hello', {
+        detach: true,
+        supersedesRunId: '0b1ee8da',
+      });
+      await finishStartupWindow(commandPromise, spawnSpy);
+      spawnCmd = (
+        (spawnSpy.mock.calls[0]?.[0] as { cmd: string[] } | undefined)?.cmd ?? []
+      ).slice();
+    } finally {
+      jest.useRealTimers();
+      process.argv = savedArgv;
+      spawnSpy.mockRestore();
+    }
+
+    const supIndex = spawnCmd.indexOf('--supersedes');
+    expect(supIndex).toBeGreaterThan(-1);
+    expect(spawnCmd[supIndex + 1]).toBe(supersededRunId);
+    expect(workflowDb.findWorkflowRunsByIdPrefix).toHaveBeenCalledWith('0b1ee8da', 'cb-1');
+    expect(mockCreateWorkflowRun).toHaveBeenCalledWith(
+      expect.objectContaining({ adopted_from_run_id: supersededRunId })
+    );
+  });
+});
+
 describe('workflowWaitCommand', () => {
   const FULL_ID = '0b1ee8da-1111-2222-3333-444455556666';
   let consoleSpy: ReturnType<typeof spyOn>;

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -2105,6 +2105,7 @@ async function runWorkflowWithOwnedSource(
     // pre-flight costs nothing and the child still re-resolves it against the live
     // checkout when it starts (its lane binds a worktree this process never touches).
     let adoptedRunId: string | undefined;
+    let supersededRunId: string | undefined;
     if (options.adoptRunId !== undefined || options.supersedesRunId !== undefined) {
       if (!detachCodebase) {
         throw new Error(
@@ -2121,7 +2122,13 @@ async function runWorkflowWithOwnedSource(
           containerRequested: options.container === true,
         });
       } else if (options.supersedesRunId !== undefined) {
-        await resolveSupersededRun(options.supersedesRunId);
+        supersededRunId = await resolveRunIdArg(
+          options.supersedesRunId,
+          cwd,
+          false,
+          detachCodebase.id
+        );
+        await resolveSupersededRun(supersededRunId);
       }
     }
 
@@ -2158,8 +2165,8 @@ async function runWorkflowWithOwnedSource(
       const continuationDeclaration =
         adoptedRunId !== undefined
           ? { mode: 'adopt' as const, runId: adoptedRunId }
-          : options.supersedesRunId !== undefined
-            ? { mode: 'supersede' as const, runId: options.supersedesRunId }
+          : supersededRunId !== undefined
+            ? { mode: 'supersede' as const, runId: supersededRunId }
             : undefined;
       try {
         // No reserved id: this process's own capture is discarded on the way out, and
@@ -2213,8 +2220,7 @@ async function runWorkflowWithOwnedSource(
     // Between-run continuation (#2747) — the child re-resolves the adoption
     // against the live filesystem/database, so pass the declaration through.
     if (adoptedRunId !== undefined) extraArgs.push('--adopt', adoptedRunId);
-    if (options.supersedesRunId !== undefined)
-      extraArgs.push('--supersedes', options.supersedesRunId);
+    if (supersededRunId !== undefined) extraArgs.push('--supersedes', supersededRunId);
     // Re-pin the source as an ABSOLUTE path (parseArgs is last-wins, same as --cwd).
     // The original argv may hold a relative `--workflow-source`, and the child is
     // spawned with a different working directory, so passing it through unresolved
@@ -2368,7 +2374,7 @@ async function runWorkflowWithOwnedSource(
       adoptedFromRunId = await resolveRunIdArg(options.adoptRunId, cwd, false, codebase.id);
     } else if (options.supersedesRunId !== undefined) {
       continuationMode = 'supersede';
-      adoptedFromRunId = options.supersedesRunId;
+      adoptedFromRunId = await resolveRunIdArg(options.supersedesRunId, cwd, false, codebase.id);
     } else {
       throw new Error('--adopt/--supersedes requires a run id.');
     }

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -117,7 +117,11 @@ import {
   SUBRUN_METADATA_KEYS,
   CONTINUATION_METADATA_KEY,
 } from '@archon/workflows/schemas/workflow-run';
-import type { WorkflowRun, WorkflowRunStatus } from '@archon/workflows/schemas/workflow-run';
+import type {
+  WorkflowRun,
+  WorkflowRunStatus,
+  ContinuationMode,
+} from '@archon/workflows/schemas/workflow-run';
 import { TERMINAL_WORKFLOW_STATUSES } from '@archon/workflows/schemas/workflow-run';
 import {
   approveWorkflow,
@@ -2357,7 +2361,7 @@ async function runWorkflowWithOwnedSource(
   // inherits nothing.
   let adoptedFromRunId: string | undefined;
   let adoptedTaskBranch: Extract<TaskBranchSelection, { kind: 'existing' }> | undefined;
-  let continuationMode: 'adopt' | 'supersede' | undefined;
+  let continuationMode: ContinuationMode | undefined;
   // Set when the adopt lane executes inside a checkout whose `.archon` may differ from
   // this process's cwd — the trigger for recaptureForLane once the path is final.
   let adoptLaneRunsIsolatedCheckout = false;

--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -510,6 +510,14 @@ describe('executeWorkflow', () => {
         }
       );
       expect(result.success).toBe(true);
+      // Metadata stamp must record the continuation mode so resume reads it.
+      expect(store.createWorkflowRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            continuation: { mode: 'supersede' },
+          }),
+        })
+      );
       // Must NOT attempt to resolve output_root for supersession.
       expect(store.getWorkflowRun).not.toHaveBeenCalledWith(supersededId);
     });

--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -484,6 +484,131 @@ describe('executeWorkflow', () => {
     });
   });
 
+  // --- Supersession is metadata-only (#3064): no estate, no output_root gate ---
+
+  describe('supersession does not gate on output_root', () => {
+    it('starts normally when the superseded run has no output_root (preflight-failed)', async () => {
+      const supersededId = 'superseded-run';
+      const store = makeStore({
+        getWorkflowRun: mock(async (id: string) =>
+          id === supersededId
+            ? makeRun({ id: supersededId, status: 'failed', output_root: null })
+            : { ...makeRun(), status: 'completed' as const }
+        ),
+      });
+      const result = await executeWorkflow(
+        makeDeps(store),
+        makePlatform(),
+        'conv-1',
+        '/tmp/ops',
+        makeWorkflow(),
+        'msg',
+        'db-conv-1',
+        {
+          adoptedFromRunId: supersededId,
+          continuationMode: 'supersede',
+        }
+      );
+      expect(result.success).toBe(true);
+      // Must NOT attempt to resolve output_root for supersession.
+      expect(store.getWorkflowRun).not.toHaveBeenCalledWith(supersededId);
+    });
+
+    it('starts normally on resume when the superseded run has no output_root', async () => {
+      const supersededId = 'superseded-run';
+      const store = makeStore({
+        getWorkflowRun: mock(async () => makeRun({ status: 'completed' as const })),
+      });
+      const result = await executeWorkflow(
+        makeDeps(store),
+        makePlatform(),
+        'conv-1',
+        '/tmp/ops',
+        makeWorkflow(),
+        'msg',
+        'db-conv-1',
+        {
+          preCreatedRun: makeRun({
+            status: 'running',
+            adopted_from_run_id: supersededId,
+            metadata: { continuation: { mode: 'supersede' } },
+          }),
+          priorCompletedNodes: new Map([['node1', { output: 'out' }]]),
+        }
+      );
+      expect(result.success).toBe(true);
+      // The resumed supersession must not fetch the superseded run at all.
+      expect(store.getWorkflowRun).not.toHaveBeenCalledWith(supersededId);
+    });
+
+    it('adoption with output_root still works (unchanged)', async () => {
+      const adoptedId = 'prior-run';
+      let capturedVar: string | undefined;
+      mockExecuteDagWorkflow.mockImplementationOnce(async () => {
+        capturedVar = substituteWorkflowVariables(
+          'Read $ADOPTED_RUN_DIR/report.md',
+          'run-123',
+          'msg',
+          '/artifacts',
+          'main',
+          'docs'
+        ).prompt;
+        return undefined;
+      });
+      const store = makeStore({
+        getWorkflowRun: mock(async (id: string) =>
+          id === adoptedId
+            ? makeRun({ id: adoptedId, status: 'completed', output_root: '/tmp/roots/prior' })
+            : id === 'run-123'
+              ? makeRun({ id: 'run-123', status: 'completed' as const })
+              : { ...makeRun(), status: 'completed' as const }
+        ),
+      });
+      const result = await executeWorkflow(
+        makeDeps(store),
+        makePlatform(),
+        'conv-1',
+        '/tmp/ops',
+        makeWorkflow(),
+        'msg',
+        'db-conv-1',
+        {
+          adoptedFromRunId: adoptedId,
+          continuationMode: 'adopt',
+        }
+      );
+      expect(result.success).toBe(true);
+      expect(capturedVar!).toBe(
+        `Read ${join('/tmp/roots/prior', 'artifacts', 'runs', adoptedId)}/report.md`
+      );
+    });
+
+    it('emits the run_adopted event with mode in data', async () => {
+      const supersededId = 'superseded-run';
+      const store = makeStore();
+      await executeWorkflow(
+        makeDeps(store),
+        makePlatform(),
+        'conv-1',
+        '/tmp/ops',
+        makeWorkflow(),
+        'msg',
+        'db-conv-1',
+        {
+          adoptedFromRunId: supersededId,
+          continuationMode: 'supersede',
+        }
+      );
+      const eventCalls = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls.filter(
+        c => (c[0] as { event_type: string }).event_type === 'workflow.run_adopted'
+      );
+      expect(eventCalls).toHaveLength(1);
+      const eventData = (eventCalls[0]![0] as { data: Record<string, unknown> }).data;
+      expect(eventData.adopted_from_run_id).toBe(supersededId);
+      expect(eventData.mode).toBe('supersede');
+    });
+  });
+
   // -------------------------------------------------------------------------
   // Concurrent-run guard
   // -------------------------------------------------------------------------

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -40,6 +40,7 @@ import {
   readContinuationMode,
   WORKFLOW_SOURCE_METADATA_KEY,
   readWorkflowSourceState,
+  type ContinuationMode,
 } from './schemas';
 import {
   WorkflowSourceIntegrityError,
@@ -686,7 +687,7 @@ export type ExecuteWorkflowOptions = ResumePayload & {
    */
   adoptedFromRunId?: string;
   /** How `adoptedFromRunId` continues: estate adoption or fresh-lane supersession. */
-  continuationMode?: 'adopt' | 'supersede';
+  continuationMode?: ContinuationMode;
   /** One model-binding phase: raw at invocation boundaries, resolved for child runs. */
   modelOverrideLayer?:
     | { kind: 'raw'; overrides: RunModelOverrides }
@@ -2188,7 +2189,9 @@ export async function executeWorkflow(
             : {}),
           // Between-run continuation (#2747): the mode stamp rides the same
           // creation write as `adopted_from_run_id` so both are write-once.
-          ...(adoptedFromRunId ? { [CONTINUATION_METADATA_KEY]: { mode: continuationMode } } : {}),
+          ...(adoptedFromRunId
+            ? { [CONTINUATION_METADATA_KEY]: { mode: continuationMode ?? 'adopt' } }
+            : {}),
           [RUN_MODEL_BINDINGS_METADATA_KEY]: modelBindingsMetadata,
           ...(runConfigMetadata ? { [WORKFLOW_RUN_CONFIG_METADATA_KEY]: runConfigMetadata } : {}),
         },

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -37,6 +37,7 @@ import {
   RUN_METADATA_KEYS,
   readIdentityUnresolved,
   CONTINUATION_METADATA_KEY,
+  readContinuationMode,
   WORKFLOW_SOURCE_METADATA_KEY,
   readWorkflowSourceState,
 } from './schemas';
@@ -1804,7 +1805,7 @@ export async function executeWorkflow(
     runConfig: callerRunConfig,
     preparedSource,
     adoptedFromRunId,
-    continuationMode = 'adopt',
+    continuationMode,
   } = opts;
 
   const executionUserId = preCreatedRun ? (preCreatedRun.user_id ?? undefined) : userId;
@@ -2535,33 +2536,45 @@ export async function executeWorkflow(
 
   // Between-run continuation (#2747): resolve $ADOPTED_RUN_DIR through the
   // adopted run's persisted `output_root` (rename-safe per #2200) and announce
-  // the adoption on THIS run's own event log so the chain renders without a
+  // the continuation on THIS run's own event log so the chain renders without a
   // column join. Read-only by contract — this run writes to its own artifacts;
   // stores are never merged, so evidence stays attributable per run.
   // Resolution also runs on resume: a resumed run carries no caller-supplied id,
-  // but its row still records the adoption, and every remaining node may reference
-  // $ADOPTED_RUN_DIR. Only the announcement event stays creation-only — it was
-  // written once when the adoption was made.
+  // but its row still records the continuation, and every remaining node may
+  // reference $ADOPTED_RUN_DIR (only for adoption; supersession has no estate).
+  // Only the announcement event stays creation-only — it was written once when
+  // the continuation was made.
   const effectiveAdoptedFromRunId = adoptedFromRunId ?? workflowRun.adopted_from_run_id;
+  // On a fresh invocation the caller supplies the mode alongside the id. On
+  // resume neither is in opts — the executor reads the row's metadata stamp.
+  const effectiveContinuationMode =
+    continuationMode ?? readContinuationMode(workflowRun.metadata) ?? 'adopt';
   let adoptedRunDir: string | undefined;
   if (effectiveAdoptedFromRunId) {
-    const adopted = await deps.store.getWorkflowRun(effectiveAdoptedFromRunId);
-    if (!adopted?.output_root) {
-      throw new Error(
-        `Cannot adopt run '${effectiveAdoptedFromRunId}': it has no persisted output root, so its ` +
-          'artifact directory cannot be addressed.'
+    // Supersession is metadata-only (#3064): no estate, so skip the output_root
+    // gate and the $ADOPTED_RUN_DIR resolution that only adoption needs.
+    if (effectiveContinuationMode !== 'supersede') {
+      const adopted = await deps.store.getWorkflowRun(effectiveAdoptedFromRunId);
+      if (!adopted?.output_root) {
+        throw new Error(
+          `Cannot adopt run '${effectiveAdoptedFromRunId}': it has no persisted output root, so its ` +
+            'artifact directory cannot be addressed.'
+        );
+      }
+      adoptedRunDir = archonPaths.getRunArtifactsDirForRoot(
+        adopted.output_root,
+        effectiveAdoptedFromRunId
       );
     }
-    adoptedRunDir = archonPaths.getRunArtifactsDirForRoot(
-      adopted.output_root,
-      effectiveAdoptedFromRunId
-    );
     if (!isContinuation) {
       try {
         await deps.store.createWorkflowEvent({
           workflow_run_id: workflowRun.id,
           event_type: 'workflow.run_adopted',
-          data: { adopted_from_run_id: effectiveAdoptedFromRunId },
+          data: {
+            adopted_from_run_id: effectiveAdoptedFromRunId,
+            mode: effectiveContinuationMode,
+          },
         });
       } catch (err) {
         getLog().warn(


### PR DESCRIPTION
## Problem and outcome

`--supersedes` is documented as metadata-only run replacement, but the executor routes it through the same `output_root` gate as `--adopt`. Superseding a preflight-failed run (no persisted output root) throws an error, making the recovery primitive unusable for the runs most likely to need replacement.

- **Outcome:** Supersession no longer gates on `output_root` or resolves `$ADOPTED_RUN_DIR`. The fresh run starts normally even when the superseded run failed during preflight. Adoption semantics are unchanged.
- **Invariant:** `--adopt` keeps its lane and artifact inheritance and still requires `output_root`. Supersession is recorded as such in the run record — neither its provenance nor its event log claim adoption.
- **Scope boundary:** No change to terminality, existence, or eligibility checks for supersession. No change to open-work filtering.
- **Root cause:** The executor treated any `adoptedFromRunId` as an adoption, so it fetched the prior run's `output_root` unconditionally and threw when it was null. The caller's continuation mode was not consulted.

## Review guidance

- **Feedback requested:** Correctness of the mode gating — `continuationMode` falls through from caller to metadata stamp to `'adopt'` default on resume; the `output_root` check is gated on `effectiveContinuationMode !== 'supersede'`.
- **Start here:** `packages/workflows/src/executor.ts:2553` — the `effectiveContinuationMode` resolution and the gated `output_root` block.
- **Review order:** `packages/workflows/src/executor.ts` (mode resolution + output_root gate), then `packages/workflows/src/executor.test.ts` (four new tests), then the cherry-picked CLI prefix-resolution commits in `packages/cli/src/commands/workflow.ts` and its test file.
- **Lower-attention areas:** The CLI prefix-resolution changes are cherry-picked from PR #3047 (still open); they are mechanically independent and covered by 7 focused tests on ID resolution only.
- **Known risk or uncertainty:** None.

## Solution

Removed the destructuring default `continuationMode = 'adopt'` so the effective mode falls through to the run row's metadata on resume. Added `readContinuationMode` import from the schemas module. `effectiveContinuationMode` now resolves as: caller-supplied mode → metadata stamp → `'adopt'` fallback. The `output_root` fetch and `adoptedRunDir` resolution are gated behind `effectiveContinuationMode !== 'supersede'`. The `workflow.run_adopted` event now includes `mode` in its data payload so consumers can distinguish adoption from supersession.

On the CLI side, the cherry-picked commits route `--supersedes` through `resolveRunIdArg` matching the existing `--adopt` behavior, so short run-id prefixes work identically for both flags.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | `--supersedes` of a preflight-failed run throws "no persisted output root" | Fresh run starts normally; supersession is metadata-only |
| **Failure behavior** | Any superseded run without `output_root` is refused (makes the recovery primitive unusable) | Only adoption without `output_root` is refused; supersession proceeds |

### User flow

```mermaid
flowchart LR
  subgraph Before
    B1[--supersedes preflight-failed-run] --> B2[Executor fetches output_root]
    B2 --> B3[output_root is null]
    B3 --> B4[Throws: cannot adopt]
  end

  subgraph After
    A1[--supersedes preflight-failed-run] --> A2[Executor checks continuationMode]
    A2 --> A3[mode is supersede]
    A3 --> A4[Skips output_root gate]
    A4 --> A5[Fresh run starts normally]
  end
```

## Architecture

```mermaid
flowchart LR
  CLI["workflow.ts (CLI)"]
  Executor["executor.ts"]
  Store["Database"]
  CLI -- continuationDeclaration{mode:supersede,runId} --> Executor
  Executor -- "effectiveContinuationMode = caller ?? metadata ?? 'adopt'" --> Executor
  Executor -- "if mode !== supersede → fetch output_root" --> Store
  Executor -- "if mode !== supersede → resolve $ADOPTED_RUN_DIR" --> Store
  Executor -- "event{mode} on fresh invocation" --> Store
```

### Changed seams

| Boundary or contract | Change | Evidence |
|---|---|---|
| `executeWorkflow opts` → `continuationMode` | Removed `= 'adopt'` default; mode falls through | `packages/workflows/src/executor.ts:1809` |
| `readContinuationMode` | New import from `./schemas` for resume path | `packages/workflows/src/executor.ts:40` |
| `output_root` + `adoptedRunDir` | Gated behind `mode !== 'supersede'` | `packages/workflows/src/executor.ts:2559-2572` |
| `workflow.run_adopted` event | `data` now includes `mode` field | `packages/workflows/src/executor.ts:2579` |
| CLI `--supersedes` resolution | Routes through `resolveRunIdArg` (cherry-picked from #3047) | `packages/cli/src/commands/workflow.ts:2128, 2379` |

## Validation

- `bun test packages/workflows/src/executor.test.ts` — 140 pass, 0 fail (4 new supersession tests plus all existing adoption tests)
- `bun test packages/cli/src/commands/workflow.test.ts -t supersedes` — 7 pass (cherry-picked prefix-resolution tests)
- `bun run --filter @archon/workflows type-check` — pass
- `bun run --filter @archon/cli type-check` — pass
- `bun run lint` — pass
- **Not verified:** Nothing material; adoption with output_root (unchanged), supersession without output_root (fresh and resume), event payload correctness, and prefix resolution cases are each covered by a focused test.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | Existing superseded runs (already metadata-only) are unaffected; `mode` field added to events is additive. | Both fresh and resume paths tested |
| Rollout / rollback | Safe reversal — revert commit restores old `output_root` gate. | Two commits; revert the main one restores the gate |
| Observability | Event `mode` field distinguishes supersession from adoption in logs. | Event payload test covers the field |

## Links

- Closes #3064
- Depends on #3047 (prefix resolution, cherry-picked into this branch)
- Related #2990 (original issue that #3047 addresses)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resolving unique shortened run IDs when superseding workflows.
  * Superseding workflows can now start without requiring artifacts from the previous run.
  * Continuation metadata and events now clearly record whether a run adopts or supersedes another run.

* **Bug Fixes**
  * Ambiguous or unknown run IDs are rejected with clearer handling.
  * Non-terminal runs cannot be superseded.
  * Adoption workflows continue to require and correctly resolve the previous run’s artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->