### PR TITLE
Record watchdog reset diagnostics

### DIFF
--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -61,7 +61,7 @@ import {
   getProviderCapabilities,
 } from '@archon/providers';
 import type { SendQueryOptions } from '@archon/providers';
-import { mergeTokenUsage, type TokenUsage } from '@archon/providers/types';
+import { mergeTokenUsage, type MessageChunk, type TokenUsage } from '@archon/providers/types';
 clearRegistry();
 registerBuiltinProviders();
 // Pi is a community provider (best-effort structured output) — register it so the
@@ -12444,6 +12444,145 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     );
     expect(nodeCompletedEvents.length).toBe(0);
     expect(store.failWorkflowRun).toHaveBeenCalled();
+    const transcript = await readTranscript(join(testDir, 'logs'), workflowRun.id);
+    expect(transcript.filter(event => event.type === 'watchdog_reset')).toHaveLength(0);
+    expect(failedData.error).toContain('No provider chunk reset the watchdog');
+  });
+
+  it('a thinking-only stream renews the watchdog and persists a type-only timeout diagnostic', async () => {
+    const privateThinking = 'reasoning that must not be logged';
+    let yielded = 0;
+    mockSendQueryDag.mockImplementation(async function* (
+      _prompt: string,
+      _cwd: string,
+      _resumeSessionId?: string,
+      options?: { abortSignal?: AbortSignal }
+    ) {
+      for (let i = 0; i < 3; i++) {
+        await new Promise(resolve => setTimeout(resolve, 30));
+        if (options?.abortSignal?.aborted) return;
+        yielded++;
+        yield { type: 'thinking', content: `${privateThinking} ${String(i)}` };
+      }
+      await new Promise<void>(resolve => {
+        if (options?.abortSignal?.aborted) resolve();
+        else options?.abortSignal?.addEventListener('abort', () => resolve(), { once: true });
+      });
+    });
+
+    const store = createMockStore();
+    const workflowRun = makeWorkflowRun('thinking-only-timeout');
+    await executeDagWorkflow(
+      dagOptions({
+        deps: createMockDeps(store),
+        cwd: testDir,
+        workflow: {
+          name: 'thinking-only-timeout',
+          nodes: [
+            {
+              id: 'review',
+              kind: 'agent',
+              source: { kind: 'command', name: 'my-cmd' },
+              idle_timeout: 70,
+              retry: { max_attempts: 0 },
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
+
+    expect(yielded).toBe(3);
+    const transcript = await readTranscript(join(testDir, 'logs'), workflowRun.id);
+    const resetEvents = transcript.filter(event => event.type === 'watchdog_reset');
+    expect(resetEvents).toHaveLength(3);
+    expect(resetEvents.map(event => event.chunk_type)).toEqual([
+      'thinking',
+      'thinking',
+      'thinking',
+    ]);
+    expect(resetEvents.every(event => !('content' in event))).toBe(true);
+    expect(resetEvents.every(event => !Number.isNaN(Date.parse(String(event.ts))))).toBe(true);
+    expect(JSON.stringify(transcript)).not.toContain(privateThinking);
+
+    const failed = transcript.find(event => event.type === 'node_error' && event.step === 'review');
+    expect(failed?.error).toContain("chunk type 'thinking'");
+  });
+
+  it('loop timeout diagnostics distinguish tool progress from assistant output', async () => {
+    const runCase = async (
+      runId: string,
+      chunk: MessageChunk
+    ): Promise<{ transcript: Array<Record<string, unknown>>; error: string }> => {
+      mockSendQueryDag.mockImplementationOnce(async function* (
+        _prompt: string,
+        _cwd: string,
+        _resumeSessionId?: string,
+        options?: { abortSignal?: AbortSignal }
+      ) {
+        yield chunk;
+        await new Promise<void>(resolve => {
+          if (options?.abortSignal?.aborted) resolve();
+          else options?.abortSignal?.addEventListener('abort', () => resolve(), { once: true });
+        });
+      });
+
+      const store = createMockStore();
+      const workflowRun = makeWorkflowRun(runId);
+      await executeDagWorkflow(
+        dagOptions({
+          deps: createMockDeps(store),
+          cwd: testDir,
+          workflow: {
+            name: runId,
+            nodes: [
+              {
+                id: 'implement',
+                kind: 'loop',
+                output_format: {
+                  type: 'object',
+                  properties: { done: { type: 'boolean' } },
+                  required: ['done'],
+                },
+                loop: {
+                  fresh_context: false,
+                  prompt: 'Implement the change.',
+                  max_iterations: 1,
+                  until_field: 'done',
+                },
+                idle_timeout: 50,
+              },
+            ],
+          },
+          workflowRun,
+        })
+      );
+
+      const transcript = await readTranscript(join(testDir, 'logs'), workflowRun.id);
+      const failed = transcript.find(event => event.type === 'node_error');
+      return { transcript, error: String(failed?.error) };
+    };
+
+    const tool = await runCase('loop-tool-timeout', {
+      type: 'tool',
+      toolName: 'Bash',
+      toolInput: { command: 'private tool input' },
+    });
+    const assistant = await runCase('loop-assistant-timeout', {
+      type: 'assistant',
+      content: 'user-visible output',
+    });
+
+    const toolReset = tool.transcript.filter(event => event.type === 'watchdog_reset');
+    const assistantReset = assistant.transcript.filter(event => event.type === 'watchdog_reset');
+    expect(toolReset.map(event => event.chunk_type)).toEqual(['tool']);
+    expect(assistantReset.map(event => event.chunk_type)).toEqual(['assistant']);
+    expect(toolReset.every(event => !('content' in event) && !('tool_input' in event))).toBe(true);
+    expect(assistantReset.every(event => !('content' in event))).toBe(true);
+    expect(tool.error).toContain("chunk type 'tool'");
+    expect(assistant.error).toContain("chunk type 'assistant'");
+    expect(tool.transcript.some(event => event.type === 'assistant')).toBe(false);
+    expect(assistant.transcript.some(event => event.type === 'assistant')).toBe(true);
   });
 
   it('idle-timeout with zero output fails a loop iteration instead of consuming its iteration budget', async () => {

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -12509,10 +12509,10 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
     expect(failed?.error).toContain("chunk type 'thinking'");
   });
 
-  it('loop timeout diagnostics distinguish tool progress from assistant output', async () => {
+  it('loop timeout diagnostics retain the latest reset and distinguish tool progress from assistant output', async () => {
     const runCase = async (
       runId: string,
-      chunk: MessageChunk
+      chunks: MessageChunk[]
     ): Promise<{ transcript: Array<Record<string, unknown>>; error: string }> => {
       mockSendQueryDag.mockImplementationOnce(async function* (
         _prompt: string,
@@ -12520,7 +12520,7 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
         _resumeSessionId?: string,
         options?: { abortSignal?: AbortSignal }
       ) {
-        yield chunk;
+        for (const chunk of chunks) yield chunk;
         await new Promise<void>(resolve => {
           if (options?.abortSignal?.aborted) resolve();
           else options?.abortSignal?.addEventListener('abort', () => resolve(), { once: true });
@@ -12563,19 +12563,24 @@ describe('executeDagWorkflow -- terminal node output selection', () => {
       return { transcript, error: String(failed?.error) };
     };
 
-    const tool = await runCase('loop-tool-timeout', {
-      type: 'tool',
-      toolName: 'Bash',
-      toolInput: { command: 'private tool input' },
-    });
-    const assistant = await runCase('loop-assistant-timeout', {
-      type: 'assistant',
-      content: 'user-visible output',
-    });
+    const tool = await runCase('loop-tool-timeout', [
+      { type: 'thinking', content: 'private reasoning' },
+      {
+        type: 'tool',
+        toolName: 'Bash',
+        toolInput: { command: 'private tool input' },
+      },
+    ]);
+    const assistant = await runCase('loop-assistant-timeout', [
+      {
+        type: 'assistant',
+        content: 'user-visible output',
+      },
+    ]);
 
     const toolReset = tool.transcript.filter(event => event.type === 'watchdog_reset');
     const assistantReset = assistant.transcript.filter(event => event.type === 'watchdog_reset');
-    expect(toolReset.map(event => event.chunk_type)).toEqual(['tool']);
+    expect(toolReset.map(event => event.chunk_type)).toEqual(['thinking', 'tool']);
     expect(assistantReset.map(event => event.chunk_type)).toEqual(['assistant']);
     expect(toolReset.every(event => !('content' in event) && !('tool_input' in event))).toBe(true);
     expect(assistantReset.every(event => !('content' in event))).toBe(true);

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -29,6 +29,7 @@ import type {
   ProviderCapabilities,
   TokenUsage,
   ResolvedModel,
+  MessageChunk,
   ExecutionContext,
   OverlayChangeSummary,
 } from '@archon/providers/types';
@@ -134,6 +135,7 @@ import {
   logTool,
   logWorkflowComplete,
   logWorkflowError,
+  logWatchdogReset,
   type WorkflowUsage,
 } from './logger';
 import { withIdleTimeout, STEP_IDLE_TIMEOUT_MS } from './utils/idle-timeout';
@@ -594,6 +596,17 @@ let cachedLog: ReturnType<typeof createLogger> | undefined;
 function getLog(): ReturnType<typeof createLogger> {
   if (!cachedLog) cachedLog = createLogger('workflow.dag-executor');
   return cachedLog;
+}
+
+interface WatchdogReset {
+  type: MessageChunk['type'];
+  at: number;
+}
+
+function formatWatchdogResetDiagnostic(lastReset: WatchdogReset | undefined): string {
+  return lastReset
+    ? ` Last watchdog reset: ${new Date(lastReset.at).toISOString()} from chunk type '${lastReset.type}'.`
+    : ' No provider chunk reset the watchdog after the stream opened.';
 }
 
 const MCP_FAILURE_PREFIX = 'MCP server connection failed: ';
@@ -2322,6 +2335,8 @@ async function executeNodeInternal(
     ...(shouldForkSession ? { forkSession: true } : {}),
   };
   let nodeIdleTimedOut = false;
+  let lastWatchdogReset: WatchdogReset | undefined;
+  let watchdogResetLog = Promise.resolve();
   const effectiveIdleTimeout = node.idle_timeout ?? STEP_IDLE_TIMEOUT_MS;
   const runningTools = new Map<string, RunningTool>();
   let anonymousToolSequence = 0;
@@ -2359,6 +2374,8 @@ async function executeNodeInternal(
     nodeCostUsd = undefined;
     nodeTokens = undefined;
     nodeIdleTimedOut = false;
+    lastWatchdogReset = undefined;
+    watchdogResetLog = Promise.resolve();
     backgroundTasksIncomplete = [];
     const backgroundTasks = createBackgroundTaskTracker();
     for await (const msg of withIdleTimeout(
@@ -2367,10 +2384,27 @@ async function executeNodeInternal(
       () => {
         nodeIdleTimedOut = true;
         getLog().warn(
-          { nodeId: node.id, timeoutMs: effectiveIdleTimeout },
+          {
+            nodeId: node.id,
+            timeoutMs: effectiveIdleTimeout,
+            ...(lastWatchdogReset
+              ? {
+                  lastResetType: lastWatchdogReset.type,
+                  lastResetAt: new Date(lastWatchdogReset.at).toISOString(),
+                }
+              : {}),
+          },
           'dag_node_idle_timeout_reached'
         );
         nodeAbortController.abort();
+      },
+      undefined,
+      (msg, resetAt) => {
+        const type = msg.type;
+        lastWatchdogReset = { type, at: resetAt };
+        watchdogResetLog = watchdogResetLog.then(() =>
+          logWatchdogReset(logDir, workflowRun.id, node.id, type, resetAt)
+        );
       }
     )) {
       const tickNow = Date.now();
@@ -2979,6 +3013,7 @@ async function executeNodeInternal(
       try {
         await runStreamPass(reaskPrompt, reaskResumeSessionId);
       } finally {
+        await watchdogResetLog;
         if (nodeCostUsd !== undefined) {
           accumulatedCostUsd = (accumulatedCostUsd ?? 0) + nodeCostUsd;
         }
@@ -3066,7 +3101,7 @@ async function executeNodeInternal(
       // and reporting it as "the model replied with prose" would mislead.
       if (nodeIdleTimedOut) {
         throw new Error(
-          `Node '${node.id}': timed out (no output for ${String(effectiveIdleTimeout / 60000)} min) before producing the required structured output.`
+          `Node '${node.id}': timed out (no output for ${String(effectiveIdleTimeout / 60000)} min) before producing the required structured output.${formatWatchdogResetDiagnostic(lastWatchdogReset)}`
         );
       }
       throw new Error(
@@ -3084,7 +3119,7 @@ async function executeNodeInternal(
       await safeSendMessage(
         platform,
         conversationId,
-        `⚠️ Node \`${node.id}\` completed via idle timeout (no output for ${String(effectiveIdleTimeout / 60000)} min). The AI likely finished but the subprocess didn't exit cleanly.`,
+        `⚠️ Node \`${node.id}\` completed via idle timeout (no output for ${String(effectiveIdleTimeout / 60000)} min).${formatWatchdogResetDiagnostic(lastWatchdogReset)} The AI likely finished but the subprocess didn't exit cleanly.`,
         nodeContext
       );
     }
@@ -3120,7 +3155,7 @@ async function executeNodeInternal(
     if (nodeOutputText.trim() === '' && structuredOutput === undefined) {
       const duration = Date.now() - nodeStartTime;
       const emptyError = nodeIdleTimedOut
-        ? `Node '${node.id}' timed out with no output (idle for ${String(effectiveIdleTimeout / 60000)} min). The provider did not emit any content before the watchdog fired — likely time-to-first-token exceeded the timeout. Consider increasing idle_timeout or reducing prompt size.`
+        ? `Node '${node.id}' timed out with no output (idle for ${String(effectiveIdleTimeout / 60000)} min).${formatWatchdogResetDiagnostic(lastWatchdogReset)} Consider increasing idle_timeout or reducing prompt size.`
         : `Node '${node.id}' produced no assistant output. The provider stream closed without yielding content — likely a silent provider rejection or stream interruption.`;
       getLog().error({ nodeId: node.id, durationMs: duration }, 'dag.node_empty_output');
       return await failAgentNode(emptyError);
@@ -5872,6 +5907,7 @@ async function executeLoopNode(
     let fullOutput = ''; // raw, for signal detection
     let cleanOutput = ''; // stripped, for platform display
     let iterationIdleTimedOut = false;
+    let lastWatchdogReset: WatchdogReset | undefined;
     let iterationPayload: unknown;
 
     // Per-attempt transient retry for AI-loop iterations (#2706): a plain AI node's
@@ -5977,6 +6013,7 @@ async function executeLoopNode(
         fullOutput = '';
         cleanOutput = '';
         iterationIdleTimedOut = false;
+        lastWatchdogReset = undefined;
         streamStopStatus = undefined;
         attemptStructured = undefined;
         iterationAbortController = new AbortController();
@@ -5986,6 +6023,7 @@ async function executeLoopNode(
         iterationTokens = undefined;
         iterationNumTurns = undefined;
         iterationUsageFolded = false;
+        let watchdogResetLog = Promise.resolve();
 
         try {
           // Build prompt — substituteWorkflowVariables throws if $BASE_BRANCH referenced but empty
@@ -6035,14 +6073,42 @@ async function executeLoopNode(
 
           const effectiveIdleTimeout = node.idle_timeout ?? STEP_IDLE_TIMEOUT_MS;
 
-          for await (const msg of withIdleTimeout(generator, effectiveIdleTimeout, () => {
-            iterationIdleTimedOut = true;
-            getLog().warn(
-              { nodeId: node.id, iteration: i, timeoutMs: effectiveIdleTimeout },
-              'loop_node.idle_timeout_reached'
-            );
-            iterationAbortController.abort();
-          })) {
+          for await (const msg of withIdleTimeout(
+            generator,
+            effectiveIdleTimeout,
+            () => {
+              iterationIdleTimedOut = true;
+              getLog().warn(
+                {
+                  nodeId: node.id,
+                  iteration: i,
+                  timeoutMs: effectiveIdleTimeout,
+                  ...(lastWatchdogReset
+                    ? {
+                        lastResetType: lastWatchdogReset.type,
+                        lastResetAt: new Date(lastWatchdogReset.at).toISOString(),
+                      }
+                    : {}),
+                },
+                'loop_node.idle_timeout_reached'
+              );
+              iterationAbortController.abort();
+            },
+            undefined,
+            (msg, resetAt) => {
+              const type = msg.type;
+              lastWatchdogReset = { type, at: resetAt };
+              watchdogResetLog = watchdogResetLog.then(() =>
+                logWatchdogReset(
+                  logDir,
+                  workflowRun.id,
+                  `${node.id}-iteration-${String(i)}`,
+                  type,
+                  resetAt
+                )
+              );
+            }
+          )) {
             // Mid-stream cancel/pause check (every CANCEL_CHECK_INTERVAL_MS) —
             // lifted from the AI-node stream loop in executeNodeInternal. Same
             // posture: `paused` is tolerated (a sibling approval node may pause
@@ -6425,12 +6491,14 @@ async function executeLoopNode(
           if (await tryIterationTransientRetry(err.message, iterRetry)) {
             continue iterationAttempt;
           }
-          return failLoopNode(`Loop iteration ${String(i)} failed: ${err.message}`, {
+          return await failLoopNode(`Loop iteration ${String(i)} failed: ${err.message}`, {
             costUsd: loopTotalCostUsd,
             ...(loopTotalTokens !== undefined ? { tokens: loopTotalTokens } : {}),
             loopIterations: i,
             data: { iteration: i },
           });
+        } finally {
+          await watchdogResetLog;
         }
 
         // Empty assistant output is an iteration failure for AI loops — same
@@ -6458,7 +6526,7 @@ async function executeLoopNode(
         if (!structuredTimeout && fullOutput.trim() === '' && attemptStructured === undefined) {
           const iterationDuration = Date.now() - iterationStart;
           const emptyError = iterationIdleTimedOut
-            ? `Loop node '${node.id}' iteration ${String(i)} timed out with no output (idle for ${String((node.idle_timeout ?? STEP_IDLE_TIMEOUT_MS) / 60000)} min). The provider did not emit any content before the watchdog fired — likely time-to-first-token exceeded the timeout. Consider increasing idle_timeout or reducing prompt size.`
+            ? `Loop node '${node.id}' iteration ${String(i)} timed out with no output (idle for ${String((node.idle_timeout ?? STEP_IDLE_TIMEOUT_MS) / 60000)} min).${formatWatchdogResetDiagnostic(lastWatchdogReset)} Consider increasing idle_timeout or reducing prompt size.`
             : 'Loop iteration produced no assistant output. The provider stream closed without yielding content — likely a silent provider rejection or stream interruption.';
           getLog().error(
             { nodeId: node.id, iteration: i, durationMs: iterationDuration },
@@ -6508,7 +6576,7 @@ async function executeLoopNode(
           await safeSendMessage(
             platform,
             conversationId,
-            `Loop node '${node.id}' iteration ${String(i)} completed via idle timeout (no output for ${String((node.idle_timeout ?? STEP_IDLE_TIMEOUT_MS) / 60000)} min)`,
+            `Loop node '${node.id}' iteration ${String(i)} completed via idle timeout (no output for ${String((node.idle_timeout ?? STEP_IDLE_TIMEOUT_MS) / 60000)} min).${formatWatchdogResetDiagnostic(lastWatchdogReset)}`,
             msgContext
           );
         }
@@ -6604,7 +6672,7 @@ async function executeLoopNode(
         // that "the model replied with prose" would send the author down the wrong path.
         return await failLoopNode(
           iterationIdleTimedOut
-            ? `Loop node '${node.id}' iteration ${String(i)}: timed out before producing the required structured output.`
+            ? `Loop node '${node.id}' iteration ${String(i)}: timed out before producing the required structured output.${formatWatchdogResetDiagnostic(lastWatchdogReset)}`
             : `Loop node '${node.id}' iteration ${String(i)}: output_format declared but the provider returned no schema-valid structured output. The model likely replied with prose, refused, or emitted unparseable JSON.`,
           {
             output: lastIterationOutput,

--- a/packages/workflows/src/logger.test.ts
+++ b/packages/workflows/src/logger.test.ts
@@ -31,6 +31,7 @@ import {
   logWorkflowComplete,
   logNodeComplete,
   logNodeError,
+  logWatchdogReset,
   type WorkflowEvent,
 } from './logger';
 
@@ -114,6 +115,26 @@ describe('Workflow Logger', () => {
 
       const events = await readLogFile('new-dir-test');
       expect(events).toHaveLength(1);
+    });
+  });
+
+  describe('logWatchdogReset', () => {
+    it('persists the reset timestamp and chunk type without chunk content', async () => {
+      const resetAt = Date.parse('2026-08-31T20:31:53.123Z');
+
+      await logWatchdogReset(testDir, 'watchdog-test', 'review', 'thinking', resetAt);
+
+      const events = await readLogFile('watchdog-test');
+      expect(events).toEqual([
+        expect.objectContaining({
+          type: 'watchdog_reset',
+          workflow_id: 'watchdog-test',
+          step: 'review',
+          chunk_type: 'thinking',
+          ts: '2026-08-31T20:31:53.123Z',
+        }),
+      ]);
+      expect(events[0].content).toBeUndefined();
     });
   });
 

--- a/packages/workflows/src/logger.ts
+++ b/packages/workflows/src/logger.ts
@@ -4,6 +4,7 @@
 import { appendFile, mkdir } from 'fs/promises';
 import { join, dirname } from 'path';
 import type { WorkflowTokenUsage } from './deps';
+import type { MessageChunk } from '@archon/providers/types';
 import { createLogger } from '@archon/paths';
 
 /** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
@@ -34,6 +35,7 @@ export interface WorkflowEvent {
     | 'node_complete'
     | 'node_skipped'
     | 'node_error'
+    | 'watchdog_reset'
     | 'exec_output';
   workflow_id: string;
   workflow_name?: string;
@@ -47,6 +49,8 @@ export interface WorkflowEvent {
   check?: string;
   result?: 'pass' | 'fail' | 'warn' | 'unknown';
   error?: string;
+  /** `watchdog_reset` only. The chunk content is deliberately never retained. */
+  chunk_type?: MessageChunk['type'];
   /** `exec_output` only — see {@link logExecOutput}. Absent means the stream was empty. */
   stdout_tail?: string;
   /** `exec_output` only — see {@link logExecOutput}. Absent means the stream was empty. */
@@ -99,7 +103,8 @@ function getLogPath(logDir: string, workflowRunId: string): string {
 export async function logWorkflowEvent(
   logDir: string,
   workflowRunId: string,
-  event: Omit<WorkflowEvent, 'ts' | 'workflow_id'>
+  event: Omit<WorkflowEvent, 'ts' | 'workflow_id'>,
+  occurredAt = Date.now()
 ): Promise<void> {
   const logPath = getLogPath(logDir, workflowRunId);
 
@@ -110,7 +115,7 @@ export async function logWorkflowEvent(
     const fullEvent: WorkflowEvent = {
       ...event,
       workflow_id: workflowRunId,
-      ts: new Date().toISOString(),
+      ts: new Date(occurredAt).toISOString(),
     };
 
     await appendFile(logPath, JSON.stringify(fullEvent) + '\n');
@@ -125,6 +130,26 @@ export async function logWorkflowEvent(
     }
     // Don't throw - logging shouldn't break workflow execution
   }
+}
+
+/** Retain the privacy-safe evidence for one watchdog renewal. */
+export async function logWatchdogReset(
+  logDir: string,
+  workflowRunId: string,
+  nodeId: string,
+  chunkType: MessageChunk['type'],
+  resetAt: number
+): Promise<void> {
+  await logWorkflowEvent(
+    logDir,
+    workflowRunId,
+    {
+      type: 'watchdog_reset',
+      step: nodeId,
+      chunk_type: chunkType,
+    },
+    resetAt
+  );
 }
 
 /**

--- a/packages/workflows/src/utils/idle-timeout.test.ts
+++ b/packages/workflows/src/utils/idle-timeout.test.ts
@@ -212,4 +212,28 @@ describe('withIdleTimeout', () => {
     expect(result).toEqual([{ type: 'assistant' }, { type: 'tool' }]);
     expect(onTimeout).toHaveBeenCalledTimes(1);
   });
+
+  test('reports the value and timestamp only when the timer resets', async () => {
+    type Msg = { type: 'assistant' | 'tool' };
+    const resets: Array<{ type: Msg['type']; resetAt: number }> = [];
+    const before = Date.now();
+
+    const values: Msg[] = [];
+    for await (const value of withIdleTimeout(
+      fromValues<Msg>([{ type: 'assistant' }, { type: 'tool' }]),
+      1000,
+      undefined,
+      msg => msg.type !== 'tool',
+      (msg, resetAt) => resets.push({ type: msg.type, resetAt })
+    )) {
+      values.push(value);
+    }
+
+    const after = Date.now();
+    expect(values).toEqual([{ type: 'assistant' }, { type: 'tool' }]);
+    expect(resets).toHaveLength(1);
+    expect(resets[0]?.type).toBe('assistant');
+    expect(resets[0]?.resetAt).toBeGreaterThanOrEqual(before);
+    expect(resets[0]?.resetAt).toBeLessThanOrEqual(after);
+  });
 });

--- a/packages/workflows/src/utils/idle-timeout.ts
+++ b/packages/workflows/src/utils/idle-timeout.ts
@@ -43,12 +43,14 @@ const IDLE_TIMEOUT_SENTINEL = Symbol('IDLE_TIMEOUT');
  * @param timeoutMs - Maximum idle time in milliseconds before terminating
  * @param onTimeout - Optional callback invoked when idle timeout fires (before return)
  * @param shouldResetTimer - Optional predicate; return false to NOT reset the timer for a value
+ * @param onTimerReset - Optional observer invoked with the value and exact reset timestamp
  */
 export async function* withIdleTimeout<T>(
   generator: AsyncGenerator<T>,
   timeoutMs: number,
   onTimeout?: () => void,
-  shouldResetTimer?: (value: T) => boolean
+  shouldResetTimer?: (value: T) => boolean,
+  onTimerReset?: (value: T, resetAt: number) => void
 ): AsyncGenerator<T> {
   let timedOut = false;
   let timerStartedAt = Date.now();
@@ -86,6 +88,7 @@ export async function* withIdleTimeout<T>(
       // Reset the timer unless the predicate says not to
       if (!shouldResetTimer || shouldResetTimer(result.value)) {
         timerStartedAt = Date.now();
+        onTimerReset?.(result.value, timerStartedAt);
       }
 
       yield result.value;


### PR DESCRIPTION
## Problem and outcome

The idle watchdog resets for every mapped provider chunk, but the run log did not show which chunk renewed it. When a stream appeared silent to an operator, a later timeout could not distinguish a genuinely silent stream from hidden thinking or tool-progress chunks.

- **Outcome:** Each actual watchdog renewal now writes a `watchdog_reset` JSONL event with its timestamp and `MessageChunk.type`; idle-timeout diagnostics include the last reset's timestamp and type.
- **Invariant:** Diagnostics retain chunk type only, never message content or tool input. Both ordinary agent streams and loop iterations continue to renew on the same chunks as before.
- **Scope boundary:** This does not change `idle_timeout` defaults, exclude thinking from renewal, or change liveness policy. Those decisions remain with #2325.
- **Root cause:** The watchdog recorded its renewal timestamp only internally, while the executor recorded neither the reset type nor a diagnostic explaining the last renewal.

## Review guidance

- **Feedback requested:** Confirm the diagnostic boundary is privacy-safe and that it observes rather than changes watchdog liveness semantics.
- **Start here:** `packages/workflows/src/dag-executor.ts:2381` — the existing agent-stream watchdog now captures and persists reset evidence.
- **Review order:** `packages/workflows/src/utils/idle-timeout.ts:47`; `packages/workflows/src/logger.ts:103`; `packages/workflows/src/dag-executor.ts:601`; `packages/workflows/src/dag-executor.test.ts:12452`.
- **Lower-attention areas:** The logger and idle-timeout unit tests are focused checks of the new event shape and observer contract.
- **Known risk or uncertainty:** Historical stalls cannot be retroactively classified; the new event makes the next occurrence discriminating.

## Solution

`withIdleTimeout` now exposes an optional observer that receives the exact timestamp used when it renews its existing timer. The two existing executor call sites use it to remember and append a type-only `watchdog_reset` event, serializing log writes so provider consumption remains unchanged. The last reset is added to timeout reasons, including the explicit no-reset case. The same path is used for agent nodes and loop iterations.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | A watchdog renewal left no run-log evidence of the provider chunk that renewed it. | Every renewal writes its timestamp and chunk type; thinking, tool, and assistant resets are distinguishable. |
| **Failure behavior** | Timeout reasons could imply no output without identifying prior hidden progress. | Timeout reasons report the last reset type and timestamp, or explicitly state that no provider chunk reset the watchdog. |

## Architecture

```mermaid
flowchart LR
  P[Provider MessageChunk] --> W[withIdleTimeout]
  W -->|existing renewal| E[Executor observer]
  E --> L[watchdog_reset JSONL event]
  E --> T[Timeout diagnostic]
```

### Changed seams

| Boundary or contract | Change | Evidence |
|---|---|---|
| `withIdleTimeout` → workflow executor | Optional reset observer exposes only the value and renewal timestamp. | `packages/workflows/src/utils/idle-timeout.ts:47` |
| workflow executor → JSONL run log | `watchdog_reset` records node, timestamp, and `MessageChunk.type`, without content. | `packages/workflows/src/logger.ts:136` |
| executor → timeout reason | Agent and loop paths include the final reset diagnostic. | `packages/workflows/src/dag-executor.ts:601` |

## Validation

- `bunx bun@1.4.0 test src/utils/idle-timeout.test.ts src/logger.test.ts` in `packages/workflows` — 36 passed, 0 failed — proves reset observation and type-only event persistence.
- `bunx bun@1.4.0 test src/dag-executor.test.ts -t "idle-timeout|thinking-only|loop timeout diagnostics"` in `packages/workflows` — 7 passed, 0 failed — proves silent streams fire, thinking-only streams renew and persist diagnostics, and tool progress differs from assistant output.
- `bunx bun@1.4.0 test src/dag-executor.test.ts` in `packages/workflows` — 705 passed, 0 failed.
- `bunx bun@1.4.0 run type-check`, `bunx bun@1.4.0 run lint --max-warnings 0`, and `bunx bun@1.4.0 run format:check` — passed in `packages/workflows`.
- `bunx bun@1.4.0 run validate` — passed, including generated-artifact checks, type checks, lint, formatting, installer tests, package tests, and script tests.
- **Not verified:** Nothing material; focused tests cover the instrumentation's silent, thinking, tool, and assistant cases, and the full repository validation passed.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Observability | Future stalls now retain the last watchdog-reset type and timestamp without retaining provider content. | `packages/workflows/src/dag-executor.test.ts:12452` |
| Security / permissions / data | The event contains only timestamp, node identifier, and chunk type; message content and tool input are not added. | `packages/workflows/src/logger.test.ts:121` |

## Links

- Relates to #2896
- Related #2325


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow timeout diagnostics by identifying the latest provider activity or reporting when no activity reset the watchdog.
  * Thinking and tool-progress events now correctly renew timeouts without exposing private reasoning or tool content.
  * Added privacy-safe watchdog reset records with accurate timestamps for improved troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->