### PR TITLE
test(server): type-check server test files

### DIFF
--- a/packages/server/src/adapters/web/persistence.test.ts
+++ b/packages/server/src/adapters/web/persistence.test.ts
@@ -13,7 +13,9 @@ mock.module('@archon/paths', () => ({
 }));
 
 // Mock @archon/core/db/messages
-const mockAddMessage = mock(() => Promise.resolve());
+const mockAddMessage = mock<
+  (...args: Parameters<(typeof import('@archon/core/db/messages'))['addMessage']>) => Promise<void>
+>(async () => {});
 mock.module('@archon/core/db/messages', () => ({
   addMessage: mockAddMessage,
 }));

--- a/packages/server/src/routes/api.auth.test.ts
+++ b/packages/server/src/routes/api.auth.test.ts
@@ -3,7 +3,7 @@ import { OpenAPIHono } from '@hono/zod-openapi';
 import type { ConversationLockManager } from '@archon/core';
 import type { WebAdapter } from '../adapters/web';
 import { validationErrorHook } from './openapi-defaults';
-import { mockAllWorkflowModules } from '../test/workflow-mock-factories';
+import { makeListDashboardRunsMock, mockAllWorkflowModules } from '../test/workflow-mock-factories';
 
 // ---------------------------------------------------------------------------
 // Mock setup — must precede the dynamic import of ./api below.
@@ -122,11 +122,7 @@ mock.module('@archon/core/db/isolation-environments', () => ({
 
 mock.module('@archon/core/db/workflows', () => ({
   listWorkflowRuns: mockListWorkflowRuns,
-  listDashboardRuns: mock(async () => ({
-    runs: [],
-    total: 0,
-    counts: { all: 0, running: 0, completed: 0, failed: 0, cancelled: 0, pending: 0 },
-  })),
+  listDashboardRuns: makeListDashboardRunsMock(),
   getWorkflowRun: mock(async () => null),
   getWorkflowRunByWorkerPlatformId: mock(async () => null),
 }));

--- a/packages/server/src/routes/api.codebases.test.ts
+++ b/packages/server/src/routes/api.codebases.test.ts
@@ -3,7 +3,7 @@ import { OpenAPIHono } from '@hono/zod-openapi';
 import type { ConversationLockManager } from '@archon/core';
 import type { WebAdapter } from '../adapters/web';
 import { validationErrorHook } from './openapi-defaults';
-import { mockAllWorkflowModules } from '../test/workflow-mock-factories';
+import { makeListDashboardRunsMock, mockAllWorkflowModules } from '../test/workflow-mock-factories';
 
 // ---------------------------------------------------------------------------
 // Mock setup — must be declared before any dynamic imports of mocked modules
@@ -140,11 +140,7 @@ mock.module('@archon/core/db/isolation-environments', () => ({
 
 mock.module('@archon/core/db/workflows', () => ({
   listWorkflowRuns: mock(async () => []),
-  listDashboardRuns: mock(async () => ({
-    runs: [],
-    total: 0,
-    counts: { all: 0, running: 0, completed: 0, failed: 0, cancelled: 0, pending: 0 },
-  })),
+  listDashboardRuns: makeListDashboardRunsMock(),
   getWorkflowRun: mock(async () => null),
   cancelWorkflowRun: mock(async () => {}),
   getWorkflowRunByWorkerPlatformId: mock(async () => null),

--- a/packages/server/src/routes/api.codebases.test.ts
+++ b/packages/server/src/routes/api.codebases.test.ts
@@ -22,7 +22,10 @@ const mockGetCodebase = mock(
       updated_at: string;
     }
 );
-const mockListCodebases = mock(async () => [] as (typeof MOCK_CODEBASE)[]);
+type MockCodebase = Omit<typeof MOCK_CODEBASE, 'repository_url'> & {
+  repository_url: string | null;
+};
+const mockListCodebases = mock(async () => [] as MockCodebase[]);
 const mockDeleteCodebase = mock(async (_id: string) => {});
 const mockCloneRepository = mock(async (_url: string) => ({
   codebaseId: 'clone-uuid-1',

--- a/packages/server/src/routes/api.health.test.ts
+++ b/packages/server/src/routes/api.health.test.ts
@@ -12,11 +12,16 @@ import {
 // Mock setup — must be before dynamic imports
 // ---------------------------------------------------------------------------
 
-const mockLoadConfig = mock(async () => ({
+type TestConfig = {
+  assistants?: { claude: { model: string } };
+  worktree?: { baseBranch: string };
+};
+
+const mockLoadConfig = mock<(_repoPath?: string) => Promise<TestConfig>>(async () => ({
   assistants: { claude: { model: 'sonnet' } },
   worktree: { baseBranch: 'main' },
 }));
-const mockGetDatabaseType = mock(() => 'sqlite' as const);
+const mockGetDatabaseType = mock<() => 'postgresql' | 'sqlite'>(() => 'sqlite');
 const mockGetSchemaVersion = mock(async () => ({
   createdAppVersion: '0.5.3' as string | null,
   appVersion: '0.6.0',
@@ -185,7 +190,7 @@ import { registerApiRoutes } from './api';
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeApp(): Hono {
+function makeApp(): OpenAPIHono {
   const app = new OpenAPIHono();
   const mockWebAdapter = {
     setConversationDbId: mock((_platformId: string, _dbId: string) => {}),

--- a/packages/server/src/routes/api.health.test.ts
+++ b/packages/server/src/routes/api.health.test.ts
@@ -6,6 +6,7 @@ import {
   makeDiscoverWorkflowsMock,
   makeLoaderMock,
   makeCommandValidationMock,
+  makeListDashboardRunsMock,
 } from '../test/workflow-mock-factories';
 
 // ---------------------------------------------------------------------------
@@ -153,11 +154,7 @@ const mockGetRunningWorkflows = mock(
 
 mock.module('@archon/core/db/workflows', () => ({
   listWorkflowRuns: mock(async () => []),
-  listDashboardRuns: mock(async () => ({
-    runs: [],
-    total: 0,
-    counts: { all: 0, running: 0, completed: 0, failed: 0, cancelled: 0, pending: 0 },
-  })),
+  listDashboardRuns: makeListDashboardRunsMock(),
   getWorkflowRun: mock(async () => null),
   cancelWorkflowRun: mock(async () => {}),
   getWorkflowRunByWorkerPlatformId: mock(async () => null),

--- a/packages/server/src/routes/api.messages.test.ts
+++ b/packages/server/src/routes/api.messages.test.ts
@@ -3,7 +3,7 @@ import { OpenAPIHono } from '@hono/zod-openapi';
 import type { ConversationLockManager } from '@archon/core';
 import type { WebAdapter } from '../adapters/web';
 import { validationErrorHook } from './openapi-defaults';
-import { mockAllWorkflowModules } from '../test/workflow-mock-factories';
+import { makeListDashboardRunsMock, mockAllWorkflowModules } from '../test/workflow-mock-factories';
 import { MAX_TOOL_OUTPUT_CHARS } from '../adapters/web/truncate';
 
 // ---------------------------------------------------------------------------
@@ -134,11 +134,7 @@ mock.module('@archon/core/db/isolation-environments', () => ({
 
 mock.module('@archon/core/db/workflows', () => ({
   listWorkflowRuns: mock(async () => []),
-  listDashboardRuns: mock(async () => ({
-    runs: [],
-    total: 0,
-    counts: { all: 0, running: 0, completed: 0, failed: 0, cancelled: 0, pending: 0 },
-  })),
+  listDashboardRuns: makeListDashboardRunsMock(),
   getWorkflowRun: mock(async () => null),
   cancelWorkflowRun: mock(async () => {}),
   getWorkflowRunByWorkerPlatformId: mock(async () => null),

--- a/packages/server/src/routes/api.messages.test.ts
+++ b/packages/server/src/routes/api.messages.test.ts
@@ -32,10 +32,13 @@ const mockAddMessage = mock(
     role: _role,
     content: _content,
     metadata: '{}',
+    user_id: null,
     created_at: new Date().toISOString(),
   })
 );
-const mockListMessages = mock(async (_conversationId: string, _limit?: number) => []);
+const mockListMessages = mock<(typeof import('@archon/core/db/messages'))['listMessages']>(
+  async () => []
+);
 const mockHandleMessage = mock(async () => {});
 
 mock.module('@archon/core', () => ({
@@ -179,6 +182,7 @@ const MOCK_MESSAGES = [
     role: 'user' as const,
     content: 'Hello there',
     metadata: '{}',
+    user_id: null,
     created_at: new Date().toISOString(),
   },
   {
@@ -187,6 +191,7 @@ const MOCK_MESSAGES = [
     role: 'assistant' as const,
     content: 'Hi! How can I help?',
     metadata: '{"toolCalls":[]}',
+    user_id: null,
     created_at: new Date().toISOString(),
   },
 ];
@@ -228,6 +233,7 @@ describe('POST /api/conversations/:id/message', () => {
       role: 'user' as const,
       content: 'Hello',
       metadata: '{}',
+      user_id: null,
       created_at: new Date().toISOString(),
     }));
     mockHandleMessage.mockImplementationOnce(async () => {});
@@ -253,6 +259,7 @@ describe('POST /api/conversations/:id/message', () => {
       role: 'user' as const,
       content: 'Test message',
       metadata: '{}',
+      user_id: null,
       created_at: new Date().toISOString(),
     }));
     mockHandleMessage.mockImplementationOnce(async () => {});
@@ -384,6 +391,7 @@ describe('GET /api/conversations/:id/messages', () => {
         content: 'Response',
         // Simulate PostgreSQL returning JSONB as an object
         metadata: { toolCalls: [{ name: 'bash' }] } as unknown as string,
+        user_id: null,
         created_at: new Date().toISOString(),
       },
     ]);
@@ -412,6 +420,7 @@ describe('GET /api/conversations/:id/messages', () => {
         content: 'Response',
         // Simulate unserializable metadata from PostgreSQL JSONB
         metadata: circular as unknown as string,
+        user_id: null,
         created_at: new Date().toISOString(),
       },
     ]);
@@ -502,6 +511,7 @@ describe('GET /api/conversations/:id/messages — tool output bounding', () => {
         role: 'assistant' as const,
         content: '',
         metadata: storedMetadata,
+        user_id: null,
         created_at: new Date().toISOString(),
       },
     ]);
@@ -535,6 +545,7 @@ describe('GET /api/conversations/:id/messages — tool output bounding', () => {
         role: 'assistant' as const,
         content: '',
         metadata,
+        user_id: null,
         created_at: new Date().toISOString(),
       },
     ]);
@@ -556,6 +567,7 @@ describe('GET /api/conversations/:id/messages — tool output bounding', () => {
         role: 'assistant' as const,
         content: 'Done.',
         metadata,
+        user_id: null,
         created_at: new Date().toISOString(),
       },
     ]);

--- a/packages/server/src/routes/api.provider-keys.test.ts
+++ b/packages/server/src/routes/api.provider-keys.test.ts
@@ -122,8 +122,8 @@ const mockStartOAuth = mock(async (_userId: string, provider: string) => ({
   url: `https://auth/${provider}`,
   expiresIn: 600,
 }));
-const mockPollOAuth = mock((_sessionId: string, _userId: string, _code?: string) => ({
-  status: 'pending' as const,
+const mockPollOAuth = mock<(typeof import('@archon/core'))['pollOAuth']>(() => ({
+  status: 'pending',
 }));
 
 mock.module('@archon/core', () => ({
@@ -287,7 +287,13 @@ describe('GET /api/auth/providers', () => {
     const body = (await res.json()) as {
       enabled: boolean;
       available: string[];
-      agents: { id: string; catalog: string; ready: boolean }[];
+      agents: {
+        id: string;
+        displayName: string;
+        catalog: string;
+        ready: boolean;
+        credentials: unknown[];
+      }[];
     };
     expect(body.enabled).toBe(false);
     expect(body.available.length).toBeGreaterThan(0);

--- a/packages/server/src/routes/api.provider-keys.test.ts
+++ b/packages/server/src/routes/api.provider-keys.test.ts
@@ -3,7 +3,7 @@ import { OpenAPIHono } from '@hono/zod-openapi';
 import type { ConversationLockManager } from '@archon/core';
 import type { WebAdapter } from '../adapters/web';
 import { validationErrorHook } from './openapi-defaults';
-import { mockAllWorkflowModules } from '../test/workflow-mock-factories';
+import { makeListDashboardRunsMock, mockAllWorkflowModules } from '../test/workflow-mock-factories';
 
 // ---------------------------------------------------------------------------
 // Mock setup — must precede the dynamic import of ./api below. Exercises the
@@ -203,11 +203,7 @@ mock.module('@archon/core/db/isolation-environments', () => ({
 
 mock.module('@archon/core/db/workflows', () => ({
   listWorkflowRuns: mock(async () => []),
-  listDashboardRuns: mock(async () => ({
-    runs: [],
-    total: 0,
-    counts: { all: 0, running: 0, completed: 0, failed: 0, cancelled: 0, pending: 0 },
-  })),
+  listDashboardRuns: makeListDashboardRunsMock(),
   getWorkflowRun: mock(async () => null),
   getWorkflowRunByWorkerPlatformId: mock(async () => null),
 }));

--- a/packages/server/src/routes/api.providers.test.ts
+++ b/packages/server/src/routes/api.providers.test.ts
@@ -242,8 +242,8 @@ describe('PATCH /api/config/tiers', () => {
     mockUpdateGlobalConfig.mockClear();
   });
 
-  function patch(tiers: unknown): Promise<Response> {
-    return app.request('/api/config/tiers', {
+  async function patch(tiers: unknown): Promise<Response> {
+    return await app.request('/api/config/tiers', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ tiers }),
@@ -305,8 +305,8 @@ describe('PATCH /api/config/aliases', () => {
     mockUpdateGlobalConfig.mockClear();
   });
 
-  function patch(aliases: unknown): Promise<Response> {
-    return app.request('/api/config/aliases', {
+  async function patch(aliases: unknown): Promise<Response> {
+    return await app.request('/api/config/aliases', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ aliases }),

--- a/packages/server/src/routes/api.providers.test.ts
+++ b/packages/server/src/routes/api.providers.test.ts
@@ -7,6 +7,7 @@ import {
   makeDiscoverWorkflowsMock,
   makeLoaderMock,
   makeCommandValidationMock,
+  makeListDashboardRunsMock,
 } from '../test/workflow-mock-factories';
 
 // ---------------------------------------------------------------------------
@@ -111,7 +112,7 @@ mock.module('@archon/core/db/isolation-environments', () => ({
 }));
 mock.module('@archon/core/db/workflows', () => ({
   listWorkflowRuns: mock(async () => []),
-  listDashboardRuns: mock(async () => ({ runs: [], total: 0, counts: {} })),
+  listDashboardRuns: makeListDashboardRunsMock(),
   getWorkflowRun: mock(async () => null),
   cancelWorkflowRun: mock(async () => {}),
   getWorkflowRunByWorkerPlatformId: mock(async () => null),

--- a/packages/server/src/routes/api.user-ai-prefs.test.ts
+++ b/packages/server/src/routes/api.user-ai-prefs.test.ts
@@ -3,7 +3,7 @@ import { OpenAPIHono } from '@hono/zod-openapi';
 import type { ConversationLockManager } from '@archon/core';
 import type { WebAdapter } from '../adapters/web';
 import { validationErrorHook } from './openapi-defaults';
-import { mockAllWorkflowModules } from '../test/workflow-mock-factories';
+import { makeListDashboardRunsMock, mockAllWorkflowModules } from '../test/workflow-mock-factories';
 
 // ---------------------------------------------------------------------------
 // Mock setup — must precede the dynamic import of ./api below. Exercises the
@@ -170,11 +170,7 @@ mock.module('@archon/core/db/isolation-environments', () => ({
 
 mock.module('@archon/core/db/workflows', () => ({
   listWorkflowRuns: mock(async () => []),
-  listDashboardRuns: mock(async () => ({
-    runs: [],
-    total: 0,
-    counts: { all: 0, running: 0, completed: 0, failed: 0, cancelled: 0, pending: 0 },
-  })),
+  listDashboardRuns: makeListDashboardRunsMock(),
   getWorkflowRun: mock(async () => null),
   getWorkflowRunByWorkerPlatformId: mock(async () => null),
 }));

--- a/packages/server/src/routes/api.workflow-runs.test.ts
+++ b/packages/server/src/routes/api.workflow-runs.test.ts
@@ -4,10 +4,15 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { OpenAPIHono } from '@hono/zod-openapi';
 import type { ConversationLockManager } from '@archon/core';
+import type { DashboardWorkflowRun } from '@archon/core/db/workflows';
 import type { WorkflowRun } from '@archon/workflows/schemas/workflow-run';
 import type { WebAdapter } from '../adapters/web';
 import { validationErrorHook } from './openapi-defaults';
-import { mockAllWorkflowModules } from '../test/workflow-mock-factories';
+import {
+  makeDashboardRunsResult,
+  makeListDashboardRunsMock,
+  mockAllWorkflowModules,
+} from '../test/workflow-mock-factories';
 
 beforeAll(async (): Promise<void> => {
   const { registerBuiltinProviders, registerCommunityProviders } =
@@ -25,24 +30,11 @@ const mockCancelWorkflowRun = mock(async (_id: string) => ({ cancelled: true }))
 type ListWorkflowRunsOptions = Parameters<
   (typeof import('@archon/core/db/workflows'))['listWorkflowRuns']
 >[0];
-type ListDashboardRunsOptions = Parameters<
-  (typeof import('@archon/core/db/workflows'))['listDashboardRuns']
->[0];
 
 const mockListWorkflowRuns = mock<
   (_options?: ListWorkflowRunsOptions) => Promise<MockWorkflowRun[]>
 >(async () => []);
-const mockListDashboardRuns = mock<
-  (_options?: ListDashboardRunsOptions) => Promise<{
-    runs: MockWorkflowRun[];
-    total: number;
-    counts: Record<string, number>;
-  }>
->(async () => ({
-  runs: [],
-  total: 0,
-  counts: { all: 0, running: 0, completed: 0, failed: 0, cancelled: 0, pending: 0 },
-}));
+const mockListDashboardRuns = makeListDashboardRunsMock();
 const mockGetWorkflowRunByWorkerPlatformId = mock(
   async (_id: string) => null as null | MockWorkflowRun
 );
@@ -383,7 +375,7 @@ import { registerApiRoutes } from './api';
 const NOW = new Date().toISOString();
 const NOW_DATE = new Date(NOW);
 
-const MOCK_RUNNING_RUN: MockWorkflowRun = {
+const MOCK_RUNNING_RUN = {
   id: 'run-uuid-1',
   workflow_name: 'deploy',
   conversation_id: 'conv-uuid-1',
@@ -401,15 +393,15 @@ const MOCK_RUNNING_RUN: MockWorkflowRun = {
   parent_run_id: null,
   adopted_from_run_id: null,
   output_root: null,
-};
+} satisfies MockWorkflowRun;
 
-const MOCK_COMPLETED_RUN: MockWorkflowRun = {
+const MOCK_COMPLETED_RUN = {
   ...MOCK_RUNNING_RUN,
   id: 'run-uuid-2',
   status: 'completed',
   outcome: 'failed',
   completed_at: NOW_DATE,
-};
+} satisfies MockWorkflowRun;
 
 const MOCK_FAILED_RUN: MockWorkflowRun = {
   ...MOCK_RUNNING_RUN,
@@ -424,6 +416,22 @@ const MOCK_PENDING_RUN: MockWorkflowRun = {
   id: 'run-uuid-3',
   status: 'pending',
 };
+
+function makeDashboardWorkflowRun(run: WorkflowRun): DashboardWorkflowRun {
+  return {
+    ...run,
+    codebase_name: null,
+    platform_type: null,
+    worker_platform_id: null,
+    parent_platform_id: null,
+    current_step_name: null,
+    total_steps: null,
+    current_step_status: null,
+    agents_completed: null,
+    agents_failed: null,
+    agents_total: null,
+  };
+}
 
 const MOCK_EVENTS: MockWorkflowEvent[] = [
   {
@@ -1467,11 +1475,16 @@ describe('GET /api/dashboard/runs', () => {
   });
 
   test('returns paginated runs with total and counts', async () => {
-    mockListDashboardRuns.mockImplementationOnce(async () => ({
-      runs: [MOCK_RUNNING_RUN, MOCK_COMPLETED_RUN],
-      total: 2,
-      counts: { all: 5, running: 1, completed: 2, failed: 1, cancelled: 1, pending: 0 },
-    }));
+    mockListDashboardRuns.mockImplementationOnce(async () =>
+      makeDashboardRunsResult({
+        runs: [
+          makeDashboardWorkflowRun(MOCK_RUNNING_RUN),
+          makeDashboardWorkflowRun(MOCK_COMPLETED_RUN),
+        ],
+        total: 2,
+        counts: { all: 5, running: 1, completed: 2, failed: 1, cancelled: 1 },
+      })
+    );
 
     const { app } = makeApp();
     const response = await app.request('/api/dashboard/runs');
@@ -1490,11 +1503,7 @@ describe('GET /api/dashboard/runs', () => {
   });
 
   test('filters by status query param', async () => {
-    mockListDashboardRuns.mockImplementationOnce(async () => ({
-      runs: [],
-      total: 0,
-      counts: { all: 0, running: 0, completed: 0, failed: 0, cancelled: 0, pending: 0 },
-    }));
+    mockListDashboardRuns.mockImplementationOnce(async () => makeDashboardRunsResult());
 
     const { app } = makeApp();
     await app.request('/api/dashboard/runs?status=running');
@@ -1504,11 +1513,7 @@ describe('GET /api/dashboard/runs', () => {
   });
 
   test('accepts paused as valid status', async () => {
-    mockListDashboardRuns.mockImplementationOnce(async () => ({
-      runs: [],
-      total: 0,
-      counts: { all: 0, running: 0, completed: 0, failed: 0, cancelled: 0, pending: 0 },
-    }));
+    mockListDashboardRuns.mockImplementationOnce(async () => makeDashboardRunsResult());
 
     const { app } = makeApp();
     await app.request('/api/dashboard/runs?status=paused');
@@ -1518,11 +1523,7 @@ describe('GET /api/dashboard/runs', () => {
   });
 
   test('ignores invalid status values in dashboard runs', async () => {
-    mockListDashboardRuns.mockImplementationOnce(async () => ({
-      runs: [],
-      total: 0,
-      counts: { all: 0, running: 0, completed: 0, failed: 0, cancelled: 0, pending: 0 },
-    }));
+    mockListDashboardRuns.mockImplementationOnce(async () => makeDashboardRunsResult());
 
     const { app } = makeApp();
     await app.request('/api/dashboard/runs?status=bogus');
@@ -1532,11 +1533,7 @@ describe('GET /api/dashboard/runs', () => {
   });
 
   test('filters by codebaseId query param', async () => {
-    mockListDashboardRuns.mockImplementationOnce(async () => ({
-      runs: [],
-      total: 0,
-      counts: { all: 0, running: 0, completed: 0, failed: 0, cancelled: 0, pending: 0 },
-    }));
+    mockListDashboardRuns.mockImplementationOnce(async () => makeDashboardRunsResult());
 
     const { app } = makeApp();
     await app.request('/api/dashboard/runs?codebaseId=cb-1');
@@ -1546,11 +1543,7 @@ describe('GET /api/dashboard/runs', () => {
   });
 
   test('filters by search query param', async () => {
-    mockListDashboardRuns.mockImplementationOnce(async () => ({
-      runs: [],
-      total: 0,
-      counts: { all: 0, running: 0, completed: 0, failed: 0, cancelled: 0, pending: 0 },
-    }));
+    mockListDashboardRuns.mockImplementationOnce(async () => makeDashboardRunsResult());
 
     const { app } = makeApp();
     await app.request('/api/dashboard/runs?search=deploy');
@@ -1560,11 +1553,7 @@ describe('GET /api/dashboard/runs', () => {
   });
 
   test('supports after and before date filters', async () => {
-    mockListDashboardRuns.mockImplementationOnce(async () => ({
-      runs: [],
-      total: 0,
-      counts: { all: 0, running: 0, completed: 0, failed: 0, cancelled: 0, pending: 0 },
-    }));
+    mockListDashboardRuns.mockImplementationOnce(async () => makeDashboardRunsResult());
 
     const { app } = makeApp();
     await app.request('/api/dashboard/runs?after=2024-01-01T00:00:00Z&before=2024-12-31T23:59:59Z');
@@ -1575,11 +1564,7 @@ describe('GET /api/dashboard/runs', () => {
   });
 
   test('caps limit at 200', async () => {
-    mockListDashboardRuns.mockImplementationOnce(async () => ({
-      runs: [],
-      total: 0,
-      counts: { all: 0, running: 0, completed: 0, failed: 0, cancelled: 0, pending: 0 },
-    }));
+    mockListDashboardRuns.mockImplementationOnce(async () => makeDashboardRunsResult());
 
     const { app } = makeApp();
     await app.request('/api/dashboard/runs?limit=9999');
@@ -1589,11 +1574,7 @@ describe('GET /api/dashboard/runs', () => {
   });
 
   test('supports offset for pagination', async () => {
-    mockListDashboardRuns.mockImplementationOnce(async () => ({
-      runs: [],
-      total: 0,
-      counts: { all: 0, running: 0, completed: 0, failed: 0, cancelled: 0, pending: 0 },
-    }));
+    mockListDashboardRuns.mockImplementationOnce(async () => makeDashboardRunsResult());
 
     const { app } = makeApp();
     await app.request('/api/dashboard/runs?offset=50');

--- a/packages/server/src/routes/api.workflow-runs.test.ts
+++ b/packages/server/src/routes/api.workflow-runs.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { OpenAPIHono } from '@hono/zod-openapi';
 import type { ConversationLockManager } from '@archon/core';
+import type { WorkflowRun } from '@archon/workflows/schemas/workflow-run';
 import type { WebAdapter } from '../adapters/web';
 import { validationErrorHook } from './openapi-defaults';
 import { mockAllWorkflowModules } from '../test/workflow-mock-factories';
@@ -21,9 +22,24 @@ beforeAll(async (): Promise<void> => {
 
 const mockGetWorkflowRun = mock(async (_id: string) => null as null | MockWorkflowRun);
 const mockCancelWorkflowRun = mock(async (_id: string) => ({ cancelled: true }));
-const mockListWorkflowRuns = mock(async () => [] as MockWorkflowRun[]);
-const mockListDashboardRuns = mock(async () => ({
-  runs: [] as MockWorkflowRun[],
+type ListWorkflowRunsOptions = Parameters<
+  (typeof import('@archon/core/db/workflows'))['listWorkflowRuns']
+>[0];
+type ListDashboardRunsOptions = Parameters<
+  (typeof import('@archon/core/db/workflows'))['listDashboardRuns']
+>[0];
+
+const mockListWorkflowRuns = mock<
+  (_options?: ListWorkflowRunsOptions) => Promise<MockWorkflowRun[]>
+>(async () => []);
+const mockListDashboardRuns = mock<
+  (_options?: ListDashboardRunsOptions) => Promise<{
+    runs: MockWorkflowRun[];
+    total: number;
+    counts: Record<string, number>;
+  }>
+>(async () => ({
+  runs: [],
   total: 0,
   counts: { all: 0, running: 0, completed: 0, failed: 0, cancelled: 0, pending: 0 },
 }));
@@ -49,7 +65,7 @@ const mockFindConversationByPlatformId = mock(
       codebase_id: string | null;
     }
 );
-const mockHandleMessage = mock(async () => {});
+const mockHandleMessage = mock<(typeof import('@archon/core'))['handleMessage']>(async () => {});
 const mockAddMessage = mock(async () => ({
   id: 'msg-1',
   conversation_id: 'conv-1',
@@ -65,20 +81,9 @@ const mockResolveTitleRequest = mock(async () => ({
 }));
 
 // Type aliases for clarity in tests
-type MockWorkflowRun = {
-  id: string;
-  workflow_name: string;
-  conversation_id: string | null;
-  parent_conversation_id: string | null;
-  codebase_id: string | null;
-  status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled' | 'paused';
-  outcome: 'succeeded' | 'failed' | null;
-  user_message: string;
-  started_at: string;
-  completed_at: string | null;
-  metadata: Record<string, unknown>;
-  working_path: string | null;
-  last_activity_at: string | null;
+type MockWorkflowRun = Omit<WorkflowRun, 'conversation_id' | 'last_activity_at'> & {
+  conversation_id: WorkflowRun['conversation_id'] | null;
+  last_activity_at: WorkflowRun['last_activity_at'] | undefined;
 };
 
 type MockWorkflowEvent = {
@@ -353,21 +358,17 @@ mock.module('@archon/core/handlers', () => ({
   resolveRunContinuation: mockResolveRunContinuation,
 }));
 
-type MockHydrated = {
-  preCreatedRun: unknown;
-  priorCompletedNodes: Map<string, unknown>;
-  priorUsage: { costUsd: number };
-  priorNodeSessions: unknown[];
-} | null;
-const mockHydrateResumableRun = mock(
-  async (_deps: unknown, run: MockWorkflowRun): Promise<MockHydrated> => ({
-    preCreatedRun: { ...run, status: 'running' },
-    priorCompletedNodes: new Map(),
-    priorUsage: { costUsd: 0 },
-    priorNodeSessions: [],
-  })
+const mockHydrateResumableRun = mock<
+  (typeof import('@archon/workflows/executor'))['hydrateResumableRun']
+>(async (_deps, run) => ({
+  preCreatedRun: { ...run, status: 'running' },
+  priorCompletedNodes: new Map(),
+  priorUsage: { costUsd: 0 },
+  priorNodeSessions: [],
+}));
+const mockExecuteWorkflow = mock<(typeof import('@archon/workflows/executor'))['executeWorkflow']>(
+  async () => ({ success: true, workflowRunId: 'run-1' })
 );
-const mockExecuteWorkflow = mock(async () => ({}) as unknown);
 mock.module('@archon/workflows/executor', () => ({
   hydrateResumableRun: mockHydrateResumableRun,
   executeWorkflow: mockExecuteWorkflow,
@@ -380,6 +381,7 @@ import { registerApiRoutes } from './api';
 // ---------------------------------------------------------------------------
 
 const NOW = new Date().toISOString();
+const NOW_DATE = new Date(NOW);
 
 const MOCK_RUNNING_RUN: MockWorkflowRun = {
   id: 'run-uuid-1',
@@ -390,11 +392,15 @@ const MOCK_RUNNING_RUN: MockWorkflowRun = {
   status: 'running',
   outcome: null,
   user_message: 'Deploy to staging',
-  started_at: NOW,
+  started_at: NOW_DATE,
   completed_at: null,
   metadata: {},
   working_path: '/tmp/worktrees/feature',
-  last_activity_at: NOW,
+  last_activity_at: NOW_DATE,
+  user_id: null,
+  parent_run_id: null,
+  adopted_from_run_id: null,
+  output_root: null,
 };
 
 const MOCK_COMPLETED_RUN: MockWorkflowRun = {
@@ -402,7 +408,7 @@ const MOCK_COMPLETED_RUN: MockWorkflowRun = {
   id: 'run-uuid-2',
   status: 'completed',
   outcome: 'failed',
-  completed_at: NOW,
+  completed_at: NOW_DATE,
 };
 
 const MOCK_FAILED_RUN: MockWorkflowRun = {
@@ -410,7 +416,7 @@ const MOCK_FAILED_RUN: MockWorkflowRun = {
   id: 'run-uuid-4',
   status: 'failed',
   outcome: 'succeeded',
-  completed_at: NOW,
+  completed_at: NOW_DATE,
 };
 
 const MOCK_PENDING_RUN: MockWorkflowRun = {
@@ -770,7 +776,7 @@ describe('POST /api/workflows/:name/run', () => {
       body: JSON.stringify({ conversationId: 'web-test-abc', message: 'Go' }),
     });
 
-    const ctx = mockHandleMessage.mock.calls[0][3] as Record<string, unknown>;
+    const ctx = mockHandleMessage.mock.calls[0]?.[3];
     expect(ctx).not.toHaveProperty('workflowInputs');
   });
 
@@ -811,7 +817,7 @@ describe('POST /api/workflows/:name/run', () => {
     });
     expect(response.status).toBe(200);
 
-    const ctx = mockHandleMessage.mock.calls[0][3] as Record<string, unknown>;
+    const ctx = mockHandleMessage.mock.calls[0]?.[3];
     expect(ctx).not.toHaveProperty('workflowInputs');
   });
 
@@ -907,8 +913,8 @@ describe('POST /api/workflows/:name/run', () => {
     });
 
     expect(response.status).toBe(200);
-    const context = mockHandleMessage.mock.calls[0][3] as Record<string, unknown>;
-    expect(context.workflowModelOverrides).toEqual({
+    const context = mockHandleMessage.mock.calls[0]?.[3];
+    expect(context?.workflowModelOverrides).toEqual({
       tiers: { large: 'openai/gpt-5.6' },
       aliases: { '@planner': 'codex/gpt-5.6-sol' },
     });
@@ -983,8 +989,8 @@ describe('POST /api/workflows/:name/run', () => {
     });
 
     expect(response.status).toBe(200);
-    const context = mockHandleMessage.mock.calls[0][3] as Record<string, unknown>;
-    expect(context.workflowRunConfig).toEqual({
+    const context = mockHandleMessage.mock.calls[0]?.[3];
+    expect(context?.workflowRunConfig).toEqual({
       source: { kind: 'http', label: 'inline' },
       layer: { docsPath: 'handbook' },
     });
@@ -1200,7 +1206,7 @@ describe('GET /api/workflows/runs', () => {
         ...MOCK_RUNNING_RUN,
         started_at: now,
         completed_at: null,
-        last_activity_at: undefined as unknown as string,
+        last_activity_at: undefined,
       },
     ]);
 
@@ -1222,9 +1228,7 @@ describe('GET /api/workflows/runs', () => {
     const { app } = makeApp();
     await app.request('/api/workflows/runs?status=running');
 
-    const [[callArgs]] = mockListWorkflowRuns.mock.calls as [
-      [{ status?: string; limit?: number }],
-    ][];
+    const [callArgs] = mockListWorkflowRuns.mock.calls[0] ?? [];
     expect(callArgs?.status).toBe('running');
   });
 
@@ -1234,9 +1238,7 @@ describe('GET /api/workflows/runs', () => {
     const { app } = makeApp();
     await app.request('/api/workflows/runs?status=invalid_status');
 
-    const [[callArgs]] = mockListWorkflowRuns.mock.calls as [
-      [{ status?: string; limit?: number }],
-    ][];
+    const [callArgs] = mockListWorkflowRuns.mock.calls[0] ?? [];
     expect(callArgs?.status).toBeUndefined();
   });
 
@@ -1246,7 +1248,7 @@ describe('GET /api/workflows/runs', () => {
     const { app } = makeApp();
     await app.request('/api/workflows/runs?conversationId=conv-123');
 
-    const [[callArgs]] = mockListWorkflowRuns.mock.calls as [[{ conversationId?: string }]][];
+    const [callArgs] = mockListWorkflowRuns.mock.calls[0] ?? [];
     expect(callArgs?.conversationId).toBe('conv-123');
   });
 
@@ -1256,7 +1258,7 @@ describe('GET /api/workflows/runs', () => {
     const { app } = makeApp();
     await app.request('/api/workflows/runs?codebaseId=cb-uuid-1');
 
-    const [[callArgs]] = mockListWorkflowRuns.mock.calls as [[{ codebaseId?: string }]][];
+    const [callArgs] = mockListWorkflowRuns.mock.calls[0] ?? [];
     expect(callArgs?.codebaseId).toBe('cb-uuid-1');
   });
 
@@ -1266,7 +1268,7 @@ describe('GET /api/workflows/runs', () => {
     const { app } = makeApp();
     await app.request('/api/workflows/runs?limit=9999');
 
-    const [[callArgs]] = mockListWorkflowRuns.mock.calls as [[{ limit?: number }]][];
+    const [callArgs] = mockListWorkflowRuns.mock.calls[0] ?? [];
     expect(callArgs?.limit).toBeLessThanOrEqual(200);
   });
 
@@ -1276,7 +1278,7 @@ describe('GET /api/workflows/runs', () => {
     const { app } = makeApp();
     await app.request('/api/workflows/runs');
 
-    const [[callArgs]] = mockListWorkflowRuns.mock.calls as [[{ limit?: number }]][];
+    const [callArgs] = mockListWorkflowRuns.mock.calls[0] ?? [];
     expect(callArgs?.limit).toBe(50);
   });
 
@@ -1311,6 +1313,7 @@ describe('GET /api/workflows/runs/:runId', () => {
     mockGetConversationById.mockImplementationOnce(async () => ({
       id: 'conv-uuid-1',
       platform_conversation_id: 'web-conv-abc',
+      platform_type: 'web',
     }));
 
     const { app } = makeApp();
@@ -1346,6 +1349,7 @@ describe('GET /api/workflows/runs/:runId', () => {
     mockGetConversationById.mockImplementationOnce(async () => ({
       id: 'conv-uuid-1',
       platform_conversation_id: 'web-conv-abc',
+      platform_type: 'web',
     }));
 
     const { app } = makeApp();
@@ -1368,6 +1372,7 @@ describe('GET /api/workflows/runs/:runId', () => {
     mockGetConversationById.mockImplementationOnce(async () => ({
       id: 'conv-uuid-1',
       platform_conversation_id: 'cli-conv-xyz',
+      platform_type: 'cli',
     }));
 
     const { app } = makeApp();
@@ -1396,11 +1401,13 @@ describe('GET /api/workflows/runs/:runId', () => {
     mockGetConversationById.mockImplementationOnce(async () => ({
       id: 'conv-uuid-1',
       platform_conversation_id: 'worker-platform-id',
+      platform_type: 'web',
     }));
     // Second call: parent conversation
     mockGetConversationById.mockImplementationOnce(async () => ({
       id: 'parent-conv-uuid',
       platform_conversation_id: 'parent-platform-id',
+      platform_type: 'web',
     }));
 
     const { app } = makeApp();
@@ -1492,7 +1499,7 @@ describe('GET /api/dashboard/runs', () => {
     const { app } = makeApp();
     await app.request('/api/dashboard/runs?status=running');
 
-    const [[callArgs]] = mockListDashboardRuns.mock.calls as [[{ status?: string }]][];
+    const [callArgs] = mockListDashboardRuns.mock.calls[0] ?? [];
     expect(callArgs?.status).toBe('running');
   });
 
@@ -1506,7 +1513,7 @@ describe('GET /api/dashboard/runs', () => {
     const { app } = makeApp();
     await app.request('/api/dashboard/runs?status=paused');
 
-    const [[callArgs]] = mockListDashboardRuns.mock.calls as [[{ status?: string }]][];
+    const [callArgs] = mockListDashboardRuns.mock.calls[0] ?? [];
     expect(callArgs?.status).toBe('paused');
   });
 
@@ -1520,7 +1527,7 @@ describe('GET /api/dashboard/runs', () => {
     const { app } = makeApp();
     await app.request('/api/dashboard/runs?status=bogus');
 
-    const [[callArgs]] = mockListDashboardRuns.mock.calls as [[{ status?: string }]][];
+    const [callArgs] = mockListDashboardRuns.mock.calls[0] ?? [];
     expect(callArgs?.status).toBeUndefined();
   });
 
@@ -1534,7 +1541,7 @@ describe('GET /api/dashboard/runs', () => {
     const { app } = makeApp();
     await app.request('/api/dashboard/runs?codebaseId=cb-1');
 
-    const [[callArgs]] = mockListDashboardRuns.mock.calls as [[{ codebaseId?: string }]][];
+    const [callArgs] = mockListDashboardRuns.mock.calls[0] ?? [];
     expect(callArgs?.codebaseId).toBe('cb-1');
   });
 
@@ -1548,7 +1555,7 @@ describe('GET /api/dashboard/runs', () => {
     const { app } = makeApp();
     await app.request('/api/dashboard/runs?search=deploy');
 
-    const [[callArgs]] = mockListDashboardRuns.mock.calls as [[{ search?: string }]][];
+    const [callArgs] = mockListDashboardRuns.mock.calls[0] ?? [];
     expect(callArgs?.search).toBe('deploy');
   });
 
@@ -1562,9 +1569,7 @@ describe('GET /api/dashboard/runs', () => {
     const { app } = makeApp();
     await app.request('/api/dashboard/runs?after=2024-01-01T00:00:00Z&before=2024-12-31T23:59:59Z');
 
-    const [[callArgs]] = mockListDashboardRuns.mock.calls as [
-      [{ after?: string; before?: string }],
-    ][];
+    const [callArgs] = mockListDashboardRuns.mock.calls[0] ?? [];
     expect(callArgs?.after).toBe('2024-01-01T00:00:00Z');
     expect(callArgs?.before).toBe('2024-12-31T23:59:59Z');
   });
@@ -1579,7 +1584,7 @@ describe('GET /api/dashboard/runs', () => {
     const { app } = makeApp();
     await app.request('/api/dashboard/runs?limit=9999');
 
-    const [[callArgs]] = mockListDashboardRuns.mock.calls as [[{ limit?: number }]][];
+    const [callArgs] = mockListDashboardRuns.mock.calls[0] ?? [];
     expect(callArgs?.limit).toBeLessThanOrEqual(200);
   });
 
@@ -1593,7 +1598,7 @@ describe('GET /api/dashboard/runs', () => {
     const { app } = makeApp();
     await app.request('/api/dashboard/runs?offset=50');
 
-    const [[callArgs]] = mockListDashboardRuns.mock.calls as [[{ offset?: number }]][];
+    const [callArgs] = mockListDashboardRuns.mock.calls[0] ?? [];
     expect(callArgs?.offset).toBe(50);
   });
 
@@ -1690,7 +1695,7 @@ describe('POST /api/workflows/runs/:runId/resume', () => {
     expect(mockGetConversationById).not.toHaveBeenCalled();
     expect(mockHydrateResumableRun).toHaveBeenCalledTimes(1);
     expect(mockExecuteWorkflow).toHaveBeenCalledTimes(1);
-    const [, , , cwd] = mockExecuteWorkflow.mock.calls[0] as [unknown, unknown, unknown, string];
+    const cwd = mockExecuteWorkflow.mock.calls[0]?.[3];
     expect(cwd).toBe('/tmp/worktrees/run-uuid-4');
   });
 
@@ -1777,11 +1782,7 @@ describe('POST /api/workflows/runs/:runId/resume', () => {
 
     // dispatchToOrchestrator → lockManager → handleMessage
     expect(mockHandleMessage).toHaveBeenCalled();
-    const [, platformConvId, dispatchedMessage] = mockHandleMessage.mock.calls[0] as [
-      unknown,
-      string,
-      string,
-    ];
+    const [, platformConvId, dispatchedMessage] = mockHandleMessage.mock.calls[0] ?? [];
     expect(platformConvId).toBe('web-plat-abc');
     expect(dispatchedMessage).toBe('/workflow resume run-uuid-4');
   });
@@ -2049,7 +2050,7 @@ describe('POST /api/workflows/runs/:runId/abandon', () => {
     mockGetWorkflowRun.mockResolvedValueOnce({
       ...MOCK_RUNNING_RUN,
       status: 'cancelled' as const,
-      completed_at: NOW,
+      completed_at: NOW_DATE,
     });
     const { app } = makeApp();
     const response = await app.request('/api/workflows/runs/run-uuid-1/abandon', {
@@ -2858,11 +2859,7 @@ describe('approve/reject auto-resume', () => {
 
     // dispatchToOrchestrator → lockManager → handleMessage
     expect(mockHandleMessage).toHaveBeenCalled();
-    const [, platformConvId, dispatchedMessage] = mockHandleMessage.mock.calls[0] as [
-      unknown,
-      string,
-      string,
-    ];
+    const [, platformConvId, dispatchedMessage] = mockHandleMessage.mock.calls[0] ?? [];
     expect(platformConvId).toBe('web-plat-abc');
     expect(dispatchedMessage).toBe('/workflow resume run-auto-resume-approve');
   });
@@ -2901,18 +2898,9 @@ describe('approve/reject auto-resume', () => {
     expect(mockCreateChildWorktreeResolver).toHaveBeenCalledWith(
       expect.objectContaining({ codebaseId: 'cb-uuid-1', codebaseName: 'owner/repo' })
     );
-    const [, , , , , , , opts] = mockExecuteWorkflow.mock.calls[0] as [
-      unknown,
-      unknown,
-      unknown,
-      unknown,
-      unknown,
-      unknown,
-      unknown,
-      { resolveChildIsolation?: unknown; baseBranch?: string },
-    ];
-    expect(opts.resolveChildIsolation).toBeDefined();
-    expect(opts.baseBranch).toBe('main');
+    const opts = mockExecuteWorkflow.mock.calls[0]?.[7];
+    expect(opts?.resolveChildIsolation).toBeDefined();
+    expect(opts?.baseBranch).toBe('main');
   });
 
   test('approve: skips the child-isolation resolver for a folder-project codebase', async () => {
@@ -3099,11 +3087,7 @@ describe('approve/reject auto-resume', () => {
     const body = (await response.json()) as { message: string };
     expect(body.message).toContain('Running on-reject prompt');
     expect(mockHandleMessage).toHaveBeenCalled();
-    const [, platformConvId, dispatchedMessage] = mockHandleMessage.mock.calls[0] as [
-      unknown,
-      string,
-      string,
-    ];
+    const [, platformConvId, dispatchedMessage] = mockHandleMessage.mock.calls[0] ?? [];
     expect(platformConvId).toBe('web-plat-xyz');
     expect(dispatchedMessage).toBe('/workflow resume run-auto-resume-reject');
   });

--- a/packages/server/src/routes/api.workflows.test.ts
+++ b/packages/server/src/routes/api.workflows.test.ts
@@ -22,13 +22,16 @@ const mockDiscoverWorkflows = mock(async (_cwd: string | null) => ({
 }));
 
 // Default: returns a valid workflow. Use mockReturnValueOnce in tests that need a parse failure.
-const mockParseWorkflow = mock((content: string, _filename: string) => {
-  const name = /^name:\s*['"]?([^'"\n]+)['"]?$/m.exec(content)?.[1] ?? 'test';
-  return {
-    workflow: makeTestWorkflow({ name, description: 'Test workflow' }),
-    error: null,
-  };
-});
+const mockParseWorkflow = mock<(typeof import('@archon/workflows/loader'))['parseWorkflow']>(
+  (content: string, _filename: string) => {
+    const name = /^name:\s*['"]?([^'"\n]+)['"]?$/m.exec(content)?.[1] ?? 'test';
+    return {
+      workflow: makeTestWorkflow({ name, description: 'Test workflow' }),
+      error: null,
+      warnings: [],
+    };
+  }
+);
 
 const mockLoadRepoConfig = mock(
   async (_repoPath: string) => ({}) as { recommendedWorkflows?: string[] }
@@ -877,6 +880,7 @@ describe('PUT /api/workflows/:name', () => {
       mockParseWorkflow.mockReturnValueOnce({
         workflow: makeTestWorkflow({ name: 'my-workflow', description: 'test' }),
         error: null,
+        warnings: [],
       });
 
       const response = await app.request('/api/workflows/my-workflow', {

--- a/packages/server/src/routes/webhooks.test.ts
+++ b/packages/server/src/routes/webhooks.test.ts
@@ -40,12 +40,12 @@ const rawPayload = JSON.stringify({
   comment: { id: 1001, body: '@archon help', user: { login: 'user123' } },
 });
 
-function postWebhook(
+async function postWebhook(
   app: OpenAPIHono,
   headers: Record<string, string>,
   body: string = rawPayload
 ): Promise<Response> {
-  return app.request('/webhooks/github', { method: 'POST', headers, body });
+  return await app.request('/webhooks/github', { method: 'POST', headers, body });
 }
 
 describe('POST /webhooks/github', () => {

--- a/packages/server/src/services/workflow-resume-service.test.ts
+++ b/packages/server/src/services/workflow-resume-service.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import type { WorkflowRun } from '@archon/workflows/schemas/workflow-run';
 import type { IWorkflowPlatform } from '@archon/workflows/deps';
+import type { WorkflowResumeCursor } from '@archon/workflows/store';
 import type { resolveRunContinuation } from '@archon/core/handlers';
+import { makeTestWorkflow } from '@archon/workflows/test-utils';
 
 type RunContinuationResult = Awaited<ReturnType<typeof resolveRunContinuation>>;
 
@@ -10,12 +12,16 @@ const mockDeferWorkflowContinuation = mock(async () => undefined);
 const mockResolveRunContinuation = mock(
   async (): Promise<RunContinuationResult> => ({ ok: false, message: 'unused' })
 );
-const mockHydrateResumableRun = mock(async () => null as null | Record<string, unknown>);
-const mockExecuteWorkflow = mock(async () => ({
-  success: true as const,
-  workflowRunId: 'run-1',
-  summary: 'done',
-}));
+const mockHydrateResumableRun = mock<
+  (typeof import('@archon/workflows/executor'))['hydrateResumableRun']
+>(async () => null);
+const mockExecuteWorkflow = mock<(typeof import('@archon/workflows/executor'))['executeWorkflow']>(
+  async () => ({
+    success: true,
+    workflowRunId: 'run-1',
+    summary: 'done',
+  })
+);
 
 mock.module('@archon/core', () => ({
   createChildWorktreeResolver: mock(() => undefined),
@@ -25,7 +31,9 @@ mock.module('@archon/core/handlers', () => ({
   resolveRunContinuation: mockResolveRunContinuation,
 }));
 mock.module('@archon/core/db/codebases', () => ({ getCodebase: mock(async () => null) }));
-const mockFailWorkflowRun = mock(async () => undefined);
+const mockFailWorkflowRun = mock<(typeof import('@archon/core/db/workflows'))['failWorkflowRun']>(
+  async () => undefined
+);
 mock.module('@archon/core/db/workflows', () => ({
   listDueWorkflowContinuations: mockListDueWorkflowContinuations,
   deferWorkflowContinuation: mockDeferWorkflowContinuation,
@@ -76,6 +84,7 @@ function run(
     working_path: '/tmp/worktree',
     user_id: null,
     parent_run_id: null,
+    adopted_from_run_id: null,
     output_root: null,
   };
 }
@@ -109,7 +118,7 @@ describe('workflow continuation scanner', () => {
       mockResolveRunContinuation.mockResolvedValueOnce({
         ok: true,
         workflowName: 'deliver',
-        workflow: { definition: { name: 'deliver', nodes: [] } },
+        workflow: { definition: makeTestWorkflow({ name: 'deliver' }), args: '' },
       });
       mockHydrateResumableRun.mockResolvedValueOnce({
         preCreatedRun: { ...paused, status: 'running' },
@@ -143,7 +152,7 @@ describe('workflow continuation scanner', () => {
       mockResolveRunContinuation.mockResolvedValueOnce({
         ok: true,
         workflowName: 'deliver',
-        workflow: { definition: { name: 'deliver', nodes: [] } },
+        workflow: { definition: makeTestWorkflow({ name: 'deliver' }), args: '' },
       });
       mockHydrateResumableRun.mockResolvedValueOnce({
         preCreatedRun: { ...paused, status: 'running' },
@@ -202,7 +211,7 @@ describe('workflow continuation scanner', () => {
       }),
       run('quota-1', 'failed', { scheduled_resume: scheduled }),
     ]);
-    const resume = mock(async (_run: WorkflowRun) => true);
+    const resume = mock(async (_run: WorkflowRun, _cursor: WorkflowResumeCursor) => true);
 
     await expect(
       scanDueWorkflowContinuations(new Date('2026-08-24T11:00:01.000Z'), resume)
@@ -306,7 +315,7 @@ describe('workflow continuation scanner', () => {
         scheduled_resume: scheduled,
       }),
     ]);
-    const resume = mock(async (_run: WorkflowRun) => true);
+    const resume = mock(async (_run: WorkflowRun, _cursor: WorkflowResumeCursor) => true);
 
     await expect(
       scanDueWorkflowContinuations(new Date('2026-08-24T11:00:01.000Z'), resume)
@@ -324,7 +333,7 @@ describe('workflow continuation scanner', () => {
     mockResolveRunContinuation.mockResolvedValueOnce({
       ok: true,
       workflowName: 'deliver',
-      workflow: { definition: { name: 'deliver', nodes: [] } },
+      workflow: { definition: makeTestWorkflow({ name: 'deliver' }), args: '' },
     });
     mockHydrateResumableRun.mockResolvedValueOnce({
       preCreatedRun: { ...paused, status: 'running' },
@@ -361,7 +370,7 @@ describe('workflow continuation scanner', () => {
     mockResolveRunContinuation.mockResolvedValueOnce({
       ok: true,
       workflowName: 'deliver',
-      workflow: { definition: { name: 'deliver', nodes: [] } },
+      workflow: { definition: makeTestWorkflow({ name: 'deliver' }), args: '' },
     });
     mockHydrateResumableRun.mockResolvedValueOnce({
       preCreatedRun: { ...paused, status: 'running' },

--- a/packages/server/src/test/workflow-mock-factories.ts
+++ b/packages/server/src/test/workflow-mock-factories.ts
@@ -1,7 +1,41 @@
 import type { Mock } from 'bun:test';
 import { mock } from 'bun:test';
+import type { DashboardRunsResult } from '@archon/core/db/workflows';
 import type { WorkflowLoadResult } from '@archon/workflows/schemas/workflow';
 import type { ParseResult } from '@archon/workflows/loader';
+
+type ListDashboardRuns = (typeof import('@archon/core/db/workflows'))['listDashboardRuns'];
+
+interface DashboardRunsOverrides {
+  runs?: DashboardRunsResult['runs'];
+  total?: number;
+  counts?: Partial<DashboardRunsResult['counts']>;
+}
+
+export function makeDashboardRunsResult({
+  runs = [],
+  total = runs.length,
+  counts = {},
+}: DashboardRunsOverrides = {}): DashboardRunsResult {
+  return {
+    runs,
+    total,
+    counts: {
+      all: 0,
+      running: 0,
+      completed: 0,
+      failed: 0,
+      cancelled: 0,
+      pending: 0,
+      paused: 0,
+      ...counts,
+    },
+  };
+}
+
+export function makeListDashboardRunsMock(): Mock<ListDashboardRuns> {
+  return mock<ListDashboardRuns>(async () => makeDashboardRunsResult());
+}
 
 /**
  * Register all 4 @archon/workflows mock.module() calls at once.

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -19,11 +19,5 @@
     "../adapters/src/**/*.ts",
     "../workflows/src/defaults/text-imports.d.ts"
   ],
-  "exclude": [
-    "node_modules",
-    "dist",
-    "**/*.test.ts",
-    "../core/src/**/*.test.ts",
-    "../adapters/src/**/*.test.ts"
-  ]
+  "exclude": ["node_modules", "dist"]
 }

--- a/scripts/test-inventory.test.ts
+++ b/scripts/test-inventory.test.ts
@@ -226,4 +226,12 @@ describe('compiler test inventory', () => {
       join(REPO_ROOT, 'packages', 'core', 'src', 'utils', 'conversation-lock.test.ts'),
     ]);
   }, 15_000);
+
+  test("server's normal TypeScript project includes its own, core, and adapter test files", () => {
+    return expectProgramToInclude('server', [
+      join(REPO_ROOT, 'packages', 'server', 'src', 'routes', 'api.health.test.ts'),
+      join(REPO_ROOT, 'packages', 'core', 'src', 'utils', 'conversation-lock.test.ts'),
+      join(REPO_ROOT, 'packages', 'adapters', 'src', 'forge', 'github', 'adapter.test.ts'),
+    ]);
+  }, 15_000);
 });


### PR DESCRIPTION
## Problem and outcome

The server TypeScript project excluded all test files, letting type regressions in server, core, and adapters tests escape the normal server static gate. This completes the server tranche of the test-typing chain.

- **Outcome:** `@archon/server` type-checks its own, core, and adapters test files through its normal TypeScript project.
- **Invariant:** Tests retain their existing assertions and coverage while their fixtures and mocks satisfy the production contracts without `any`, `@ts-expect-error`, or a separate test tsconfig.
- **Scope boundary:** CLI test-file exclusions are unchanged; they are the final chain tranche.

## Review guidance

- **Feedback requested:** Confirm the normal server type-check now covers all intended test sources and that the derived fixtures preserve each suite's behavior.
- **Start here:** `packages/server/tsconfig.json` — removes the three test-file exclusions from the existing server project.
- **Review order:** Review the tsconfig change, then the shared-contract fixture and mock updates in `api.workflow-runs.test.ts` and `workflow-resume-service.test.ts`, followed by the smaller route-test corrections.
- **Lower-attention areas:** The remaining route-test edits complete stale fixture fields and derive mock signatures from their production exports; server type-check and tests cover them.
- **Known risk or uncertainty:** None.

## Solution

The server project now includes test files instead of maintaining test exclusions. The affected tests derive mock signatures from the functions they replace and derive workflow-run fixtures from `WorkflowRun`, so production contract changes surface at the test boundary. The continuation suite reuses `makeTestWorkflow` for valid workflow definitions, and route fixtures include the fields required by their current schemas.

## Behavior change

| | Before | After |
|---|---|---|
| **Static checking** | Server, core, and adapters test files were excluded from the server TypeScript project. | The normal server type-check verifies those test files. |
| **Test setup drift** | Mocks and fixtures could diverge from their production contracts without a compiler failure. | Derived signatures and shared valid fixtures make contract drift a compiler failure. |

## Validation

- `bun run type-check` in `packages/server` — passed after the fixes and after reverting a deliberate server-test type error — proves the normal check includes server tests.
- `bun run test` in `packages/server` — passed — preserves the package test suite.
- `bun test src/routes/api.workflow-runs.test.ts` — 132 passed, 0 failed — covers the largest refactored fixture and mock surface.
- `bun run lint --max-warnings 0` — passed.
- `bun run validate` — passed, including generated-artifact checks, package type checks, lint, format, installer tests, and the repository test suite.
- `git diff --check` — passed.
- **Not verified:** Nothing material; the available Bun version was 1.3.11 while `package.json` declares 1.4.0, but every listed check passed with the available executable.

## Links

- Closes #3054


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded workflow-run coverage for resuming executions, dashboard filtering, storage resolution, signals, artifacts, approvals, and error handling.
  * Improved test reliability with shared, strongly typed mocks and fixtures.
  * Added validation that server, core, and adapter tests are included in TypeScript compilation.
* **Refactor**
  * Updated test data and mock responses to match current message, workflow, and configuration schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->