### PR TITLE
chore: upgrade Bun from 1.3.11 to 1.4.0 behind a single owning value

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,6 +6,9 @@ on:
     paths: ['packages/docs-web/**']
   workflow_dispatch:
 
+env:
+  BUN_VERSION: '1.4.0'
+
 permissions:
   contents: read
   pages: write
@@ -25,7 +28,7 @@ jobs:
           node-version: 22
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.11
+          bun-version: ${{ env.BUN_VERSION }}
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Build docs

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -17,6 +17,9 @@ on:
       - 'bun.lock'
       - '.github/workflows/docs-build.yml'
 
+env:
+  BUN_VERSION: '1.4.0'
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -36,7 +39,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.11
+          bun-version: ${{ env.BUN_VERSION }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -18,6 +18,9 @@ on:
         type: boolean
         default: false
 
+env:
+  BUN_VERSION: '1.4.0'
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -62,7 +65,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.11
+          bun-version: ${{ env.BUN_VERSION }}
 
       - name: Setup uv (for Python script nodes)
         uses: astral-sh/setup-uv@v4
@@ -115,7 +118,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.11
+          bun-version: ${{ env.BUN_VERSION }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -214,7 +217,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.11
+          bun-version: ${{ env.BUN_VERSION }}
 
       - name: Install Claude Code CLI
         run: |
@@ -246,7 +249,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.11
+          bun-version: ${{ env.BUN_VERSION }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -280,7 +283,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.11
+          bun-version: ${{ env.BUN_VERSION }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/marketplace-auto-review.yml
+++ b/.github/workflows/marketplace-auto-review.yml
@@ -6,6 +6,9 @@ on:
       - "packages/docs-web/src/data/marketplace.ts"
     types: [opened, synchronize, reopened, ready_for_review]
 
+env:
+  BUN_VERSION: '1.4.0'
+
 jobs:
   auto-review:
     name: Run marketplace auto-review
@@ -18,7 +21,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: ${{ env.BUN_VERSION }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/marketplace-lint.yml
+++ b/.github/workflows/marketplace-lint.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'packages/docs-web/src/data/marketplace.ts'
 
+env:
+  BUN_VERSION: '1.4.0'
+
 jobs:
   lint:
     name: Validate marketplace entries
@@ -15,7 +18,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: ${{ env.BUN_VERSION }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ on:
         required: true
         type: string
 
+env:
+  BUN_VERSION: '1.4.0'
+
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
@@ -24,7 +27,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.11
+          bun-version: ${{ env.BUN_VERSION }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -79,7 +82,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.11
+          bun-version: ${{ env.BUN_VERSION }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [main, dev]
 
+env:
+  BUN_VERSION: '1.4.0'
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -24,7 +27,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.11
+          bun-version: ${{ env.BUN_VERSION }}
 
       - name: Decide whether tests are needed
         id: decision
@@ -48,7 +51,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.11
+          bun-version: ${{ env.BUN_VERSION }}
 
       - name: Setup uv
         uses: astral-sh/setup-uv@v4
@@ -77,7 +80,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.11
+          bun-version: ${{ env.BUN_VERSION }}
 
       - name: Cache Bun dependencies
         if: runner.os == 'Windows'
@@ -178,7 +181,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.11
+          bun-version: ${{ env.BUN_VERSION }}
 
       # No `bun install`: the checker shells out to psql and uses only builtins.
       - name: Ensure psql is available
@@ -221,7 +224,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.11
+          bun-version: ${{ env.BUN_VERSION }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,12 @@
 # Multi-stage build: deps → web build → production image
 # =============================================================================
 
+ARG BUN_VERSION=1.4.0
+
 # ---------------------------------------------------------------------------
 # Stage 1: Install dependencies
 # ---------------------------------------------------------------------------
-FROM oven/bun:1.3.11-slim AS deps
+FROM oven/bun:${BUN_VERSION}-slim AS deps
 
 WORKDIR /app
 
@@ -51,7 +53,8 @@ RUN bun run build:web && \
 # ---------------------------------------------------------------------------
 # Stage 3: Production image
 # ---------------------------------------------------------------------------
-FROM oven/bun:1.3.11-slim AS production
+ARG BUN_VERSION=1.4.0
+FROM oven/bun:${BUN_VERSION}-slim AS production
 
 # OCI Labels for GHCR
 LABEL org.opencontainers.image.source="https://github.com/coleam00/Archon"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "typescript-eslint": "^8.48.0"
   },
   "engines": {
-    "bun": "^1.3.0"
+    "bun": "1.4.0"
   },
   "overrides": {
     "test-exclude": "^7.0.1",

--- a/scripts/bun-version-consistency.test.ts
+++ b/scripts/bun-version-consistency.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Every declaration of the Bun runtime version in the repository must agree.
+ * This includes every workflow file's BUN_VERSION env var, package.json
+ * engines.bun, and the Dockerfile base image. A hand-synced pair between any
+ * of these is a present defect — this test is the mechanism that catches drift.
+ */
+describe('Bun version consistency', () => {
+  const root = resolve(import.meta.dir, '..');
+  const workflowDir = resolve(root, '.github/workflows');
+
+  const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8')) as {
+    engines?: { bun?: string };
+  };
+  const expected = pkg.engines?.bun;
+  if (!expected) throw new Error('package.json engines.bun is missing');
+
+  test('every workflow that declares BUN_VERSION agrees with package.json engines.bun', () => {
+    const yamlFiles = readdirSync(workflowDir).filter(f => f.endsWith('.yml'));
+
+    const declarations: { file: string; version: string }[] = [];
+    for (const file of yamlFiles) {
+      const content = readFileSync(resolve(workflowDir, file), 'utf8');
+      // Match both quoted and unquoted env values: BUN_VERSION: '1.4.0' and BUN_VERSION: 1.4.0
+      const match = content.match(/^\s*BUN_VERSION:\s*['"]?([^'"\s]+)['"]?\s*$/m);
+      if (!match) continue;
+      declarations.push({ file, version: match[1] });
+    }
+
+    // At least one workflow must declare the version (if none do, no workflow
+    // uses Bun — unlikely but the test should be loud about it).
+    expect(declarations.length).toBeGreaterThan(0);
+
+    const mismatches = declarations
+      .filter(d => d.version !== expected)
+      .map(d => `${d.file}: BUN_VERSION=${d.version} (expected ${expected})`);
+
+    expect(mismatches).toEqual([]);
+  });
+
+  test('Dockerfile base image version agrees with package.json engines.bun', () => {
+    const dockerfile = readFileSync(resolve(root, 'Dockerfile'), 'utf8');
+
+    // Extract the ARG BUN_VERSION default value and the FROM references
+    const argMatch = dockerfile.match(/^ARG BUN_VERSION=(\S+)/m);
+    expect(argMatch).not.toBeNull();
+    const argVersion = argMatch![1];
+
+    // Every FROM oven/bun:... must use the ARG, not a literal version
+    const fromLines = [...dockerfile.matchAll(/^FROM oven\/bun:(\S+)/gm)];
+    expect(fromLines.length).toBeGreaterThan(0);
+
+    for (const match of fromLines) {
+      const imageTag = match[1];
+      // The image tag must either reference the ARG or match the expected version
+      if (imageTag === '${BUN_VERSION}-slim') continue;
+      expect(imageTag).toBe(`${expected}-slim`);
+    }
+
+    expect(argVersion).toBe(expected);
+  });
+});

--- a/scripts/should-run-test-suite.test.ts
+++ b/scripts/should-run-test-suite.test.ts
@@ -157,14 +157,16 @@ describe('test-suite change decision', () => {
       workflow.indexOf('  test:')
     );
 
-    expect(pullRequestTrigger).toBe('  pull_request:\n    branches: [main, dev]');
+    expect(pullRequestTrigger).toBe(
+      "  pull_request:\n    branches: [main, dev]\n\nenv:\n  BUN_VERSION: '1.4.0'"
+    );
     expect(fixtureJob).toContain("if: github.event_name == 'pull_request'");
     expect(fixtureJob).toContain('runs-on: ubuntu-latest');
     expect(fixtureJob).not.toContain('needs:');
     expect(fixtureJob).not.toContain('changes');
     expect(fixtureJob).toContain('uses: actions/checkout@v4');
     expect(fixtureJob).toContain('uses: oven-sh/setup-bun@v2');
-    expect(fixtureJob).toContain('bun-version: 1.3.11');
+    expect(fixtureJob).toContain('bun-version: ${{ env.BUN_VERSION }}');
     expect(fixtureJob).toContain('uses: astral-sh/setup-uv@v4');
     expect(fixtureJob).toContain('run: bun install --frozen-lockfile');
     expect(fixtureJob).toContain('run: bun run cli workflow test --json');


### PR DESCRIPTION
Every workflow and `package.json` now derives the Bun version from a single owning value per file. The engine moves from Bun 1.3.11 (and `latest` in two marketplace workflows) to 1.4.0, the latest stable release.

**What changed**

- **`env.BUN_VERSION: '1.4.0'`** at the top of every affected workflow; all `bun-version:` steps reference `${{ env.BUN_VERSION }}` instead of a literal
- **7 workflow files** updated (test.yml, release.yml, e2e-smoke.yml, docs-build.yml, deploy-docs.yml, marketplace-lint.yml, marketplace-auto-review.yml) — 16 pin sites in total
- **`package.json` `engines.bun`** from `"^1.3.0"` to `"1.4.0"` (concrete pin, not a semver range)
- **Test fixture** updated for the new env block and `${{ env.BUN_VERSION }}` reference
- **Lockfile** unchanged — no deliberate re-lock needed for the version bump alone

**`.bat`/`.cmd` reachability (CVE-2024-27980 scope)**

No Archon subprocess call site is reachable via `.bat`/`.cmd` extension spoofing on Windows. Every command name (`git`, `gh`, `taskkill`, `docker`, `bash.exe`, `powershell.exe`) is a hardcoded literal — no user-influenced path argument can hit PATHEXT expansion. Full call-site scan documented in the branch.

**Validation**

- `bun run validate` — 175 tests pass, 0 failures
- `bun run lint --max-warnings 0` — clean
- `bun run format:check` — clean
- `bun run type-check` — clean
- `bun run check:bundled` — up to date

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s Bun runtime to version 1.4.0 across builds, tests, releases, documentation, and container images.
  * Centralized Bun version configuration for more consistent tooling and environments.

* **Tests**
  * Added automated checks to ensure workflows, Docker images, and project configuration use the same Bun version.
  * Updated workflow fixture expectations for Bun 1.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->