### PR TITLE
Attach graph plans to resolved workflows

### DIFF
--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -84,6 +84,7 @@ import {
   assertWorkflowRequirementsMet,
   resolveTopLevelInputs,
 } from '@archon/workflows/utils/workflow-requirements';
+import type { RequirementBearingWorkflow } from '@archon/workflows/utils/workflow-requirements';
 import { parseInputAssignments } from '@archon/workflows/workflow-inputs';
 import { formatDeprecationNotice } from '@archon/workflows/deprecation';
 import {
@@ -808,7 +809,9 @@ function assertWorkflowNotWorktreePinnedForFolder(
  * GitHub App + TOKEN_ENCRYPTION_KEY are both configured — identical semantics
  * to the orchestrator gate.
  */
-async function assertCliWorkflowRequirementsMet(workflow: WorkflowDefinition): Promise<void> {
+async function assertCliWorkflowRequirementsMet(
+  workflow: RequirementBearingWorkflow
+): Promise<void> {
   if (!isPerUserGitHubEnabled() || !workflow.requires?.length) return;
 
   // Resolve the acting CLI user (ARCHON_USER_ID, else $USER/$USERNAME) → Archon
@@ -869,7 +872,9 @@ function resolveTitleAssistantType(
  * `archon ai tier list`.
  */
 export async function maybePrintTierNotice(
-  workflow: WorkflowDefinition,
+  workflow: Pick<WorkflowDefinition, 'model'> & {
+    readonly nodes: readonly WorkflowDefinition['nodes'][number][];
+  },
   cwd: string,
   cliUserId: string | undefined,
   quiet: boolean | undefined
@@ -1070,7 +1075,9 @@ export function emitParseWarnings(
  * a user driving runs programmatically still has to learn the default they
  * picked is scheduled for removal.
  */
-export function emitDeprecationNotice(workflow: WorkflowDefinition): void {
+export function emitDeprecationNotice(
+  workflow: Pick<WorkflowDefinition, 'name' | 'deprecated'>
+): void {
   const notice = formatDeprecationNotice(workflow);
   if (notice) console.warn(notice);
 }

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -104,7 +104,6 @@ import type {
   WorkflowSource,
   WorkflowWithSource,
 } from '@archon/workflows/schemas/workflow';
-import type { DagNode } from '@archon/workflows/schemas/dag-node';
 import type { WorkflowRunConfigInput } from '@archon/workflows/schemas/run-config';
 import {
   workflowRunStatusSchema,
@@ -1987,10 +1986,7 @@ async function runWorkflowWithOwnedSource(
     // discoverable via `workflow status`/`runs`, not a silent hang nobody knows exists.
     if (!isContinuation) {
       assertInteractiveClassNotBackgrounded(workflow);
-      // Already-expanded — discoverWorkflowsWithConfig's output never contains an
-      // IncludeDirective (#2486); the type admits one only for the pre-expansion display
-      // shape (`WorkflowWithSource.declared`), which `workflow` here is not.
-      assertComposedGateDriveable(workflow.nodes as DagNode[]);
+      assertComposedGateDriveable(workflow.nodes);
     }
 
     const childConversationId = options.conversationId ?? generateConversationId();

--- a/packages/core/src/handlers/command-handler.ts
+++ b/packages/core/src/handlers/command-handler.ts
@@ -25,7 +25,7 @@ import { createWorkflowDeps } from '../workflows/store-adapter';
 import type {
   WorkflowWithSource,
   WorkflowLoadError,
-  WorkflowDefinition,
+  ResolvedWorkflow,
 } from '@archon/workflows/schemas/workflow';
 import { isContainerRun } from '@archon/workflows/schemas/workflow-run';
 import * as workflowDb from '../db/workflows';
@@ -1158,7 +1158,7 @@ async function handleWorkflowCommand(
         'cmd.workflows_discovered'
       );
 
-      let workflow: WorkflowDefinition | undefined;
+      let workflow: ResolvedWorkflow | undefined;
       try {
         workflow = resolveWorkflowName(workflowName, workflows);
       } catch (err) {

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -15,6 +15,7 @@
 import { mock, describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { createMockLogger } from '../test/mocks/logger';
 import {
+  makeTestResolvedWorkflow,
   makeTestWorkflow,
   makeTestWorkflowWithSource,
   withObservableCapturedSource,
@@ -2142,7 +2143,7 @@ describe('workflow dispatch routing — interactive flag', () => {
       success: true,
       message: 'ok',
       workflow: {
-        definition: makeTestWorkflow({
+        definition: makeTestResolvedWorkflow({
           name: 'test-workflow',
           interactive,
           ...(options.inputs ? { inputs: options.inputs } : {}),
@@ -2948,7 +2949,7 @@ describe('workflow dispatch routing — interactive flag', () => {
     // `willContinueExistingRun` was true, leaving `preparedSource` undefined and the
     // executor in `source_unprepared_live` mode against the prior run's frozen graph.
     const { prepareWorkflowSource } = await import('@archon/workflows/executor');
-    const freshWorkflow = makeTestWorkflow({
+    const freshWorkflow = makeTestResolvedWorkflow({
       name: 'test-workflow',
       description: 'freshly captured from disk',
     });
@@ -3632,7 +3633,7 @@ describe('workflow dispatch routing — interactive flag', () => {
 // ─── Natural-language approval routing ──────────────────────────────────────
 
 describe('paused approval gate routing', () => {
-  const approvalWorkflow = makeTestWorkflow({ name: 'prd', interactive: true });
+  const approvalWorkflow = makeTestResolvedWorkflow({ name: 'prd', interactive: true });
 
   type ManageRunHandler = (input: Record<string, unknown>) => Promise<string>;
 
@@ -4082,7 +4083,7 @@ describe('paused approval gate routing', () => {
 // ─── handleWorkflowRunCommand E2 path — single codebase auto-select ──────────
 
 describe('handleWorkflowRunCommand — E2 single codebase auto-select', () => {
-  const assistWorkflow = makeTestWorkflow({ name: 'assist' });
+  const assistWorkflow = makeTestResolvedWorkflow({ name: 'assist' });
 
   beforeEach(() => {
     mockGetOrCreateConversation.mockReset();
@@ -4412,7 +4413,7 @@ describe('handleWorkflowRunCommand — E2 single codebase auto-select', () => {
   });
 
   test('resolves workflow by case-insensitive name when exact match fails', async () => {
-    const upperWorkflow = makeTestWorkflow({ name: 'Assist' });
+    const upperWorkflow = makeTestResolvedWorkflow({ name: 'Assist' });
     const conversation = makeConversation({ codebase_id: null });
     const codebase = makeCodebaseForSync();
     mockGetOrCreateConversation.mockReturnValueOnce(Promise.resolve(conversation));
@@ -4449,7 +4450,7 @@ describe('handleWorkflowRunCommand — E2 single codebase auto-select', () => {
       Promise.resolve({
         success: true,
         message: 'Running workflow...',
-        workflow: { definition: makeTestWorkflow({ name: 'missing' }), args: 'test' },
+        workflow: { definition: makeTestResolvedWorkflow({ name: 'missing' }), args: 'test' },
       })
     );
     mockListCodebases.mockReturnValueOnce(Promise.resolve([codebase]));

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -532,7 +532,7 @@ function resolveCodebaseName(name: string, codebases: readonly Codebase[]): Code
 export function parseOrchestratorCommands(
   response: string,
   codebases: readonly Codebase[],
-  workflows: readonly WorkflowDefinition[]
+  workflows: readonly Pick<WorkflowDefinition, 'name'>[]
 ): OrchestratorCommands {
   const result: OrchestratorCommands = {
     workflowInvocation: null,

--- a/packages/core/src/orchestrator/orchestrator-agent.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.ts
@@ -64,6 +64,7 @@ import {
 import { WorkflowInputContractError } from '@archon/workflows/workflow-inputs';
 import { formatDeprecationNotice } from '@archon/workflows/deprecation';
 import type {
+  ResolvedWorkflow,
   WorkflowDefinition,
   WorkflowWithSource,
   WorkflowLoadError,
@@ -642,7 +643,7 @@ interface WorkflowDispatchOptions {
    * resume, approve and reject. A value rather than an "already done" flag, so it cannot
    * claim something it does not carry.
    */
-  resolvedContinuation?: WorkflowDefinition;
+  resolvedContinuation?: ResolvedWorkflow;
   /**
    * Keys the engine dropped from the workflow's YAML (#2213). Mirrored into the
    * conversation before the run starts — chat and the console are where most
@@ -756,7 +757,7 @@ async function dispatchOrchestratorWorkflowOwned(
   conversationId: string,
   conversation: Conversation,
   codebase: Codebase,
-  workflow: WorkflowDefinition,
+  workflow: ResolvedWorkflow,
   userMessage: string,
   isolationHints?: HandleMessageContext['isolationHints'],
   userId?: string,
@@ -892,7 +893,7 @@ async function dispatchOrchestratorWorkflowOwned(
   // `freshCaptured` directly, so the helper's narrowed return type survives.
   let preparedSource: PreparedWorkflowSource | undefined;
   let freshCaptured:
-    | { preparedSource: PreparedWorkflowSource; workflow: WorkflowDefinition }
+    | { preparedSource: PreparedWorkflowSource; workflow: ResolvedWorkflow }
     | undefined;
 
   if (willContinueExistingRun && resumableRun) {
@@ -954,7 +955,7 @@ async function dispatchOrchestratorWorkflowOwned(
   // branch's vintage only after isolation resolves its worktree, so these gates must
   // run AFTER that swap there — otherwise required inputs or `requires:` declared on
   // the branch would bypass them entirely.
-  const runSignatureGates = async (definition: WorkflowDefinition): Promise<boolean> => {
+  const runSignatureGates = async (definition: ResolvedWorkflow): Promise<boolean> => {
     // Resolve this invocation's declared inputs from the values its channel supplied —
     // the run route's `inputs` map today; chat platforms supply nothing and so still
     // refuse a required-input workflow here. The workflow still lists/loads normally.
@@ -1472,11 +1473,11 @@ async function dispatchOrchestratorWorkflowOwned(
 async function captureFreshSource(
   owner: CapturedSourceOwner,
   runCwd: string,
-  workflow: WorkflowDefinition,
+  workflow: ResolvedWorkflow,
   conversationId: string,
   platform: IPlatformAdapter,
   explicitSourceRoot?: string
-): Promise<{ preparedSource: PreparedWorkflowSource; workflow: WorkflowDefinition } | undefined> {
+): Promise<{ preparedSource: PreparedWorkflowSource; workflow: ResolvedWorkflow } | undefined> {
   try {
     const workflowSourceRoot = explicitSourceRoot ?? (await resolveWorkflowSourceRoot(runCwd));
     const preparedSource = await prepareWorkflowSource(createWorkflowDeps(), {
@@ -1536,7 +1537,7 @@ async function dispatchOrchestratorWorkflow(
   conversationId: string,
   conversation: Conversation,
   codebase: Codebase,
-  workflow: WorkflowDefinition,
+  workflow: ResolvedWorkflow,
   userMessage: string,
   isolationHints?: HandleMessageContext['isolationHints'],
   userId?: string,
@@ -1624,7 +1625,7 @@ export async function continueResolvedGateRun(
     // since the run started is missing from it, and this path would then refuse a run
     // whose own captured source still holds it. `/workflow resume` resolves it this way
     // too — the two gate surfaces must not disagree about what a run is.
-    let resolvedContinuation: WorkflowDefinition | undefined;
+    let resolvedContinuation: ResolvedWorkflow | undefined;
     try {
       resolvedContinuation = (
         await resolveContinuationWorkflow(
@@ -2216,7 +2217,7 @@ export async function handleMessage(
       codebase: discoveredCodebase,
       remote: syncRemote,
     } = await discoverAllWorkflows(conversation);
-    const workflows: readonly WorkflowDefinition[] = workflowsWithSource.map(ws => ws.workflow);
+    const workflows: readonly ResolvedWorkflow[] = workflowsWithSource.map(ws => ws.workflow);
     if (workflowErrors.length > 0) {
       getLog().warn(
         { errorCount: workflowErrors.length, errors: workflowErrors },
@@ -2566,7 +2567,7 @@ export async function handleMessage(
             return true;
           },
           startWorkflow: async (workflowName, msg): Promise<string> => {
-            let wf: WorkflowDefinition | undefined;
+            let wf: ResolvedWorkflow | undefined;
             try {
               wf = resolveWorkflowName(workflowName, workflows);
             } catch (e: unknown) {
@@ -3583,7 +3584,7 @@ async function handleWorkflowRunCommand(
   platform: IPlatformAdapter,
   conversationId: string,
   conversation: Conversation,
-  workflow: WorkflowDefinition,
+  workflow: ResolvedWorkflow,
   userMessage: string,
   isolationHints?: HandleMessageContext['isolationHints'],
   userId?: string,

--- a/packages/core/src/orchestrator/orchestrator-isolation.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-isolation.test.ts
@@ -14,10 +14,11 @@ import type { WorkflowRoutingContext } from './orchestrator';
 import type { PreparedWorkflowSource } from '@archon/workflows/executor';
 import type * as WorkflowExecutor from '@archon/workflows/executor';
 import { TerminalStatusWriteError } from '@archon/workflows/terminal-status-write';
-import type { WorkflowDefinition } from '@archon/workflows/schemas/workflow';
+import type { ResolvedWorkflow, WorkflowDefinition } from '@archon/workflows/schemas/workflow';
 import type { IWorkflowStore } from '@archon/workflows/store';
 import {
   makeTestComposedWorkflow,
+  makeTestResolvedWorkflow,
   makeTestWorkflow,
   withObservableCapturedSource,
 } from '@archon/workflows/test-utils';
@@ -425,13 +426,13 @@ describe('validateAndResolveIsolation', () => {
 describe('dispatchBackgroundWorkflow', () => {
   let platform: MockPlatformAdapter;
 
-  function makeWorkflow(overrides?: Partial<WorkflowDefinition>): WorkflowDefinition {
-    return {
+  function makeWorkflow(overrides?: Partial<WorkflowDefinition>): ResolvedWorkflow {
+    return makeTestResolvedWorkflow({
       name: 'bg-workflow',
       description: 'background dispatch test workflow',
       nodes: [],
       ...overrides,
-    } as WorkflowDefinition;
+    });
   }
 
   function makeRoutingCtx(overrides?: Partial<WorkflowRoutingContext>): WorkflowRoutingContext {

--- a/packages/core/src/orchestrator/orchestrator.test.ts
+++ b/packages/core/src/orchestrator/orchestrator.test.ts
@@ -818,7 +818,7 @@ describe('orchestrator-agent handleMessage', () => {
       mockDiscoverWorkflows.mockResolvedValue({
         workflows: [
           {
-            workflow: { ...workflowDefinition, name: 'other-workflow' },
+            workflow: makeTestResolvedWorkflow({ name: 'other-workflow' }),
             source: 'bundled' as const,
           },
         ],

--- a/packages/core/src/orchestrator/orchestrator.test.ts
+++ b/packages/core/src/orchestrator/orchestrator.test.ts
@@ -1153,7 +1153,7 @@ describe('orchestrator-agent handleMessage', () => {
       mockListCodebases.mockResolvedValue([mockCodebase]);
       mockDiscoverWorkflows.mockResolvedValue({ workflows: testWorkflows, errors: [] });
       mockFindWorkflow.mockImplementation(
-        <T extends WorkflowDefinition>(name: string, workflows: readonly T[]) =>
+        <T extends Pick<WorkflowDefinition, 'name'>>(name: string, workflows: readonly T[]) =>
           workflows.find(workflow => workflow.name === name)
       );
 
@@ -1186,7 +1186,7 @@ describe('orchestrator-agent handleMessage', () => {
       mockListCodebases.mockResolvedValue([mockCodebase]);
       mockDiscoverWorkflows.mockResolvedValue({ workflows: testWorkflows, errors: [] });
       mockFindWorkflow.mockImplementation(
-        <T extends WorkflowDefinition>(name: string, workflows: readonly T[]) =>
+        <T extends Pick<WorkflowDefinition, 'name'>>(name: string, workflows: readonly T[]) =>
           workflows.find(workflow => workflow.name === name)
       );
 
@@ -1248,7 +1248,7 @@ describe('orchestrator-agent handleMessage', () => {
       mockListCodebases.mockResolvedValue([mockCodebase]);
       mockDiscoverWorkflows.mockResolvedValue({ workflows: testWorkflows, errors: [] });
       mockFindWorkflow.mockImplementation(
-        <T extends WorkflowDefinition>(name: string, workflows: readonly T[]) =>
+        <T extends Pick<WorkflowDefinition, 'name'>>(name: string, workflows: readonly T[]) =>
           workflows.find(workflow => workflow.name === name)
       );
 
@@ -1277,7 +1277,7 @@ describe('orchestrator-agent handleMessage', () => {
       mockListCodebases.mockResolvedValue([mockCodebase]);
       mockDiscoverWorkflows.mockResolvedValue({ workflows: testWorkflows, errors: [] });
       mockFindWorkflow.mockImplementation(
-        <T extends WorkflowDefinition>(name: string, workflows: readonly T[]) =>
+        <T extends Pick<WorkflowDefinition, 'name'>>(name: string, workflows: readonly T[]) =>
           workflows.find(workflow => workflow.name === name)
       );
 
@@ -1354,7 +1354,7 @@ describe('orchestrator-agent handleMessage', () => {
       mockListCodebases.mockResolvedValue([mockCodebase]);
       mockDiscoverWorkflows.mockResolvedValue({ workflows: testWorkflows, errors: [] });
       mockFindWorkflow.mockImplementation(
-        <T extends WorkflowDefinition>(name: string, workflows: readonly T[]) =>
+        <T extends Pick<WorkflowDefinition, 'name'>>(name: string, workflows: readonly T[]) =>
           workflows.find(workflow => workflow.name === name)
       );
     });
@@ -1515,7 +1515,7 @@ describe('orchestrator-agent handleMessage', () => {
 
       let callCount = 0;
       mockFindWorkflow.mockImplementation(
-        <T extends WorkflowDefinition>(name: string, workflows: readonly T[]) => {
+        <T extends Pick<WorkflowDefinition, 'name'>>(name: string, workflows: readonly T[]) => {
           callCount++;
           // First call (parseOrchestratorCommands) finds the workflow
           // Second call (handleWorkflowInvocationResult) does not

--- a/packages/core/src/orchestrator/orchestrator.test.ts
+++ b/packages/core/src/orchestrator/orchestrator.test.ts
@@ -6,13 +6,14 @@ import { join, resolve } from 'path';
 import { MockPlatformAdapter } from '../test/mocks/platform';
 import { createMockLogger } from '../test/mocks/logger';
 import {
-  makeTestWorkflow,
+  makeTestResolvedWorkflow,
   makeTestWorkflowList,
   withObservableCapturedSource,
 } from '@archon/workflows/test-utils';
 import type { Conversation, Codebase, Session } from '../types';
 import { ConversationNotFoundError } from '../types';
 import type { WorkflowDefinition } from '@archon/workflows/schemas/workflow';
+import { resolveWorkflow } from '@archon/workflows/graph-plan';
 import type { IAgentProvider, ProviderCapabilities } from '@archon/providers/types';
 import type * as Providers from '@archon/providers';
 import type * as CodebaseDb from '../db/codebases';
@@ -498,8 +499,8 @@ const mockSession: Session = {
 };
 
 const testWorkflowDefs = makeTestWorkflowList(['fix-bug', 'add-feature', 'archon-assist']);
-const testWorkflows = testWorkflowDefs.map(w => ({
-  workflow: w,
+const testWorkflows = testWorkflowDefs.map(workflow => ({
+  workflow: resolveWorkflow(workflow),
   source: 'bundled' as const,
 }));
 
@@ -781,7 +782,7 @@ describe('orchestrator-agent handleMessage', () => {
     });
 
     test('uses CommandResult workflow definition without rediscovery for /workflow run', async () => {
-      const workflowDefinition = makeTestWorkflow({
+      const workflowDefinition = makeTestResolvedWorkflow({
         name: 'test-workflow',
         description: 'A test workflow',
       });
@@ -804,7 +805,7 @@ describe('orchestrator-agent handleMessage', () => {
     });
 
     test('validates workflow exists in auto-selected project before dispatch', async () => {
-      const workflowDefinition = makeTestWorkflow({
+      const workflowDefinition = makeTestResolvedWorkflow({
         name: 'test-workflow',
         description: 'A test workflow',
       });
@@ -1152,8 +1153,8 @@ describe('orchestrator-agent handleMessage', () => {
       mockListCodebases.mockResolvedValue([mockCodebase]);
       mockDiscoverWorkflows.mockResolvedValue({ workflows: testWorkflows, errors: [] });
       mockFindWorkflow.mockImplementation(
-        (name: string, workflows: readonly WorkflowDefinition[]) =>
-          workflows.find(w => w.name === name)
+        <T extends WorkflowDefinition>(name: string, workflows: readonly T[]) =>
+          workflows.find(workflow => workflow.name === name)
       );
 
       mockClient.sendQuery.mockImplementation(async function* () {
@@ -1185,8 +1186,8 @@ describe('orchestrator-agent handleMessage', () => {
       mockListCodebases.mockResolvedValue([mockCodebase]);
       mockDiscoverWorkflows.mockResolvedValue({ workflows: testWorkflows, errors: [] });
       mockFindWorkflow.mockImplementation(
-        (name: string, workflows: readonly WorkflowDefinition[]) =>
-          workflows.find(w => w.name === name)
+        <T extends WorkflowDefinition>(name: string, workflows: readonly T[]) =>
+          workflows.find(workflow => workflow.name === name)
       );
 
       mockClient.sendQuery.mockImplementation(async function* () {
@@ -1247,8 +1248,8 @@ describe('orchestrator-agent handleMessage', () => {
       mockListCodebases.mockResolvedValue([mockCodebase]);
       mockDiscoverWorkflows.mockResolvedValue({ workflows: testWorkflows, errors: [] });
       mockFindWorkflow.mockImplementation(
-        (name: string, workflows: readonly WorkflowDefinition[]) =>
-          workflows.find(w => w.name === name)
+        <T extends WorkflowDefinition>(name: string, workflows: readonly T[]) =>
+          workflows.find(workflow => workflow.name === name)
       );
 
       mockClient.sendQuery.mockImplementation(async function* () {
@@ -1276,8 +1277,8 @@ describe('orchestrator-agent handleMessage', () => {
       mockListCodebases.mockResolvedValue([mockCodebase]);
       mockDiscoverWorkflows.mockResolvedValue({ workflows: testWorkflows, errors: [] });
       mockFindWorkflow.mockImplementation(
-        (name: string, workflows: readonly WorkflowDefinition[]) =>
-          workflows.find(w => w.name === name)
+        <T extends WorkflowDefinition>(name: string, workflows: readonly T[]) =>
+          workflows.find(workflow => workflow.name === name)
       );
 
       mockClient.sendQuery.mockImplementation(async function* () {
@@ -1353,8 +1354,8 @@ describe('orchestrator-agent handleMessage', () => {
       mockListCodebases.mockResolvedValue([mockCodebase]);
       mockDiscoverWorkflows.mockResolvedValue({ workflows: testWorkflows, errors: [] });
       mockFindWorkflow.mockImplementation(
-        (name: string, workflows: readonly WorkflowDefinition[]) =>
-          workflows.find(w => w.name === name)
+        <T extends WorkflowDefinition>(name: string, workflows: readonly T[]) =>
+          workflows.find(workflow => workflow.name === name)
       );
     });
 
@@ -1514,7 +1515,7 @@ describe('orchestrator-agent handleMessage', () => {
 
       let callCount = 0;
       mockFindWorkflow.mockImplementation(
-        (name: string, workflows: readonly WorkflowDefinition[]) => {
+        <T extends WorkflowDefinition>(name: string, workflows: readonly T[]) => {
           callCount++;
           // First call (parseOrchestratorCommands) finds the workflow
           // Second call (handleWorkflowInvocationResult) does not

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -70,8 +70,7 @@ import {
   SUBRUN_METADATA_KEYS,
   CONTINUATION_METADATA_KEY,
 } from '@archon/workflows/schemas/workflow-run';
-import type { WorkflowDefinition, WorkflowSource } from '@archon/workflows/schemas/workflow';
-import type { DagNode } from '@archon/workflows/schemas/dag-node';
+import type { ResolvedWorkflow, WorkflowSource } from '@archon/workflows/schemas/workflow';
 import type { RunModelOverrides } from '@archon/workflows/model-validation';
 import type { WorkflowRunConfigInput } from '@archon/workflows/schemas/run-config';
 import { createWorkflowDeps } from '../workflows/store-adapter';
@@ -279,7 +278,7 @@ export interface WorkflowRoutingContext {
   readonly originalMessage: string;
   readonly conversationDbId: string;
   readonly codebaseId?: string;
-  readonly availableWorkflows: readonly WorkflowDefinition[];
+  readonly availableWorkflows: readonly ResolvedWorkflow[];
   /**
    * GitHub issue/PR context built from webhook events.
    * Contains formatted markdown with: issue title, author, labels, and body.
@@ -345,7 +344,7 @@ export interface WorkflowRoutingContext {
 async function dispatchBackgroundWorkflowOwned(
   owner: CapturedSourceOwner,
   ctx: WorkflowRoutingContext,
-  workflow: WorkflowDefinition,
+  workflow: ResolvedWorkflow,
   isolationContext?: {
     branchName?: string;
     isPrReview?: boolean;
@@ -365,9 +364,7 @@ async function dispatchBackgroundWorkflowOwned(
   // rule that fails open the moment a third appears. Throws before the worker conversation
   // exists, so a refusal leaves nothing behind.
   assertInteractiveClassNotBackgrounded(workflow);
-  // Already-expanded — discoverWorkflowsWithConfig's output never contains an
-  // IncludeDirective (#2486).
-  assertComposedGateDriveable(workflow.nodes as DagNode[]);
+  assertComposedGateDriveable(workflow.nodes);
 
   // 1. Generate worker conversation ID
   const workerPlatformId = `web-worker-${Date.now()}-${Math.random().toString(36).substring(2, 8)}`;
@@ -778,7 +775,7 @@ async function dispatchBackgroundWorkflowOwned(
  */
 export async function dispatchBackgroundWorkflow(
   ctx: WorkflowRoutingContext,
-  workflow: WorkflowDefinition,
+  workflow: ResolvedWorkflow,
   isolationContext?: {
     branchName?: string;
     isPrReview?: boolean;

--- a/packages/core/src/orchestrator/prompt-builder.ts
+++ b/packages/core/src/orchestrator/prompt-builder.ts
@@ -12,6 +12,10 @@ import {
 } from '@archon/workflows/schemas/workflow-run';
 import type { WorkflowRun } from '@archon/workflows/schemas/workflow-run';
 
+type PromptWorkflow = Pick<WorkflowDefinition, 'name' | 'description'> & {
+  readonly nodes: readonly unknown[];
+};
+
 /**
  * Format a single project for the orchestrator prompt.
  */
@@ -28,7 +32,7 @@ export function formatProjectSection(codebase: Codebase): string {
 /**
  * Format workflow list for the orchestrator prompt.
  */
-export function formatWorkflowSection(workflows: readonly WorkflowDefinition[]): string {
+export function formatWorkflowSection(workflows: readonly PromptWorkflow[]): string {
   if (workflows.length === 0) {
     return 'No workflows available. Users can create workflows in `.archon/workflows/` as YAML files.\n';
   }
@@ -286,7 +290,7 @@ IMPORTANT: Always clone into ~/.archon/workspaces/{owner}/{repo}/source unless t
  */
 export function buildOrchestratorPrompt(
   codebases: readonly Codebase[],
-  workflows: readonly WorkflowDefinition[]
+  workflows: readonly PromptWorkflow[]
 ): string {
   let prompt = `# Archon Orchestrator
 
@@ -324,7 +328,7 @@ You can answer questions directly or invoke workflows for structured development
 export function buildProjectScopedPrompt(
   scopedCodebase: Codebase,
   allCodebases: readonly Codebase[],
-  workflows: readonly WorkflowDefinition[]
+  workflows: readonly PromptWorkflow[]
 ): string {
   const otherCodebases = allCodebases.filter(c => c.id !== scopedCodebase.id);
 
@@ -400,7 +404,7 @@ When the user asks what's running, whether a run passed/failed, or to approve / 
 export function buildOrchestratorSystemAppend(
   conversation: Conversation,
   codebases: readonly Codebase[],
-  workflows: readonly WorkflowDefinition[]
+  workflows: readonly PromptWorkflow[]
 ): string {
   const scopedCodebase = conversation.codebase_id
     ? codebases.find(c => c.id === conversation.codebase_id)

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,7 +1,7 @@
 /**
  * Core type definitions for the Remote Coding Agent platform
  */
-import type { WorkflowDefinition } from '@archon/workflows/schemas/workflow';
+import type { ResolvedWorkflow } from '@archon/workflows/schemas/workflow';
 import type { WorkflowRun } from '@archon/workflows/schemas/workflow-run';
 import type { RunModelOverrides } from '@archon/workflows/model-validation';
 import type { WorkflowRunConfigInput } from '@archon/workflows/schemas/run-config';
@@ -86,7 +86,7 @@ export interface CommandResult {
   modified?: boolean; // Indicates if conversation state was modified
   workflow?: {
     // If set, orchestrator should execute this workflow
-    definition: WorkflowDefinition;
+    definition: ResolvedWorkflow;
     args: string;
     force?: boolean;
     resumeRunId?: string;
@@ -97,7 +97,7 @@ export interface CommandResult {
      * Carried so dispatch does not repeat the digest verification and discovery the
      * handler just paid for. A value, not a flag: it cannot claim work it did not do.
      */
-    resolvedContinuation?: WorkflowDefinition;
+    resolvedContinuation?: ResolvedWorkflow;
     /** Keys the engine dropped from this workflow's YAML (#2213). */
     parseWarnings?: readonly string[];
   };

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -3340,7 +3340,7 @@ export function registerApiRoutes(
           // node config onto the nodes and removes it (#1764), so the declared values are
           // layered back over the definition for this listing only — the console reads
           // `workflow.provider` to label a card, and execution never reads this response.
-          workflow: { ...ws.workflow, ...ws.declared },
+          workflow: Object.assign({}, ws.workflow, ws.declared),
           source: ws.source,
           // Keys the engine dropped from this YAML (#2213) — the console is the
           // surface most authors edit workflows on, so it has to carry them.

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -20,6 +20,7 @@
     "./defaults": "./src/defaults/bundled-defaults.ts",
     "./validator": "./src/validator.ts",
     "./dry-run": "./src/dry-run.ts",
+    "./graph-plan": "./src/graph-plan.ts",
     "./utils/tool-formatter": "./src/utils/tool-formatter.ts",
     "./utils/workflow-requirements": "./src/utils/workflow-requirements.ts",
     "./workflow-inputs": "./src/workflow-inputs.ts",

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -74,7 +74,6 @@ registerOpencodeProvider();
 
 // --- Imports (after mocks) ---
 import {
-  buildTopologicalLayers,
   checkTriggerRule,
   substituteNodeOutputRefs,
   substituteLoopPrevRefs,
@@ -87,6 +86,7 @@ import {
   type ExecuteDagWorkflowOptions,
   type RunChildWorkflowFn,
 } from './dag-executor';
+import { planGraph, resolveWorkflow, resolvedBodyNodes } from './graph-plan';
 import { writeNodeArtifact, readNodeArtifacts } from './artifacts-index';
 import { getWorkflowEventEmitter, type WorkflowEmitterEvent } from './event-emitter';
 import { loadMcpConfig } from '@archon/providers/mcp/config';
@@ -95,11 +95,13 @@ import type {
   AgentNode,
   ExecNode,
   LoopGroupNode,
+  LoopGroupNodeConfig,
   IncludeDirective,
   NodeOutput,
   WorkflowRun,
   WorkflowRunNodeSession,
   WorkflowDefinition,
+  ResolvedWorkflow,
   WorkflowRunStatus,
   ApprovalContext,
   WorkflowWaitContext,
@@ -382,8 +384,18 @@ const minimalConfig: WorkflowConfig = {
  * `deps`, `cwd`, `workflow`, and `workflowRun` carry each test's own fixtures, so every call
  * supplies them; the run directories derive from `cwd` the way every call site built them.
  */
-type DagOptionsOverrides = Partial<ExecuteDagWorkflowOptions> &
-  Pick<ExecuteDagWorkflowOptions, 'deps' | 'cwd' | 'workflow' | 'workflowRun'>;
+type TestWorkflowDefinition = Omit<WorkflowDefinition, 'description'> & {
+  description?: string;
+};
+
+type DagOptionsOverrides = Omit<Partial<ExecuteDagWorkflowOptions>, 'workflow'> &
+  Pick<ExecuteDagWorkflowOptions, 'deps' | 'cwd' | 'workflowRun'> & {
+    workflow: TestWorkflowDefinition;
+  };
+
+function resolveTestWorkflow(workflow: TestWorkflowDefinition): ResolvedWorkflow {
+  return resolveWorkflow({ ...workflow, description: workflow.description ?? workflow.name });
+}
 
 /**
  * Options for a direct `executeDagWorkflow` call, built from only what a test varies. The
@@ -395,7 +407,7 @@ type DagOptionsOverrides = Partial<ExecuteDagWorkflowOptions> &
  * resolved model decision (#2302); this builder is not that guard's audience.
  */
 function dagOptions(overrides: DagOptionsOverrides): ExecuteDagWorkflowOptions {
-  const { cwd } = overrides;
+  const { cwd, workflow, ...rest } = overrides;
   return {
     platform: createMockPlatform(),
     conversationId: 'conv-dag',
@@ -407,7 +419,9 @@ function dagOptions(overrides: DagOptionsOverrides): ExecuteDagWorkflowOptions {
     baseBranch: 'main',
     docsDir: 'docs/',
     config: minimalConfig,
-    ...overrides,
+    ...rest,
+    cwd,
+    workflow: resolveTestWorkflow(workflow),
   };
 }
 
@@ -418,7 +432,7 @@ describe('executeDagWorkflow options type contract', () => {
       platform: createMockPlatform(),
       conversationId: 'type-contract',
       cwd: '/tmp/type-contract',
-      workflow: { name: 'type-contract', nodes: [] },
+      workflow: resolveTestWorkflow({ name: 'type-contract', nodes: [] }),
       workflowRun: makeWorkflowRun('type-contract'),
       workflowProvider: 'claude',
       workflowModel: undefined,
@@ -476,14 +490,8 @@ describe('executeDagWorkflow options type contract', () => {
 
 // --- Helpers ---
 
-/**
- * A parsed `WorkflowDefinition`'s `nodes` admits `IncludeDirective` for the general
- * pre-expansion case (#2486); every workflow built for these tests is a flat,
- * already-expanded fixture with no `include:` nodes, so this narrows it back to what
- * `executeDagWorkflow` actually requires.
- */
-function ready(wf: WorkflowDefinition): Omit<WorkflowDefinition, 'nodes'> & { nodes: DagNode[] } {
-  return { ...wf, nodes: wf.nodes as DagNode[] };
+function ready(wf: WorkflowDefinition): ResolvedWorkflow {
+  return resolveWorkflow(wf);
 }
 
 function node(id: string, depends_on?: string[], opts?: Partial<AgentNode>): AgentNode {
@@ -582,11 +590,11 @@ function expectLoopGateEvidence(
 }
 
 function loaderBypassingWorkflow(
-  workflow: Parameters<typeof executeDagWorkflow>[0]['workflow'] & {
+  workflow: TestWorkflowDefinition & {
     modelReasoningEffort: string;
   }
-): Parameters<typeof executeDagWorkflow>[0]['workflow'] {
-  return workflow;
+): ResolvedWorkflow & { modelReasoningEffort: string } {
+  return { ...resolveTestWorkflow(workflow), modelReasoningEffort: workflow.modelReasoningEffort };
 }
 
 // --- Tests ---
@@ -604,15 +612,15 @@ const readTranscript = async (
     .split('\n')
     .map(line => JSON.parse(line) as Record<string, unknown>);
 
-describe('buildTopologicalLayers', () => {
+describe('planGraph', () => {
   it('single node with no dependencies -> one layer', () => {
-    const layers = buildTopologicalLayers([node('a')]);
+    const layers = planGraph([node('a')]).layers;
     expect(layers).toHaveLength(1);
     expect(layers[0].map(n => n.id)).toEqual(['a']);
   });
 
   it('linear chain -> one node per layer', () => {
-    const layers = buildTopologicalLayers([node('a'), node('b', ['a']), node('c', ['b'])]);
+    const layers = planGraph([node('a'), node('b', ['a']), node('c', ['b'])]).layers;
     expect(layers).toHaveLength(3);
     expect(layers[0].map(n => n.id)).toEqual(['a']);
     expect(layers[1].map(n => n.id)).toEqual(['b']);
@@ -620,11 +628,11 @@ describe('buildTopologicalLayers', () => {
   });
 
   it('fan-out: classify -> [investigate, plan] in same layer', () => {
-    const layers = buildTopologicalLayers([
+    const layers = planGraph([
       node('classify'),
       node('investigate', ['classify']),
       node('plan', ['classify']),
-    ]);
+    ]).layers;
     expect(layers).toHaveLength(2);
     expect(layers[0].map(n => n.id)).toEqual(['classify']);
     const layer1Ids = layers[1].map(n => n.id).sort();
@@ -632,45 +640,79 @@ describe('buildTopologicalLayers', () => {
   });
 
   it('fan-in: [a, b] -> implement in its own layer', () => {
-    const layers = buildTopologicalLayers([node('a'), node('b'), node('implement', ['a', 'b'])]);
+    const layers = planGraph([node('a'), node('b'), node('implement', ['a', 'b'])]).layers;
     expect(layers).toHaveLength(2);
     expect(layers[0].map(n => n.id).sort()).toEqual(['a', 'b']);
     expect(layers[1].map(n => n.id)).toEqual(['implement']);
   });
 
   it('diamond: classify -> [investigate, plan] -> implement', () => {
-    const layers = buildTopologicalLayers([
+    const layers = planGraph([
       node('classify'),
       node('investigate', ['classify']),
       node('plan', ['classify']),
       node('implement', ['investigate', 'plan']),
-    ]);
+    ]).layers;
     expect(layers).toHaveLength(3);
     expect(layers[0].map(n => n.id)).toEqual(['classify']);
     expect(layers[1].map(n => n.id).sort()).toEqual(['investigate', 'plan']);
     expect(layers[2].map(n => n.id)).toEqual(['implement']);
   });
 
-  it('throws on cyclic graph (runtime safety check)', () => {
+  it('throws on a cyclic graph', () => {
     const cyclic = [node('a', ['b']), node('b', ['a'])];
-    expect(() => buildTopologicalLayers(cyclic)).toThrow('Cycle detected');
+    expect(() => planGraph(cyclic)).toThrow('Cycle detected');
   });
 
   it('self-referential node throws', () => {
     const selfRef = [node('a', ['a'])];
-    expect(() => buildTopologicalLayers(selfRef)).toThrow('Cycle detected');
+    expect(() => planGraph(selfRef)).toThrow('Cycle detected');
   });
 
   it('two independent chains share layers correctly', () => {
-    const layers = buildTopologicalLayers([
-      node('a'),
-      node('b', ['a']),
-      node('c'),
-      node('d', ['c']),
-    ]);
+    const layers = planGraph([node('a'), node('b', ['a']), node('c'), node('d', ['c'])]).layers;
     expect(layers).toHaveLength(2);
     expect(layers[0].map(n => n.id).sort()).toEqual(['a', 'c']);
     expect(layers[1].map(n => n.id).sort()).toEqual(['b', 'd']);
+  });
+
+  it('records every sink in definition order', () => {
+    const plan = planGraph([node('root'), node('left', ['root']), node('right', ['root'])]);
+    expect(plan.sinks).toEqual(['left', 'right']);
+  });
+
+  it('attaches the complete plan to a resolved workflow', () => {
+    const workflow = resolveTestWorkflow({
+      name: 'representative',
+      nodes: [node('root'), node('left', ['root']), node('right', ['root'])],
+    });
+
+    expect(workflow.plan.layers.map(layer => layer.map(item => item.id))).toEqual([
+      ['root'],
+      ['left', 'right'],
+    ]);
+    expect(workflow.plan.sinks).toEqual(['left', 'right']);
+  });
+
+  it('rejects an include directive that survived expansion and names it', () => {
+    const include: IncludeDirective = { id: 'block', kind: 'include', include: 'child' };
+    expect(() => planGraph([include])).toThrow("include node 'block'");
+    expect(() =>
+      resolveWorkflow({ name: 'invalid', description: 'invalid', nodes: [include] })
+    ).toThrow("include node 'block'");
+  });
+});
+
+describe('resolvedBodyNodes', () => {
+  it('rejects an include directive in a nested body and names it', () => {
+    const include: IncludeDirective = { id: 'nested', kind: 'include', include: 'child' };
+    const group: LoopGroupNodeConfig = {
+      until: 'DONE',
+      max_iterations: 1,
+      fresh_context: false,
+      nodes: [include],
+    };
+    expect(() => resolvedBodyNodes(group)).toThrow("include node 'nested'");
   });
 });
 
@@ -24703,104 +24745,6 @@ describe('executeDagWorkflow -- flattened include expansion', () => {
     expect(events.some(e => e.event_type === 'node_completed' && e.step_name === 'inc__a')).toBe(
       true
     );
-  });
-});
-
-// ---------------------------------------------------------------------------
-// An unexpanded include node must FAIL LOUDLY, never silently skip — the
-// fail-fast guard runs before resume-skip / when / trigger-rule handling.
-// ---------------------------------------------------------------------------
-
-describe('executeDagWorkflow -- unexpanded include node fail-fast guard', () => {
-  let testDir: string;
-
-  beforeEach(async () => {
-    testDir = join(tmpdir(), `dag-inc-guard-${Date.now()}-${Math.random().toString(36).slice(2)}`);
-    await mkdir(testDir, { recursive: true });
-  });
-
-  afterEach(async () => {
-    try {
-      await rm(testDir, { recursive: true, force: true });
-    } catch {
-      // ignore cleanup errors
-    }
-  });
-
-  function events(
-    deps: WorkflowDeps
-  ): Array<{ event_type: string; step_name: string; data: unknown }> {
-    return (deps.store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls.map(
-      (call: unknown[]) => call[0] as { event_type: string; step_name: string; data: unknown }
-    );
-  }
-
-  it('fails (not skips) an unexpanded include node that matches a prior-completed entry', async () => {
-    const mockDeps = createMockDeps();
-    const platform = createMockPlatform();
-    const workflowRun = makeWorkflowRun('inc-guard-resume', { workflow_name: 'inc-guard' });
-
-    // A raw include node reaching the executor with a resume entry for its own id: the
-    // guard must fire BEFORE the resume-skip check, so it fails instead of being skipped.
-    const includeNode = dagNodeSchema.parse({ id: 'inc', include: 'some-block' }) as DagNode;
-    const prior = new Map([['inc', { output: 'stale prior output' }]]);
-
-    await executeDagWorkflow(
-      dagOptions({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-inc-guard',
-        cwd: testDir,
-        workflow: { name: 'inc-guard', nodes: [includeNode] },
-        workflowRun,
-        priorCompletedNodes: prior,
-      })
-    );
-
-    const evs = events(mockDeps);
-    const failed = evs.find(e => e.event_type === 'node_failed' && e.step_name === 'inc');
-    expect(failed).toBeDefined();
-    expect((failed!.data as { error: string }).error).toContain('reached the executor unexpanded');
-    // Crucially, it was NOT silently skipped as a prior success.
-    expect(evs.some(e => e.event_type === 'node_skipped_prior_success')).toBe(false);
-  });
-
-  it('fails (not skips) an unexpanded include node whose when: would evaluate false', async () => {
-    const mockDeps = createMockDeps();
-    const platform = createMockPlatform();
-    const workflowRun = makeWorkflowRun('inc-guard-when', { workflow_name: 'inc-guard' });
-
-    // `flag` emits NO; the include's when checks == YES (false → would normally skip). The
-    // guard must fire first and fail the node instead.
-    const nodes = [
-      dagNodeSchema.parse({ id: 'flag', bash: 'echo NO' }),
-      dagNodeSchema.parse({
-        id: 'inc',
-        include: 'some-block',
-        depends_on: ['flag'],
-        when: "$flag.output == 'YES'",
-      }),
-    ];
-
-    await executeDagWorkflow(
-      dagOptions({
-        deps: mockDeps,
-        platform,
-        conversationId: 'conv-inc-guard',
-        cwd: testDir,
-        // Deliberately includes an unexpanded include directive — the test exercises the
-        // `when:` guard firing BEFORE the executor would ever need to resolve it.
-        workflow: { name: 'inc-guard', nodes: nodes as DagNode[] },
-        workflowRun,
-      })
-    );
-
-    const evs = events(mockDeps);
-    const failed = evs.find(e => e.event_type === 'node_failed' && e.step_name === 'inc');
-    expect(failed).toBeDefined();
-    expect((failed!.data as { error: string }).error).toContain('reached the executor unexpanded');
-    // It was NOT skipped via the when: gate.
-    expect(evs.some(e => e.event_type === 'node_skipped' && e.step_name === 'inc')).toBe(false);
   });
 });
 

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -384,8 +384,9 @@ const minimalConfig: WorkflowConfig = {
  * `deps`, `cwd`, `workflow`, and `workflowRun` carry each test's own fixtures, so every call
  * supplies them; the run directories derive from `cwd` the way every call site built them.
  */
-type TestWorkflowDefinition = Omit<WorkflowDefinition, 'description'> & {
+type TestWorkflowDefinition = Omit<WorkflowDefinition, 'description' | 'nodes'> & {
   description?: string;
+  nodes: readonly (DagNode | IncludeDirective)[];
 };
 
 type DagOptionsOverrides = Omit<Partial<ExecuteDagWorkflowOptions>, 'workflow'> &
@@ -394,7 +395,11 @@ type DagOptionsOverrides = Omit<Partial<ExecuteDagWorkflowOptions>, 'workflow'> 
   };
 
 function resolveTestWorkflow(workflow: TestWorkflowDefinition): ResolvedWorkflow {
-  return resolveWorkflow({ ...workflow, description: workflow.description ?? workflow.name });
+  return resolveWorkflow({
+    ...workflow,
+    description: workflow.description ?? workflow.name,
+    nodes: [...workflow.nodes],
+  });
 }
 
 /**
@@ -490,8 +495,8 @@ describe('executeDagWorkflow options type contract', () => {
 
 // --- Helpers ---
 
-function ready(wf: WorkflowDefinition): ResolvedWorkflow {
-  return resolveWorkflow(wf);
+function ready(wf: TestWorkflowDefinition): ResolvedWorkflow {
+  return resolveTestWorkflow(wf);
 }
 
 function node(id: string, depends_on?: string[], opts?: Partial<AgentNode>): AgentNode {
@@ -695,6 +700,15 @@ describe('planGraph', () => {
     ]);
     expect(workflow.plan.sinks).toEqual(['left', 'right']);
     expect(workflow.nodes).toBe(workflow.plan.nodes);
+
+    if (false) {
+      // @ts-expect-error Resolved workflow nodes are immutable after planning.
+      workflow.nodes.push(node('late'));
+      // @ts-expect-error The plan exposes the same immutable node set.
+      workflow.plan.nodes.splice(0, 1);
+      // @ts-expect-error Planned layers cannot be mutated after construction.
+      workflow.plan.layers[0]?.push(node('late'));
+    }
   });
 
   it('does not let a typed caller pair a plan with another node set', () => {
@@ -26512,7 +26526,7 @@ describe('executeDagWorkflow -- a workflow runs as authored, standalone or compo
     runName: string,
     options: { expand?: boolean; profileProvider?: string; tiers?: RawTiersConfig } = {}
   ): Promise<Map<string, EffectiveConfig>> {
-    let workflow: WorkflowDefinition;
+    let workflow: TestWorkflowDefinition;
     if (options.expand === false) {
       workflow = defs.find(d => d.name === runName)!;
     } else {
@@ -28637,7 +28651,7 @@ function waitTerminatedLoopGroupWorkflow(): WorkflowDefinition {
 function includedProbeWaitTerminatedLoopGroupWorkflow(
   markerPath: string,
   quoteOutputRef = false
-): WorkflowDefinition {
+): ResolvedWorkflow {
   const stateRef = quoteOutputRef ? '"$ci-probe.output.state"' : '$ci-probe.output.state';
   const block = workflowDefinitionSchema.parse({
     name: 'probe-wait-block',

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -594,7 +594,9 @@ function loaderBypassingWorkflow(
     modelReasoningEffort: string;
   }
 ): ResolvedWorkflow & { modelReasoningEffort: string } {
-  return { ...resolveTestWorkflow(workflow), modelReasoningEffort: workflow.modelReasoningEffort };
+  return Object.assign(resolveTestWorkflow(workflow), {
+    modelReasoningEffort: workflow.modelReasoningEffort,
+  });
 }
 
 // --- Tests ---
@@ -692,6 +694,16 @@ describe('planGraph', () => {
       ['left', 'right'],
     ]);
     expect(workflow.plan.sinks).toEqual(['left', 'right']);
+    expect(workflow.nodes).toBe(workflow.plan.nodes);
+  });
+
+  it('does not let a typed caller pair a plan with another node set', () => {
+    const first = resolveTestWorkflow({ name: 'first', nodes: [node('first')] });
+    const second = resolveTestWorkflow({ name: 'second', nodes: [node('second')] });
+
+    // @ts-expect-error Object spread loses the factory-only resolved-workflow identity.
+    const mismatched: ResolvedWorkflow = { ...first, nodes: second.nodes };
+    expect(mismatched.plan.nodes).not.toBe(mismatched.nodes);
   });
 
   it('rejects an include directive that survived expansion and names it', () => {

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -61,10 +61,10 @@ import type {
   SandboxSettings,
   WebSearchMode,
   WorkflowSource,
-  WorkflowDefinition,
+  GraphPlan,
+  ResolvedWorkflow,
   LoopGateRunMetadata,
   ApprovalContext,
-  WorkflowEvidencePolicy,
   WorkflowRunOutcome,
   NodeArtifactLoopFrame,
   WorkflowRunNodeSession,
@@ -94,6 +94,7 @@ import {
 } from './schemas';
 import type { BindingDirective } from './schemas';
 import { mapNodeTemplateSlots } from './template-walker';
+import { planGraph, resolvedBodyNodes } from './graph-plan';
 import { FAN_OUT_CANCEL_REASONS } from './store';
 import type { DagResumeSnapshot, FanOutCancelReason, PersistedNodeOutput } from './store';
 import { formatToolCall } from './utils/tool-formatter';
@@ -2005,56 +2006,6 @@ export function checkComposedBlockBoundaries(
     }
   }
   return 'run';
-}
-
-/**
- * Build topological layers from DAG nodes using Kahn's algorithm.
- * Layer 0: nodes with no dependencies.
- * Layer N: nodes whose dependencies are all in layers 0..N-1.
- *
- * Cycle detection: if the sum of all layer sizes < nodes.length, a cycle exists.
- * (Cycle detection at load time is the primary guard; this is a runtime safety check.)
- */
-export function buildTopologicalLayers(nodes: readonly DagNode[]): DagNode[][] {
-  const inDegree = new Map<string, number>();
-  const dependents = new Map<string, string[]>();
-
-  for (const node of nodes) {
-    inDegree.set(node.id, node.depends_on?.length ?? 0);
-    for (const dep of node.depends_on ?? []) {
-      const existing = dependents.get(dep) ?? [];
-      existing.push(node.id);
-      dependents.set(dep, existing);
-    }
-  }
-
-  const layers: DagNode[][] = [];
-  let ready = [...nodes].filter(n => (inDegree.get(n.id) ?? 0) === 0);
-
-  while (ready.length > 0) {
-    layers.push(ready);
-    const nextIds: string[] = [];
-    for (const node of ready) {
-      for (const depId of dependents.get(node.id) ?? []) {
-        const newDegree = (inDegree.get(depId) ?? 0) - 1;
-        inDegree.set(depId, newDegree);
-        if (newDegree === 0) nextIds.push(depId);
-      }
-    }
-    ready = nextIds
-      .map(id => nodes.find(n => n.id === id))
-      .filter((n): n is DagNode => n !== undefined);
-  }
-
-  const totalPlaced = layers.reduce((sum, l) => sum + l.length, 0);
-  if (totalPlaced < nodes.length) {
-    // Should never happen — cycle detection runs at load time
-    throw new Error(
-      '[DagExecutor] Cycle detected at runtime — was cycle detection skipped at load?'
-    );
-  }
-
-  return layers;
 }
 
 /**
@@ -4622,6 +4573,7 @@ async function executeLoopGroupNode(
     execContext,
   } = ctx;
   const group = node.loop_group;
+  const bodyNodes = resolvedBodyNodes(group);
   const msgContext = { workflowId: workflowRun.id, nodeName: node.id };
   // This group's OWN persisted step_name — namespaced by any enclosing group so nested
   // loop_groups compose (e.g. `outer.inner`); '' → node.id at the top level (#2090).
@@ -4641,8 +4593,8 @@ async function executeLoopGroupNode(
   // THIS group's immediate ids — an id in knownBodyIds but not directBodyIds belongs to a
   // nested group and its token is preserved for that inner group's own pass. Computed once
   // (body shape is static) and threaded into every applyLoopPrevToBodyNode call.
-  const knownBodyIds = collectLoopBodyNodeIds(group.nodes);
-  const directBodyIds = new Set(group.nodes.map(n => n.id));
+  const knownBodyIds = collectLoopBodyNodeIds(bodyNodes);
+  const directBodyIds = new Set(bodyNodes.map(n => n.id));
 
   // Detect loop resume (mirrors executeLoopNode). Two shapes recognized:
   //  - the ORIGINAL interactive_loop gate (group.interactive + gate_message).
@@ -4713,7 +4665,7 @@ async function executeLoopGroupNode(
   }
 
   if (isEscalatedWaitResume) {
-    const terminalNode = findLoopGroupTerminalSuspendNode(group.nodes as DagNode[]);
+    const terminalNode = findLoopGroupTerminalSuspendNode(bodyNodes);
     if (terminalNode?.kind !== 'wait') {
       throw new Error(`Loop group '${node.id}' resumed with wait state but has no terminal wait`);
     }
@@ -4748,7 +4700,7 @@ async function executeLoopGroupNode(
   // substituteLoopPrevRefs finds them exactly as it would mid-loop.
   if (isLoopResume) {
     const restoredLoopPrevOutputs = new Map<string, NodeOutput>();
-    const bodyNodesById = new Map((group.nodes as DagNode[]).map(n => [n.id, n]));
+    const bodyNodesById = new Map(bodyNodes.map(n => [n.id, n]));
     for (const id of directBodyIds) {
       const prior = outerNodeOutputs.get(bodyStepNamePrefix + id);
       if (!prior) continue;
@@ -4788,7 +4740,7 @@ async function executeLoopGroupNode(
   // iteration boundary, so the pre-gate body nodes' already-produced outputs are
   // safe to reuse as-is; only the gate's own answer needed reconstructing.
   if ((isEscalatedGateResume || isEscalatedWaitResume) && loopPrevOutputs !== undefined) {
-    const terminalNode = findLoopGroupTerminalSuspendNode(group.nodes as DagNode[]);
+    const terminalNode = findLoopGroupTerminalSuspendNode(bodyNodes);
     const terminalSink = terminalNode ? loopPrevOutputs.get(terminalNode.id) : undefined;
     if (terminalSink !== undefined) {
       const resumedIteration = resumeIteration;
@@ -5014,9 +4966,7 @@ async function executeLoopGroupNode(
     // iteration of an interactive loop.
     const prevSnapshot = loopPrevOutputs;
     const userInputForIter = isLoopResume && i === startIteration ? loopUserInput : '';
-    // The executor only ever receives already-expanded nodes (see the justification at
-    // the other `applyLoopPrevToBodyNode` call site above), so the body is include-free.
-    const iterBodyNodes = (group.nodes as DagNode[]).map(n =>
+    const iterBodyNodes = bodyNodes.map(n =>
       applyLoopPrevToBodyNode(
         n,
         prevSnapshot,
@@ -5028,7 +4978,7 @@ async function executeLoopGroupNode(
     );
     // Re-layer from the (possibly substituted) body nodes — runLayers walks ctx.layers,
     // not ctx.nodes, so the layers must reference the substituted nodes to take effect.
-    const iterBodyLayers = buildTopologicalLayers(iterBodyNodes);
+    const iterBodyLayers = planGraph(iterBodyNodes).layers;
 
     // Fresh scoped output map per iteration. Seed it read-only with the outer DAG's
     // upstream outputs so body nodes can reference outer context via $nodeId.output if
@@ -8157,8 +8107,8 @@ async function resolveFanOutChildDefinition(
   source?: WorkflowSourceRoots | string
 ): Promise<
   | {
-      definition: WorkflowDefinition;
-      definitions: WorkflowDefinition[];
+      definition: ResolvedWorkflow;
+      definitions: ResolvedWorkflow[];
       commandContents: ReadonlyMap<string, IncludeCommandContent>;
     }
   | { unresolved: string }
@@ -8932,7 +8882,7 @@ function expandComposeInstance(
   node: ComposeFanOutNode,
   identity: string,
   inputs: Record<string, JsonValue>,
-  definition: WorkflowDefinition,
+  definition: ResolvedWorkflow,
   commandContents: ReadonlyMap<string, IncludeCommandContent>
 ): { nodes: DagNode[]; primarySink: string } | { error: string } {
   const directiveId = `${node.id}__${identity}`;
@@ -9378,7 +9328,9 @@ async function executeComposeFanOutNode(
         persistScopeKey: ctx.persistScopeKey,
         workflowPersistSessions: ctx.workflowPersistSessions,
         scopeArtifactsDir: undefined,
-        layers: buildTopologicalLayers(expanded.nodes),
+        // Runtime cardinality changes only the deterministic instance prefix; the body
+        // was fully resolved and validated before any parent node ran.
+        layers: planGraph(expanded.nodes).layers,
         nodeOutputs: instanceNodeOutputs,
         priorCompletedNodes: instancePriorNodes,
         claimedWorkPausePolicy: 'finish_through_parent_pause',
@@ -9723,7 +9675,7 @@ interface RunDerived {
 interface RunLayersContext extends RunInputs, RunDerived {
   // --- per-subgraph mutable state (varies between top-level DAG and loop_group body) ---
   /** Pre-computed topological layers (caller builds once — body shape is static). runLayers walks ONLY these; there is deliberately no flat node list here. */
-  layers: DagNode[][];
+  layers: GraphPlan['layers'];
   /** Shared node-output map (caller owns; runLayers writes node results here). */
   nodeOutputs: Map<string, NodeOutput>;
   /** Prior body outputs available to a loop-group iteration's `when:` conditions. */
@@ -9946,20 +9898,6 @@ async function runLayers(ctx: RunLayersContext): Promise<void> {
       (node): (() => Promise<LayerNodeResult>) =>
         async (): Promise<LayerNodeResult> => {
           try {
-            // Include nodes are expanded away at discovery time (include-expander.ts): one
-            // must never reach the executor. This guard is FIRST in the per-node body — before
-            // resume-skip, `when:`, and trigger-rule handling — so an unexpanded include node
-            // cannot slip through by matching a prior-completed entry, a false `when:`, or a
-            // failing trigger rule. If one gets here, discovery was bypassed; fail loud rather
-            // than silently accepting an invalid runtime DAG.
-            if (isIncludeDirective(node as DagNode | IncludeDirective)) {
-              const includeNode = node as unknown as IncludeDirective;
-              throw new Error(
-                `Internal error: include node '${includeNode.id}' reached the executor unexpanded. ` +
-                  'Include nodes must be resolved by expandWorkflowIncludes() during discovery.'
-              );
-            }
-
             const checkpointSessionForProvider = (
               provider: string
             ): SessionCheckpoint | undefined => {
@@ -11516,21 +11454,7 @@ async function raiseWriteBackGate(
 
 /** Inputs accepted by {@link executeDagWorkflow}. */
 export interface ExecuteDagWorkflowOptions extends RunInputs {
-  workflow: {
-    name: string;
-    nodes: readonly DagNode[];
-    /** Workflow-level default for per-node `persist_session` (read directly here). */
-    persist_sessions?: boolean;
-    /** Raw workflow-level `model` ref — used only to derive the workflow tier
-     *  keyword for node_started attribution (resolution uses `workflowModel`). */
-    model?: string;
-    /** Terminal-success evidence gate (#2230) — read at the completion path. */
-    evidence_policy?: WorkflowEvidencePolicy;
-    /** Declared `returns:` node id (#2470) — rebinds a CHILD run's terminal output. */
-    returns?: string;
-    /** Required boolean property on `returns:` that authors the durable run outcome. */
-    outcome_field?: string;
-  } & WorkflowLevelOptions;
+  workflow: ResolvedWorkflow;
   priorCompletedNodes?: Map<string, PersistedNodeOutput>;
   /** Discovery source — telemetry only (custom-vs-default + name redaction). */
   source?: WorkflowSource;
@@ -11677,7 +11601,7 @@ export async function executeDagWorkflow(
     webSearchMode: workflow.webSearchMode,
     workflowTier,
   };
-  const layers = buildTopologicalLayers(workflow.nodes);
+  const layers = workflow.plan.layers;
   const nodeOutputs = new Map<string, NodeOutput>();
 
   // Pre-populate nodeOutputs from prior run so already-completed nodes are
@@ -12323,10 +12247,8 @@ export async function executeDagWorkflow(
       terminalOutput = '';
     }
   } else {
-    const allDependencies = new Set(workflow.nodes.flatMap(n => n.depends_on ?? []));
-    const terminalSink = workflow.nodes
-      .filter(n => !allDependencies.has(n.id))
-      .map(n => nodeOutputs.get(n.id))
+    const terminalSink = workflow.plan.sinks
+      .map(nodeId => nodeOutputs.get(nodeId))
       .find(o => o?.state === 'completed' && o.output.trim().length > 0);
     terminalOutput = terminalSink?.output;
     terminalStructuredOutput =

--- a/packages/workflows/src/defaults/bundled-defaults.test.ts
+++ b/packages/workflows/src/defaults/bundled-defaults.test.ts
@@ -25,6 +25,7 @@ import {
 } from '../packaged-workflow';
 import { parseWorkflow } from '../loader';
 import { dryRunWorkflow } from '../dry-run';
+import { resolveWorkflow } from '../graph-plan';
 import { makeTestWorkflow } from '../test-utils';
 
 // Resolve the on-disk defaults directories relative to this test file so the
@@ -690,11 +691,11 @@ describe('bundled-defaults', () => {
           },
         ],
       }).nodes[0];
-      const workflow = {
+      const workflow = resolveWorkflow({
         ...parsed.workflow,
         name: scenario.name,
         nodes: [producer!, { ...flipReady, depends_on: ['pr'] }],
-      };
+      });
       const directory = mkdtempSync(join(tmpdir(), 'archon-flip-ready-'));
       const bin = join(directory, 'bin');
       const log = join(directory, 'gh.log');

--- a/packages/workflows/src/deprecation.ts
+++ b/packages/workflows/src/deprecation.ts
@@ -11,7 +11,9 @@ import type { WorkflowDefinition } from './schemas/workflow';
  * pack — carried by the declared message — and keeping a copy under project or
  * global `.archon/workflows/`, which wins discovery by filename).
  */
-export function formatDeprecationNotice(workflow: WorkflowDefinition): string | undefined {
+export function formatDeprecationNotice(
+  workflow: Pick<WorkflowDefinition, 'name' | 'deprecated'>
+): string | undefined {
   if (!workflow.deprecated) return undefined;
   return (
     `⚠️ \`${workflow.name}\` is deprecated and will be removed in an upcoming release. ` +

--- a/packages/workflows/src/dry-run.test.ts
+++ b/packages/workflows/src/dry-run.test.ts
@@ -15,22 +15,29 @@ import { resolveWorkflow } from './graph-plan';
 import { buildAiProfile } from './model-validation';
 import { resolveWorkflowModelScope } from './node-model-resolution';
 import { expandWorkflowIncludes } from './include-expander';
-import type { WorkflowDefinition } from './schemas';
+import type { ResolvedWorkflow, WorkflowDefinition } from './schemas';
 
-function createDryRunStubScaffold(workflow: WorkflowDefinition) {
-  return createResolvedDryRunStubScaffold(resolveWorkflow(workflow));
+function asResolvedWorkflow(workflow: WorkflowDefinition | ResolvedWorkflow): ResolvedWorkflow {
+  return 'plan' in workflow ? workflow : resolveWorkflow(workflow);
 }
 
-function writeDryRunStubScaffold(workflow: WorkflowDefinition, path: string) {
-  return writeResolvedDryRunStubScaffold(resolveWorkflow(workflow), path);
+function createDryRunStubScaffold(workflow: WorkflowDefinition | ResolvedWorkflow) {
+  return createResolvedDryRunStubScaffold(asResolvedWorkflow(workflow));
+}
+
+function writeDryRunStubScaffold(workflow: WorkflowDefinition | ResolvedWorkflow, path: string) {
+  return writeResolvedDryRunStubScaffold(asResolvedWorkflow(workflow), path);
 }
 
 type TestDryRunOptions = Omit<Parameters<typeof dryRunResolvedWorkflow>[0], 'workflow'> & {
-  workflow: WorkflowDefinition;
+  workflow: WorkflowDefinition | ResolvedWorkflow;
 };
 
 function dryRunWorkflow(options: TestDryRunOptions) {
-  return dryRunResolvedWorkflow({ ...options, workflow: resolveWorkflow(options.workflow) });
+  return dryRunResolvedWorkflow({
+    ...options,
+    workflow: asResolvedWorkflow(options.workflow),
+  });
 }
 
 const temporaryDirectories: string[] = [];
@@ -49,7 +56,7 @@ function temporaryFile(content: string): string {
   return path;
 }
 
-function composedReviewWorkflow(gateNodes: unknown[], includeWhen?: string): WorkflowDefinition {
+function composedReviewWorkflow(gateNodes: unknown[], includeWhen?: string): ResolvedWorkflow {
   const block = makeTestWorkflow({
     name: 'review-block',
     nodes: [

--- a/packages/workflows/src/dry-run.test.ts
+++ b/packages/workflows/src/dry-run.test.ts
@@ -4,17 +4,34 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { makeTestComposedWorkflow, makeTestWorkflow } from './test-utils';
 import {
-  createDryRunStubScaffold,
-  dryRunWorkflow,
+  createDryRunStubScaffold as createResolvedDryRunStubScaffold,
+  dryRunWorkflow as dryRunResolvedWorkflow,
   formatDryRunTrace,
   loadDryRunStubs,
-  writeDryRunStubScaffold,
+  writeDryRunStubScaffold as writeResolvedDryRunStubScaffold,
 } from './dry-run';
 import type { DryRunResolution } from './dry-run';
+import { resolveWorkflow } from './graph-plan';
 import { buildAiProfile } from './model-validation';
 import { resolveWorkflowModelScope } from './node-model-resolution';
 import { expandWorkflowIncludes } from './include-expander';
 import type { WorkflowDefinition } from './schemas';
+
+function createDryRunStubScaffold(workflow: WorkflowDefinition) {
+  return createResolvedDryRunStubScaffold(resolveWorkflow(workflow));
+}
+
+function writeDryRunStubScaffold(workflow: WorkflowDefinition, path: string) {
+  return writeResolvedDryRunStubScaffold(resolveWorkflow(workflow), path);
+}
+
+type TestDryRunOptions = Omit<Parameters<typeof dryRunResolvedWorkflow>[0], 'workflow'> & {
+  workflow: WorkflowDefinition;
+};
+
+function dryRunWorkflow(options: TestDryRunOptions) {
+  return dryRunResolvedWorkflow({ ...options, workflow: resolveWorkflow(options.workflow) });
+}
 
 const temporaryDirectories: string[] = [];
 

--- a/packages/workflows/src/dry-run.test.ts
+++ b/packages/workflows/src/dry-run.test.ts
@@ -498,6 +498,35 @@ describe('dry-run stub scaffolding and sparse defaults (#2624)', () => {
 });
 
 describe('dryRunWorkflow', () => {
+  test('uses the attached plan for trace order and summary selection', async () => {
+    const workflow = resolveWorkflow(
+      makeTestWorkflow({
+        name: 'authoritative-plan',
+        nodes: [
+          { id: 'first', prompt: 'first' },
+          { id: 'second', prompt: 'second' },
+        ],
+      })
+    );
+    const [first, second] = workflow.nodes;
+    if (first === undefined || second === undefined) throw new Error('invalid test workflow');
+
+    // Deliberately vary both decisions so either production read becoming a
+    // recomputation makes this regression fail.
+    Reflect.set(workflow.plan, 'layers', [[second], [first]]);
+    Reflect.set(workflow.plan, 'sinks', ['second']);
+
+    const result = await dryRunResolvedWorkflow({
+      workflow,
+      userMessage: '',
+      cwd: process.cwd(),
+      stubs: { first: 'first output', second: 'second output' },
+    });
+
+    expect(result.trace.map(entry => entry.nodeId)).toEqual(['second', 'first']);
+    expect(result.summary).toBe('second output');
+  });
+
   test('hydrates object stubs and resolves workflow and strict output variables', async () => {
     const workflow = makeTestWorkflow({
       name: 'structured',

--- a/packages/workflows/src/dry-run.ts
+++ b/packages/workflows/src/dry-run.ts
@@ -7,13 +7,13 @@ import { randomUUID } from 'node:crypto';
 import { mkdir, open, rm } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import {
-  buildTopologicalLayers,
   checkComposedBlockBoundaries,
   checkTriggerRule,
   resolveNodeBindings,
   substituteNodeOutputRefs,
   type ShellInputContext,
 } from './dag-executor';
+import { planGraph, resolvedBodyNodes } from './graph-plan';
 import { evaluateCondition } from './condition-evaluator';
 import {
   COMPILED_LOOP_COMMAND,
@@ -53,7 +53,8 @@ import {
   isWorkflowNode,
   type DagNode,
   type NodeOutput,
-  type WorkflowDefinition,
+  type GraphPlan,
+  type ResolvedWorkflow,
 } from './schemas';
 
 /** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
@@ -223,7 +224,7 @@ function collectsStub(node: DagNode): boolean {
 }
 
 /** Build the complete static stub map for an already-expanded workflow definition. */
-export function createDryRunStubScaffold(workflow: WorkflowDefinition): DryRunStubs {
+export function createDryRunStubScaffold(workflow: ResolvedWorkflow): DryRunStubs {
   const stubs = new Map<string, { candidates: DryRunStubValue[]; consumers: DagNode[] }>();
   const visit = (nodes: readonly DagNode[]): void => {
     for (const node of nodes) {
@@ -237,14 +238,10 @@ export function createDryRunStubScaffold(workflow: WorkflowDefinition): DryRunSt
           existing.consumers.push(node);
         }
       }
-      if (isLoopGroupNode(node)) visit(node.loop_group.nodes as DagNode[]);
+      if (isLoopGroupNode(node)) visit(resolvedBodyNodes(node.loop_group));
     }
   };
-  // "Already-expanded" per this function's own docblock — dry-run always simulates a
-  // fully-expanded WorkflowDefinition, so `workflow.nodes` never actually holds an
-  // `IncludeDirective` here even though the type admits one for the general
-  // pre-expansion case (#2486).
-  visit(workflow.nodes as DagNode[]);
+  visit(workflow.nodes);
   return Object.fromEntries(
     [...stubs].map(([id, entry]) => {
       const value = entry.candidates.find(candidate =>
@@ -262,7 +259,7 @@ export function createDryRunStubScaffold(workflow: WorkflowDefinition): DryRunSt
 
 /** Write a scaffold without ever overwriting an existing fixture. */
 export async function writeDryRunStubScaffold(
-  workflow: WorkflowDefinition,
+  workflow: ResolvedWorkflow,
   path: string
 ): Promise<DryRunStubs> {
   const stubs = createDryRunStubScaffold(workflow);
@@ -448,7 +445,7 @@ function completedOutput(node: DagNode, stub: DryRunStubValue): NodeOutput {
 }
 
 interface DryRunContext {
-  workflow: WorkflowDefinition;
+  workflow: ResolvedWorkflow;
   userMessage: string;
   cwd: string;
   /**
@@ -934,20 +931,17 @@ async function simulateLoopGroup(
   iteration?: number
 ): Promise<void> {
   if (!isLoopGroupNode(node)) return;
-  // Already-expanded (see createDryRunStubScaffold's justification above) — never
-  // actually holds an `IncludeDirective` here.
-  const bodyNodes = node.loop_group.nodes as DagNode[];
+  const bodyNodes = resolvedBodyNodes(node.loop_group);
+  const bodyPlan = planGraph(bodyNodes);
   let lastOutput = '';
   for (let current = 1; current <= node.loop_group.max_iterations; current++) {
     const bodyOutputs = new Map(outputs);
-    await simulateNodes(bodyNodes, bodyOutputs, ctx, current);
-    const bodyDependencies = new Set(node.loop_group.nodes.flatMap(body => body.depends_on ?? []));
+    await simulateNodes(bodyPlan, bodyOutputs, ctx, current);
     lastOutput =
-      node.loop_group.nodes
-        .filter(body => !bodyDependencies.has(body.id))
-        .map(body => bodyOutputs.get(body.id))
+      bodyPlan.sinks
+        .map(bodyId => bodyOutputs.get(bodyId))
         .find(output => output?.state === 'completed' && output.output.trim())?.output ?? '';
-    const failed = node.loop_group.nodes.some(body => bodyOutputs.get(body.id)?.state === 'failed');
+    const failed = bodyNodes.some(body => bodyOutputs.get(body.id)?.state === 'failed');
     if (failed) {
       recordFailed(
         node,
@@ -1198,12 +1192,12 @@ async function simulateNode(
 }
 
 async function simulateNodes(
-  nodes: readonly DagNode[],
+  plan: GraphPlan,
   outputs: Map<string, NodeOutput>,
   ctx: DryRunContext,
   iteration?: number
 ): Promise<void> {
-  for (const layer of buildTopologicalLayers(nodes)) {
+  for (const layer of plan.layers) {
     for (const node of layer) {
       if (ctx.halted) return;
       await simulateNode(node, outputs, ctx, iteration);
@@ -1212,7 +1206,7 @@ async function simulateNodes(
 }
 
 export async function dryRunWorkflow(options: {
-  workflow: WorkflowDefinition;
+  workflow: ResolvedWorkflow;
   userMessage: string;
   cwd: string;
   stubs?: DryRunStubs;
@@ -1283,8 +1277,7 @@ export async function dryRunWorkflow(options: {
   };
   const outputs = new Map<string, NodeOutput>();
   try {
-    // Already-expanded (see createDryRunStubScaffold's justification above).
-    await simulateNodes(options.workflow.nodes as DagNode[], outputs, ctx);
+    await simulateNodes(options.workflow.plan, outputs, ctx);
   } finally {
     // Simulations are throwaway: whatever exec'd nodes wrote is discarded with the
     // per-run root (`force: true` makes the nothing-executed case a no-op). A cleanup
@@ -1297,10 +1290,8 @@ export async function dryRunWorkflow(options: {
     });
   }
 
-  const dependencies = new Set(options.workflow.nodes.flatMap(node => node.depends_on ?? []));
-  const summary = options.workflow.nodes
-    .filter(node => !dependencies.has(node.id))
-    .map(node => outputs.get(node.id))
+  const summary = options.workflow.plan.sinks
+    .map(nodeId => outputs.get(nodeId))
     .find(output => output?.state === 'completed' && output.output.trim())?.output;
   const anyFailed = [...outputs.values()].some(output => output.state === 'failed');
   const outcome =

--- a/packages/workflows/src/executor-preamble.test.ts
+++ b/packages/workflows/src/executor-preamble.test.ts
@@ -9,7 +9,8 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import type { WorkflowDeps, IWorkflowPlatform, WorkflowConfig } from './deps';
 import type { IWorkflowStore } from './store';
-import type { WorkflowDefinition, WorkflowRun } from './schemas';
+import type { ResolvedWorkflow, WorkflowDefinition, WorkflowRun } from './schemas';
+import { resolveWorkflow } from './graph-plan';
 
 // ---------------------------------------------------------------------------
 // Mock logger (must precede all module-under-test imports)
@@ -158,13 +159,13 @@ function makeDeps(store?: IWorkflowStore): WorkflowDeps {
 }
 
 /** Minimal DAG workflow fixture — the preamble doesn't care about node details */
-function makeWorkflow(overrides: Partial<WorkflowDefinition> = {}): WorkflowDefinition {
-  return {
+function makeWorkflow(overrides: Partial<WorkflowDefinition> = {}): ResolvedWorkflow {
+  return resolveWorkflow({
     name: 'test-workflow',
     description: 'Test',
     nodes: [{ id: 'test', kind: 'agent', source: { kind: 'command', name: 'test' } }],
     ...overrides,
-  };
+  });
 }
 
 function makeRun(overrides: Partial<WorkflowRun> = {}): WorkflowRun {

--- a/packages/workflows/src/executor.test.ts
+++ b/packages/workflows/src/executor.test.ts
@@ -166,10 +166,16 @@ import {
   resolveProjectPaths,
   resolveScopeArtifactsDir,
 } from './executor';
+import { resolveWorkflow } from './graph-plan';
 import { keepAwake } from './utils/keep-awake';
 import type { WorkflowDeps, IWorkflowPlatform, WorkflowConfig } from './deps';
 import type { IWorkflowStore } from './store';
-import type { WorkflowDefinition, WorkflowRun, WorkflowRunNodeSession } from './schemas';
+import type {
+  ResolvedWorkflow,
+  WorkflowDefinition,
+  WorkflowRun,
+  WorkflowRunNodeSession,
+} from './schemas';
 import { RUN_METADATA_KEYS, workflowDefinitionSchema } from './schemas';
 import type { WorkflowRunConfigMetadata } from './schemas/run-config';
 import { substituteWorkflowVariables } from './executor-shared';
@@ -248,13 +254,13 @@ function makeDeps(store?: IWorkflowStore): WorkflowDeps {
   } as unknown as WorkflowDeps;
 }
 
-function makeWorkflow(overrides: Partial<WorkflowDefinition> = {}): WorkflowDefinition {
-  return {
+function makeWorkflow(overrides: Partial<WorkflowDefinition> = {}): ResolvedWorkflow {
+  return resolveWorkflow({
     name: 'test-workflow',
     description: 'Test',
     nodes: [{ id: 'node1', kind: 'agent', source: { kind: 'inline', prompt: 'Do something' } }],
     ...overrides,
-  };
+  });
 }
 
 function makeRun(overrides: Partial<WorkflowRun> = {}): WorkflowRun {
@@ -293,12 +299,14 @@ describe('executeWorkflow', () => {
   });
 
   it('rejects a structurally valid but semantically invalid outcome declaration before side effects', async () => {
-    const workflow = workflowDefinitionSchema.parse({
-      name: 'invalid-authored-outcome',
-      description: 'missing selected return node',
-      outcome_field: 'green',
-      nodes: [{ id: 'node1', prompt: 'Do something' }],
-    });
+    const workflow = resolveWorkflow(
+      workflowDefinitionSchema.parse({
+        name: 'invalid-authored-outcome',
+        description: 'missing selected return node',
+        outcome_field: 'green',
+        nodes: [{ id: 'node1', prompt: 'Do something' }],
+      })
+    );
     const store = makeStore();
     const deps = makeDeps(store);
 
@@ -317,11 +325,13 @@ describe('executeWorkflow', () => {
 
   describe('container resume guard', () => {
     it('rejects a fresh container workflow with a durable wait before creating a run', async () => {
-      const workflow = workflowDefinitionSchema.parse({
-        name: 'container-wait',
-        description: 'unsupported durable wait in container isolation',
-        nodes: [{ id: 'delay', wait: { duration_ms: 1000 } }],
-      });
+      const workflow = resolveWorkflow(
+        workflowDefinitionSchema.parse({
+          name: 'container-wait',
+          description: 'unsupported durable wait in container isolation',
+          nodes: [{ id: 'delay', wait: { duration_ms: 1000 } }],
+        })
+      );
       const store = makeStore();
 
       await expect(
@@ -344,11 +354,13 @@ describe('executeWorkflow', () => {
     // The guard keys on "is this a fresh dispatch", not on who wrote the row. A row
     // pre-created by a launching process (#2872, `--detach`) is still a fresh dispatch.
     it('refuses the same durable wait when the fresh run row was pre-created', async () => {
-      const workflow = workflowDefinitionSchema.parse({
-        name: 'container-wait',
-        description: 'unsupported durable wait in container isolation',
-        nodes: [{ id: 'delay', wait: { duration_ms: 1000 } }],
-      });
+      const workflow = resolveWorkflow(
+        workflowDefinitionSchema.parse({
+          name: 'container-wait',
+          description: 'unsupported durable wait in container isolation',
+          nodes: [{ id: 'delay', wait: { duration_ms: 1000 } }],
+        })
+      );
 
       await expect(
         executeWorkflow(

--- a/packages/workflows/src/executor.ts
+++ b/packages/workflows/src/executor.ts
@@ -14,7 +14,7 @@ import { getDefaultBranch, toRepoPath } from '@archon/git';
 import type {
   DagNode,
   IncludeDirective,
-  WorkflowDefinition,
+  ResolvedWorkflow,
   WorkflowRun,
   WorkflowExecutionResult,
   WorkflowSource,
@@ -905,7 +905,7 @@ export async function resolveContinuationWorkflow(
 
 /** What a continuation resolved to, plus the discovery it already paid for. */
 export interface ResolvedContinuation {
-  workflow: WorkflowDefinition;
+  workflow: ResolvedWorkflow;
   roots: WorkflowSourceRoots;
   workflows: readonly WorkflowWithSource[];
   errors: readonly WorkflowLoadError[];
@@ -1232,7 +1232,7 @@ async function runChildWorkflow(
   //    Resolution runs BEFORE the cycle check so a case-variant / suffix / substring
   //    reference to an ancestor (e.g. `workflow: SELFIE` naming its own run) is caught
   //    as a cycle by canonical name, not left to the less-informative depth cap.
-  let childWorkflow: WorkflowDefinition | undefined;
+  let childWorkflow: ResolvedWorkflow | undefined;
   try {
     // DELIBERATE AFFORDANCE — do not "fix" this by adding a load-time existence
     // check for `workflow:` targets. Discovery runs HERE, when the node executes,
@@ -1655,7 +1655,7 @@ async function maybeResumeParentRun(
     return;
   }
 
-  let parentWorkflow: WorkflowDefinition | undefined;
+  let parentWorkflow: ResolvedWorkflow | undefined;
   try {
     // Reload the parent's graph from the source IT started with. Rediscovering from
     // `parentCwd` is how a mid-run authoring edit used to change an already-running
@@ -1774,7 +1774,7 @@ export async function executeWorkflow(
   platform: IWorkflowPlatform,
   conversationId: string,
   cwd: string,
-  workflow: WorkflowDefinition,
+  workflow: ResolvedWorkflow,
   userMessage: string,
   conversationDbId: string,
   opts: ExecuteWorkflowOptions = {}
@@ -2830,10 +2830,7 @@ export async function executeWorkflow(
     // workflows report their real name, custom ones report "custom". No PII —
     // descriptions/prompts/paths are never sent. Machine context + version ride
     // along as super-properties. Opt out: ARCHON_TELEMETRY_DISABLED=1 / DO_NOT_TRACK=1.
-    // Already-expanded — the run is about to execute this workflow, so `workflow.nodes`
-    // never actually holds an `IncludeDirective` here even though the type admits one
-    // for the general pre-expansion case (#2486).
-    const telemetryNodes = workflow.nodes as DagNode[];
+    const telemetryNodes = workflow.nodes;
     captureWorkflowInvoked({
       workflowName: workflow.name,
       workflowSource: source,
@@ -3052,10 +3049,8 @@ export async function executeWorkflow(
         }
       : workflowRun;
 
-    // Execute the DAG workflow. Already-expanded (see `telemetryNodes` above) — the
-    // executor's own `DagNode[]` parameter type is correctly narrow; this boundary
-    // cast reflects that invariant, not a new one. The adopted-dir scope (#2747)
-    // encloses only the DAG: a child sub-run spawned from a node re-enters
+    // The adopted-dir scope (#2747) encloses only the DAG: a child sub-run spawned
+    // from a node re-enters
     // `executeWorkflow` and scopes its own (absent) adoption.
     const dagSummary = await runWithAdoptedRunDir(adoptedRunDir, () =>
       executeDagWorkflow({
@@ -3063,7 +3058,7 @@ export async function executeWorkflow(
         platform,
         conversationId,
         cwd,
-        workflow: { ...workflow, nodes: telemetryNodes },
+        workflow,
         workflowRun: runForDag,
         workflowProvider: resolvedProvider,
         workflowModel: resolvedModel,

--- a/packages/workflows/src/fixture-runner.test.ts
+++ b/packages/workflows/src/fixture-runner.test.ts
@@ -57,8 +57,12 @@ function workflowsOnDisk(cwd: string, names: string[], pack = 'pack'): WorkflowW
     if (!parsed.workflow) throw new Error(parsed.error.error);
     const raw = new Map([[parsed.workflow.name, parsed.workflow]]);
     const expanded = expandWorkflowIncludes(raw);
+    const workflow = expanded.workflows.get(name);
+    if (workflow === undefined) {
+      throw new Error(`workflow expansion failed: ${JSON.stringify(expanded.errors)}`);
+    }
     return {
-      workflow: expanded.workflows.get(name) ?? parsed.workflow,
+      workflow,
       source: 'project' as const,
     };
   });

--- a/packages/workflows/src/graph-plan.ts
+++ b/packages/workflows/src/graph-plan.ts
@@ -1,0 +1,74 @@
+import { isIncludeDirective } from './schemas/dag-node';
+import type { DagNode, IncludeDirective, LoopGroupNodeConfig } from './schemas/dag-node';
+import type { GraphPlan, ResolvedWorkflow, WorkflowDefinition } from './schemas/workflow';
+
+function requireResolvedNodes(nodes: readonly (DagNode | IncludeDirective)[]): DagNode[] {
+  const resolved: DagNode[] = [];
+  for (const node of nodes) {
+    if (isIncludeDirective(node)) {
+      throw new Error(
+        `Internal error: include node '${node.id}' reached a resolved graph unexpanded. ` +
+          'Include nodes must be resolved by expandWorkflowIncludes() during discovery.'
+      );
+    }
+    resolved.push(node);
+  }
+  return resolved;
+}
+
+function planResolvedNodes(nodes: readonly DagNode[]): GraphPlan {
+  const inDegree = new Map<string, number>();
+  const dependents = new Map<string, string[]>();
+
+  for (const node of nodes) {
+    inDegree.set(node.id, node.depends_on?.length ?? 0);
+    for (const dependency of node.depends_on ?? []) {
+      const existing = dependents.get(dependency) ?? [];
+      existing.push(node.id);
+      dependents.set(dependency, existing);
+    }
+  }
+
+  const layers: DagNode[][] = [];
+  let ready = [...nodes].filter(node => (inDegree.get(node.id) ?? 0) === 0);
+
+  while (ready.length > 0) {
+    layers.push(ready);
+    const nextIds: string[] = [];
+    for (const node of ready) {
+      for (const dependentId of dependents.get(node.id) ?? []) {
+        const nextDegree = (inDegree.get(dependentId) ?? 0) - 1;
+        inDegree.set(dependentId, nextDegree);
+        if (nextDegree === 0) nextIds.push(dependentId);
+      }
+    }
+    ready = nextIds
+      .map(id => nodes.find(node => node.id === id))
+      .filter((node): node is DagNode => node !== undefined);
+  }
+
+  const totalPlaced = layers.reduce((sum, layer) => sum + layer.length, 0);
+  if (totalPlaced < nodes.length) {
+    throw new Error('[GraphPlan] Cycle detected while planning workflow graph');
+  }
+
+  const dependencies = new Set(nodes.flatMap(node => node.depends_on ?? []));
+  const sinks = nodes.filter(node => !dependencies.has(node.id)).map(node => node.id);
+  return { layers, sinks };
+}
+
+/** Plan an already-authored node set, rejecting any include directive that survived expansion. */
+export function planGraph(nodes: readonly (DagNode | IncludeDirective)[]): GraphPlan {
+  return planResolvedNodes(requireResolvedNodes(nodes));
+}
+
+/** Construct the include-free workflow shape accepted by execution boundaries. */
+export function resolveWorkflow(definition: WorkflowDefinition): ResolvedWorkflow {
+  const nodes = requireResolvedNodes(definition.nodes);
+  return { ...definition, nodes, plan: planResolvedNodes(nodes) };
+}
+
+/** Narrow an expanded loop-group body at its shared execution boundary. */
+export function resolvedBodyNodes(group: LoopGroupNodeConfig): readonly DagNode[] {
+  return requireResolvedNodes(group.nodes);
+}

--- a/packages/workflows/src/graph-plan.ts
+++ b/packages/workflows/src/graph-plan.ts
@@ -16,7 +16,7 @@ function requireResolvedNodes(nodes: readonly (DagNode | IncludeDirective)[]): D
   return resolved;
 }
 
-function planResolvedNodes(nodes: DagNode[]): GraphPlan {
+function planResolvedNodes(nodes: readonly DagNode[]): GraphPlan {
   const inDegree = new Map<string, number>();
   const dependents = new Map<string, string[]>();
 

--- a/packages/workflows/src/graph-plan.ts
+++ b/packages/workflows/src/graph-plan.ts
@@ -16,7 +16,7 @@ function requireResolvedNodes(nodes: readonly (DagNode | IncludeDirective)[]): D
   return resolved;
 }
 
-function planResolvedNodes(nodes: readonly DagNode[]): GraphPlan {
+function planResolvedNodes(nodes: DagNode[]): GraphPlan {
   const inDegree = new Map<string, number>();
   const dependents = new Map<string, string[]>();
 
@@ -54,7 +54,7 @@ function planResolvedNodes(nodes: readonly DagNode[]): GraphPlan {
 
   const dependencies = new Set(nodes.flatMap(node => node.depends_on ?? []));
   const sinks = nodes.filter(node => !dependencies.has(node.id)).map(node => node.id);
-  return { layers, sinks };
+  return { nodes, layers, sinks };
 }
 
 /** Plan an already-authored node set, rejecting any include directive that survived expansion. */
@@ -64,8 +64,14 @@ export function planGraph(nodes: readonly (DagNode | IncludeDirective)[]): Graph
 
 /** Construct the include-free workflow shape accepted by execution boundaries. */
 export function resolveWorkflow(definition: WorkflowDefinition): ResolvedWorkflow {
-  const nodes = requireResolvedNodes(definition.nodes);
-  return { ...definition, nodes, plan: planResolvedNodes(nodes) };
+  const plan = planResolvedNodes(requireResolvedNodes(definition.nodes));
+  const resolved = { ...definition, nodes: plan.nodes, plan };
+  Object.defineProperties(resolved, {
+    nodes: { enumerable: true, get: () => plan.nodes },
+    plan: { enumerable: true, value: plan },
+  });
+  // This constructor is the sole attachment point for the private type identity.
+  return resolved as ResolvedWorkflow;
 }
 
 /** Narrow an expanded loop-group body at its shared execution boundary. */

--- a/packages/workflows/src/include-expander.test.ts
+++ b/packages/workflows/src/include-expander.test.ts
@@ -1,7 +1,8 @@
 import { describe, test, expect } from 'bun:test';
 import { expandWorkflowIncludes, INCLUDE_MAX_DEPTH } from './include-expander';
+import { resolvedBodyNodes } from './graph-plan';
 import { dagNodeSchema } from './schemas';
-import type { WorkflowDefinition, DagNode } from './schemas';
+import type { WorkflowDefinition, ResolvedWorkflow, DagNode } from './schemas';
 import { COMPOSE_FAN_OUT_STEP_MARKER } from './fan-out-identity';
 import {
   COMPILED_LOOP_COMMAND,
@@ -31,10 +32,8 @@ function mapOf(...workflows: WorkflowDefinition[]): Map<string, WorkflowDefiniti
   return new Map(workflows.map(w => [w.name, w]));
 }
 
-function nodeById(w: WorkflowDefinition, id: string): DagNode | undefined {
-  // Callers always pass an expandWorkflowIncludes() result, which never contains
-  // an IncludeDirective (#2486).
-  return (w.nodes as DagNode[]).find(n => n.id === id);
+function nodeById(w: ResolvedWorkflow, id: string): DagNode | undefined {
+  return w.nodes.find(node => node.id === id);
 }
 
 function composedMeta(node: DagNode | undefined): ComposedNodeMeta | undefined {
@@ -68,7 +67,7 @@ function loopGroupOf(
   node: DagNode | undefined
 ): { nodes: DagNode[]; until_bash?: string } | undefined {
   if (!node || !('loop_group' in node)) return undefined;
-  return { ...node.loop_group, nodes: node.loop_group.nodes as DagNode[] };
+  return { ...node.loop_group, nodes: [...resolvedBodyNodes(node.loop_group)] };
 }
 
 /** The body nodes of a `loop_group` node, or undefined for any other kind. */
@@ -120,6 +119,11 @@ describe('expandWorkflowIncludes — composed fan-out deferral (#2512)', () => {
 
     const expanded = workflows.get('parent')!;
     expect(expanded.nodes).toHaveLength(2);
+    expect(expanded.plan.layers.map(layer => layer.map(node => node.id))).toEqual([
+      ['list'],
+      ['fan'],
+    ]);
+    expect(expanded.plan.sinks).toEqual(['fan']);
     const deferred = expanded.nodes.find(n => n.id === 'fan');
     expect(deferred).toMatchObject({ kind: 'compose_fan_out', include: 'blk' });
   });

--- a/packages/workflows/src/include-expander.ts
+++ b/packages/workflows/src/include-expander.ts
@@ -898,14 +898,14 @@ function warnDroppedWorkflowLevelFields(
   child: ResolvedWorkflow,
   consumedFields?: ReadonlySet<string>
 ): void {
-  const childRecord = child as Record<string, unknown>;
-  const droppedFields = Object.keys(child)
+  const droppedFields = Object.entries(child)
     .filter(
-      key =>
+      ([key, value]) =>
         !NON_DROPPED_WORKFLOW_KEYS.has(key) &&
         consumedFields?.has(key) !== true &&
-        childRecord[key] !== undefined
+        value !== undefined
     )
+    .map(([key]) => key)
     .sort();
   if (droppedFields.length === 0) return;
 

--- a/packages/workflows/src/include-expander.ts
+++ b/packages/workflows/src/include-expander.ts
@@ -39,6 +39,7 @@ import type {
   IncludeDirective,
   WorkflowBase,
   WorkflowRequirement,
+  ResolvedWorkflow,
 } from './schemas';
 import {
   isIncludeDirective,
@@ -65,6 +66,7 @@ import { resolveDeclaredInputs } from './workflow-inputs';
 import { resolveWorkflowName } from './router';
 import { parseWhenAtom, whenAtoms } from './when-atom';
 import { mapNodeTemplateSlots, mapNodeTemplateValueSlots } from './template-walker';
+import { resolveWorkflow, resolvedBodyNodes } from './graph-plan';
 import {
   COMPILED_LOOP_COMMAND,
   COMPOSED_NODE,
@@ -689,7 +691,7 @@ function cloneNodeForInclude<T extends DagNode | IncludeDirective>(node: T): T {
  */
 function inlineInclude(
   includeNode: IncludeDirective,
-  child: WorkflowDefinition,
+  child: ResolvedWorkflow,
   commandContents: ReadonlyMap<string, IncludeCommandContent>
 ): ExpandedInclude {
   // Prove the child's lexical boundary before its nodes share the parent's flat id/output
@@ -701,20 +703,12 @@ function inlineInclude(
       `Node '${includeNode.id}': included workflow '${child.name}' is not hermetic: ${childStructureError}`
     );
   }
-  // `child` is the result of `expandOne`, which fully expands its own includes before
-  // returning (the function's own documented invariant: "Output workflows contain
-  // ZERO include nodes") — so `child.nodes` never actually holds an `IncludeDirective`
-  // here, even though `WorkflowDefinition.nodes`'s type admits one for the general
-  // pre-expansion case (#2486; splitting an authored-vs-resolved `WorkflowDefinition`
-  // type is #2487's job, not this one's).
-  const childNodes = child.nodes as DagNode[];
+  const childNodes = child.nodes;
   const prefix = `${includeNode.id}__`;
   const childTopLevelIds = new Set(childNodes.map(n => n.id));
   const rename = (id: string): string => (childTopLevelIds.has(id) ? prefix + id : id);
 
-  // Sinks: child top-level nodes that nothing else in the child depends on (definition order).
-  const childDeps = new Set(childNodes.flatMap(n => n.depends_on ?? []));
-  const sinkOriginalIds = childNodes.filter(n => !childDeps.has(n.id)).map(n => n.id);
+  const sinkOriginalIds = child.plan.sinks;
 
   const parentDeps = includeNode.depends_on ?? [];
   const entryTriggerRules = childNodes
@@ -840,7 +834,7 @@ function inlineInclude(
  */
 export function instantiateResolvedInclude(
   includeNode: IncludeDirective,
-  child: WorkflowDefinition,
+  child: ResolvedWorkflow,
   commandContents: ReadonlyMap<string, IncludeCommandContent> = new Map()
 ): ExpandedInclude {
   return inlineInclude(includeNode, child, commandContents);
@@ -850,6 +844,7 @@ export function instantiateResolvedInclude(
  * Workflow-level keys that are NOT dropped-config and must be excluded from the warning.
  *   - name/description: the block's identity, never inheritable config.
  *   - nodes: not dropped — they ARE what gets inlined.
+ *   - plan: engine-owned metadata consumed while inlining, never authored config.
  *   - tags: cosmetic UI keyword-inference metadata with no runtime effect, so dropping it
  *     is behaviorally inert; reporting it would be noise.
  */
@@ -857,6 +852,7 @@ const NON_DROPPED_WORKFLOW_KEYS: ReadonlySet<string> = new Set([
   'name',
   'description',
   'nodes',
+  'plan',
   'tags',
   // #2470: both are CONSUMED by inlining, not dropped — `returns` drives the block's
   // primarySink and `inputs` validates the caller's `with:`. Warning "dropped" would be
@@ -899,7 +895,7 @@ const COMPOSE_FAN_OUT_CONSUMED_WORKFLOW_KEYS: ReadonlySet<string> = new Set(['mu
  */
 function warnDroppedWorkflowLevelFields(
   includeNode: IncludeDirective,
-  child: WorkflowDefinition,
+  child: ResolvedWorkflow,
   consumedFields?: ReadonlySet<string>
 ): void {
   const childRecord = child as Record<string, unknown>;
@@ -1022,9 +1018,7 @@ function materializeBlockCommandPrompts(
   }
 
   if (isLoopGroupNode(node)) {
-    // A loop_group body is expanded (include-free) by the same recursive invariant
-    // as the top-level `childNodes` this function is ultimately called against.
-    const bodyNodes = node.loop_group.nodes as DagNode[];
+    const bodyNodes = resolvedBodyNodes(node.loop_group);
     const bodyIds = new Set(bodyNodes.map(body => body.id));
     const bodyEnclosingIds = new Set([...enclosingIds, ...currentIds]);
     return {
@@ -1070,10 +1064,10 @@ export function expandWorkflowIncludes(
   rawByName: Map<string, WorkflowDefinition>,
   commandContents?: ReadonlyMap<string, IncludeCommandContent>
 ): {
-  workflows: Map<string, WorkflowDefinition>;
+  workflows: Map<string, ResolvedWorkflow>;
   errors: WorkflowLoadError[];
 } {
-  const memo = new Map<string, WorkflowDefinition>();
+  const memo = new Map<string, ResolvedWorkflow>();
   const failed = new Set<string>();
   const errors: WorkflowLoadError[] = [];
 
@@ -1103,7 +1097,7 @@ export function expandWorkflowIncludes(
         // Width is runtime data, but the body remains ordinary static composition.
         // Expanding it here validates its complete include closure and carries its
         // requirements onto the parent before any upstream node can spend.
-        let child: WorkflowDefinition;
+        let child: ResolvedWorkflow;
         try {
           child = expandOne(node.include, [...stack, workflowName]);
         } catch (e) {
@@ -1150,7 +1144,7 @@ export function expandWorkflowIncludes(
       }
 
       if (isIncludeDirective(node)) {
-        let child: WorkflowDefinition;
+        let child: ResolvedWorkflow;
         try {
           child = expandOne(node.include, [...stack, workflowName]);
         } catch (e) {
@@ -1215,7 +1209,7 @@ export function expandWorkflowIncludes(
     return { nodes: expandedNodes, includedRequirements, renameIncludeRef };
   }
 
-  function expandOne(name: string, stack: string[]): WorkflowDefinition {
+  function expandOne(name: string, stack: string[]): ResolvedWorkflow {
     // Cycle + depth are checked BEFORE the memo so a node memoized via a shallow path
     // can never mask a too-deep or cyclic reference reaching it via a longer path.
     if (stack.includes(name)) {
@@ -1276,7 +1270,7 @@ export function expandWorkflowIncludes(
     }
 
     const dedupedRequires = [...new Set(requires)];
-    const result: WorkflowDefinition = {
+    const authoredResult: WorkflowDefinition = {
       ...collapsed,
       nodes: expanded.nodes,
       // `returns:` may name an include directive that no longer exists after flattening.
@@ -1288,10 +1282,11 @@ export function expandWorkflowIncludes(
         : {}),
       ...(dedupedRequires.length > 0 ? { requires: dedupedRequires } : {}),
     };
-    const outcomeDeclarationError = validateWorkflowOutcomeDeclaration(result);
+    const outcomeDeclarationError = validateWorkflowOutcomeDeclaration(authoredResult);
     if (outcomeDeclarationError !== null) {
       throw new IncludeExpansionError(outcomeDeclarationError);
     }
+    const result = resolveWorkflow(authoredResult);
     memo.set(name, result);
     return result;
   }
@@ -1310,7 +1305,7 @@ export function expandWorkflowIncludes(
     }
   }
 
-  const workflows = new Map<string, WorkflowDefinition>();
+  const workflows = new Map<string, ResolvedWorkflow>();
   for (const name of rawByName.keys()) {
     if (failed.has(name)) continue;
     const expanded = memo.get(name);

--- a/packages/workflows/src/include-expander.ts
+++ b/packages/workflows/src/include-expander.ts
@@ -106,6 +106,10 @@ export interface ComposedSuspensionPath {
   reason: string;
 }
 
+type SuspensionWorkflow = Pick<WorkflowDefinition, 'name' | 'interactive'> & {
+  readonly nodes: readonly (DagNode | IncludeDirective)[];
+};
+
 /**
  * Find every path in a static include/workflow closure that can pause an instance.
  * Composed fan-out currently owns one parent cursor, not one cursor per item, so both
@@ -113,14 +117,14 @@ export interface ComposedSuspensionPath {
  * Durable interactive instances are tracked separately in #2810.
  */
 export function collectComposedSuspensionPaths(
-  root: WorkflowDefinition,
-  definitions: readonly WorkflowDefinition[]
+  root: SuspensionWorkflow,
+  definitions: readonly SuspensionWorkflow[]
 ): ComposedSuspensionPath[] {
   const byName = new Map(definitions.map(definition => [definition.name, definition]));
   const visited = new Set<string>();
   const found: ComposedSuspensionPath[] = [];
 
-  const visitDefinition = (definition: WorkflowDefinition): void => {
+  const visitDefinition = (definition: SuspensionWorkflow): void => {
     if (visited.has(definition.name)) return;
     visited.add(definition.name);
     if (definition.interactive === true) {
@@ -130,7 +134,7 @@ export function collectComposedSuspensionPaths(
   };
 
   const visitTarget = (name: string, ownerId: string, kind: 'include' | 'workflow'): void => {
-    let target: WorkflowDefinition | undefined;
+    let target: SuspensionWorkflow | undefined;
     try {
       target = kind === 'workflow' ? resolveWorkflowName(name, definitions) : byName.get(name);
     } catch (_err) {
@@ -630,7 +634,7 @@ export interface ExpandedInclude {
  */
 function resolveIncludeInputs(
   includeNode: IncludeDirective,
-  child: WorkflowDefinition
+  child: Pick<WorkflowDefinition, 'name' | 'inputs'>
 ): Record<string, JsonValue> {
   try {
     return resolveDeclaredInputs(
@@ -947,7 +951,7 @@ function warnDroppedWorkflowLevelFields(
 function materializeBlockCommandPrompts(
   node: DagNode,
   includeNode: IncludeDirective,
-  child: WorkflowDefinition,
+  child: Pick<WorkflowDefinition, 'name'>,
   commandContents: ReadonlyMap<string, IncludeCommandContent>,
   currentIds: ReadonlySet<string>,
   enclosingIds: ReadonlySet<string>,

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -976,7 +976,7 @@ nodes:
       const yaml = `name: bare\ndescription: no fallbacks\nnodes:\n  - id: only\n    prompt: p\n`;
       await writeFile(join(workflowDir, 'bare.yaml'), yaml);
       const result = await discoverWorkflows(testDir, { loadDefaults: false });
-      const wf = result.workflows[0].workflow as Record<string, unknown>;
+      const wf = result.workflows[0].workflow;
       expect(wf.effort).toBeUndefined();
       expect(wf.thinking).toBeUndefined();
       expect(wf.fallbackModel).toBeUndefined();
@@ -1007,7 +1007,7 @@ nodes:
       const result = await discoverWorkflows(testDir, { loadDefaults: false });
       expect(result.errors).toEqual([]);
       expect(result.workflows).toHaveLength(1);
-      const wf = result.workflows[0].workflow as Record<string, unknown>;
+      const wf = result.workflows[0].workflow;
       expect(wf.effort).toBeUndefined();
       expect(wf.thinking).toBeUndefined();
       expect(wf.fallbackModel).toBeUndefined();

--- a/packages/workflows/src/loader.ts
+++ b/packages/workflows/src/loader.ts
@@ -175,7 +175,9 @@ function nodeIdForMessages(raw: unknown, index: number): string {
  * on the final flat workflow, where every selected node is executable.
  */
 export function validateWorkflowOutcomeDeclaration(
-  workflow: Pick<WorkflowDefinition, 'returns' | 'outcome_field' | 'nodes'>
+  workflow: Pick<WorkflowDefinition, 'returns' | 'outcome_field'> & {
+    readonly nodes: readonly (DagNode | IncludeDirective)[];
+  }
 ): string | null {
   const field = workflow.outcome_field;
   if (field === undefined) return null;
@@ -781,7 +783,7 @@ const GATE_ON_A_SHELL_NODE =
  * the free-form-AI check needs that producer's type and `output_format`.
  */
 export function validateDagStructure(
-  nodes: (DagNode | IncludeDirective)[],
+  nodes: readonly (DagNode | IncludeDirective)[],
   enclosingNodes?: ReadonlyMap<string, DagNode | IncludeDirective>
 ): string | null {
   // Check ID uniqueness

--- a/packages/workflows/src/router.ts
+++ b/packages/workflows/src/router.ts
@@ -203,7 +203,7 @@ export function parseWorkflowInvocation(
 /**
  * Find a workflow by name
  */
-export function findWorkflow<T extends WorkflowDefinition>(
+export function findWorkflow<T extends Pick<WorkflowDefinition, 'name'>>(
   name: string,
   workflows: readonly T[]
 ): T | undefined {
@@ -220,7 +220,7 @@ export function findWorkflow<T extends WorkflowDefinition>(
  * Returns the matched workflow, or undefined if no match found.
  * Throws an Error if multiple workflows match at the same tier (ambiguous).
  */
-export function resolveWorkflowName<T extends WorkflowDefinition>(
+export function resolveWorkflowName<T extends Pick<WorkflowDefinition, 'name'>>(
   name: string,
   workflows: readonly T[]
 ): T | undefined {

--- a/packages/workflows/src/router.ts
+++ b/packages/workflows/src/router.ts
@@ -203,10 +203,10 @@ export function parseWorkflowInvocation(
 /**
  * Find a workflow by name
  */
-export function findWorkflow(
+export function findWorkflow<T extends WorkflowDefinition>(
   name: string,
-  workflows: readonly WorkflowDefinition[]
-): WorkflowDefinition | undefined {
+  workflows: readonly T[]
+): T | undefined {
   return workflows.find(w => w.name === name);
 }
 
@@ -220,10 +220,10 @@ export function findWorkflow(
  * Returns the matched workflow, or undefined if no match found.
  * Throws an Error if multiple workflows match at the same tier (ambiguous).
  */
-export function resolveWorkflowName(
+export function resolveWorkflowName<T extends WorkflowDefinition>(
   name: string,
-  workflows: readonly WorkflowDefinition[]
-): WorkflowDefinition | undefined {
+  workflows: readonly T[]
+): T | undefined {
   // Tier 1: Exact match
   const exact = workflows.find(w => w.name === name);
   if (exact) return exact;
@@ -231,10 +231,7 @@ export function resolveWorkflowName(
   const lowerName = name.toLowerCase();
 
   // Returns the single match, throws on ambiguity, returns undefined for no match
-  function checkTier(
-    matches: WorkflowDefinition[],
-    logEvent: string
-  ): WorkflowDefinition | undefined {
+  function checkTier(matches: T[], logEvent: string): T | undefined {
     if (matches.length === 1) {
       getLog().info({ requested: name, matched: matches[0].name }, logEvent);
       return matches[0];

--- a/packages/workflows/src/schemas/index.ts
+++ b/packages/workflows/src/schemas/index.ts
@@ -258,6 +258,8 @@ export type {
   WorkflowExecutionResult,
   WorkflowLoadError,
   WorkflowLoadResult,
+  GraphPlan,
+  ResolvedWorkflow,
   WorkflowSource,
   WorkflowWithSource,
   DeclaredWorkflowConfig,

--- a/packages/workflows/src/schemas/workflow.ts
+++ b/packages/workflows/src/schemas/workflow.ts
@@ -292,15 +292,22 @@ export type WorkflowDefinition = z.infer<typeof workflowDefinitionSchema> & { pr
 
 /** Static execution plan attached after include expansion and graph validation. */
 export interface GraphPlan {
+  readonly nodes: DagNode[];
   readonly layers: readonly (readonly DagNode[])[];
   readonly sinks: readonly string[];
 }
 
+/** Nominal identity retained only by values produced through `resolveWorkflow`. */
+declare class ResolvedWorkflowIdentity {
+  private readonly identity: never;
+}
+
 /** Include-free workflow accepted by execution and simulation boundaries. */
-export type ResolvedWorkflow = Omit<WorkflowDefinition, 'nodes'> & {
-  nodes: DagNode[];
-  plan: GraphPlan;
-};
+export type ResolvedWorkflow = Omit<WorkflowDefinition, 'nodes'> &
+  ResolvedWorkflowIdentity & {
+    readonly nodes: DagNode[];
+    readonly plan: GraphPlan;
+  };
 
 // ---------------------------------------------------------------------------
 // Known workflow keys — used by the loader to detect unknown/misplaced keys

--- a/packages/workflows/src/schemas/workflow.ts
+++ b/packages/workflows/src/schemas/workflow.ts
@@ -292,7 +292,7 @@ export type WorkflowDefinition = z.infer<typeof workflowDefinitionSchema> & { pr
 
 /** Static execution plan attached after include expansion and graph validation. */
 export interface GraphPlan {
-  readonly nodes: DagNode[];
+  readonly nodes: readonly DagNode[];
   readonly layers: readonly (readonly DagNode[])[];
   readonly sinks: readonly string[];
 }
@@ -305,7 +305,7 @@ declare class ResolvedWorkflowIdentity {
 /** Include-free workflow accepted by execution and simulation boundaries. */
 export type ResolvedWorkflow = Omit<WorkflowDefinition, 'nodes'> &
   ResolvedWorkflowIdentity & {
-    readonly nodes: DagNode[];
+    readonly nodes: readonly DagNode[];
     readonly plan: GraphPlan;
   };
 

--- a/packages/workflows/src/schemas/workflow.ts
+++ b/packages/workflows/src/schemas/workflow.ts
@@ -11,7 +11,7 @@ import {
   betasSchema,
   KNOWN_DAG_NODE_KEYS,
 } from './dag-node';
-import type { NestedKeySpec } from './dag-node';
+import type { DagNode, NestedKeySpec } from './dag-node';
 import { jsonValueSchema } from '../output-ref';
 
 // ---------------------------------------------------------------------------
@@ -287,14 +287,20 @@ export const workflowDefinitionSchema = workflowBaseSchema.extend({
   nodes: z.array(dagNodeSchema),
 });
 
-/**
- * Workflow definition with fully typed nodes derived from the schema. `nodes`'
- * element type is `DagNode | IncludeDirective` (not `DagNode[]` alone) because
- * `dagNodeSchema` still parses `include:` entries at this pre-expansion stage
- * (#2486) — `expandWorkflowIncludes` consumes every `IncludeDirective` before
- * the executor ever sees a `WorkflowDefinition`.
- */
+/** Authored workflow definition parsed from YAML, before include expansion. */
 export type WorkflowDefinition = z.infer<typeof workflowDefinitionSchema> & { prompt?: never };
+
+/** Static execution plan attached after include expansion and graph validation. */
+export interface GraphPlan {
+  readonly layers: readonly (readonly DagNode[])[];
+  readonly sinks: readonly string[];
+}
+
+/** Include-free workflow accepted by execution and simulation boundaries. */
+export type ResolvedWorkflow = Omit<WorkflowDefinition, 'nodes'> & {
+  nodes: DagNode[];
+  plan: GraphPlan;
+};
 
 // ---------------------------------------------------------------------------
 // Known workflow keys — used by the loader to detect unknown/misplaced keys
@@ -420,7 +426,7 @@ export interface DeclaredWorkflowConfig {
 
 /** A workflow definition paired with its discovery source. */
 export interface WorkflowWithSource {
-  readonly workflow: WorkflowDefinition;
+  readonly workflow: ResolvedWorkflow;
   readonly source: WorkflowSource;
   /** Warnings from YAML parsing (e.g. unknown keys) — never hard-fails. */
   readonly parseWarnings?: readonly string[];

--- a/packages/workflows/src/script-node-deps.test.ts
+++ b/packages/workflows/src/script-node-deps.test.ts
@@ -46,7 +46,8 @@ mock.module('@archon/paths', () => ({
 
 // --- Imports (after all mock.module calls) ---
 import { executeDagWorkflow, type ExecuteDagWorkflowOptions } from './dag-executor';
-import type { ExecNode, WorkflowRun } from './schemas';
+import { resolveWorkflow } from './graph-plan';
+import type { ExecNode, WorkflowDefinition, WorkflowRun } from './schemas';
 import type { WorkflowDeps, IWorkflowPlatform, WorkflowConfig } from './deps';
 import type { IWorkflowStore } from './store';
 
@@ -224,8 +225,14 @@ const minimalConfig: WorkflowConfig = {
  * `deps`, `cwd`, `workflow`, and `workflowRun` carry each test's own fixtures, so every call
  * supplies them; the run directories derive from `cwd` the way every call site built them.
  */
-type DagOptionsOverrides = Partial<ExecuteDagWorkflowOptions> &
-  Pick<ExecuteDagWorkflowOptions, 'deps' | 'cwd' | 'workflow' | 'workflowRun'>;
+type TestWorkflowDefinition = Omit<WorkflowDefinition, 'description'> & {
+  description?: string;
+};
+
+type DagOptionsOverrides = Omit<Partial<ExecuteDagWorkflowOptions>, 'workflow'> &
+  Pick<ExecuteDagWorkflowOptions, 'deps' | 'cwd' | 'workflowRun'> & {
+    workflow: TestWorkflowDefinition;
+  };
 
 /**
  * Options for a direct `executeDagWorkflow` call, built from only what a test varies. The
@@ -234,7 +241,7 @@ type DagOptionsOverrides = Partial<ExecuteDagWorkflowOptions> &
  * own mocks, and the two do not have to agree.
  */
 function dagOptions(overrides: DagOptionsOverrides): ExecuteDagWorkflowOptions {
-  const { cwd } = overrides;
+  const { cwd, workflow, ...rest } = overrides;
   return {
     platform: createMockPlatform(),
     conversationId: 'conv-deps',
@@ -246,7 +253,12 @@ function dagOptions(overrides: DagOptionsOverrides): ExecuteDagWorkflowOptions {
     baseBranch: 'main',
     docsDir: 'docs/',
     config: minimalConfig,
-    ...overrides,
+    ...rest,
+    cwd,
+    workflow: resolveWorkflow({
+      ...workflow,
+      description: workflow.description ?? workflow.name,
+    }),
   };
 }
 

--- a/packages/workflows/src/subrun.test.ts
+++ b/packages/workflows/src/subrun.test.ts
@@ -117,7 +117,7 @@ import { validateWorkflowResources } from './validator';
 import type { WorkflowDeps, IWorkflowPlatform, WorkflowConfig } from './deps';
 import type { IWorkflowStore } from './store';
 import type { WorkflowRun } from './schemas/workflow-run';
-import type { WorkflowDefinition } from './schemas/workflow';
+import type { ResolvedWorkflow } from './schemas/workflow';
 import type { WorkflowRunConfigMetadata } from './schemas/run-config';
 import type {
   ChildIsolationResolver,
@@ -587,7 +587,7 @@ describe('workflow: sub-run e2e (#2121 Phase 2)', () => {
     await writeFile(join(cwd, '.archon', 'workflows', `${name}.yaml`), yaml);
   }
 
-  async function discover(name: string): Promise<WorkflowDefinition> {
+  async function discover(name: string): Promise<ResolvedWorkflow> {
     const result = await discoverWorkflows(cwd, { loadDefaults: false });
     const wf = result.workflows.find(w => w.workflow.name === name);
     if (!wf) throw new Error(`workflow ${name} not found: ${JSON.stringify(result.errors)}`);
@@ -4192,7 +4192,7 @@ describe('workflow: late resolution is a deliberate affordance', () => {
     await writeFile(join(cwd, '.archon', 'workflows', `${name}.yaml`), yaml);
   }
 
-  async function discover(name: string): Promise<WorkflowDefinition> {
+  async function discover(name: string): Promise<ResolvedWorkflow> {
     const result = await discoverWorkflows(cwd, { loadDefaults: false });
     const wf = result.workflows.find(w => w.workflow.name === name);
     if (!wf) throw new Error(`workflow ${name} not found: ${JSON.stringify(result.errors)}`);
@@ -4704,7 +4704,7 @@ describe('workflow: declared input contract at runtime (#2470)', () => {
     await writeFile(join(cwd, '.archon', 'workflows', `${name}.yaml`), yaml);
   }
 
-  async function discover(name: string): Promise<WorkflowDefinition> {
+  async function discover(name: string): Promise<ResolvedWorkflow> {
     const result = await discoverWorkflows(cwd, { loadDefaults: false });
     const wf = result.workflows.find(w => w.workflow.name === name);
     if (!wf) throw new Error(`workflow ${name} not found: ${JSON.stringify(result.errors)}`);
@@ -4953,7 +4953,7 @@ describe('workflow: runtime $INPUTS delivery and cold resume (#2470)', () => {
     await writeFile(join(cwd, '.archon', 'workflows', `${name}.yaml`), yaml);
   }
 
-  async function discover(name: string): Promise<WorkflowDefinition> {
+  async function discover(name: string): Promise<ResolvedWorkflow> {
     const result = await discoverWorkflows(cwd, { loadDefaults: false });
     const wf = result.workflows.find(w => w.workflow.name === name);
     if (!wf) throw new Error(`workflow ${name} not found: ${JSON.stringify(result.errors)}`);
@@ -5432,7 +5432,7 @@ describe('workflow: returns rebinds the child terminal output (#2470)', () => {
     await writeFile(join(cwd, '.archon', 'workflows', `${name}.yaml`), yaml);
   }
 
-  async function discover(name: string): Promise<WorkflowDefinition> {
+  async function discover(name: string): Promise<ResolvedWorkflow> {
     const result = await discoverWorkflows(cwd, { loadDefaults: false });
     const wf = result.workflows.find(w => w.workflow.name === name);
     if (!wf) throw new Error(`workflow ${name} not found: ${JSON.stringify(result.errors)}`);
@@ -5586,7 +5586,7 @@ describe('workflow: typed value transport (#2637)', () => {
     await writeFile(join(cwd, '.archon', 'workflows', `${name}.yaml`), yaml);
   }
 
-  async function discover(name: string): Promise<WorkflowDefinition> {
+  async function discover(name: string): Promise<ResolvedWorkflow> {
     const result = await discoverWorkflows(cwd, { loadDefaults: false });
     const wf = result.workflows.find(w => w.workflow.name === name);
     if (!wf) throw new Error(`workflow ${name} not found: ${JSON.stringify(result.errors)}`);
@@ -6219,7 +6219,7 @@ describe('sub-run staged capture is reclaimed when the recursive rename fails (#
     await writeFile(join(cwd, '.archon', 'workflows', `${name}.yaml`), yaml);
   }
 
-  async function discover(name: string): Promise<WorkflowDefinition> {
+  async function discover(name: string): Promise<ResolvedWorkflow> {
     const result = await discoverWorkflows(cwd, { loadDefaults: false });
     const wf = result.workflows.find(w => w.workflow.name === name);
     if (!wf) throw new Error(`workflow ${name} not found: ${JSON.stringify(result.errors)}`);
@@ -6310,7 +6310,7 @@ describe("a child's terminal status write fails during setup (#2910)", () => {
     await writeFile(join(cwd, '.archon', 'workflows', `${name}.yaml`), yaml);
   }
 
-  async function discover(name: string): Promise<WorkflowDefinition> {
+  async function discover(name: string): Promise<ResolvedWorkflow> {
     const result = await discoverWorkflows(cwd, { loadDefaults: false });
     const wf = result.workflows.find(w => w.workflow.name === name);
     if (!wf) throw new Error(`workflow ${name} not found: ${JSON.stringify(result.errors)}`);
@@ -6329,7 +6329,7 @@ describe("a child's terminal status write fails during setup (#2910)", () => {
     else process.env.ARCHON_HOME = originalArchonHome;
   });
 
-  async function writeSubRunPair(): Promise<WorkflowDefinition> {
+  async function writeSubRunPair(): Promise<ResolvedWorkflow> {
     await writeWorkflow(
       'child-setup-write',
       `

--- a/packages/workflows/src/test-utils.ts
+++ b/packages/workflows/src/test-utils.ts
@@ -5,11 +5,13 @@
 import { workflowDefinitionSchema } from './schemas/workflow';
 import type {
   DeclaredWorkflowConfig,
+  ResolvedWorkflow,
   WorkflowDefinition,
   WorkflowWithSource,
   WorkflowSource,
 } from './schemas/workflow';
 import { expandWorkflowIncludes } from './include-expander';
+import { resolveWorkflow } from './graph-plan';
 import type { CapturedSourceOwner } from './executor';
 
 const DEFAULT_NODE = { id: 'default', command: 'test-command' };
@@ -31,6 +33,10 @@ export function makeTestWorkflowList(names: string[]): WorkflowDefinition[] {
   return names.map(name => makeTestWorkflow({ name }));
 }
 
+export function makeTestResolvedWorkflow(overrides: TestWorkflowOverrides): ResolvedWorkflow {
+  return resolveWorkflow(makeTestWorkflow(overrides));
+}
+
 /**
  * Wrap a WorkflowDefinition as a WorkflowWithSource entry for test mocks.
  *
@@ -46,14 +52,18 @@ export function makeTestWorkflowWithSource(
   parseWarnings?: readonly string[]
 ): WorkflowWithSource {
   const raw = makeTestWorkflow(overrides);
-  const { workflows } = expandWorkflowIncludes(new Map([[raw.name, raw]]));
+  const { workflows, errors } = expandWorkflowIncludes(new Map([[raw.name, raw]]));
+  const workflow = workflows.get(raw.name);
+  if (workflow === undefined) {
+    throw new Error(`makeTestWorkflowWithSource: expansion failed: ${JSON.stringify(errors)}`);
+  }
   const declared: DeclaredWorkflowConfig = {
     ...(raw.provider !== undefined ? { provider: raw.provider } : {}),
     ...(raw.model !== undefined ? { model: raw.model } : {}),
     ...(raw.effort !== undefined ? { effort: raw.effort } : {}),
   };
   return {
-    workflow: workflows.get(raw.name) ?? raw,
+    workflow,
     source,
     ...(parseWarnings ? { parseWarnings } : {}),
     ...(Object.keys(declared).length > 0 ? { declared } : {}),
@@ -71,7 +81,7 @@ export function makeTestWorkflowWithSource(
 export function makeTestComposedWorkflow(
   defs: readonly WorkflowDefinition[],
   name: string
-): WorkflowDefinition {
+): ResolvedWorkflow {
   const { workflows, errors } = expandWorkflowIncludes(new Map(defs.map(d => [d.name, d])));
   if (errors.length > 0) {
     throw new Error(`makeTestComposedWorkflow: expansion failed: ${JSON.stringify(errors)}`);

--- a/packages/workflows/src/utils/workflow-requirements.ts
+++ b/packages/workflows/src/utils/workflow-requirements.ts
@@ -14,6 +14,7 @@ import type { DagNode } from '../schemas/dag-node';
 import { isGateNode, isLoopGroupNode } from '../schemas/dag-node';
 import { readComposedMeta } from '../compiled-command';
 import { resolveDeclaredInputs, WorkflowInputContractError } from '../workflow-inputs';
+import { resolvedBodyNodes } from '../graph-plan';
 
 /** Minimal shape needed to evaluate requirements — avoids a full WorkflowDefinition dep. */
 export interface RequirementBearingWorkflow {
@@ -81,9 +82,7 @@ export function findComposedApprovalGate(nodes: readonly DagNode[]): ComposedApp
     const origin = readComposedMeta(node)?.origin;
     if (origin !== undefined && isGateNode(node)) return { nodeId: node.id, origin };
     if (isLoopGroupNode(node)) {
-      // Invoked at run dispatch, against an already-expanded workflow (#2486) — the
-      // body never actually holds an `IncludeDirective` here.
-      const nested = findComposedApprovalGate(node.loop_group.nodes as DagNode[]);
+      const nested = findComposedApprovalGate(resolvedBodyNodes(node.loop_group));
       if (nested !== null) return nested;
     }
   }

--- a/packages/workflows/src/validator.ts
+++ b/packages/workflows/src/validator.ts
@@ -381,7 +381,9 @@ function getBundledWorkflowDefs(): WorkflowDefinition[] {
  * Call this AFTER parseWorkflow() has passed (Levels 1-2 are prerequisites).
  */
 export async function validateWorkflowResources(
-  workflow: WorkflowDefinition,
+  workflow: Omit<WorkflowDefinition, 'nodes'> & {
+    readonly nodes: readonly (DagNode | IncludeDirective)[];
+  },
   cwd: string,
   config?: ValidationConfig,
   defaultProvider?: string

--- a/packages/workflows/src/workflow-discovery.ts
+++ b/packages/workflows/src/workflow-discovery.ts
@@ -562,7 +562,9 @@ async function resolveIncludeBlockCommandContents(
  */
 export async function resolveWorkflowCommandContents(
   roots: WorkflowSourceRoots,
-  workflows: readonly WorkflowDefinition[]
+  workflows: readonly {
+    readonly nodes: readonly (DagNode | IncludeDirective)[];
+  }[]
 ): Promise<Map<string, IncludeCommandContent>> {
   const contents = new Map<string, IncludeCommandContent>();
   for (const workflow of workflows) {

--- a/scripts/check-test-cleanup-drift.ts
+++ b/scripts/check-test-cleanup-drift.ts
@@ -374,7 +374,7 @@ export const LEGACY_RECURSIVE_CLEANUP: ReadonlyMap<string, number> = buildLedger
   ['packages/server/src/routes/api.workflow-runs.test.ts', 2],
   ['packages/server/src/routes/api.workflows.test.ts', 29],
   ['packages/workflows/src/artifacts-index.test.ts', 1],
-  ['packages/workflows/src/dag-executor.test.ts', 57],
+  ['packages/workflows/src/dag-executor.test.ts', 56],
   ['packages/workflows/src/defaults/generate-bundled-defaults.test.ts', 6],
   ['packages/workflows/src/dry-run.test.ts', 1],
   ['packages/workflows/src/executor-preamble.test.ts', 1],


### PR DESCRIPTION
## Problem and outcome

Authored workflow definitions and include-expanded execution graphs shared one type, so execution, simulation, and orchestration each had to reassert that no `include:` directive remained and recompute graph layers at runtime.

- **Outcome:** Discovery now produces `ResolvedWorkflow`, carrying include-free `DagNode[]` nodes plus a `GraphPlan` of execution layers and sinks; execution and dry run consume that plan.
- **Invariant:** An execution boundary can only accept a resolved, planned workflow; a surviving include directive fails at the shared resolution boundary with its node id.
- **Scope boundary:** Runtime-shaped loop and composed fan-out bodies still receive a fresh plan after their deterministic substitutions or instance prefixes are applied.

## Review guidance

- **Feedback requested:** Validate the authored-to-resolved workflow boundary and the plan ownership across include expansion, execution, and dry run.
- **Start here:** `packages/workflows/src/graph-plan.ts:60` — creates graph plans and constructs the only resolved workflow shape accepted by execution.
- **Review order:** `graph-plan.ts`, `include-expander.ts`, then `dag-executor.ts` and `dry-run.ts`; test updates follow the changed contracts.
- **Lower-attention areas:** Core and CLI changes propagate the resolved type; test fixture changes construct resolved workflows through the shared helper.
- **Known risk or uncertainty:** None.

## Solution

`WorkflowDefinition` remains the authored YAML shape. `ResolvedWorkflow` derives from it with `DagNode[]` and an attached `GraphPlan`. Include expansion validates and resolves each flattened workflow once, reusing the plan's sinks for include wiring.

The DAG executor reads the top-level plan rather than rebuilding layers or terminal sinks. Dry run follows the same plan. Loop-group and composed fan-out instances retain runtime planning because their node bodies are shaped at runtime; their include-free node boundary is checked through the shared helper.

## Behavior change

| | Before | After |
|---|---|---|
| **Workflow representation** | Authored and expanded workflows shared `WorkflowDefinition`; consumers narrowed nodes with casts. | Expanded workflows are `ResolvedWorkflow`, whose nodes and graph plan carry the execution invariant. |
| **Graph scheduling** | Top-level execution and dry run recomputed layers and sinks. | They use the plan attached during resolution. |
| **Invalid include state** | The executor had a runtime guard for an unexpanded include. | Resolution rejects a surviving include before an execution boundary can receive the workflow. |

## Architecture

```mermaid
flowchart LR
  A[Authored WorkflowDefinition] --> B[Include expansion]
  B --> C[resolveWorkflow]
  C --> D[ResolvedWorkflow: nodes + GraphPlan]
  D --> E[Executor]
  D --> F[Dry run]
```

### Changed seams

| Boundary or contract | Change | Evidence |
|---|---|---|
| Include expansion → execution | Expansion returns `ResolvedWorkflow` and attaches the plan after flattened-graph validation. | `packages/workflows/src/include-expander.ts:1063`, `packages/workflows/src/include-expander.ts:1289` |
| Resolution → executor | Executor accepts `ResolvedWorkflow` and reads `workflow.plan.layers` and `workflow.plan.sinks`. | `packages/workflows/src/dag-executor.ts:11604`, `packages/workflows/src/dag-executor.ts:12247` |
| Resolution → dry run | Dry run accepts the resolved shape and simulates its attached plan. | `packages/workflows/src/dry-run.ts:1208`, `packages/workflows/src/dry-run.ts:1280` |

## Validation

- `bun install --frozen-lockfile` — passed; lockfile unchanged.
- Focused workflow and core tests for DAG execution, include expansion, dry run, executor preamble/execution, sub-runs, and orchestration — passed.
- `bun run validate` — passed, including generated-artifact checks, API type generation, package type checks, lint, formatting, installer tests, package tests, and script tests.
- `git diff --check b27f988d41451c53ec64205b345c3a266acd1277..HEAD` — passed.
- `rg -n "as DagNode\\[\\]" packages --glob '!**/*.test.ts'` — no production matches.
- `rg -n "buildTopologicalLayers" packages` — no matches.

## Links

- Closes #2487


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workflow graph planning with execution layers, terminal-node tracking, cycle detection, and include validation.
  * Added resolved workflow support and public exports for graph planning utilities.
* **Bug Fixes**
  * Workflows with unresolved includes now fail clearly instead of falling back to incomplete definitions.
  * Improved handling of loop-group nodes during execution and dry runs.
* **Tests**
  * Expanded coverage for graph planning, cycle detection, execution ordering, and resolved workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->