### PR TITLE
test(adapters): type-check adapter test suites

### DIFF
--- a/packages/adapters/src/chat/slack/adapter.test.ts
+++ b/packages/adapters/src/chat/slack/adapter.test.ts
@@ -24,11 +24,29 @@ mock.module('@archon/paths', () => ({
   createLogger: mock(() => mockLogger),
 }));
 
+interface PostMessageArgs {
+  channel: string;
+  text: string;
+  thread_ts?: string;
+  blocks?: { type: string; text: string }[];
+}
+
+interface UserInfoResult {
+  user?: {
+    id?: string;
+    real_name?: string;
+    name?: string;
+    profile?: { email?: string; display_name?: string };
+  };
+}
+
 // Create mock functions
-const mockPostMessage = mock(() => Promise.resolve(undefined));
+const mockPostMessage = mock(
+  async (_args: PostMessageArgs): Promise<{ ts?: string } | undefined> => undefined
+);
 const mockReplies = mock(() => Promise.resolve({ messages: [] }));
-const mockUsersInfo = mock(() =>
-  Promise.resolve({
+const mockUsersInfo = mock(
+  async (): Promise<UserInfoResult> => ({
     user: {
       id: 'U123',
       real_name: 'Alice Liddell',
@@ -36,11 +54,23 @@ const mockUsersInfo = mock(() =>
     },
   })
 );
-const mockEvent = mock(() => {});
+const mockEvent = mock((_name: string, _handler: unknown) => {});
 const mockStart = mock(() => Promise.resolve(undefined));
 const mockStop = mock(() => Promise.resolve(undefined));
-const mockCommand = mock(() => {});
-const mockAction = mock(() => {});
+const mockCommand = mock((_name: string, _handler: unknown) => {});
+const mockAction = mock((_pattern: RegExp, _handler: unknown) => {});
+
+function postedMessage(index: number): PostMessageArgs {
+  const call = mockPostMessage.mock.calls[index];
+  if (!call) throw new Error(`postMessage call ${String(index)} was not recorded`);
+  return call[0];
+}
+
+function postedBlocks(index: number): NonNullable<PostMessageArgs['blocks']> {
+  const blocks = postedMessage(index).blocks;
+  if (!blocks) throw new Error(`postMessage call ${String(index)} did not include blocks`);
+  return blocks;
+}
 
 const mockApp = {
   client: {
@@ -351,9 +381,7 @@ describe('SlackAdapter', () => {
           text: 'test message',
         })
       );
-      expect((mockPostMessage as Mock<typeof mockPostMessage>).mock.calls[1][0]).not.toHaveProperty(
-        'blocks'
-      );
+      expect(postedMessage(1)).not.toHaveProperty('blocks');
     });
 
     test('should split long messages into multiple markdown blocks', async () => {
@@ -365,12 +393,8 @@ describe('SlackAdapter', () => {
 
       expect(mockPostMessage).toHaveBeenCalledTimes(2);
       // Both calls should use markdown blocks
-      expect((mockPostMessage as Mock<typeof mockPostMessage>).mock.calls[0][0]).toHaveProperty(
-        'blocks'
-      );
-      expect((mockPostMessage as Mock<typeof mockPostMessage>).mock.calls[1][0]).toHaveProperty(
-        'blocks'
-      );
+      expect(postedMessage(0)).toHaveProperty('blocks');
+      expect(postedMessage(1)).toHaveProperty('blocks');
     });
 
     test('should handle empty message without crashing', async () => {
@@ -386,7 +410,7 @@ describe('SlackAdapter', () => {
     test('single-chunk message is sent without _part footer', async () => {
       await adapter.sendMessage('C1:111.0', 'short message');
       expect(mockPostMessage).toHaveBeenCalledTimes(1);
-      const blocks = (mockPostMessage as Mock<typeof mockPostMessage>).mock.calls[0][0].blocks;
+      const blocks = postedBlocks(0);
       expect(blocks[0].text).toBe('short message');
       expect(blocks[0].text).not.toContain('_part ');
     });
@@ -396,9 +420,8 @@ describe('SlackAdapter', () => {
       const paragraph2 = 'b'.repeat(10000);
       await adapter.sendMessage('C1:111.0', `${paragraph1}\n\n${paragraph2}`);
       expect(mockPostMessage).toHaveBeenCalledTimes(2);
-      const calls = (mockPostMessage as Mock<typeof mockPostMessage>).mock.calls;
-      expect(calls[0][0].blocks[0].text).toContain('_part 1/2_');
-      expect(calls[1][0].blocks[0].text).toContain('_part 2/2_');
+      expect(postedBlocks(0)[0]?.text).toContain('_part 1/2_');
+      expect(postedBlocks(1)[0]?.text).toContain('_part 2/2_');
     });
   });
 
@@ -449,7 +472,7 @@ describe('SlackAdapter', () => {
 
     function makeSlashArgs(overrides: Record<string, unknown> = {}) {
       const ack = mock(async () => {});
-      const respond = mock(async () => {});
+      const respond = mock(async (_response?: { response_type: string; text?: string }) => {});
       const fakeClient = { chat: { postMessage: mockPostMessage } };
       return {
         ack,
@@ -505,7 +528,7 @@ describe('SlackAdapter', () => {
       const failingPost = mock(async () => Promise.reject(seedError));
       const fakeClient = { chat: { postMessage: failingPost } };
       const ack = mock(async () => {});
-      const respond = mock(async () => {});
+      const respond = mock(async (_response?: { response_type: string; text?: string }) => {});
 
       const handler = findCommandHandler('/archon');
       await handler({
@@ -522,9 +545,9 @@ describe('SlackAdapter', () => {
 
       expect(failingPost).toHaveBeenCalledTimes(1);
       expect(onMessage).not.toHaveBeenCalled();
-      const respondCalls = (respond as Mock<() => Promise<void>>).mock.calls;
+      const respondCalls = respond.mock.calls;
       expect(respondCalls.length).toBe(1);
-      expect((respondCalls[0]![0] as { response_type: string }).response_type).toBe('ephemeral');
+      expect(respondCalls[0]?.[0]?.response_type).toBe('ephemeral');
     });
   });
 

--- a/packages/adapters/src/chat/slack/auth.test.ts
+++ b/packages/adapters/src/chat/slack/auth.test.ts
@@ -1,6 +1,8 @@
 /**
  * Unit tests for Slack authorization utilities
  */
+import { describe, expect, test } from 'bun:test';
+
 import { parseAllowedUserIds, isSlackUserAuthorized } from './auth';
 
 describe('slack-auth', () => {

--- a/packages/adapters/src/chat/slack/blocks.test.ts
+++ b/packages/adapters/src/chat/slack/blocks.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from 'bun:test';
+
 import {
   buildApprovalBlocks,
   buildApprovalResolutionBlocks,

--- a/packages/adapters/src/chat/slack/workflow-bridge.test.ts
+++ b/packages/adapters/src/chat/slack/workflow-bridge.test.ts
@@ -63,18 +63,23 @@ void isSlackUserAuthorized;
 
 // ─── Test doubles for the SlackAdapter ────────────────────────────────────
 
+interface SlackBlock {
+  type?: string;
+  elements?: Array<{ action_id?: string; text?: string }>;
+}
+
 interface PostedMessage {
   channel: string;
   thread_ts?: string;
   text?: string;
-  blocks?: unknown[];
+  blocks?: SlackBlock[];
 }
 
 interface UpdatedMessage {
   channel: string;
   ts: string;
   text?: string;
-  blocks?: unknown[];
+  blocks?: SlackBlock[];
 }
 
 interface ReactionCall {
@@ -248,9 +253,7 @@ describe('SlackWorkflowBridge', () => {
     const approval = posted[posted.length - 1];
     expect(approval?.thread_ts).toBe('111.0');
     expect(approval?.text).toContain('Approval needed');
-    const actionsBlock = (approval?.blocks ?? []).find(
-      (b: { type?: string }) => b?.type === 'actions'
-    ) as { elements?: Array<{ action_id?: string }> } | undefined;
+    const actionsBlock = (approval?.blocks ?? []).find(block => block.type === 'actions');
     expect(actionsBlock?.elements?.[0]?.action_id).toBe('approve:r1:review');
     expect(actionsBlock?.elements?.[1]?.action_id).toBe('reject:r1:review');
   });
@@ -476,9 +479,7 @@ describe('SlackWorkflowBridge', () => {
       name: 'white_check_mark',
     });
     expect(updated.length).toBeGreaterThan(0);
-    const ctx = (updated[updated.length - 1]?.blocks ?? []).find(
-      (b: { type?: string }) => b?.type === 'context'
-    ) as { elements?: Array<{ text?: string }> } | undefined;
+    const ctx = (updated[updated.length - 1]?.blocks ?? []).find(block => block.type === 'context');
     expect(ctx?.elements?.[0]?.text).toContain('total cost: $0.0234');
   });
 
@@ -507,9 +508,7 @@ describe('SlackWorkflowBridge', () => {
       timestamp: '111.0',
       name: 'x',
     });
-    const ctx = (updated[updated.length - 1]?.blocks ?? []).find(
-      (b: { type?: string }) => b?.type === 'context'
-    ) as { elements?: Array<{ text?: string }> } | undefined;
+    const ctx = (updated[updated.length - 1]?.blocks ?? []).find(block => block.type === 'context');
     expect(ctx?.elements?.[0]?.text).toContain('plan node crashed');
   });
 });

--- a/packages/adapters/src/chat/telegram/adapter.test.ts
+++ b/packages/adapters/src/chat/telegram/adapter.test.ts
@@ -7,6 +7,7 @@
  */
 import { describe, test, expect, mock, beforeEach } from 'bun:test';
 import type { Mock } from 'bun:test';
+import type { Api } from 'grammy';
 
 // Mock logger to suppress noisy output during tests
 const mockLogger = {
@@ -28,6 +29,8 @@ mock.module('@archon/paths', () => ({
 }));
 
 import { TelegramAdapter } from './adapter';
+
+type SendMessage = Api['sendMessage'];
 
 describe('TelegramAdapter', () => {
   describe('streaming mode configuration', () => {
@@ -58,14 +61,21 @@ describe('TelegramAdapter', () => {
 
   describe('message formatting', () => {
     let adapter: TelegramAdapter;
-    let mockSendMessage: Mock<() => Promise<void>>;
+    let mockSendMessage: Mock<SendMessage>;
 
     beforeEach(() => {
       adapter = new TelegramAdapter('fake-token-for-testing');
-      mockSendMessage = mock(() => Promise.resolve());
-      // Override bot's sendMessage
-      (adapter.getBot().api as unknown as { sendMessage: Mock<() => Promise<void>> }).sendMessage =
-        mockSendMessage;
+      mockSendMessage = mock<SendMessage>(async (chatId, text) => ({
+        message_id: 1,
+        date: 0,
+        chat: {
+          id: typeof chatId === 'number' ? chatId : 0,
+          type: 'private',
+          first_name: 'Test',
+        },
+        text,
+      }));
+      adapter.getBot().api.sendMessage = mockSendMessage;
     });
 
     test('should send with MarkdownV2 parse_mode', async () => {
@@ -80,9 +90,7 @@ describe('TelegramAdapter', () => {
     });
 
     test('should fallback to plain text when MarkdownV2 fails', async () => {
-      mockSendMessage
-        .mockRejectedValueOnce(new Error("Bad Request: can't parse entities"))
-        .mockResolvedValueOnce(undefined);
+      mockSendMessage.mockRejectedValueOnce(new Error("Bad Request: can't parse entities"));
 
       await adapter.sendMessage('12345', '**test**');
 
@@ -152,9 +160,7 @@ describe('TelegramAdapter', () => {
 
     test('should fall back to plain text and use line-based batching when MarkdownV2 fails on chunk', async () => {
       // First MarkdownV2 attempt fails; second call is plain-text fallback
-      mockSendMessage
-        .mockRejectedValueOnce(new Error("Bad Request: can't parse entities"))
-        .mockResolvedValueOnce(undefined);
+      mockSendMessage.mockRejectedValueOnce(new Error("Bad Request: can't parse entities"));
 
       await adapter.sendMessage('77777', 'plain fallback text');
 

--- a/packages/adapters/src/chat/telegram/auth.test.ts
+++ b/packages/adapters/src/chat/telegram/auth.test.ts
@@ -1,6 +1,8 @@
 /**
  * Unit tests for Telegram authorization utilities
  */
+import { describe, expect, test } from 'bun:test';
+
 import { parseAllowedUserIds, isUserAuthorized } from './auth';
 
 describe('telegram-auth', () => {

--- a/packages/adapters/src/chat/telegram/markdown.test.ts
+++ b/packages/adapters/src/chat/telegram/markdown.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from 'bun:test';
+
 import { convertToTelegramMarkdown, escapeMarkdownV2, isAlreadyEscaped } from './markdown';
 
 describe('telegram-markdown', () => {

--- a/packages/adapters/src/community/chat/discord/adapter.test.ts
+++ b/packages/adapters/src/community/chat/discord/adapter.test.ts
@@ -70,6 +70,29 @@ mock.module('discord.js', () => ({
 import { DiscordAdapter } from './adapter';
 import type { DiscordMessageContext } from './types';
 
+interface HistoryMessage {
+  author: { bot: boolean; displayName?: string; username: string };
+  content: string;
+}
+
+interface StartThreadOptions {
+  name: string;
+  autoArchiveDuration: number;
+  reason: string;
+}
+
+type StartThread = (options: StartThreadOptions) => Promise<{ id: string }>;
+
+function makeStartThread(id: string): Mock<StartThread> {
+  return mock(async () => ({ id }));
+}
+
+function startThreadOptions(startThread: Mock<StartThread>): StartThreadOptions {
+  const options = startThread.mock.calls[0]?.[0];
+  if (!options) throw new Error('startThread was not called');
+  return options;
+}
+
 describe('DiscordAdapter', () => {
   beforeEach(() => {
     mockChannelSend.mockClear();
@@ -379,7 +402,7 @@ describe('DiscordAdapter', () => {
       };
 
       // Mock a Map-like iterable (Discord returns Collection)
-      const mockMessagesMap = new Map([
+      const mockMessagesMap = new Map<string, HistoryMessage>([
         ['id3', msg3], // newest - first in Collection
         ['id2', msg2],
         ['id1', msg1], // oldest - last in Collection
@@ -476,7 +499,7 @@ describe('DiscordAdapter', () => {
     test('should use exact content when at or under 100 chars', async () => {
       const adapter = new DiscordAdapter('fake-token-for-testing');
       const content = 'a'.repeat(100);
-      const mockStartThread = mock(() => Promise.resolve({ id: 'thread-exact' }));
+      const mockStartThread = makeStartThread('thread-exact');
       const mockMessage = {
         id: 'msg-gen-1',
         channelId: 'chan-gen',
@@ -489,7 +512,7 @@ describe('DiscordAdapter', () => {
 
       await adapter.ensureThread('chan-gen', mockMessage);
 
-      const callArgs = mockStartThread.mock.calls[0][0] as { name: string };
+      const callArgs = startThreadOptions(mockStartThread);
       expect(callArgs.name).toBe(content);
       expect(callArgs.name.endsWith('...')).toBe(false);
     });
@@ -497,7 +520,7 @@ describe('DiscordAdapter', () => {
     test('should truncate to 97 chars + ellipsis when content exceeds 100 chars', async () => {
       const adapter = new DiscordAdapter('fake-token-for-testing');
       const content = 'x'.repeat(150);
-      const mockStartThread = mock(() => Promise.resolve({ id: 'thread-trunc' }));
+      const mockStartThread = makeStartThread('thread-trunc');
       const mockMessage = {
         id: 'msg-gen-2',
         channelId: 'chan-gen',
@@ -510,14 +533,14 @@ describe('DiscordAdapter', () => {
 
       await adapter.ensureThread('chan-gen', mockMessage);
 
-      const callArgs = mockStartThread.mock.calls[0][0] as { name: string };
+      const callArgs = startThreadOptions(mockStartThread);
       expect(callArgs.name).toBe('x'.repeat(97) + '...');
       expect(callArgs.name.length).toBe(100);
     });
 
     test('should normalize whitespace in thread name', async () => {
       const adapter = new DiscordAdapter('fake-token-for-testing');
-      const mockStartThread = mock(() => Promise.resolve({ id: 'thread-ws' }));
+      const mockStartThread = makeStartThread('thread-ws');
       const mockMessage = {
         id: 'msg-gen-3',
         channelId: 'chan-gen',
@@ -530,7 +553,7 @@ describe('DiscordAdapter', () => {
 
       await adapter.ensureThread('chan-gen', mockMessage);
 
-      const callArgs = mockStartThread.mock.calls[0][0] as { name: string };
+      const callArgs = startThreadOptions(mockStartThread);
       expect(callArgs.name).toBe('hello world foo');
     });
   });
@@ -538,7 +561,7 @@ describe('DiscordAdapter', () => {
   describe('createThreadFromMessage (via ensureThread)', () => {
     test('should pass autoArchiveDuration of 1440 (OneDay)', async () => {
       const adapter = new DiscordAdapter('fake-token-for-testing');
-      const mockStartThread = mock(() => Promise.resolve({ id: 'thread-archive' }));
+      const mockStartThread = makeStartThread('thread-archive');
       const mockMessage = {
         id: 'msg-arc-1',
         channelId: 'chan-arc',
@@ -551,10 +574,7 @@ describe('DiscordAdapter', () => {
 
       await adapter.ensureThread('chan-arc', mockMessage);
 
-      const callArgs = mockStartThread.mock.calls[0][0] as {
-        autoArchiveDuration: number;
-        reason: string;
-      };
+      const callArgs = startThreadOptions(mockStartThread);
       // ThreadAutoArchiveDuration.OneDay = 1440 minutes
       expect(callArgs.autoArchiveDuration).toBe(1440);
       expect(callArgs.reason).toBe('Bot response thread');
@@ -562,7 +582,7 @@ describe('DiscordAdapter', () => {
 
     test('should strip bot mention before generating thread name', async () => {
       const adapter = new DiscordAdapter('fake-token-for-testing');
-      const mockStartThread = mock(() => Promise.resolve({ id: 'thread-strip' }));
+      const mockStartThread = makeStartThread('thread-strip');
       const mockMessage = {
         id: 'msg-strip-1',
         channelId: 'chan-strip',
@@ -575,7 +595,7 @@ describe('DiscordAdapter', () => {
 
       await adapter.ensureThread('chan-strip', mockMessage);
 
-      const callArgs = mockStartThread.mock.calls[0][0] as { name: string };
+      const callArgs = startThreadOptions(mockStartThread);
       expect(callArgs.name).toBe('please help me');
     });
   });
@@ -692,7 +712,7 @@ describe('DiscordAdapter', () => {
     });
 
     test('should create thread for channel message', async () => {
-      const mockStartThread = mock(() => Promise.resolve({ id: 'newthread123' }));
+      const mockStartThread = makeStartThread('newthread123');
       const mockMessage = {
         id: 'msg123',
         channelId: 'channel456',
@@ -719,7 +739,7 @@ describe('DiscordAdapter', () => {
 
     test('should truncate long thread names', async () => {
       const longContent = 'a'.repeat(150);
-      const mockStartThread = mock(() => Promise.resolve({ id: 'newthread123' }));
+      const mockStartThread = makeStartThread('newthread123');
       const mockMessage = {
         id: 'msg123',
         channelId: 'channel456',
@@ -736,13 +756,15 @@ describe('DiscordAdapter', () => {
 
       await adapter.ensureThread('channel456', mockMessage);
 
-      const callArgs = mockStartThread.mock.calls[0][0] as { name: string };
+      const callArgs = startThreadOptions(mockStartThread);
       expect(callArgs.name.length).toBeLessThanOrEqual(100);
       expect(callArgs.name.endsWith('...')).toBe(true);
     });
 
     test('should fall back to channel ID on thread creation error', async () => {
-      const mockStartThread = mock(() => Promise.reject(new Error('Permission denied')));
+      const mockStartThread = mock<StartThread>(async () => {
+        throw new Error('Permission denied');
+      });
       const mockMessage = {
         id: 'msg123',
         channelId: 'channel456',
@@ -768,7 +790,7 @@ describe('DiscordAdapter', () => {
         resolveThread = resolve;
       });
 
-      const mockStartThread = mock(() => threadPromise);
+      const mockStartThread = mock<StartThread>(() => threadPromise);
       const mockMessage = {
         id: 'msg123',
         channelId: 'channel456',
@@ -801,7 +823,7 @@ describe('DiscordAdapter', () => {
     });
 
     test('should use Bot Response as thread name for empty content', async () => {
-      const mockStartThread = mock(() => Promise.resolve({ id: 'newthread123' }));
+      const mockStartThread = makeStartThread('newthread123');
       const mockMessage = {
         id: 'msg123',
         channelId: 'channel456',
@@ -818,7 +840,7 @@ describe('DiscordAdapter', () => {
 
       await adapter.ensureThread('channel456', mockMessage);
 
-      const callArgs = mockStartThread.mock.calls[0][0] as { name: string };
+      const callArgs = startThreadOptions(mockStartThread);
       expect(callArgs.name).toBe('Bot Response');
     });
   });

--- a/packages/adapters/src/community/forge/gitea/adapter.test.ts
+++ b/packages/adapters/src/community/forge/gitea/adapter.test.ts
@@ -5,6 +5,7 @@
  * database modules to avoid test pollution issues with Bun's mock.module.
  */
 import { describe, test, expect, mock, spyOn, beforeEach, afterEach } from 'bun:test';
+import type { Mock } from 'bun:test';
 import { createHmac } from 'node:crypto';
 import type { Codebase, Conversation } from '@archon/core';
 
@@ -114,21 +115,55 @@ mock.module('@archon/core', () => ({
 
 import { GiteaAdapter } from './adapter';
 import type { WebhookEvent } from './types';
-import { ConversationLockManager } from '@archon/core';
+
+type FetchCall = (...args: Parameters<typeof fetch>) => ReturnType<typeof fetch>;
+type FetchMock = Mock<FetchCall> & Pick<typeof fetch, 'preconnect'>;
+
+function jsonResponse(data: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(data), init);
+}
+
+async function copyResponse(response: Response): Promise<Response> {
+  const body = await response.clone().arrayBuffer();
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: [...response.headers.entries()],
+  });
+}
+
+function makeFetchMock(response: Response = jsonResponse({}, { status: 200 })): FetchMock {
+  return Object.assign(
+    mock<FetchCall>(() => copyResponse(response)),
+    {
+      preconnect: mock<typeof fetch.preconnect>(() => undefined),
+    }
+  );
+}
+
+function postedBody(fetchMock: FetchMock, index: number): string {
+  const body = fetchMock.mock.calls[index]?.[1]?.body;
+  if (typeof body !== 'string') throw new Error(`fetch call ${String(index)} has no string body`);
+  const parsed: unknown = JSON.parse(body);
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    !('body' in parsed) ||
+    typeof parsed.body !== 'string'
+  ) {
+    throw new Error(`fetch call ${String(index)} has no JSON body field`);
+  }
+  return parsed.body;
+}
 
 // Create a mock lock manager that immediately executes handlers
+const mockAcquireLock = mock(async (_id: string, handler: () => Promise<void>) => {
+  await handler();
+  return { status: 'started' as const };
+});
 const mockLockManager = {
-  acquireLock: mock(async (_id: string, handler: () => Promise<void>) => {
-    await handler();
-  }),
-  getStats: () => ({
-    active: 0,
-    queuedTotal: 0,
-    queuedByConversation: [],
-    maxConcurrent: 10,
-    activeConversationIds: [],
-  }),
-} as unknown as ConversationLockManager;
+  acquireLock: mockAcquireLock,
+};
 
 describe('GiteaAdapter', () => {
   let adapter: GiteaAdapter;
@@ -280,7 +315,7 @@ describe('GiteaAdapter', () => {
     beforeEach(() => {
       originalAllowedUsers = process.env.GITEA_ALLOWED_USERS;
       delete process.env.GITEA_ALLOWED_USERS;
-      mockLockManager.acquireLock.mockClear();
+      mockAcquireLock.mockClear();
     });
 
     afterEach(() => {
@@ -296,7 +331,7 @@ describe('GiteaAdapter', () => {
       await adapter.handleWebhook(payload, 'mock-signature');
 
       // Bot's own comments should be silently dropped - no lock acquired, no processing
-      expect(mockLockManager.acquireLock).not.toHaveBeenCalled();
+      expect(mockAcquireLock).not.toHaveBeenCalled();
     });
 
     test('should handle case-insensitive username matching', async () => {
@@ -306,7 +341,7 @@ describe('GiteaAdapter', () => {
       await adapter.handleWebhook(payload, 'mock-signature');
 
       // Bot's own comments should be silently dropped regardless of case
-      expect(mockLockManager.acquireLock).not.toHaveBeenCalled();
+      expect(mockAcquireLock).not.toHaveBeenCalled();
     });
 
     test('should NOT filter comments from real users', async () => {
@@ -334,7 +369,7 @@ describe('GiteaAdapter', () => {
       await adapter.handleWebhook(payload, 'mock-signature');
 
       // Marked comments should be silently dropped
-      expect(mockLockManager.acquireLock).not.toHaveBeenCalled();
+      expect(mockAcquireLock).not.toHaveBeenCalled();
     });
 
     test('should process comments without bot marker from same user', async () => {
@@ -367,13 +402,8 @@ describe('GiteaAdapter', () => {
 
   describe('conversationId format', () => {
     test('should parse valid owner/repo#number format for issues', async () => {
-      const mockFetch = mock(() =>
-        Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({}),
-        })
-      );
-      globalThis.fetch = mockFetch as typeof fetch;
+      const mockFetch = makeFetchMock();
+      globalThis.fetch = mockFetch;
 
       await adapter.sendMessage('owner/repo#123', 'test');
 
@@ -382,18 +412,15 @@ describe('GiteaAdapter', () => {
       expect(callArgs[0]).toBe(
         'https://gitea.example.com/api/v1/repos/owner/repo/issues/123/comments'
       );
-      expect(callArgs[1].method).toBe('POST');
-      expect(callArgs[1].headers.Authorization).toBe('token fake-token-for-testing');
+      expect(callArgs[1]?.method).toBe('POST');
+      expect(new Headers(callArgs[1]?.headers).get('Authorization')).toBe(
+        'token fake-token-for-testing'
+      );
     });
 
     test('should parse valid owner/repo!number format for PRs', async () => {
-      const mockFetch = mock(() =>
-        Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({}),
-        })
-      );
-      globalThis.fetch = mockFetch as typeof fetch;
+      const mockFetch = makeFetchMock();
+      globalThis.fetch = mockFetch;
 
       await adapter.sendMessage('owner/repo!456', 'test');
 
@@ -406,30 +433,20 @@ describe('GiteaAdapter', () => {
     });
 
     test('postComment appends bot marker to outgoing comments', async () => {
-      const mockFetch = mock(() =>
-        Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({}),
-        })
-      );
-      globalThis.fetch = mockFetch as typeof fetch;
+      const mockFetch = makeFetchMock();
+      globalThis.fetch = mockFetch;
 
       await adapter.sendMessage('owner/repo#123', 'Hello world');
 
-      const body = JSON.parse(mockFetch.mock.calls[0][1].body as string).body as string;
+      const body = postedBody(mockFetch, 0);
       expect(body).toContain('Hello world');
       expect(body).toContain('<!-- archon-bot-response -->');
       expect(body).toBe('Hello world\n\n<!-- archon-bot-response -->');
     });
 
     test('should reject invalid conversationId format', async () => {
-      const mockFetch = mock(() =>
-        Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({}),
-        })
-      );
-      globalThis.fetch = mockFetch as typeof fetch;
+      const mockFetch = makeFetchMock();
+      globalThis.fetch = mockFetch;
 
       // Invalid format should return early without calling API
       await adapter.sendMessage('owner/repo#pr-42', 'test');
@@ -512,13 +529,8 @@ describe('GiteaAdapter', () => {
 
   describe('message splitting', () => {
     test('should split long messages into multiple chunks', async () => {
-      const mockFetch = mock(() =>
-        Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({}),
-        })
-      );
-      globalThis.fetch = mockFetch as typeof fetch;
+      const mockFetch = makeFetchMock();
+      globalThis.fetch = mockFetch;
 
       // Create message exceeding MAX_LENGTH (65000)
       const paragraph1 = 'a'.repeat(40000);
@@ -531,11 +543,11 @@ describe('GiteaAdapter', () => {
       expect(mockFetch).toHaveBeenCalledTimes(2);
 
       // First chunk should contain paragraph1
-      const firstBody = JSON.parse(mockFetch.mock.calls[0][1].body as string).body as string;
+      const firstBody = postedBody(mockFetch, 0);
       expect(firstBody).toContain('aaa');
 
       // Second chunk should contain paragraph2
-      const secondBody = JSON.parse(mockFetch.mock.calls[1][1].body as string).body as string;
+      const secondBody = postedBody(mockFetch, 1);
       expect(secondBody).toContain('bbb');
 
       // Verify chunk sizes are within limits
@@ -544,13 +556,8 @@ describe('GiteaAdapter', () => {
     });
 
     test('should not split message at exactly MAX_LENGTH', async () => {
-      const mockFetch = mock(() =>
-        Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({}),
-        })
-      );
-      globalThis.fetch = mockFetch as typeof fetch;
+      const mockFetch = makeFetchMock();
+      globalThis.fetch = mockFetch;
 
       // Message exactly at MAX_LENGTH (65000) should not be split
       const message = 'a'.repeat(65000);
@@ -560,13 +567,8 @@ describe('GiteaAdapter', () => {
     });
 
     test('should handle message without paragraph breaks', async () => {
-      const mockFetch = mock(() =>
-        Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({}),
-        })
-      );
-      globalThis.fetch = mockFetch as typeof fetch;
+      const mockFetch = makeFetchMock();
+      globalThis.fetch = mockFetch;
 
       // Message under MAX_LENGTH with no paragraph breaks
       const message = 'a'.repeat(50000);
@@ -576,15 +578,12 @@ describe('GiteaAdapter', () => {
     });
 
     test('should throw error when chunk posting fails', async () => {
-      const mockFetch = mock()
-        .mockResolvedValueOnce({ ok: true }) // First chunk succeeds
-        .mockResolvedValueOnce({
-          ok: false,
-          status: 429,
-          statusText: 'Too Many Requests',
-          text: () => Promise.resolve('Rate limit exceeded'),
-        }); // Second chunk fails
-      globalThis.fetch = mockFetch as typeof fetch;
+      const mockFetch = makeFetchMock()
+        .mockResolvedValueOnce(new Response(null, { status: 200 })) // First chunk succeeds
+        .mockResolvedValueOnce(
+          new Response('Rate limit exceeded', { status: 429, statusText: 'Too Many Requests' })
+        ); // Second chunk fails
+      globalThis.fetch = mockFetch;
 
       // Create message that will be split into 2 chunks
       const paragraph1 = 'a'.repeat(40000);
@@ -603,10 +602,10 @@ describe('GiteaAdapter', () => {
 
   describe('retry logic', () => {
     test('should retry on transient network errors', async () => {
-      const mockFetch = mock()
+      const mockFetch = makeFetchMock()
         .mockRejectedValueOnce(new Error('fetch failed')) // First attempt fails
-        .mockResolvedValueOnce({ ok: true }); // Second attempt succeeds
-      globalThis.fetch = mockFetch as typeof fetch;
+        .mockResolvedValueOnce(new Response(null, { status: 200 })); // Second attempt succeeds
+      globalThis.fetch = mockFetch;
 
       await adapter.sendMessage('owner/repo#123', 'test message');
 
@@ -615,13 +614,10 @@ describe('GiteaAdapter', () => {
     });
 
     test('should not retry on non-retryable errors', async () => {
-      const mockFetch = mock().mockResolvedValue({
-        ok: false,
-        status: 401,
-        statusText: 'Unauthorized',
-        text: () => Promise.resolve('Bad credentials'),
-      });
-      globalThis.fetch = mockFetch as typeof fetch;
+      const mockFetch = makeFetchMock(
+        new Response('Bad credentials', { status: 401, statusText: 'Unauthorized' })
+      );
+      globalThis.fetch = mockFetch;
 
       // Should throw immediately without retry
       await expect(adapter.sendMessage('owner/repo#123', 'test message')).rejects.toThrow(
@@ -633,8 +629,8 @@ describe('GiteaAdapter', () => {
     });
 
     test('should throw after exhausting retries', async () => {
-      const mockFetch = mock().mockRejectedValue(new Error('fetch failed'));
-      globalThis.fetch = mockFetch as typeof fetch;
+      const mockFetch = makeFetchMock().mockRejectedValue(new Error('fetch failed'));
+      globalThis.fetch = mockFetch;
 
       await expect(adapter.sendMessage('owner/repo#123', 'test message')).rejects.toThrow(
         'fetch failed'
@@ -744,18 +740,14 @@ describe('GiteaAdapter', () => {
 
   describe('fetchCommentHistory', () => {
     test('should fetch and format comment history', async () => {
-      const mockFetch = mock(() =>
-        Promise.resolve({
-          ok: true,
-          json: () =>
-            Promise.resolve([
-              { user: { login: 'user1' }, body: 'First comment' },
-              { user: { login: 'user2' }, body: 'Second comment' },
-              { user: { login: 'user3' }, body: 'Third comment' },
-            ]),
-        })
+      const mockFetch = makeFetchMock(
+        jsonResponse([
+          { user: { login: 'user1' }, body: 'First comment' },
+          { user: { login: 'user2' }, body: 'Second comment' },
+          { user: { login: 'user3' }, body: 'Third comment' },
+        ])
       );
-      globalThis.fetch = mockFetch as typeof fetch;
+      globalThis.fetch = mockFetch;
 
       // @ts-expect-error - calling private method for testing
       const history = await adapter.fetchCommentHistory('owner', 'repo', 123);
@@ -775,14 +767,10 @@ describe('GiteaAdapter', () => {
     });
 
     test('should return empty array on API error', async () => {
-      const mockFetch = mock(() =>
-        Promise.resolve({
-          ok: false,
-          status: 429,
-          statusText: 'Too Many Requests',
-        })
+      const mockFetch = makeFetchMock(
+        new Response(null, { status: 429, statusText: 'Too Many Requests' })
       );
-      globalThis.fetch = mockFetch as typeof fetch;
+      globalThis.fetch = mockFetch;
 
       // @ts-expect-error - calling private method for testing
       const history = await adapter.fetchCommentHistory('owner', 'repo', 123);
@@ -794,13 +782,8 @@ describe('GiteaAdapter', () => {
         user: { login: `user${String(i + 1)}` },
         body: `Comment ${String(i + 1)}`,
       }));
-      const mockFetch = mock(() =>
-        Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve(manyComments),
-        })
-      );
-      globalThis.fetch = mockFetch as typeof fetch;
+      const mockFetch = makeFetchMock(jsonResponse(manyComments));
+      globalThis.fetch = mockFetch;
 
       // @ts-expect-error - calling private method for testing
       const history = await adapter.fetchCommentHistory('owner', 'repo', 123);
@@ -931,9 +914,7 @@ describe('GiteaAdapter', () => {
     let fetchSpy: ReturnType<typeof spyOn<typeof globalThis, 'fetch'>>;
 
     beforeEach(() => {
-      fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(
-        () => Promise.resolve(new Response('[]', { status: 200 })) as ReturnType<typeof fetch>
-      );
+      fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(new Response('[]', { status: 200 }));
       mockFindOrCreateUserByPlatformIdentity.mockClear();
       mockFindOrCreateUserByPlatformIdentity.mockImplementation(async () => ({
         id: 'user-test-uuid',

--- a/packages/adapters/src/community/forge/gitea/adapter.ts
+++ b/packages/adapters/src/community/forge/gitea/adapter.ts
@@ -15,7 +15,7 @@ import {
   classifyAndFormatError,
   toError,
   onConversationClosed,
-  ConversationLockManager,
+  type ConversationLockManager,
 } from '@archon/core';
 import * as userDb from '@archon/core/db/users';
 import {
@@ -51,20 +51,22 @@ const MAX_LENGTH = 65000; // Gitea comment limit (similar to GitHub)
 /** Hidden marker added to bot comments to prevent self-triggering loops */
 const BOT_RESPONSE_MARKER = '<!-- archon-bot-response -->';
 
+type ConversationLocker = Pick<ConversationLockManager, 'acquireLock'>;
+
 export class GiteaAdapter implements IPlatformAdapter {
   private baseUrl: string;
   private token: string;
   private webhookSecret: string;
   private allowedUsers: string[];
   private botMention: string;
-  private lockManager: ConversationLockManager;
+  private lockManager: ConversationLocker;
   private readonly retryDelayFn: (attempt: number) => number;
 
   constructor(
     baseUrl: string,
     token: string,
     webhookSecret: string,
-    lockManager: ConversationLockManager,
+    lockManager: ConversationLocker,
     botMention?: string,
     options?: { retryDelayMs?: (attempt: number) => number }
   ) {

--- a/packages/adapters/src/community/forge/gitlab/adapter.test.ts
+++ b/packages/adapters/src/community/forge/gitlab/adapter.test.ts
@@ -4,6 +4,29 @@
  * Runs in its own test batch to avoid mock.module pollution with other adapters.
  */
 import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import type { Mock } from 'bun:test';
+import type { Codebase, Conversation } from '@archon/core';
+
+type FetchCall = (...args: Parameters<typeof fetch>) => ReturnType<typeof fetch>;
+type FetchMock = Mock<FetchCall> & Pick<typeof fetch, 'preconnect'>;
+
+async function copyResponse(response: Response): Promise<Response> {
+  const body = await response.clone().arrayBuffer();
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: [...response.headers.entries()],
+  });
+}
+
+function makeFetchMock(response: Response): FetchMock {
+  return Object.assign(
+    mock<FetchCall>(() => copyResponse(response)),
+    {
+      preconnect: mock<typeof fetch.preconnect>(() => undefined),
+    }
+  );
+}
 
 // Mock @archon/paths to suppress noisy logger output during tests
 const mockLogger = {
@@ -45,9 +68,13 @@ const mockFindOrCreateUserByPlatformIdentity = mock(
 mock.module('@archon/core/db/users', () => ({
   findOrCreateUserByPlatformIdentity: mockFindOrCreateUserByPlatformIdentity,
 }));
-const mockGetOrCreateConversation = mock(async () => {
-  throw new Error('DB not mocked in tests');
-});
+const mockGetOrCreateConversation = mock(
+  async (): Promise<
+    Pick<Conversation, 'id' | 'codebase_id' | 'platform_type' | 'platform_conversation_id'>
+  > => {
+    throw new Error('DB not mocked in tests');
+  }
+);
 const mockUpdateConversation = mock(async () => {
   throw new Error('DB not mocked in tests');
 });
@@ -58,7 +85,9 @@ mock.module('@archon/core/db/conversations', () => ({
   getConversation: mockGetConversation,
 }));
 
-const mockFindCodebaseByRepoUrl = mock(async () => null);
+const mockFindCodebaseByRepoUrl = mock(
+  async (): Promise<Pick<Codebase, 'id' | 'repository_url' | 'default_cwd' | 'name'> | null> => null
+);
 const mockCreateCodebase = mock(async () => {
   throw new Error('DB not mocked in tests');
 });
@@ -83,8 +112,9 @@ mock.module('@archon/core', () => ({
   onConversationClosed: mockOnConversationClosed,
   ConversationNotFoundError: class extends Error {},
   ConversationLockManager: class {
-    async acquireLock(_id: string, fn: () => Promise<void>): Promise<void> {
+    async acquireLock(_id: string, fn: () => Promise<void>): Promise<{ status: 'started' }> {
       await fn();
+      return { status: 'started' };
     }
   },
 }));
@@ -106,8 +136,8 @@ mock.module('@archon/isolation', () => ({
 }));
 
 // Mock global fetch to prevent real HTTP calls (gitlab.example.com hangs on CI Linux)
-const mockFetch = mock(() => Promise.resolve(new Response(JSON.stringify({}), { status: 200 })));
-globalThis.fetch = mockFetch as typeof globalThis.fetch;
+const mockFetch = makeFetchMock(new Response(JSON.stringify({}), { status: 200 }));
+globalThis.fetch = mockFetch;
 
 // Now import the adapter (after all mocks)
 const { GitLabAdapter } = await import('./adapter');
@@ -124,7 +154,7 @@ function createAdapter(options?: {
   return new GitLabAdapter(
     options?.token ?? 'test-token',
     options?.secret ?? 'test-secret',
-    lockManager as never,
+    lockManager,
     options?.gitlabUrl ?? 'https://gitlab.example.com',
     options?.botMention ?? 'archon'
   );
@@ -714,11 +744,9 @@ describe('GitLabAdapter', () => {
   });
 
   describe('sendMessage', () => {
-    let mockFetch: ReturnType<typeof mock>;
-
     beforeEach(() => {
-      mockFetch = mock(() => Promise.resolve(new Response(JSON.stringify({}), { status: 200 })));
-      globalThis.fetch = mockFetch as typeof fetch;
+      mockFetch.mockReset();
+      mockFetch.mockImplementation(async () => new Response(JSON.stringify({}), { status: 200 }));
     });
 
     test('posts to correct issue notes API endpoint', async () => {

--- a/packages/adapters/src/community/forge/gitlab/adapter.ts
+++ b/packages/adapters/src/community/forge/gitlab/adapter.ts
@@ -14,7 +14,7 @@ import {
   classifyAndFormatError,
   toError,
   onConversationClosed,
-  ConversationLockManager,
+  type ConversationLockManager,
 } from '@archon/core';
 import {
   ensureProjectStructure,
@@ -50,18 +50,20 @@ const MAX_LENGTH = 65000; // Practical limit for GitLab notes
 /** Hidden marker added to bot comments to prevent self-triggering loops */
 const BOT_RESPONSE_MARKER = '<!-- archon-bot-response -->';
 
+type ConversationLocker = Pick<ConversationLockManager, 'acquireLock'>;
+
 export class GitLabAdapter implements IPlatformAdapter {
   private readonly gitlabUrl: string;
   private readonly token: string;
   private readonly webhookSecret: string;
   private readonly allowedUsers: string[];
   private readonly botMention: string;
-  private readonly lockManager: ConversationLockManager;
+  private readonly lockManager: ConversationLocker;
 
   constructor(
     token: string,
     webhookSecret: string,
-    lockManager: ConversationLockManager,
+    lockManager: ConversationLocker,
     gitlabUrl?: string,
     botMention?: string
   ) {

--- a/packages/adapters/src/forge/github/adapter.test.ts
+++ b/packages/adapters/src/forge/github/adapter.test.ts
@@ -31,6 +31,8 @@ import {
   beforeEach,
   afterEach,
 } from 'bun:test';
+import type { Mock } from 'bun:test';
+import type { Octokit } from '@octokit/rest';
 import { createHmac, randomUUID } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -135,8 +137,14 @@ mock.module('@archon/core/config/resolve-assistant', () => ({
 }));
 
 // Mock @archon/git for ensureRepoReady integration tests
-const mockCloneRepository = mock(async () => ({ ok: true, value: undefined }));
-const mockSyncRepository = mock(async () => ({ ok: true, value: undefined }));
+const mockCloneRepository = mock<(typeof import('@archon/git'))['cloneRepository']>(async () => ({
+  ok: true,
+  value: undefined,
+}));
+const mockSyncRepository = mock<(typeof import('@archon/git'))['syncRepository']>(async () => ({
+  ok: true,
+  value: undefined,
+}));
 const mockAddSafeDirectory = mock(async () => undefined);
 const mockIsWorktreePath = mock(async () => false);
 
@@ -161,24 +169,18 @@ mock.module('@archon/git', () => ({
 
 import { GitHubAdapter } from './adapter';
 import type { WebhookEvent } from './types';
-import { ConversationLockManager } from '@archon/core';
 // Namespace import so the dedup tests can spyOn(core, 'handleMessage') — the
 // orchestrator entry point the adapter calls after webhook setup succeeds.
 import * as core from '@archon/core';
 
 // Create a mock lock manager that immediately executes handlers
+const mockAcquireLock = mock(async (_id: string, handler: () => Promise<void>) => {
+  await handler();
+  return { status: 'started' as const };
+});
 const mockLockManager = {
-  acquireLock: mock(async (_id: string, handler: () => Promise<void>) => {
-    await handler();
-  }),
-  getStats: () => ({
-    active: 0,
-    queuedTotal: 0,
-    queuedByConversation: [],
-    maxConcurrent: 10,
-    activeConversationIds: [],
-  }),
-} as unknown as ConversationLockManager;
+  acquireLock: mockAcquireLock,
+};
 
 /**
  * File-wide stubs for the `@archon/core` functions `handleWebhook()` reaches in
@@ -236,22 +238,59 @@ function unclonedPath(): string {
  * steps 8-13 unmocked; the first payload or code change that gets past step 7
  * then silently falls into real I/O. Stub the whole surface instead.
  */
+type CreateCommentArgs = NonNullable<Parameters<Octokit['rest']['issues']['createComment']>[0]>;
+type ListCommentsArgs = NonNullable<Parameters<Octokit['rest']['issues']['listComments']>[0]>;
+type ListComment = Awaited<ReturnType<Octokit['rest']['issues']['listComments']>>['data'][number];
+type ListCommentUser = Pick<NonNullable<ListComment['user']>, 'login'>;
+type CreateComment = (args: CreateCommentArgs) => Promise<unknown>;
+type ListComments = (args: ListCommentsArgs) => Promise<{
+  data: { body?: ListComment['body'] | null; user?: ListCommentUser | null }[];
+}>;
+type RepositoryData = Awaited<ReturnType<Octokit['rest']['repos']['get']>>['data'];
+type PullRequestData = Awaited<ReturnType<Octokit['rest']['pulls']['get']>>['data'];
+
 interface OctokitStubs {
-  reposGet: ReturnType<typeof mock>;
-  listComments: ReturnType<typeof mock>;
-  createComment: ReturnType<typeof mock>;
-  pullsGet: ReturnType<typeof mock>;
+  reposGet: Mock<
+    (
+      args: NonNullable<Parameters<Octokit['rest']['repos']['get']>[0]>
+    ) => Promise<{ data: Pick<RepositoryData, 'default_branch'> }>
+  >;
+  listComments: Mock<ListComments>;
+  createComment: Mock<CreateComment>;
+  pullsGet: Mock<
+    (args: NonNullable<Parameters<Octokit['rest']['pulls']['get']>[0]>) => Promise<{
+      data: {
+        head: Pick<PullRequestData['head'], 'ref' | 'sha'> & {
+          repo: Pick<NonNullable<PullRequestData['head']['repo']>, 'full_name'> | null;
+        };
+        base: { repo: Pick<PullRequestData['base']['repo'], 'full_name'> };
+      };
+    }>
+  >;
+}
+
+function makeCreateCommentMock(): Mock<CreateComment> {
+  return mock(async () => ({ data: {} }));
+}
+
+function makeListCommentsMock(
+  data: Awaited<ReturnType<ListComments>>['data'] = []
+): Mock<ListComments> {
+  return mock(async () => ({ data }));
 }
 
 /**
  * Replaces an adapter's private Octokit client with that surface and returns
  * the stubs, for the callers that assert against them.
  */
-function installOctokitStubs(adapter: GitHubAdapter): OctokitStubs {
+function installOctokitStubs(
+  adapter: GitHubAdapter,
+  overrides: Partial<Pick<OctokitStubs, 'createComment' | 'listComments'>> = {}
+): OctokitStubs {
   const stubs: OctokitStubs = {
     reposGet: mock(async () => ({ data: { default_branch: 'main' } })),
-    listComments: mock(async () => ({ data: [] })),
-    createComment: mock(async () => ({ data: {} })),
+    listComments: overrides.listComments ?? makeListCommentsMock(),
+    createComment: overrides.createComment ?? makeCreateCommentMock(),
     pullsGet: mock(async () => ({
       data: {
         head: {
@@ -279,7 +318,7 @@ function installOctokitStubs(adapter: GitHubAdapter): OctokitStubs {
  * Reduces duplication across tests that need to verify comment posting behavior.
  */
 async function createTestAdapterWithMockedOctokit(
-  mockCreateComment: ReturnType<typeof mock>,
+  mockCreateComment: Mock<CreateComment>,
   options?: { retryDelayMs?: (attempt: number) => number }
 ): Promise<GitHubAdapter> {
   const testAdapter = new GitHubAdapter(
@@ -290,14 +329,7 @@ async function createTestAdapterWithMockedOctokit(
     options
   );
   await testAdapter.start();
-  // @ts-expect-error - accessing private property for testing
-  testAdapter.octokit = {
-    rest: {
-      issues: {
-        createComment: mockCreateComment,
-      },
-    },
-  };
+  installOctokitStubs(testAdapter, { createComment: mockCreateComment });
   return testAdapter;
 }
 
@@ -449,7 +481,7 @@ describe('GitHubAdapter', () => {
     beforeEach(() => {
       originalAllowedUsers = process.env.GITHUB_ALLOWED_USERS;
       delete process.env.GITHUB_ALLOWED_USERS;
-      mockLockManager.acquireLock.mockClear();
+      mockAcquireLock.mockClear();
       mockGetOrCreateConversation.mockClear();
       mockFindCodebaseByRepoUrl.mockClear();
       mockCreateCodebase.mockClear();
@@ -528,7 +560,7 @@ describe('GitHubAdapter', () => {
       await adapter.handleWebhook(payload, 'mock-signature');
 
       // Bot's own comments should be silently dropped - no lock acquired, no processing
-      expect(mockLockManager.acquireLock).not.toHaveBeenCalled();
+      expect(mockAcquireLock).not.toHaveBeenCalled();
     });
 
     test('should handle case-insensitive username matching', async () => {
@@ -538,7 +570,7 @@ describe('GitHubAdapter', () => {
       await adapter.handleWebhook(payload, 'mock-signature');
 
       // Bot's own comments should be silently dropped regardless of case
-      expect(mockLockManager.acquireLock).not.toHaveBeenCalled();
+      expect(mockAcquireLock).not.toHaveBeenCalled();
     });
 
     test('should NOT filter comments from real users', async () => {
@@ -563,7 +595,7 @@ describe('GitHubAdapter', () => {
       await adapter.handleWebhook(payload, 'mock-signature');
 
       // Marked comments should be silently dropped
-      expect(mockLockManager.acquireLock).not.toHaveBeenCalled();
+      expect(mockAcquireLock).not.toHaveBeenCalled();
     });
 
     test('should process comments without bot marker from same user', async () => {
@@ -655,7 +687,7 @@ describe('GitHubAdapter', () => {
     beforeEach(() => {
       originalAllowedUsers = process.env.GITHUB_ALLOWED_USERS;
       delete process.env.GITHUB_ALLOWED_USERS;
-      mockLockManager.acquireLock.mockClear();
+      mockAcquireLock.mockClear();
       mockGetOrCreateConversation.mockClear();
       mockLogger.info.mockClear();
       handleMessageSpy.mockClear();
@@ -783,7 +815,7 @@ describe('GitHubAdapter', () => {
 
   describe('conversationId format', () => {
     test('should parse valid owner/repo#number format', async () => {
-      const mockCreateComment = mock(() => Promise.resolve({ data: {} }));
+      const mockCreateComment = makeCreateCommentMock();
       const testAdapter = await createTestAdapterWithMockedOctokit(mockCreateComment);
 
       await testAdapter.sendMessage('owner/repo#123', 'test');
@@ -797,7 +829,7 @@ describe('GitHubAdapter', () => {
     });
 
     test('postComment appends bot marker to outgoing comments', async () => {
-      const mockCreateComment = mock(() => Promise.resolve({ data: {} }));
+      const mockCreateComment = makeCreateCommentMock();
       const testAdapter = await createTestAdapterWithMockedOctokit(mockCreateComment);
 
       await testAdapter.sendMessage('owner/repo#123', 'Hello world');
@@ -809,7 +841,7 @@ describe('GitHubAdapter', () => {
     });
 
     test('should reject invalid conversationId format', async () => {
-      const mockCreateComment = mock(() => Promise.resolve({ data: {} }));
+      const mockCreateComment = makeCreateCommentMock();
       const testAdapter = await createTestAdapterWithMockedOctokit(mockCreateComment);
 
       // Invalid format (pr-42 is not a number) should return early without calling API
@@ -963,7 +995,7 @@ describe('GitHubAdapter', () => {
 
   describe('message splitting', () => {
     test('should split long messages into multiple chunks', async () => {
-      const mockCreateComment = mock(() => Promise.resolve({ data: {} }));
+      const mockCreateComment = makeCreateCommentMock();
       const testAdapter = await createTestAdapterWithMockedOctokit(mockCreateComment);
 
       // Create message exceeding MAX_LENGTH (65000)
@@ -1000,7 +1032,7 @@ describe('GitHubAdapter', () => {
     });
 
     test('should not split message at exactly MAX_LENGTH', async () => {
-      const mockCreateComment = mock(() => Promise.resolve({ data: {} }));
+      const mockCreateComment = makeCreateCommentMock();
       const testAdapter = await createTestAdapterWithMockedOctokit(mockCreateComment);
 
       // Message exactly at MAX_LENGTH (65000) should not be split
@@ -1011,7 +1043,7 @@ describe('GitHubAdapter', () => {
     });
 
     test('should handle message without paragraph breaks', async () => {
-      const mockCreateComment = mock(() => Promise.resolve({ data: {} }));
+      const mockCreateComment = makeCreateCommentMock();
       const testAdapter = await createTestAdapterWithMockedOctokit(mockCreateComment);
 
       // Message under MAX_LENGTH with no paragraph breaks
@@ -1022,7 +1054,7 @@ describe('GitHubAdapter', () => {
     });
 
     test('should throw error when chunk posting fails', async () => {
-      const mockCreateComment = mock()
+      const mockCreateComment = makeCreateCommentMock()
         .mockResolvedValueOnce({ data: {} }) // First chunk succeeds
         .mockRejectedValueOnce(new Error('API rate limit exceeded')); // Second chunk fails
       const testAdapter = await createTestAdapterWithMockedOctokit(mockCreateComment);
@@ -1044,7 +1076,7 @@ describe('GitHubAdapter', () => {
 
   describe('retry logic', () => {
     test('should retry on transient network errors', async () => {
-      const mockCreateComment = mock()
+      const mockCreateComment = makeCreateCommentMock()
         .mockRejectedValueOnce(new Error('fetch failed')) // First attempt fails
         .mockResolvedValueOnce({ data: {} }); // Second attempt succeeds
       const testAdapter = await createTestAdapterWithMockedOctokit(mockCreateComment, {
@@ -1059,7 +1091,7 @@ describe('GitHubAdapter', () => {
 
     test('should retry on transient status errors', async () => {
       const transientError = Object.assign(new Error('Gateway failure'), { status: 502 });
-      const mockCreateComment = mock()
+      const mockCreateComment = makeCreateCommentMock()
         .mockRejectedValueOnce(transientError) // First attempt fails
         .mockResolvedValueOnce({ data: {} }); // Second attempt succeeds
       const testAdapter = await createTestAdapterWithMockedOctokit(mockCreateComment, {
@@ -1073,7 +1105,9 @@ describe('GitHubAdapter', () => {
     });
 
     test('should not retry on non-retryable errors', async () => {
-      const mockCreateComment = mock().mockRejectedValue(new Error('Bad credentials'));
+      const mockCreateComment = makeCreateCommentMock().mockRejectedValue(
+        new Error('Bad credentials')
+      );
       const testAdapter = await createTestAdapterWithMockedOctokit(mockCreateComment);
 
       // Should throw immediately without retry
@@ -1087,7 +1121,7 @@ describe('GitHubAdapter', () => {
 
     test('should not retry on auth status errors', async () => {
       const authError = Object.assign(new Error('Unauthorized'), { status: 401 });
-      const mockCreateComment = mock().mockRejectedValue(authError);
+      const mockCreateComment = makeCreateCommentMock().mockRejectedValue(authError);
       const testAdapter = await createTestAdapterWithMockedOctokit(mockCreateComment);
 
       // Should throw immediately without retry
@@ -1100,7 +1134,9 @@ describe('GitHubAdapter', () => {
     });
 
     test('should throw after exhausting retries', async () => {
-      const mockCreateComment = mock().mockRejectedValue(new Error('fetch failed'));
+      const mockCreateComment = makeCreateCommentMock().mockRejectedValue(
+        new Error('fetch failed')
+      );
       const testAdapter = await createTestAdapterWithMockedOctokit(mockCreateComment, {
         retryDelayMs: () => 1,
       });
@@ -1200,16 +1236,13 @@ describe('GitHubAdapter', () => {
     /**
      * Helper to create adapter with mocked listComments for fetchCommentHistory tests.
      */
-    function createAdapterWithListComments(
-      mockListComments: ReturnType<typeof mock>
-    ): GitHubAdapter {
+    function createAdapterWithListComments(mockListComments: Mock<ListComments>): GitHubAdapter {
       const testAdapter = new GitHubAdapter(
         { kind: 'pat', token: 'fake-token-for-testing' },
         'fake-webhook-secret',
         mockLockManager
       );
-      // @ts-expect-error - accessing private property for testing
-      testAdapter.octokit = { rest: { issues: { listComments: mockListComments } } };
+      installOctokitStubs(testAdapter, { listComments: mockListComments });
       return testAdapter;
     }
 
@@ -1222,16 +1255,12 @@ describe('GitHubAdapter', () => {
     }
 
     test('should fetch and format comment history', async () => {
-      const mockListComments = mock(() =>
-        Promise.resolve({
-          data: [
-            // API returns in desc order (newest first) because direction: 'desc'
-            { user: { login: 'user3' }, body: 'Third comment' },
-            { user: { login: 'user2' }, body: 'Second comment' },
-            { user: { login: 'user1' }, body: 'First comment' },
-          ],
-        })
-      );
+      const mockListComments = makeListCommentsMock([
+        // API returns in desc order (newest first) because direction: 'desc'
+        { user: { login: 'user3' }, body: 'Third comment' },
+        { user: { login: 'user2' }, body: 'Second comment' },
+        { user: { login: 'user1' }, body: 'First comment' },
+      ]);
 
       const testAdapter = createAdapterWithListComments(mockListComments);
       const history = await callFetchCommentHistory(testAdapter);
@@ -1255,9 +1284,7 @@ describe('GitHubAdapter', () => {
 
     test('should preserve full comment content without truncation', async () => {
       const longBody = 'a'.repeat(5000);
-      const mockListComments = mock(() =>
-        Promise.resolve({ data: [{ user: { login: 'user1' }, body: longBody }] })
-      );
+      const mockListComments = makeListCommentsMock([{ user: { login: 'user1' }, body: longBody }]);
 
       const testAdapter = createAdapterWithListComments(mockListComments);
       const history = await callFetchCommentHistory(testAdapter);
@@ -1268,15 +1295,11 @@ describe('GitHubAdapter', () => {
     });
 
     test('should handle comments without user or body (null and undefined)', async () => {
-      const mockListComments = mock(() =>
-        Promise.resolve({
-          data: [
-            { user: null, body: 'Comment without user' },
-            { user: { login: 'user1' }, body: null },
-            { user: { login: 'user2' } }, // body property not present (undefined)
-          ],
-        })
-      );
+      const mockListComments = makeListCommentsMock([
+        { user: null, body: 'Comment without user' },
+        { user: { login: 'user1' }, body: null },
+        { user: { login: 'user2' } }, // body property not present (undefined)
+      ]);
 
       const testAdapter = createAdapterWithListComments(mockListComments);
       const history = await callFetchCommentHistory(testAdapter);
@@ -1286,7 +1309,9 @@ describe('GitHubAdapter', () => {
     });
 
     test('should return empty array on API error', async () => {
-      const mockListComments = mock(() => Promise.reject(new Error('API rate limit exceeded')));
+      const mockListComments = makeListCommentsMock().mockRejectedValue(
+        new Error('API rate limit exceeded')
+      );
 
       const testAdapter = createAdapterWithListComments(mockListComments);
       const history = await callFetchCommentHistory(testAdapter);
@@ -1295,7 +1320,7 @@ describe('GitHubAdapter', () => {
     });
 
     test('should handle empty comment list', async () => {
-      const mockListComments = mock(() => Promise.resolve({ data: [] }));
+      const mockListComments = makeListCommentsMock();
 
       const testAdapter = createAdapterWithListComments(mockListComments);
       const history = await callFetchCommentHistory(testAdapter);
@@ -1340,7 +1365,7 @@ describe('GitHubAdapter', () => {
       expect(mockCloneRepository).toHaveBeenCalledTimes(1);
       const [url, path] = mockCloneRepository.mock.calls[0];
       expect(url).toBe('https://github.com/owner/repo.git');
-      expect(path).toBe('/nonexistent/path');
+      expect(String(path)).toBe('/nonexistent/path');
       // 3rd arg is { token } when GITHUB_TOKEN is set, undefined otherwise
       expect(mockAddSafeDirectory).toHaveBeenCalledWith('/nonexistent/path');
     });
@@ -1459,13 +1484,26 @@ describe('GitHubAdapter', () => {
       getToken: ReturnType<typeof mock>;
       prime: ReturnType<typeof mock>;
       invalidate: ReturnType<typeof mock>;
+      invalidateRepo: ReturnType<typeof mock>;
       resolveId: ReturnType<typeof mock>;
       installationIdFor: (owner: string) => number;
     } {
       const installationIdFor = (owner: string): number =>
         Math.abs(owner.charCodeAt(0) * 37 + (owner.charCodeAt(1) ?? 0));
 
-      const octokitInstances = new Map<number, unknown>();
+      type AppOctokit = {
+        __installationId: number;
+        rest: {
+          issues: {
+            createComment: Mock<CreateComment>;
+            listComments: Mock<ListComments>;
+          };
+          repos: { get: OctokitStubs['reposGet'] };
+          pulls: { get: OctokitStubs['pullsGet'] };
+        };
+      };
+
+      const octokitInstances = new Map<number, AppOctokit>();
       const lookups = new Map<string, number>();
 
       const getToken = mock(async (owner: string, _repo: string) => {
@@ -1484,26 +1522,30 @@ describe('GitHubAdapter', () => {
       // Each per-installation Octokit mock starts with createComment/repos/pulls
       // mocked. Test bodies can call `.mockResolvedValueOnce(...)` /
       // `.mockRejectedValueOnce(...)` on those fields as needed.
-      function octokitFor(installationId: number): unknown {
+      function octokitFor(installationId: number): AppOctokit {
         let oct = octokitInstances.get(installationId);
         if (!oct) {
+          const reposGet: OctokitStubs['reposGet'] = mock(async () => ({
+            data: { default_branch: 'main' },
+          }));
+          const pullsGet: OctokitStubs['pullsGet'] = mock(async () => ({
+            data: {
+              head: { ref: 'feature', sha: 'abc123def', repo: { full_name: 'o/r' } },
+              base: { repo: { full_name: 'o/r' } },
+            },
+          }));
           oct = {
             __installationId: installationId,
             rest: {
               issues: {
-                createComment: mock(async () => ({ data: { id: 1 } })),
-                listComments: mock(async () => ({ data: [] })),
+                createComment: makeCreateCommentMock(),
+                listComments: makeListCommentsMock(),
               },
               repos: {
-                get: mock(async () => ({ data: { default_branch: 'main' } })),
+                get: reposGet,
               },
               pulls: {
-                get: mock(async () => ({
-                  data: {
-                    head: { ref: 'feature', sha: 'abc123def', repo: { full_name: 'o/r' } },
-                    base: { repo: { full_name: 'o/r' } },
-                  },
-                })),
+                get: pullsGet,
               },
             },
           };
@@ -1550,8 +1592,7 @@ describe('GitHubAdapter', () => {
     } {
       const provider = makeMockProvider(opts);
       const adapter = new GitHubAdapter(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mock provider isn't structurally identical to the real interface (suffices for these tests)
-        { kind: 'app', provider: provider.provider as any },
+        { kind: 'app', provider: provider.provider },
         'fake-webhook-secret',
         mockLockManager,
         'archon'
@@ -1634,11 +1675,7 @@ describe('GitHubAdapter', () => {
     test('401 from Octokit triggers invalidateRepo + retry once', async () => {
       const { adapter, provider } = createAppModeAdapter();
       // First call to Octokit.createComment throws 401; second succeeds.
-      const octokit = (await provider.getOctokit('owner', 'repo')) as {
-        rest: {
-          issues: { createComment: ReturnType<typeof mock> };
-        };
-      };
+      const octokit = await provider.getOctokit('owner', 'repo');
       const err401 = Object.assign(new Error('Unauthorized'), { status: 401 });
       octokit.rest.issues.createComment
         .mockRejectedValueOnce(err401)
@@ -1652,9 +1689,7 @@ describe('GitHubAdapter', () => {
 
     test('T3: second consecutive 401 propagates (no infinite retry)', async () => {
       const { adapter, provider } = createAppModeAdapter();
-      const octokit = (await provider.getOctokit('owner', 'repo')) as {
-        rest: { issues: { createComment: ReturnType<typeof mock> } };
-      };
+      const octokit = await provider.getOctokit('owner', 'repo');
       const err401a = Object.assign(new Error('Unauthorized A'), { status: 401 });
       const err401b = Object.assign(new Error('Unauthorized B'), { status: 401 });
       // Two consecutive 401s — retry path must surface the second error and
@@ -1681,9 +1716,7 @@ describe('GitHubAdapter', () => {
       // BOTH caches) and not invalidateToken (which used to leave lookupCache
       // populated with the stale id).
       const { adapter, provider } = createAppModeAdapter();
-      const octokit = (await provider.getOctokit('owner', 'repo')) as {
-        rest: { issues: { createComment: ReturnType<typeof mock> } };
-      };
+      const octokit = await provider.getOctokit('owner', 'repo');
       const err401 = Object.assign(new Error('Unauthorized'), { status: 401 });
       octokit.rest.issues.createComment
         .mockRejectedValueOnce(err401)

--- a/packages/adapters/src/forge/github/adapter.ts
+++ b/packages/adapters/src/forge/github/adapter.ts
@@ -15,7 +15,7 @@ import {
   toError,
   getLinkedIssueNumbers,
   onConversationClosed,
-  ConversationLockManager,
+  type ConversationLockManager,
   DeliveryDeduplicator,
   AppNotInstalledError,
   installCredentialHelper,
@@ -54,6 +54,52 @@ const MAX_LENGTH = 65000; // GitHub comment limit (~65,536, leave buffer for saf
 /** Hidden marker added to bot comments to prevent self-triggering loops */
 const BOT_RESPONSE_MARKER = '<!-- archon-bot-response -->';
 
+type ConversationLocker = Pick<ConversationLockManager, 'acquireLock'>;
+
+type CreateCommentArgs = NonNullable<Parameters<Octokit['rest']['issues']['createComment']>[0]>;
+type ListCommentsArgs = NonNullable<Parameters<Octokit['rest']['issues']['listComments']>[0]>;
+type ListComment = Awaited<ReturnType<Octokit['rest']['issues']['listComments']>>['data'][number];
+type ListCommentUser = Pick<NonNullable<ListComment['user']>, 'login'>;
+type RepositoryData = Awaited<ReturnType<Octokit['rest']['repos']['get']>>['data'];
+type PullRequestData = Awaited<ReturnType<Octokit['rest']['pulls']['get']>>['data'];
+type PullRequestHead = Pick<PullRequestData['head'], 'ref' | 'sha'> & {
+  repo: Pick<NonNullable<PullRequestData['head']['repo']>, 'full_name'> | null;
+};
+
+interface GitHubApi {
+  rest: {
+    issues: {
+      createComment(args: CreateCommentArgs): Promise<unknown>;
+      listComments(args: ListCommentsArgs): Promise<{
+        data: { body?: ListComment['body'] | null; user?: ListCommentUser | null }[];
+      }>;
+    };
+    repos: {
+      get(
+        args: NonNullable<Parameters<Octokit['rest']['repos']['get']>[0]>
+      ): Promise<{ data: Pick<RepositoryData, 'default_branch'> }>;
+    };
+    pulls: {
+      get(args: NonNullable<Parameters<Octokit['rest']['pulls']['get']>[0]>): Promise<{
+        data: {
+          head: PullRequestHead;
+          base: { repo: Pick<PullRequestData['base']['repo'], 'full_name'> };
+        };
+      }>;
+    };
+  };
+}
+
+type GitHubAppAuth = Extract<GitHubAuth, { kind: 'app' }>;
+type GitHubAdapterAuth =
+  | Exclude<GitHubAuth, { kind: 'app' }>
+  | {
+      kind: 'app';
+      provider: Omit<GitHubAppAuth['provider'], 'getOctokitForInstallation'> & {
+        getOctokitForInstallation(owner: string, repo: string): Promise<GitHubApi>;
+      };
+    };
+
 export class GitHubAdapter implements IPlatformAdapter {
   /**
    * PAT-mode Octokit: a singleton constructed at startup. Null in App mode —
@@ -61,12 +107,12 @@ export class GitHubAdapter implements IPlatformAdapter {
    * Octokit from the auth provider. Tests reach in via `@ts-expect-error` and
    * assign a mock object to this field.
    */
-  private octokit: Octokit | null;
-  private readonly auth: GitHubAuth;
+  private octokit: GitHubApi | null;
+  private readonly auth: GitHubAdapterAuth;
   private webhookSecret: string;
   private allowedUsers: string[];
   private botMention: string;
-  private lockManager: ConversationLockManager;
+  private lockManager: ConversationLocker;
   /**
    * Ingest idempotency: drops repeat deliveries of one logical comment event
    * (dual repo+App subscriptions, LB double-forwards, redeliveries) before
@@ -91,9 +137,9 @@ export class GitHubAdapter implements IPlatformAdapter {
   private readonly userOctokitCache = new Map<string, { octokit: Octokit; expiresAt: number }>();
 
   constructor(
-    auth: GitHubAuth,
+    auth: GitHubAdapterAuth,
     webhookSecret: string,
-    lockManager: ConversationLockManager,
+    lockManager: ConversationLocker,
     botMention?: string,
     options?: {
       retryDelayMs?: (attempt: number) => number;
@@ -148,7 +194,7 @@ export class GitHubAdapter implements IPlatformAdapter {
    * the constructor-created singleton; in App mode it's a per-installation
    * Octokit fetched from the auth provider (which caches by installation id).
    */
-  private async resolveOctokit(owner: string, repo: string): Promise<Octokit> {
+  private async resolveOctokit(owner: string, repo: string): Promise<GitHubApi> {
     if (this.auth.kind === 'pat') {
       // Non-null in PAT mode by construction; tests overwrite this field directly.
       if (!this.octokit) {
@@ -178,7 +224,7 @@ export class GitHubAdapter implements IPlatformAdapter {
   private async withTokenRefresh<T>(
     owner: string,
     repo: string,
-    fn: (octokit: Octokit) => Promise<T>
+    fn: (octokit: GitHubApi) => Promise<T>
   ): Promise<T> {
     const octokit = await this.resolveOctokit(owner, repo);
     try {

--- a/packages/adapters/src/forge/github/auth.test.ts
+++ b/packages/adapters/src/forge/github/auth.test.ts
@@ -1,6 +1,8 @@
 /**
  * Unit tests for GitHub authorization utilities
  */
+import { describe, expect, test } from 'bun:test';
+
 import { parseAllowedUsers, isGitHubUserAuthorized } from './auth';
 
 describe('github-auth', () => {

--- a/packages/adapters/src/forge/github/context.test.ts
+++ b/packages/adapters/src/forge/github/context.test.ts
@@ -40,7 +40,7 @@ mock.module('@archon/paths', () => ({
   createLogger: mock(() => mockLogger),
 }));
 
-const mockHandleMessage = mock(async () => {});
+const mockHandleMessage = mock<(typeof import('@archon/core'))['handleMessage']>(async () => {});
 
 const mockGetOrCreateConversation = mock(async () => ({
   id: 'conv-1',
@@ -73,8 +73,9 @@ mock.module('@archon/core', () => ({
   getArchonWorkspacesPath: () => '/workspace',
   getCommandFolderSearchPaths: () => [],
   ConversationLockManager: class {
-    async acquireLock(_id: string, handler: () => Promise<void>): Promise<void> {
+    async acquireLock(_id: string, handler: () => Promise<void>): Promise<{ status: 'started' }> {
       await handler();
+      return { status: 'started' };
     }
     getStats() {
       return {
@@ -229,15 +230,9 @@ function createTestAdapter(): GitHubAdapter {
   const adapter = new GitHubAdapter({ kind: 'pat', token: 'fake-token' }, WEBHOOK_SECRET, {
     acquireLock: mock(async (_id: string, handler: () => Promise<void>) => {
       await handler();
+      return { status: 'started' as const };
     }),
-    getStats: () => ({
-      active: 0,
-      queuedTotal: 0,
-      queuedByConversation: [],
-      maxConcurrent: 10,
-      activeConversationIds: [],
-    }),
-  } as unknown as InstanceType<typeof import('@archon/core').ConversationLockManager>);
+  });
 
   // @ts-expect-error - mock private method for testing
   adapter.verifySignature = mock(() => true);

--- a/packages/adapters/tsconfig.json
+++ b/packages/adapters/tsconfig.json
@@ -12,5 +12,5 @@
     }
   },
   "include": ["src/**/*", "../core/src/**/*.ts", "../workflows/src/defaults/text-imports.d.ts"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts", "../core/src/**/*.test.ts"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/scripts/test-inventory.test.ts
+++ b/scripts/test-inventory.test.ts
@@ -218,12 +218,12 @@ describe('compiler test inventory', () => {
     return expectProgramToInclude('core', [
       join(REPO_ROOT, 'packages', 'core', 'src', 'utils', 'conversation-lock.test.ts'),
     ]);
-  });
+  }, 15_000);
 
   test("adapters' normal TypeScript project includes its own and imported core test files", () => {
     return expectProgramToInclude('adapters', [
       join(REPO_ROOT, 'packages', 'adapters', 'src', 'forge', 'github', 'adapter.test.ts'),
       join(REPO_ROOT, 'packages', 'core', 'src', 'utils', 'conversation-lock.test.ts'),
     ]);
-  });
+  }, 15_000);
 });

--- a/scripts/test-inventory.test.ts
+++ b/scripts/test-inventory.test.ts
@@ -5,8 +5,8 @@
  *
  * Keep the batches explicit. The package-script guard below verifies that every
  * TypeScript test is selected by a file or directory argument and that selected
- * paths still exist. The compiler guard separately protects core's normal project
- * from excluding its tests again. `bun run test` discovers both through its final
+ * paths still exist. The compiler guard separately protects normal package projects
+ * from excluding their tests again. `bun run test` discovers both through its final
  * `bun test ./scripts/` invocation.
  */
 import { describe, test } from 'bun:test';
@@ -183,8 +183,11 @@ describe('package test inventory', () => {
 });
 
 describe('compiler test inventory', () => {
-  test("core's normal TypeScript project includes test files", async () => {
-    const projectPath = join(REPO_ROOT, 'packages', 'core', 'tsconfig.json');
+  async function expectProgramToInclude(
+    packageName: string,
+    expectedFiles: string[]
+  ): Promise<void> {
+    const projectPath = join(REPO_ROOT, 'packages', packageName, 'tsconfig.json');
     const process = Bun.spawn(
       ['bun', 'x', 'tsc', '--noEmit', '--listFilesOnly', '--project', projectPath],
       { cwd: REPO_ROOT, stdout: 'pipe', stderr: 'pipe' }
@@ -196,16 +199,31 @@ describe('compiler test inventory', () => {
     ]);
 
     if (exitCode !== 0) {
-      throw new Error(`Could not list the core TypeScript program:\n${stderr}`);
+      throw new Error(`Could not list the ${packageName} TypeScript program:\n${stderr}`);
     }
 
-    const programFiles = stdout.split(/\r?\n/).map(normalizePath);
-    const representativeTest = normalizePath(
-      join(REPO_ROOT, 'packages', 'core', 'src', 'utils', 'conversation-lock.test.ts')
+    const programFiles = new Set(stdout.split(/\r?\n/).map(normalizePath));
+    const missingFiles = expectedFiles.filter(
+      (expectedFile): boolean => !programFiles.has(normalizePath(expectedFile))
     );
 
-    if (!programFiles.includes(representativeTest)) {
-      throw new Error(`Core's normal TypeScript project did not include ${representativeTest}`);
+    if (missingFiles.length > 0) {
+      throw new Error(
+        `The normal ${packageName} TypeScript project did not include:\n${missingFiles.join('\n')}`
+      );
     }
+  }
+
+  test("core's normal TypeScript project includes test files", () => {
+    return expectProgramToInclude('core', [
+      join(REPO_ROOT, 'packages', 'core', 'src', 'utils', 'conversation-lock.test.ts'),
+    ]);
+  });
+
+  test("adapters' normal TypeScript project includes its own and imported core test files", () => {
+    return expectProgramToInclude('adapters', [
+      join(REPO_ROOT, 'packages', 'adapters', 'src', 'forge', 'github', 'adapter.test.ts'),
+      join(REPO_ROOT, 'packages', 'core', 'src', 'utils', 'conversation-lock.test.ts'),
+    ]);
   });
 });


### PR DESCRIPTION
## Problem and outcome

Adapter test files were excluded from the package TypeScript project, so test-only type regressions could pass static checks. This completes the adapters tranche of the test-typing chain by making those files part of the normal type-check and correcting the mocks whose incomplete shapes surfaced once they were included.

- **Outcome:** `packages/adapters` type-checks its test suites, and its existing tests remain green.
- **Invariant:** The fixes preserve test behavior without adding `any`, new `@ts-expect-error` directives, or a separate test tsconfig.
- **Scope boundary:** Only the adapters package tsconfig, its compiler-inventory regression guard, and the adapter/test contracts required to type-check its existing suites changed; server and CLI tranches are outside this PR.

## Review guidance

- **Feedback requested:** Verify that the narrowed adapter dependencies and SDK-derived GitHub API surface accurately cover the production calls.
- **Start here:** `packages/adapters/tsconfig.json` — test-file exclusions are removed, making the previously unchecked suites part of the normal project.
- **Review order:** Review the tsconfig change, then `src/forge/github/adapter.ts` and its test helpers; the Slack, Telegram, Discord, Gitea, and GitLab changes apply the same typed-fixture approach locally.
- **Lower-attention areas:** Explicit `bun:test` imports and typed mock annotations are mechanical. The package type-check and 419-test suite validate them.
- **Known risk or uncertainty:** None.

## Solution

The adapter tsconfig now includes test files and no longer excludes imported core test sources. Where that exposed incomplete mock contracts, the tests use small typed factories and call accessors instead of repeated casts and partial setup literals.

The forge adapters accept only the lock operation they use. GitHub similarly depends on an SDK-derived subset of its Octokit surface, allowing the production adapter and its app-mode test provider to share a sound, narrow contract. `makeMockProvider` now declares `invalidateRepo`, matching the value it supplies and the assertions that consume it.

## Validation

- `cd packages/adapters && bun run type-check` — passed with adapter test files included.
- `cd packages/adapters && bun run test` — 419 passed, 0 failed.
- `bun run validate` — passed after the final commit, including generated-artifact checks, root type-check, lint, formatting, installer tests, and the full repository test suite.
- Deliberate gate probe — adding `const adapterTestTypeGuard: string = 1` to `src/chat/slack/auth.test.ts` made `bun run type-check` fail with TS2322 and TS6133; the probe was reverted.
- **Not verified:** Nothing material; the type-check inclusion gate and all adapter tests were exercised.

## Links

- Closes #3053

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety across GitHub, GitLab, and Gitea integrations without changing runtime behavior.
  * Simplified integration dependencies to require only the capabilities used.
  * Standardized test mocks and helpers for clearer, more reliable test coverage.

* **Tests**
  * Updated adapter tests with realistic responses and stronger assertions.
  * Added coverage confirming package projects include the expected test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->