### PR TITLE
docs(agents): classifying vendor output by wording is a last resort, not a carve-out

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ This file is the canonical project guidance for coding agents. Keep it short, du
 - Put determinism after interpretation: give the agent typed tools, then validate resolved identifiers, arguments, permissions, and invariants at the tool boundary.
 - If exact syntax is required, expose a structured interface such as a CLI flag, typed tool, button action, or schema.
 - In a workflow, prose inside a node is model reasoning. Prose passed between nodes as a token to parse is an invented protocol; use structured output, typed inputs, exit status, or another explicit engine channel.
-- Third-party output classification is different. It is valid to classify git, SDK, or vendor errors that Archon does not control.
+- Vendor output is prose too. Classifying git, SDK, or vendor error text with a pattern is a last resort, not a carve-out: prefer the structured channel (exit code, typed error class, `--json` or porcelain output), then agent classification into a typed value, then an honest unclassified failure carrying the original evidence. A match that survives anchors to a machine token embedded in the message (an errno, an error code) and may enrich a report — never gate retry, fallback, or suppression, where a vendor rewording silently changes behavior.
 
 ### Do not guess lifecycle ownership
 


### PR DESCRIPTION
## Problem and outcome

`AGENTS.md` carves third-party output classification out of the "natural language is not a wire format" rule: "It is valid to classify git, SDK, or vendor errors that Archon does not control." Vendor error messages are natural language too — unversioned, reworded without notice — and a pattern match over them fails exactly like a pattern over user prose: silently, into whatever the fallthrough branch does. The carve-out reads as a license and teaches agents the wrong default.

- **Outcome:** the bullet states the actual ladder — structured channel first (exit codes, typed error classes, `--json`/porcelain), agent classification into a typed value second, honest unclassified failure last — and confines any surviving match to machine tokens embedded in the message, enriching a report but never gating retry, fallback, or suppression.
- **Invariant:** the rest of the section is unchanged; parsing your own instructed structured output remains fine, and the rule stays about what is parsed, not about the regex mechanism.
- **Scope boundary:** guidance only. No code changes; the review pack's errors lens gains the matching hunting probe in a separate PR.

## Review guidance

- **Feedback requested:** whether the replacement wording draws the line where intended — last resort with a named ladder, not a ban on classifying vendor output.
- **Start here:** `AGENTS.md`, the last bullet of "Natural language is not a wire format".
- **Review order:** single-bullet diff.
- **Known risk or uncertainty:** None.

## Solution

One bullet replaced in place. The ladder orders the alternatives by how honestly they survive a vendor rewording: a structured channel cannot be reworded, an agent classifier absorbs rewording, an unclassified failure surfaces it — while a behavior-gating pattern silently degrades. The residue clause keeps legitimate uses (matching an errno or error code to improve a message) from reading as violations.

## Validation

- Prose-only change to a steering file; no commands apply.

## Links

- Related #2555 (the natural-language rule's origin in agent-first input resolution)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated error-classification guidance to prioritize structured error details and explicit classifications.
  * Clarified that message pattern matching should only supplement reports, not control retries, fallbacks, or error suppression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->