### PR TITLE
Centralize agent node failure finalization

### DIFF
--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -15669,6 +15669,11 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
     expect(cancelRow?.error).toBe('Cancelled by user');
     expect(cancelRow?.cost_usd).toBe(0.02);
     expect(cancelRow?.tokens).toEqual({ input: 30, output: 3 });
+
+    const failedEvent = store.createWorkflowEvent.mock.calls
+      .map(([event]) => event)
+      .find(event => event.event_type === 'node_failed' && event.step_name === 'only');
+    expect(typeof failedEvent?.data?.duration_ms).toBe('number');
   });
 
   it('a cancel that surfaces as a thrown error still leaves a transcript row', async () => {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -13611,6 +13611,7 @@ describe('executeDagWorkflow -- credit exhaustion', () => {
     const deps = createMockDeps(store);
     const platform = createMockPlatform();
     const workflowRun = makeWorkflowRun('credit-exhaustion-run');
+    const logDir = join(testDir, 'logs');
 
     await executeDagWorkflow(
       dagOptions({
@@ -13629,15 +13630,27 @@ describe('executeDagWorkflow -- credit exhaustion', () => {
           ],
         },
         workflowRun,
+        logDir,
       })
     );
 
     // node_failed (not node_completed) must have been stored
-    const events = (
-      store.createWorkflowEvent as Mock<IWorkflowStore['createWorkflowEvent']>
-    ).mock.calls.map((c: unknown[]) => (c[0] as { event_type: string }).event_type);
+    const eventCalls = (store.createWorkflowEvent as Mock<IWorkflowStore['createWorkflowEvent']>)
+      .mock.calls;
+    const events = eventCalls.map((c: unknown[]) => (c[0] as { event_type: string }).event_type);
     expect(events).toContain('node_failed');
     expect(events).not.toContain('node_completed');
+    const failedEvent = eventCalls.find(
+      (c: unknown[]) => (c[0] as { event_type: string }).event_type === 'node_failed'
+    );
+    expect(
+      typeof (failedEvent?.[0] as { data?: { duration_ms?: unknown } }).data?.duration_ms
+    ).toBe('number');
+
+    const transcriptFailures = (await readTranscript(logDir, workflowRun.id)).filter(
+      row => row.type === 'node_error' && row.step === 'investigate'
+    );
+    expect(transcriptFailures).toHaveLength(1);
 
     // Overall workflow should be marked failed
     expect(store.failWorkflowRun).toHaveBeenCalled();
@@ -15589,6 +15602,9 @@ describe('executeDagWorkflow -- run usage survives every disposition', () => {
     );
     expect(failedEvents.length).toBe(1);
     expect((failedEvents[0][0] as { data: Record<string, unknown> }).data.cost_usd).toBe(0.02);
+    expect(typeof (failedEvents[0][0] as { data: Record<string, unknown> }).data.duration_ms).toBe(
+      'number'
+    );
 
     // And the run total is the money burned across both nodes.
     expect(runUsageWrites(store)).toEqual([

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -2157,6 +2157,65 @@ async function executeNodeInternal(
     ...(resolvedEffort !== undefined ? { effort: resolvedEffort } : {}),
   });
 
+  let nodeTokens: TokenUsage | undefined;
+  let nodeCostUsd: number | undefined;
+
+  const nodeUsageEventData = (): WorkflowUsage => ({
+    ...(nodeTokens !== undefined ? { tokens: nodeTokens } : {}),
+    ...(nodeCostUsd !== undefined ? { cost_usd: nodeCostUsd } : {}),
+  });
+
+  const nodeKey = `${workflowRun.id}:${node.id}`;
+
+  // Every failed result after node_started passes through this finalizer so the
+  // transcript, persisted event, emitter, and throttle cleanup cannot drift.
+  const failAgentNode = async (
+    error: string,
+    extras: { output?: string; data?: Record<string, unknown> } = {}
+  ): Promise<NodeExecutionResult> => {
+    const usage = nodeUsageEventData();
+    await logNodeError(logDir, workflowRun.id, node.id, error, usage);
+
+    deps.store
+      .createWorkflowEvent({
+        workflow_run_id: workflowRun.id,
+        event_type: 'node_failed',
+        step_name: stepName,
+        data: {
+          error,
+          duration_ms: Date.now() - nodeStartTime,
+          ...usage,
+          ...namedSessionAuditData,
+          ...(extras.data ?? {}),
+        },
+      })
+      .catch((err: Error) => {
+        getLog().error(
+          { err, workflowRunId: workflowRun.id, eventType: 'node_failed' },
+          'workflow_event_persist_failed'
+        );
+      });
+
+    emitter.emit({
+      type: 'node_failed',
+      runId: workflowRun.id,
+      nodeId: node.id,
+      nodeName: commandName ?? node.id,
+      error,
+    });
+
+    lastNodeCancelCheck.delete(nodeKey);
+    lastNodeActivityUpdate.delete(nodeKey);
+
+    return {
+      state: 'failed',
+      output: extras.output ?? '',
+      error,
+      costUsd: nodeCostUsd,
+      ...(nodeTokens !== undefined ? { tokens: nodeTokens } : {}),
+    };
+  };
+
   // Load prompt
   let rawPrompt: string;
   if (commandName !== undefined) {
@@ -2170,28 +2229,7 @@ async function executeNodeInternal(
     if (!promptResult.success) {
       const errMsg = promptResult.message;
       getLog().error({ nodeId: node.id, error: errMsg }, 'dag_node_command_load_failed');
-      await logNodeError(logDir, workflowRun.id, node.id, errMsg);
-      deps.store
-        .createWorkflowEvent({
-          workflow_run_id: workflowRun.id,
-          event_type: 'node_failed',
-          step_name: stepName,
-          data: { error: errMsg, ...namedSessionAuditData },
-        })
-        .catch((err: Error) => {
-          getLog().error(
-            { err, workflowRunId: workflowRun.id, eventType: 'node_failed' },
-            'workflow_event_persist_failed'
-          );
-        });
-      emitter.emit({
-        type: 'node_failed',
-        runId: workflowRun.id,
-        nodeId: node.id,
-        nodeName: commandName,
-        error: errMsg,
-      });
-      return { state: 'failed', output: '', error: errMsg };
+      return failAgentNode(errMsg);
     }
     rawPrompt = promptResult.content;
   } else {
@@ -2248,38 +2286,14 @@ async function executeNodeInternal(
   } catch (error) {
     const err = error as Error;
     getLog().error({ nodeId: node.id, error: err.message }, 'dag.node_prompt_substitution_failed');
-    await logNodeError(logDir, workflowRun.id, node.id, err.message);
-    // Emit the terminal event (mirrors the command-load failure path above).
-    // Without it the node emits node_started and then vanishes with no terminal
-    // event, so downstream all_success rules silently skip instead of the run
-    // surfacing the failure.
-    deps.store
-      .createWorkflowEvent({
-        workflow_run_id: workflowRun.id,
-        event_type: 'node_failed',
-        step_name: stepName,
-        data: { error: err.message, ...namedSessionAuditData },
-      })
-      .catch((persistErr: Error) => {
-        getLog().error(
-          { err: persistErr, workflowRunId: workflowRun.id, eventType: 'node_failed' },
-          'workflow_event_persist_failed'
-        );
-      });
-    emitter.emit({
-      type: 'node_failed',
-      runId: workflowRun.id,
-      nodeId: node.id,
-      nodeName: commandName ?? node.id,
-      error: err.message,
-    });
+    const result = await failAgentNode(err.message);
     await safeSendMessage(
       platform,
       conversationId,
       `Node '${node.id}' failed: ${err.message}`,
       nodeContext
     );
-    return { state: 'failed', output: '', error: err.message };
+    return result;
   }
 
   // Substitute upstream node output references
@@ -2292,20 +2306,10 @@ async function executeNodeInternal(
   let structuredOutput: unknown;
   let newSessionId: string | undefined;
   let nodeResumed: boolean | undefined;
-  let nodeTokens: TokenUsage | undefined;
-  let nodeCostUsd: number | undefined;
   let nodeStopReason: string | undefined;
   let nodeNumTurns: number | undefined;
   let nodeResolvedModel: ResolvedModel | undefined;
   const batchMessages: string[] = [];
-
-  // What this node reported, built once and passed whole rather than re-listed per sink:
-  // the DB event and the JSONL transcript row, on every outcome that can hold spend —
-  // completion, failure, and user cancellation alike (#2693). See WorkflowUsage.
-  const nodeUsageEventData = (): WorkflowUsage => ({
-    ...(nodeTokens !== undefined ? { tokens: nodeTokens } : {}),
-    ...(nodeCostUsd !== undefined ? { cost_usd: nodeCostUsd } : {}),
-  });
 
   // Create per-node abort controller for idle timeout cleanup
   const nodeAbortController = new AbortController();
@@ -2370,7 +2374,6 @@ async function executeNodeInternal(
       }
     )) {
       const tickNow = Date.now();
-      const nodeKey = `${workflowRun.id}:${node.id}`;
 
       // Cancel/pause check — read-only, no write contention in WAL mode (every 10s).
       //
@@ -3093,55 +3096,7 @@ async function executeNodeInternal(
         { nodeId: node.id, durationMs: duration },
         'dag_node_cancelled_during_streaming'
       );
-      // Cancellation is a terminal outcome like any other failure, and the work it
-      // interrupted was already paid for. This branch wrote no transcript row at all
-      // until #2693, so a cancelled node's spend reached the DB and nothing else.
-      await logNodeError(
-        logDir,
-        workflowRun.id,
-        node.id,
-        'Cancelled by user',
-        nodeUsageEventData()
-      );
-
-      deps.store
-        .createWorkflowEvent({
-          workflow_run_id: workflowRun.id,
-          event_type: 'node_failed',
-          step_name: stepName,
-          data: {
-            error: 'Cancelled by user',
-            duration_ms: duration,
-            ...nodeUsageEventData(),
-            ...namedSessionAuditData,
-          },
-        })
-        .catch((err: Error) => {
-          getLog().error(
-            { err, workflowRunId: workflowRun.id, eventType: 'node_failed' },
-            'workflow_event_persist_failed'
-          );
-        });
-
-      emitter.emit({
-        type: 'node_failed',
-        runId: workflowRun.id,
-        nodeId: node.id,
-        nodeName: commandName ?? node.id,
-        error: 'Cancelled by user',
-      });
-
-      // Clean up throttle entries
-      lastNodeCancelCheck.delete(`${workflowRun.id}:${node.id}`);
-      lastNodeActivityUpdate.delete(`${workflowRun.id}:${node.id}`);
-
-      return {
-        state: 'failed',
-        output: nodeOutputText,
-        error: 'Cancelled by user',
-        costUsd: nodeCostUsd,
-        ...(nodeTokens !== undefined ? { tokens: nodeTokens } : {}),
-      };
+      return await failAgentNode('Cancelled by user', { output: nodeOutputText });
     }
 
     if (streamingMode === 'batch' && batchMessages.length > 0) {
@@ -3158,40 +3113,7 @@ async function executeNodeInternal(
     if (creditError) {
       const duration = Date.now() - nodeStartTime;
       getLog().warn({ nodeId: node.id, durationMs: duration }, 'dag.node_credit_exhausted');
-      await logNodeError(logDir, workflowRun.id, node.id, creditError, nodeUsageEventData());
-
-      deps.store
-        .createWorkflowEvent({
-          workflow_run_id: workflowRun.id,
-          event_type: 'node_failed',
-          step_name: stepName,
-          data: { error: creditError, ...nodeUsageEventData(), ...namedSessionAuditData },
-        })
-        .catch((err: Error) => {
-          getLog().error(
-            { err, workflowRunId: workflowRun.id, eventType: 'node_failed' },
-            'workflow_event_persist_failed'
-          );
-        });
-
-      emitter.emit({
-        type: 'node_failed',
-        runId: workflowRun.id,
-        nodeId: node.id,
-        nodeName: commandName ?? node.id,
-        error: creditError,
-      });
-
-      lastNodeCancelCheck.delete(`${workflowRun.id}:${node.id}`);
-      lastNodeActivityUpdate.delete(`${workflowRun.id}:${node.id}`);
-
-      return {
-        state: 'failed',
-        output: nodeOutputText,
-        error: creditError,
-        costUsd: nodeCostUsd,
-        ...(nodeTokens !== undefined ? { tokens: nodeTokens } : {}),
-      };
+      return await failAgentNode(creditError, { output: nodeOutputText });
     }
 
     // Fail for zero output: covers both silent non-timeout exits AND idle-timeout before first token (time-to-first-token exceeded the window).
@@ -3201,45 +3123,7 @@ async function executeNodeInternal(
         ? `Node '${node.id}' timed out with no output (idle for ${String(effectiveIdleTimeout / 60000)} min). The provider did not emit any content before the watchdog fired — likely time-to-first-token exceeded the timeout. Consider increasing idle_timeout or reducing prompt size.`
         : `Node '${node.id}' produced no assistant output. The provider stream closed without yielding content — likely a silent provider rejection or stream interruption.`;
       getLog().error({ nodeId: node.id, durationMs: duration }, 'dag.node_empty_output');
-      await logNodeError(logDir, workflowRun.id, node.id, emptyError, nodeUsageEventData());
-
-      deps.store
-        .createWorkflowEvent({
-          workflow_run_id: workflowRun.id,
-          event_type: 'node_failed',
-          step_name: stepName,
-          data: {
-            error: emptyError,
-            duration_ms: duration,
-            ...nodeUsageEventData(),
-            ...namedSessionAuditData,
-          },
-        })
-        .catch((err: Error) => {
-          getLog().error(
-            { err, workflowRunId: workflowRun.id, eventType: 'node_failed' },
-            'workflow_event_persist_failed'
-          );
-        });
-
-      emitter.emit({
-        type: 'node_failed',
-        runId: workflowRun.id,
-        nodeId: node.id,
-        nodeName: commandName ?? node.id,
-        error: emptyError,
-      });
-
-      lastNodeCancelCheck.delete(`${workflowRun.id}:${node.id}`);
-      lastNodeActivityUpdate.delete(`${workflowRun.id}:${node.id}`);
-
-      return {
-        state: 'failed',
-        output: '',
-        error: emptyError,
-        costUsd: nodeCostUsd,
-        ...(nodeTokens !== undefined ? { tokens: nodeTokens } : {}),
-      };
+      return await failAgentNode(emptyError);
     }
 
     if (namedResumeSourceNodeId !== undefined) {
@@ -3343,10 +3227,6 @@ async function executeNodeInternal(
   } catch (error) {
     const err = error as Error;
 
-    // Clean up throttle entries on failure
-    lastNodeCancelCheck.delete(`${workflowRun.id}:${node.id}`);
-    lastNodeActivityUpdate.delete(`${workflowRun.id}:${node.id}`);
-
     const cancelled = nodeAbortController.signal.aborted && !nodeIdleTimedOut;
     const failureMessage = cancelled ? 'Cancelled by user' : err.message;
     if (cancelled) {
@@ -3354,44 +3234,7 @@ async function executeNodeInternal(
     } else {
       getLog().error({ err, nodeId: node.id }, 'dag_node_failed');
     }
-    // Transcript row on BOTH branches. The persisted event below is written either way,
-    // so the transcript must not disagree with it depending on how the cancel arrived.
-    // A cancel reaches this catch mainly through the engine's own structured-output
-    // gate: it runs before the streaming-cancel branch and cannot reask once the signal
-    // is aborted, so an aborted node declaring `output_format` throws here instead of
-    // returning there. A provider SDK that throws on abort also lands here. Neither is
-    // a reason for a node to be missing from the run's transcript (#2693).
-    await logNodeError(logDir, workflowRun.id, node.id, failureMessage, nodeUsageEventData());
-
-    deps.store
-      .createWorkflowEvent({
-        workflow_run_id: workflowRun.id,
-        event_type: 'node_failed',
-        step_name: stepName,
-        data: { error: failureMessage, ...nodeUsageEventData(), ...namedSessionAuditData },
-      })
-      .catch((err: Error) => {
-        getLog().error(
-          { err, workflowRunId: workflowRun.id, eventType: 'node_failed' },
-          'workflow_event_persist_failed'
-        );
-      });
-
-    emitter.emit({
-      type: 'node_failed',
-      runId: workflowRun.id,
-      nodeId: node.id,
-      nodeName: commandName ?? node.id,
-      error: failureMessage,
-    });
-
-    return {
-      state: 'failed',
-      output: '',
-      error: failureMessage,
-      costUsd: nodeCostUsd,
-      ...(nodeTokens !== undefined ? { tokens: nodeTokens } : {}),
-    };
+    return failAgentNode(failureMessage);
   }
 }
 


### PR DESCRIPTION
## Problem and outcome

Agent-node failures in `executeNodeInternal` were finalized by six separate blocks. That let the JSONL transcript, persisted `node_failed` event, emitted event, throttle cleanup, and returned failure result drift; credit-exhaustion and catch paths also omitted `duration_ms`.

- **Outcome:** Every agent-node failure after `node_started` now uses one finalizer, and every resulting `node_failed` event includes `duration_ms`.
- **Invariant:** The transcript, persisted event, emitter, cache cleanup, failed result, and reported usage describe the same terminal failure.
- **Scope boundary:** `executeBashNode`, `executeScriptNode`, and other deterministic executor failure writers are unchanged.
- **Root cause:** Separate terminal writers repeated the same lifecycle work with different payloads and cleanup.

## Review guidance

- **Feedback requested:** Confirm the finalizer owns all six `executeNodeInternal` failure exits while preserving each call site's diagnostic behavior.
- **Start here:** `packages/workflows/src/dag-executor.ts:2172` — `failAgentNode` is the single terminal-failure owner.
- **Review order:** Review the finalizer, then its six call sites, then the transcript and duration assertions in `packages/workflows/src/dag-executor.test.ts`.
- **Lower-attention areas:** The test edits add focused assertions only; no generated artifacts or schema changes.
- **Known risk or uncertainty:** None.

## Solution

`failAgentNode` builds usage once and writes the transcript error row, persisted event (including duration), emitter event, throttle-cache cleanup, and failed result. Command loading, prompt substitution, streaming cancellation, credit exhaustion, empty output, and the outer catch now delegate to it. Local diagnostic logging and the prompt-substitution user message remain at their original call sites.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Failure sinks could disagree about a node's terminal lifecycle data. | All six agent-node failure exits use one lifecycle finalizer. |
| **Failure behavior** | Credit-exhaustion and catch-path `node_failed` events omitted `duration_ms`. | Every finalizer-owned `node_failed` event records `duration_ms`; transcript failures retain node usage. |

## Validation

- `bun test src/dag-executor.test.ts` — 703 passed, 0 failed — exercises credit-exhaustion transcript and duration handling plus provider-error duration handling.
- `bun run type-check` in `packages/workflows` — passed.
- `bun run lint --max-warnings 0` — passed.
- `bun run validate` — passed, including generated-artifact checks, API type generation, package type checks, lint, formatting, installer tests, package tests, and script tests.
- **Not verified:** Nothing material; focused lifecycle assertions and the full validation suite passed.

## Links

- Closes #2698


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow failure handling so agent-node errors are consistently recorded and reported.
  * Failed workflow events now include execution duration, usage, and session audit details.
  * Ensured cancellation, credit exhaustion, empty results, and other failure scenarios clean up correctly.
  * Preserved accurate failure costs and token usage in workflow results.
* **Tests**
  * Added coverage verifying failure and cancellation events include valid execution durations.
  * Added validation that credit-exhausted workflows produce the expected error transcript and failure event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->