### PR TITLE
chore(providers): upgrade Claude, Codex, and Pi agent SDKs to latest releases

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "archon",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.3.247",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.251",
         "@opencode-ai/sdk": "^1.17.3",
       },
       "devDependencies": {
@@ -28,7 +28,7 @@
     },
     "packages/adapters": {
       "name": "@archon/adapters",
-      "version": "0.9.0",
+      "version": "0.10.1",
       "dependencies": {
         "@archon/core": "workspace:*",
         "@archon/git": "workspace:*",
@@ -48,7 +48,7 @@
     },
     "packages/cli": {
       "name": "@archon/cli",
-      "version": "0.9.0",
+      "version": "0.10.1",
       "bin": {
         "archon": "./src/cli.ts",
       },
@@ -70,7 +70,7 @@
     },
     "packages/core": {
       "name": "@archon/core",
-      "version": "0.9.0",
+      "version": "0.10.1",
       "dependencies": {
         "@archon/git": "workspace:*",
         "@archon/isolation": "workspace:*",
@@ -93,7 +93,7 @@
     },
     "packages/docs-web": {
       "name": "@archon/docs-web",
-      "version": "0.9.0",
+      "version": "0.10.1",
       "dependencies": {
         "@astrojs/starlight": "^0.38.0",
         "astro": "^6.1.0",
@@ -103,7 +103,7 @@
     },
     "packages/git": {
       "name": "@archon/git",
-      "version": "0.9.0",
+      "version": "0.10.1",
       "dependencies": {
         "@archon/paths": "workspace:*",
       },
@@ -113,7 +113,7 @@
     },
     "packages/isolation": {
       "name": "@archon/isolation",
-      "version": "0.9.0",
+      "version": "0.10.1",
       "dependencies": {
         "@archon/git": "workspace:*",
         "@archon/paths": "workspace:*",
@@ -125,7 +125,7 @@
     },
     "packages/paths": {
       "name": "@archon/paths",
-      "version": "0.9.0",
+      "version": "0.10.1",
       "dependencies": {
         "dotenv": "^17",
         "pino": "^9",
@@ -138,14 +138,14 @@
     },
     "packages/providers": {
       "name": "@archon/providers",
-      "version": "0.9.0",
+      "version": "0.10.1",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.3.247",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.251",
         "@archon/paths": "workspace:*",
-        "@earendil-works/pi-ai": "^0.84.3",
-        "@earendil-works/pi-coding-agent": "^0.84.3",
+        "@earendil-works/pi-ai": "^0.84.4",
+        "@earendil-works/pi-coding-agent": "^0.84.4",
         "@github/copilot-sdk": "~1.0.1",
-        "@openai/codex-sdk": "^0.150.1",
+        "@openai/codex-sdk": "^0.151.0",
         "@opencode-ai/sdk": "^1.17.3",
         "@sinclair/typebox": "^0.34.41",
         "ajv": "^8.20.0",
@@ -161,7 +161,7 @@
     },
     "packages/server": {
       "name": "@archon/server",
-      "version": "0.9.0",
+      "version": "0.10.1",
       "dependencies": {
         "@archon/adapters": "workspace:*",
         "@archon/core": "workspace:*",
@@ -183,7 +183,7 @@
     },
     "packages/web": {
       "name": "@archon/web",
-      "version": "0.9.0",
+      "version": "0.10.1",
       "dependencies": {
         "@dagrejs/dagre": "^2.0.4",
         "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -236,7 +236,7 @@
     },
     "packages/workflows": {
       "name": "@archon/workflows",
-      "version": "0.9.0",
+      "version": "0.10.1",
       "dependencies": {
         "@archon/git": "workspace:*",
         "@archon/paths": "workspace:*",
@@ -263,23 +263,23 @@
   "packages": {
     "@antfu/ni": ["@antfu/ni@25.0.0", "", { "dependencies": { "ansis": "^4.0.0", "fzf": "^0.5.2", "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" }, "bin": { "na": "bin/na.mjs", "ni": "bin/ni.mjs", "nr": "bin/nr.mjs", "nci": "bin/nci.mjs", "nlx": "bin/nlx.mjs", "nun": "bin/nun.mjs", "nup": "bin/nup.mjs" } }, "sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA=="],
 
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.247", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.247", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.247", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.247", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.247", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.247", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.247", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.247", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.247" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-T9BDPloZxABkGREDRbWA7TVa9SLBMWI5GQXw39+XotQLCIX3McRic9OJdUnAdXa7sutwQ4nNrXwTSazN4IphjA=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.251", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.251", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.251", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.251", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.251", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.251", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.251", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.251", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.251" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-DqSi8mH2tQYRlVV0G+lJnQ/WbjJZ/a+8cJ3vPuYoqh8esIIvXHm1ZOXV1UPGsFYRnbBytEoiSGitguEXd+sQ+Q=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.247", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vvCMAXy2KmiGHbJuThv+W6a+49qjofMR6S71FM8FTbkAAKg62cYcEyzVMVM3pNpBM5PtkMe8lRCqKnT9NUo6ng=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.251", "", { "os": "darwin", "cpu": "arm64" }, "sha512-C23h+Dbddcc4gai95+lhm4/94am2IOq+bf3IdEDDS7EPqDQqajo2s5q1/ZSwq9rOc0RJLT7Ws72ZCzYJh67KSg=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.247", "", { "os": "darwin", "cpu": "x64" }, "sha512-742ZXrdAxHvw+vzMFJMMvfbH8mWWCBajQH27BT+3fQU3Frjqu9gXKvA63dvQgxwjqO1gYU9TSy/A6PKq7zujaQ=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.251", "", { "os": "darwin", "cpu": "x64" }, "sha512-HrLnb3ggk+vMbymUvbosgPmxWp4W6Ot+0mNVjoBYDn5OZrTV3C3LRtbWf7jwcGyKMcg0xJf0AqiudQ2BRrlr8A=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.247", "", { "os": "linux", "cpu": "arm64" }, "sha512-5/3ZQ9vOwrLv6w0CFjdbaTxPFyabHNLAEojkeiYmKzqlZ/taXG58/kVKgjqgx2qQhjcHCzy9JXDw5kp3RKJoGw=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.251", "", { "os": "linux", "cpu": "arm64" }, "sha512-3E27F5j82EWOyEniRW7crmo0jWYYQmPDdP52jWq6Y6aytiyYIdUFMEGZZ6chVHNlZiU7GsjTa3teKk2xlQ68lQ=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.247", "", { "os": "linux", "cpu": "arm64" }, "sha512-8UNRQcSy9lpLhknXryid5cTfxHxBZft4oK5R0XIIZUXY/tXvsNP3+kVYAHQUNyc1J8IDa15sd19iKkMJMqFodA=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.251", "", { "os": "linux", "cpu": "arm64" }, "sha512-RTUf7TPBUkQ6oV3pDkEdcD47I0uH0ZpvmZlXHnrLGznFqyLr+7XHupOxUMJD0Jwm9v5qeqpNiPAYB0dL4RYiHg=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.247", "", { "os": "linux", "cpu": "x64" }, "sha512-+tEIHgblLvBF+datSZb9WwnODXsFI7JxSFvm++oliH0eQO5zGDq0LD0hbY6h/A3nqODnBbIwVVBykwXMn68GPg=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.251", "", { "os": "linux", "cpu": "x64" }, "sha512-qCD87XPjcNM1u4ukqmcgpHDl3Y6l+cW8j7kPzH91Y5yLBYJ5xYZA2KtJ7AYNEPOteVyOGJw/efmva0S8CRr0fg=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.247", "", { "os": "linux", "cpu": "x64" }, "sha512-iMLjkVHbcxQ5WY2WwieOJK57kD4c8Cc2tpHwpEmdTDsnWLfmNt3XFuJdmeROwyra+tcVA52oHL0dWr51+V50Pg=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.251", "", { "os": "linux", "cpu": "x64" }, "sha512-SzXrdy7jjrjJIuTG+VMRAY0YZ3G/8w21WuhAozwnvnEUAPo6NDv6lgFinu7NO8J6CPE+MK2sGze6JeCF+ljgUg=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.247", "", { "os": "win32", "cpu": "arm64" }, "sha512-Sni6U2xR55bUEJRv7Eikm6oC27IOn3rlVJZAzXRFCAgkf9+aBqq/dEUJiIcRT2xbXOIe5QdPGUmpnYfU1BsHMw=="],
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.251", "", { "os": "win32", "cpu": "arm64" }, "sha512-FH1ZLcyc97ie3h7CSlIxA1ppXILgf0V8sFQrWnHyKBrthJXQkMHXhsTq9OZV/2KhXslNf2hTe0gHpZ1nCL1Gmg=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.247", "", { "os": "win32", "cpu": "x64" }, "sha512-yWfZo2ER3EIS/3pv6EX1M/VrZXu+zFzKhgWJjGgFSlcupbaCAxrVBRTdCyfv5UYBKWH9kl5HjgV2HhLHq67LSw=="],
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.251", "", { "os": "win32", "cpu": "x64" }, "sha512-/jmtFIvfF0UFMxSZ8WV2Aus8aGA3+8Ft6AHvWuBJkY5jM2ubfqi6GnBjKCAL831TTllp2rKZlViANtWWRBvpvg=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.93.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-q9vaSZQVFx6B/gPxetGYfLXSJD5v0sOmh0OpZDq7yCrTSA+Rscvrtyol7JJTW40wEpQB4U1B4JXzxQitbQ3CAA=="],
 
@@ -479,19 +479,19 @@
 
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.54.1", "", { "dependencies": { "commander": "^11.1.0", "dotenv": "^17.2.1", "eciesjs": "^0.4.10", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "picomatch": "^4.0.2", "which": "^4.0.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-41gU3q7v05GM92QPuPUf4CmUw+mmF8p4wLUh6MCRlxpCkJ9ByLcY9jUf6MwrMNmiKyG/rIckNxj9SCfmNCmCqw=="],
 
-    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.84.3", "", { "dependencies": { "@earendil-works/pi-ai": "^0.84.3", "@earendil-works/pi-telemetry": "^0.84.3", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.3.7", "yaml": "2.9.0" } }, "sha512-VURr+xBRl3RxYcw3kT9Pn3yfi6LbRoCJgHF7h1mAblMjtLNV/MfG/RyF0uJizBAM886AEakSiw3j9c/aSngppg=="],
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.84.4", "", { "dependencies": { "@earendil-works/pi-ai": "^0.84.4", "@earendil-works/pi-telemetry": "^0.84.4", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.3.7", "yaml": "2.9.0" } }, "sha512-HyUnjaOXj6oN/6SNcr8A1J/ElRQA50FtIE0XUTSKAQVqmdlb9qdojOyUQwF/jULE5+yOEtGuVgi/N1RnBiNG+g=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.84.3", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@earendil-works/pi-telemetry": "^0.84.3", "@google/genai": "1.52.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.40.0", "partial-json": "0.1.7", "typebox": "1.3.7" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-M0YUV8vNO3y2WwWSyY8ijKJV5W4gkSUixuvk+Z00ZBjsyMfsdXfITsHEwP1UIf09YRWXT6oGn0GlCamt+P32XQ=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.84.4", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@earendil-works/pi-telemetry": "^0.84.4", "@google/genai": "1.52.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.40.0", "partial-json": "0.1.7", "typebox": "1.3.7" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-AClAZxf5+c4RRu44NJPS6wyQy+Nmq+Mzyyrdvm4ZVMNuixelO02RZX4G4Aq1F145Yzp43wnM5S+hLlSI7ypfVw=="],
 
-    "@earendil-works/pi-client": ["@earendil-works/pi-client@0.84.3", "", { "dependencies": { "@earendil-works/pi-protocol": "^0.84.3" } }, "sha512-zfErYane+390W0xpBJ/FWCp6aktPpkpcIcXUeZiAziWLoxE80ZNQALRyOSa/gGS5V+1OkNnMYxRxbzN0zUvnOA=="],
+    "@earendil-works/pi-client": ["@earendil-works/pi-client@0.84.4", "", { "dependencies": { "@earendil-works/pi-protocol": "^0.84.4" } }, "sha512-q398WY/3ZQHTizk7IKxApzqFV0xt4yM9LkSkwyqeLK5Bj5RwRjOWxESt26z4LgNp4O+8hqhqFPf/8fj4H5rE4A=="],
 
-    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.84.3", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.84.3", "@earendil-works/pi-ai": "^0.84.3", "@earendil-works/pi-client": "^0.84.3", "@earendil-works/pi-protocol": "^0.84.3", "@earendil-works/pi-tui": "^0.84.3", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "grok-mermaid": "0.2.2", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.3.7", "undici": "8.9.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/bundle/cli.js" } }, "sha512-Yr2p9PubrbFZmYEPYI+C8KmZP9xlFuLDnAG64RtU0ZDgrdiXYWa+y7WGyJO5OlqPliOkVCMd9IzVszO3/t0D0w=="],
+    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.84.4", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.84.4", "@earendil-works/pi-ai": "^0.84.4", "@earendil-works/pi-client": "^0.84.4", "@earendil-works/pi-protocol": "^0.84.4", "@earendil-works/pi-tui": "^0.84.4", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "grok-mermaid": "0.2.2", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.3.7", "undici": "8.9.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/bundle/cli.js" } }, "sha512-jmOlrqUmvhh/siNWFRXjYLJzhKFIHNsAQaysRwzQPQFnPAaV/vhqHsLH/MBsIISA1Rjj7WTUFR3nJrpXoLx39w=="],
 
-    "@earendil-works/pi-protocol": ["@earendil-works/pi-protocol@0.84.3", "", { "dependencies": { "typebox": "1.3.7" } }, "sha512-9a4g6WhLOvRqvsIOFaWxg/2gdrbY4Thclwj5ipLUPAWChfsDJ/8XdPc2sRhSOkD6EsxpEFJz3xppcfwI6EcZDg=="],
+    "@earendil-works/pi-protocol": ["@earendil-works/pi-protocol@0.84.4", "", { "dependencies": { "typebox": "1.3.7" } }, "sha512-acyE9ozxkMiWiz/xyWpU0O9vwnYv0hyG889Vniv6Sg9c9zfsX+8MePnDNphBacY2Fvm1rxdsGmiVDSZl9yuDFA=="],
 
-    "@earendil-works/pi-telemetry": ["@earendil-works/pi-telemetry@0.84.3", "", {}, "sha512-sgEkWoKrvSGaKn+YfLLFZmn+/A7B/w62eLwTD57nI+C9to8ITlFFVbgC2OtwvPnT3NFGHdCd53qhBEMIlptD1g=="],
+    "@earendil-works/pi-telemetry": ["@earendil-works/pi-telemetry@0.84.4", "", {}, "sha512-8e2CuxM+ht+hedQXTZmi5JVl6/xDK9RpSDL2+MbITevKYQhMZ/z6lJOTFgox3HQyGxO8mOZEtYGVeQNaD4OzqA=="],
 
-    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.84.3", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-fS6OEQKEEALnKa6Uw8LcgZZ+9CWck7f3MQSCETQp6leUgIFwMEDtKmOUnL9nsYm+RIPmy7OmplVxYRbV6hiaFg=="],
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.84.4", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-nPUnwDkLtupPXnZQYrCwPFcuTydCDqTY6ZbFqhsL4S4kVq0AT418kPa/6uXwtaCD+MjBNBltb7ScTYX65yeE1w=="],
 
     "@ecies/ciphers": ["@ecies/ciphers@0.2.5", "", { "peerDependencies": { "@noble/ciphers": "^1.0.0" } }, "sha512-GalEZH4JgOMHYYcYmVqnFirFsjZHeoGMDt9IxEnM9F7GRUUyUksJ7Ou53L83WHJq3RWKD3AcBpo0iQh0oMpf8A=="],
 
@@ -779,21 +779,21 @@
 
     "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
 
-    "@openai/codex": ["@openai/codex@0.150.1", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.150.1-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.150.1-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.150.1-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.150.1-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.150.1-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.150.1-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-knrbhpJH3mEULAVStcZW4F5WEt9MQhBj6KFOonBSIUGTLcHlu9CE7FRmr95E33y94+sWNZSeVBBV/kYvlfgxkQ=="],
+    "@openai/codex": ["@openai/codex@0.151.0", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.151.0-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.151.0-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.151.0-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.151.0-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.151.0-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.151.0-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-mhtWmOZRdmWD1jPbLDnQb59BsaVP/V+lXe/OFNR9ZcLZU0UCiBwn98Fcav1ss7sDIlHkuqj6nWd44IPeXoOhJA=="],
 
-    "@openai/codex-darwin-arm64": ["@openai/codex@0.150.1-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Z614kKSI3/p+YMotBJMxCc4kvRCYEgsVmnaCG6U8HDraqTFxYcQYQ79B4/GBCBS88/KtacHI6qzjA+4Mu5BynA=="],
+    "@openai/codex-darwin-arm64": ["@openai/codex@0.151.0-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-g7YzpaCZGCw19R/gly3vRPjnLqaW7JcBAu2WQQ6e8PIlvBPmS/gMplIUURMgNO6gi8LsPzdlQtLqkwoeOOlIdg=="],
 
-    "@openai/codex-darwin-x64": ["@openai/codex@0.150.1-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-vcvJ7Q4IP2vA5ZR3v9Pj9VLKtlhD7efujxHqqW/NJ8F2/XqTD4iPjErV07190Om3wONW48yploTgul16QUk9Mg=="],
+    "@openai/codex-darwin-x64": ["@openai/codex@0.151.0-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-0y+g8TVpP+Fn10mjoKYXER6qYjn29w7xBUsbPXJ6Accu/FoM4Qp4WbKXQPmE0G0yUACTQVZRjzTSsdWUezNgkg=="],
 
-    "@openai/codex-linux-arm64": ["@openai/codex@0.150.1-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-U0BY5UDsCy1up/O2YzGtVtDbcumNerVyZVVx55PW9gGQsFOL0utOyBJiG/UiocFAXix8JNvNJxYMRt2Jx0FJKg=="],
+    "@openai/codex-linux-arm64": ["@openai/codex@0.151.0-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-CsLgFeX4TQ6I2Gdrxd2r5UbgIbDLCdtcLAlnMYjr06bCL057MTNGec7Ewb3+Z2DBiMuXCljdTBGqLOePkMV0sQ=="],
 
-    "@openai/codex-linux-x64": ["@openai/codex@0.150.1-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-B3Bu5MF/G9qFhbSMrdyZz9ocknXOo45DnOdWrREJaxWTjiuUO1ogoDR0/ttdc29JRFkbbXs3aC+Td8vIx3X0oA=="],
+    "@openai/codex-linux-x64": ["@openai/codex@0.151.0-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-xcVyY1FtwvVYhh2JBmz8fX8CQqFAxO/lxJ2IXsh8x5uwxZVHVl5fZHFHf8JdRaOGG0vpkYmu/DKKVoLd56/DDQ=="],
 
-    "@openai/codex-sdk": ["@openai/codex-sdk@0.150.1", "", { "dependencies": { "@openai/codex": "0.150.1" } }, "sha512-/Xp8CM2POoXcZd7MZ+07oXstAgNvflr0Mj7IUPKhyv1HAzaqoedv6PAcgJPUyiNU0vi1lfbkgcJU5QC+lxspSw=="],
+    "@openai/codex-sdk": ["@openai/codex-sdk@0.151.0", "", { "dependencies": { "@openai/codex": "0.151.0" } }, "sha512-vI4gr5ipvVwH4YHW9DGUmaUI1hJzJOCO/0d5NYFnAECsQGEvBmuTocPzRP8yGzLtsYklMnrtGtm2TyBicihVxw=="],
 
-    "@openai/codex-win32-arm64": ["@openai/codex@0.150.1-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-8I7N3ppKS1ql9GUr2RHS5Gw+KkRCKfIMIDDK/brxq6HizLgHoDK4CIR0OTvEgdX3Yh/2reBbxr9P4L1e+61e+Q=="],
+    "@openai/codex-win32-arm64": ["@openai/codex@0.151.0-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-zDWzOoh9wHm+Om1Nhn7os47rAVeSGPh0SnM3YOttdq6iPJz2zn4vBnbGUZjeih1qW/3mvNF3Oyd4owlaHmphmg=="],
 
-    "@openai/codex-win32-x64": ["@openai/codex@0.150.1-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-1P1tscFnw4A4ip/WN1R5WYPdfuAlxLctPpcE1QAPQnOtbkJR5NX8da4kNTQmiDN/Flx3TLJPDTRHP9Jn435eJg=="],
+    "@openai/codex-win32-x64": ["@openai/codex@0.151.0-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-sLT7xvID3jhU6tkzcwRPnMEclKRwUPbpo0mtfxIF9KpdZH3VJV7sM2/kXWXyvUM7Zt/YeyOaeATTEysbRz8Yog=="],
 
     "@opencode-ai/sdk": ["@opencode-ai/sdk@1.17.3", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-oXrEjOuP3+J9pPNw3cmOnRma/xiVQ4WIIvGd6YkhPQgqqi2PnD/b1qfNY0AMead3QfNhKwKdDM4QFJdN2LpByg=="],
 

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "sharp": "^0.35.0"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.247",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.251",
     "@opencode-ai/sdk": "^1.17.3"
   }
 }

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -29,13 +29,13 @@
     "type-check": "bun x tsc --noEmit"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.247",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.251",
     "@archon/paths": "workspace:*",
     "@github/copilot-sdk": "~1.0.1",
-    "@earendil-works/pi-ai": "^0.84.3",
-    "@earendil-works/pi-coding-agent": "^0.84.3",
+    "@earendil-works/pi-ai": "^0.84.4",
+    "@earendil-works/pi-coding-agent": "^0.84.4",
     "@opencode-ai/sdk": "^1.17.3",
-    "@openai/codex-sdk": "^0.150.1",
+    "@openai/codex-sdk": "^0.151.0",
     "@sinclair/typebox": "^0.34.41",
     "ajv": "^8.20.0",
     "jsonrepair": "^3.14.0",

--- a/packages/providers/src/claude/capabilities.ts
+++ b/packages/providers/src/claude/capabilities.ts
@@ -2,7 +2,7 @@ import type { ProviderCapabilities } from '../types';
 
 /**
  * Built-in Claude Code tool names, hand-audited against
- * @anthropic-ai/claude-agent-sdk 0.3.247. The SDK exposes tool restrictions as
+ * @anthropic-ai/claude-agent-sdk 0.3.251. The SDK exposes tool restrictions as
  * plain `string[]` options and exports NO runtime tool-name constant or
  * literal union, so this list is maintained by hand — refresh it when bumping
  * the SDK. Used for advisory (warning-level) validation only, so a tool added

--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -1048,7 +1048,7 @@ async function* streamClaudeMessages(
           yield { type: 'system', content: `MCP server connection failed: ${names}` };
         }
       } else if (subtype === 'task_started' && sysMsg.task_id) {
-        // Ambient / housekeeping tasks (SDK v0.3.247 signals them directly;
+        // Ambient / housekeeping tasks (SDK v0.3.247+ signals them directly;
         // older emitters use skip_transcript) are SDK-internal — they bloat
         // the Web UI's tasks panel without telling
         // the user anything actionable. Drop them at the provider boundary;

--- a/packages/providers/src/codex/config.ts
+++ b/packages/providers/src/codex/config.ts
@@ -33,6 +33,7 @@ export const CODEX_EFFORTS = [
   'xhigh',
   'max',
   'ultra',
+  'persistent',
 ] as const satisfies readonly ModelReasoningEffort[];
 
 /** Coverage, which `satisfies` above cannot express — a rung the SDK gains must

--- a/packages/providers/src/codex/provider.test.ts
+++ b/packages/providers/src/codex/provider.test.ts
@@ -1187,7 +1187,7 @@ describe('CodexProvider', () => {
       );
     });
 
-    test.each(['max', 'ultra'] as const)(
+    test.each(['max', 'ultra', 'persistent'] as const)(
       'passes `effort: %s` to the SDK natively',
       async effort => {
         mockRunStreamed.mockResolvedValue({

--- a/packages/providers/src/shared/effort.test.ts
+++ b/packages/providers/src/shared/effort.test.ts
@@ -26,6 +26,9 @@ describe('clampEffort', () => {
   test('clamps down to the nearest supported rung', () => {
     // The top of Archon's ladder means "as deep as this model goes", so it
     // lands on each provider's strongest rung rather than disappearing.
+    expect(clampEffort('persistent', CLAUDE)).toBe('max');
+    expect(clampEffort('persistent', PI)).toBe('max');
+    expect(clampEffort('persistent', COPILOT)).toBe('xhigh');
     expect(clampEffort('ultra', CLAUDE)).toBe('max');
     expect(clampEffort('ultra', PI)).toBe('max');
     expect(clampEffort('ultra', COPILOT)).toBe('xhigh');

--- a/packages/providers/src/shared/effort.ts
+++ b/packages/providers/src/shared/effort.ts
@@ -15,7 +15,16 @@
  */
 
 /** Reasoning-depth rungs, weakest → strongest. Order is load-bearing: `clampEffort` walks it. */
-export const EFFORT_LADDER = ['minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'] as const;
+export const EFFORT_LADDER = [
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+  'ultra',
+  'persistent',
+] as const;
 
 /**
  * Compile-time proof that a provider's rung list COVERS its SDK's vocabulary.

--- a/packages/providers/src/types.ts
+++ b/packages/providers/src/types.ts
@@ -29,7 +29,15 @@ export interface CodexProviderDefaults {
   /** The Codex SDK's `ModelReasoningEffort`, restated by hand because this file
    *  may not import an SDK. `CODEX_EFFORTS` in ./codex/config.ts pins the same
    *  values to the SDK's own type, so upstream drift fails type-check there. */
-  modelReasoningEffort?: 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra';
+  modelReasoningEffort?:
+    | 'minimal'
+    | 'low'
+    | 'medium'
+    | 'high'
+    | 'xhigh'
+    | 'max'
+    | 'ultra'
+    | 'persistent';
   /** Structurally matches @archon/workflows WebSearchMode */
   webSearchMode?: 'disabled' | 'cached' | 'live';
   additionalDirectories?: string[];

--- a/packages/web/src/experiments/console/lib/model-options.ts
+++ b/packages/web/src/experiments/console/lib/model-options.ts
@@ -118,6 +118,7 @@ export const EFFORT_OPTIONS = [
   'xhigh',
   'max',
   'ultra',
+  'persistent',
 ] as const;
 
 export type EffortOption = (typeof EFFORT_OPTIONS)[number];
@@ -133,6 +134,7 @@ export const CODEX_CONFIG_EFFORT_OPTIONS = [
   'xhigh',
   'max',
   'ultra',
+  'persistent',
 ] as const;
 
 /**

--- a/packages/web/src/lib/api.generated.d.ts
+++ b/packages/web/src/lib/api.generated.d.ts
@@ -3433,12 +3433,20 @@ export interface components {
       provider?: string;
       model?: string;
       /** @enum {string} */
-      modelReasoningEffort?: 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra';
+      modelReasoningEffort?:
+        | 'minimal'
+        | 'low'
+        | 'medium'
+        | 'high'
+        | 'xhigh'
+        | 'max'
+        | 'ultra'
+        | 'persistent';
       /** @enum {string} */
       webSearchMode?: 'disabled' | 'cached' | 'live';
       interactive?: boolean;
       /** @enum {string} */
-      effort?: 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra';
+      effort?: 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra' | 'persistent';
       thinking?:
         | {
             /** @enum {string} */
@@ -3711,7 +3719,7 @@ export interface components {
         };
       };
       /** @enum {string} */
-      effort?: 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra';
+      effort?: 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra' | 'persistent';
       thinking?:
         | {
             /** @enum {string} */

--- a/packages/workflows/src/model-validation.test.ts
+++ b/packages/workflows/src/model-validation.test.ts
@@ -829,7 +829,7 @@ describe('isLiteralSpec type guard', () => {
 // #2556: one vocabulary, gated by one capability flag. Before this, effort
 // "routed" only on Claude and Codex, each with its own enum, so a tier's
 // `effort` was silently dropped on Pi and Copilot — which do have the control.
-const LADDER = ['minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'];
+const LADDER = ['minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra', 'persistent'];
 
 describe('validEffortsForProvider', () => {
   test('returns the one ladder for every provider with a reasoning control', () => {
@@ -877,7 +877,16 @@ describe('resolvePresetEffort', () => {
 
 describe('isEffortValidForProvider', () => {
   test('accepts every rung on a provider that has the control', () => {
-    for (const rung of ['minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra']) {
+    for (const rung of [
+      'minimal',
+      'low',
+      'medium',
+      'high',
+      'xhigh',
+      'max',
+      'ultra',
+      'persistent',
+    ]) {
       expect(isEffortValidForProvider('codex', rung)).toBe(true);
       expect(isEffortValidForProvider('claude', rung)).toBe(true);
     }

--- a/packages/workflows/src/schemas/workflow.ts
+++ b/packages/workflows/src/schemas/workflow.ts
@@ -39,6 +39,7 @@ export const modelReasoningEffortSchema = z.enum([
   'xhigh',
   'max',
   'ultra',
+  'persistent',
 ]);
 
 export type ModelReasoningEffort = z.infer<typeof modelReasoningEffortSchema>;


### PR DESCRIPTION
## Problem and outcome

The Claude Agent SDK, Codex SDK, and Pi agent SDKs have published new releases containing upstream bug fixes, features, and expanded model configurations. Archon's provider integration packages need to track these latest versions while strictly maintaining typed translation layers, compile-time exhaustiveness assertions, and provider authentication boundaries.

- **Outcome:** Upgraded `@anthropic-ai/claude-agent-sdk` to `0.3.251`, `@openai/codex-sdk` to `0.151.0`, `@earendil-works/pi-ai` to `0.84.4`, and `@earendil-works/pi-coding-agent` to `0.84.4`. The newly introduced Codex `persistent` reasoning effort rung is absorbed across translation layers, schemas, and UI options without loose typecasts.
- **Invariant:** Provider-boundary contracts, compile-time coverage asserts (`AssertNever`), and subscription/OAuth authentication flows remain fully preserved.
- **Scope boundary:** OpenCode and GitHub Copilot SDK pins remain unchanged.

## Review guidance

- **Feedback requested:** Correctness of the new `persistent` reasoning effort mapping and clamping behavior across providers.
- **Start here:** `packages/providers/src/codex/config.ts:36` — shows absorption of `persistent` into `CODEX_EFFORTS` ensuring `AssertNever` exhaustiveness coverage passes at compile time.
- **Review order:**
  1. `packages/providers/package.json` and `package.json` for dependency version bumps.
  2. `packages/providers/src/codex/config.ts` and `packages/providers/src/shared/effort.ts` for effort ladder updates and compile-time guards.
  3. `packages/workflows/src/schemas/workflow.ts` and `packages/web/src/lib/api.generated.d.ts` for schema and generated API type synchronization.
  4. `packages/providers/src/codex/provider.test.ts`, `packages/providers/src/shared/effort.test.ts`, and `packages/workflows/src/model-validation.test.ts` for unit test coverage.
- **Lower-attention areas:** Generated OpenAPI definitions in `packages/web/src/lib/api.generated.d.ts` and lockfile updates in `bun.lock`.
- **Known risk or uncertainty:** None.

## Solution

- Bumps `@anthropic-ai/claude-agent-sdk` (to `0.3.251`), `@openai/codex-sdk` (to `0.151.0`), and Pi agent packages (to `0.84.4`).
- Handles Codex SDK 0.151.0's new `persistent` reasoning effort rung:
  - Added `persistent` to `CODEX_EFFORTS` to maintain the compile-time `AssertNever<Exclude<ModelReasoningEffort, (typeof CODEX_EFFORTS)[number]>>` check.
  - Added `persistent` to `EFFORT_LADDER`, `CodexProviderDefaults`, `modelReasoningEffortSchema`, and console UI model options.
  - Added tests to verify `clampEffort` clamps `persistent` down to `max` for Claude and Pi, and `xhigh` for Copilot.
- Regenerated `packages/web/src/lib/api.generated.d.ts` to match the updated schemas.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Reasoning effort rungs in Codex and workflow schemas ended at `ultra`. | `persistent` is available as a reasoning effort option for Codex workflows and console sessions. |
| **Failure behavior** | Passing `persistent` reasoning effort failed schema validation. | `persistent` is accepted and safely clamped down on providers without a matching rung. |

## Architecture

### Changed seams

| Boundary or contract | Change | Evidence |
|---|---|---|
| `Codex SDK → @archon/providers` | Absorbed `persistent` reasoning effort in `CODEX_EFFORTS` | `packages/providers/src/codex/config.ts:36` |
| `@archon/workflows → Provider translation` | Extended workflow reasoning effort schema and shared effort ladder | `packages/workflows/src/schemas/workflow.ts:42`, `packages/providers/src/shared/effort.ts:25` |

## Validation

- `bun run check:bundled` — OK — proves bundled workflows and schemas remain valid.
- `bun run check:api-types` — OK — proves generated web API types match schemas.
- `bun run check:capability-matrix` — OK — proves capability matrix is synchronized.
- `bun run type-check` — OK — proves strict TypeScript exhaustiveness assertions (`AssertNever`) pass across all packages.
- `bun run lint --max-warnings 0` — OK — proves code style and lint rules pass.
- `bun run test` — OK — proves all unit and provider tests pass.
- `bun run validate` — OK — complete validation suite passes cleanly.
- **Not verified:** Nothing material. All updated SDK surfaces, translation logic, schema additions, and effort clamping are covered by unit and integration tests.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | Additive schema changes for `persistent` reasoning effort; backwards-compatible with existing workflows. | `packages/workflows/src/schemas/workflow.ts` |
| Security / permissions / data | Preserved native configuration discovery, credential routing, and subscription/OAuth authentication flows. | `packages/providers/src/claude/provider.ts`, `packages/providers/src/pi/provider.ts` |
| Observability | Provider SDK versions recorded and errors propagated without alteration. | `packages/providers/src/` |

## Links

- Closes #3072


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added **Persistent** as a supported reasoning-effort option for compatible models.
  * Added Persistent to model configuration menus and workflow validation.
  * Updated effort handling to automatically select the nearest supported level when needed.

* **Bug Fixes**
  * Updated provider integrations to support the latest SDK capabilities and reasoning-effort values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->