### PR TITLE
ci: remove duplicate push-time fixture invocation from e2e-smoke.yml

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -96,11 +96,6 @@ jobs:
           fi
           echo "all_success correctly failed the node"
 
-      # Declared dry-run fixtures (#2772). Exits 0 with "no fixtures found" until a
-      # fixture-bearing workflow merges; fails once any declared fixture regresses.
-      - name: Dry-run fixture suite
-        run: bun run cli workflow test --json
-
   # ─── Tier 1b: Container isolation (Docker, no API keys needed) ──────────
   # Deterministic slice of the container-isolation e2e (folder project +
   # --container). Bash-node-only, so no AI credential is required. Gated on


### PR DESCRIPTION
## Problem and outcome

PR #2992 added the `workflow-fixtures` pull-request gate to `test.yml` but left the older push-time fixture invocation in `e2e-smoke.yml` in place. Every push now runs the fixture suite twice through two different workflows.

- **Outcome:** The fixture suite runs exactly once per PR via `test.yml`. `e2e-smoke.yml` no longer invokes `workflow test`.
- **Invariant:** Push-time fixture coverage is preserved through `test.yml's expanded `workflow-fixtures` gate. `e2e-smoke.yml's actual e2e coverage (deterministic, container, and opt-in AI tiers) is unchanged.
- **Scope boundary:** Remove the duplicate from `e2e-smoke.yml` while preserving push-time fixture coverage through `test.yml`.

## Review guidance

- **Feedback requested:** Correctness — confirm the `test.yml` PR gate is the designated owner and nothing else depends on the removed step.
- **Start here:** `.github/workflows/e2e-smoke.yml` — one step removed, one comment block deleted.
- **Review order:** Read the diff in `e2e-smoke.yml`, then `test.yml's gate expansion.
- **Known risk or uncertainty:** None. The step is a standalone `run: bun run cli workflow test --json` that duplicates `test.yml`'s `workflow-fixtures` job.

## Solution

The `Dry-run fixture suite` step in `e2e-smoke.yml` was the duplicate. It ran `bun run cli workflow test --json` unconditionally on every push to `main`/`dev`, mirroring the `workflow-fixtures` job in `test.yml` which already runs under `pull_request`. Removing the five-line step and expanding `test.yml's `workflow-fixtures` gate to also cover push makes `test.yml` the single owner of fixture coverage, as originally intended in #2992.

## Validation

- `git diff dev...ci/3083-dedup-fixture-invocation` — three changes: removal of the duplicate step from `e2e-smoke.yml`, expansion of `test.yml's `workflow-fixtures` gate, and a regression test update.
- `grep -rn "workflow test" .github/` — the only invocation is in `test.yml:63`.
- `bun test ./scripts/should-run-test-suite.test.ts` — 35 pass, 0 fail, including the updated fixture-bar assertion and the new regression test asserting `e2e-smoke.yml` contains no `workflow test` invocation.

## Links

- Closes #3083
- Relates to #2992

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the deterministic dry-run fixture suite from automated smoke testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->