### PR TITLE
test(server): restore green dev — resume-service tests build ResolvedWorkflow

### DIFF
--- a/packages/server/src/services/workflow-resume-service.test.ts
+++ b/packages/server/src/services/workflow-resume-service.test.ts
@@ -3,8 +3,7 @@ import type { WorkflowRun } from '@archon/workflows/schemas/workflow-run';
 import type { IWorkflowPlatform } from '@archon/workflows/deps';
 import type { WorkflowResumeCursor } from '@archon/workflows/store';
 import type { resolveRunContinuation } from '@archon/core/handlers';
-import { makeTestWorkflow } from '@archon/workflows/test-utils';
-import { resolveWorkflow } from '@archon/workflows/graph-plan';
+import { makeTestResolvedWorkflow } from '@archon/workflows/test-utils';
 
 type RunContinuationResult = Awaited<ReturnType<typeof resolveRunContinuation>>;
 
@@ -119,7 +118,7 @@ describe('workflow continuation scanner', () => {
       mockResolveRunContinuation.mockResolvedValueOnce({
         ok: true,
         workflowName: 'deliver',
-        workflow: { definition: resolveWorkflow(makeTestWorkflow({ name: 'deliver' })), args: '' },
+        workflow: { definition: makeTestResolvedWorkflow({ name: 'deliver' }), args: '' },
       });
       mockHydrateResumableRun.mockResolvedValueOnce({
         preCreatedRun: { ...paused, status: 'running' },
@@ -153,7 +152,7 @@ describe('workflow continuation scanner', () => {
       mockResolveRunContinuation.mockResolvedValueOnce({
         ok: true,
         workflowName: 'deliver',
-        workflow: { definition: resolveWorkflow(makeTestWorkflow({ name: 'deliver' })), args: '' },
+        workflow: { definition: makeTestResolvedWorkflow({ name: 'deliver' }), args: '' },
       });
       mockHydrateResumableRun.mockResolvedValueOnce({
         preCreatedRun: { ...paused, status: 'running' },
@@ -334,7 +333,7 @@ describe('workflow continuation scanner', () => {
     mockResolveRunContinuation.mockResolvedValueOnce({
       ok: true,
       workflowName: 'deliver',
-      workflow: { definition: resolveWorkflow(makeTestWorkflow({ name: 'deliver' })), args: '' },
+      workflow: { definition: makeTestResolvedWorkflow({ name: 'deliver' }), args: '' },
     });
     mockHydrateResumableRun.mockResolvedValueOnce({
       preCreatedRun: { ...paused, status: 'running' },
@@ -371,7 +370,7 @@ describe('workflow continuation scanner', () => {
     mockResolveRunContinuation.mockResolvedValueOnce({
       ok: true,
       workflowName: 'deliver',
-      workflow: { definition: resolveWorkflow(makeTestWorkflow({ name: 'deliver' })), args: '' },
+      workflow: { definition: makeTestResolvedWorkflow({ name: 'deliver' }), args: '' },
     });
     mockHydrateResumableRun.mockResolvedValueOnce({
       preCreatedRun: { ...paused, status: 'running' },

--- a/packages/server/src/services/workflow-resume-service.test.ts
+++ b/packages/server/src/services/workflow-resume-service.test.ts
@@ -4,6 +4,7 @@ import type { IWorkflowPlatform } from '@archon/workflows/deps';
 import type { WorkflowResumeCursor } from '@archon/workflows/store';
 import type { resolveRunContinuation } from '@archon/core/handlers';
 import { makeTestWorkflow } from '@archon/workflows/test-utils';
+import { resolveWorkflow } from '@archon/workflows/graph-plan';
 
 type RunContinuationResult = Awaited<ReturnType<typeof resolveRunContinuation>>;
 
@@ -118,7 +119,7 @@ describe('workflow continuation scanner', () => {
       mockResolveRunContinuation.mockResolvedValueOnce({
         ok: true,
         workflowName: 'deliver',
-        workflow: { definition: makeTestWorkflow({ name: 'deliver' }), args: '' },
+        workflow: { definition: resolveWorkflow(makeTestWorkflow({ name: 'deliver' })), args: '' },
       });
       mockHydrateResumableRun.mockResolvedValueOnce({
         preCreatedRun: { ...paused, status: 'running' },
@@ -152,7 +153,7 @@ describe('workflow continuation scanner', () => {
       mockResolveRunContinuation.mockResolvedValueOnce({
         ok: true,
         workflowName: 'deliver',
-        workflow: { definition: makeTestWorkflow({ name: 'deliver' }), args: '' },
+        workflow: { definition: resolveWorkflow(makeTestWorkflow({ name: 'deliver' })), args: '' },
       });
       mockHydrateResumableRun.mockResolvedValueOnce({
         preCreatedRun: { ...paused, status: 'running' },
@@ -333,7 +334,7 @@ describe('workflow continuation scanner', () => {
     mockResolveRunContinuation.mockResolvedValueOnce({
       ok: true,
       workflowName: 'deliver',
-      workflow: { definition: makeTestWorkflow({ name: 'deliver' }), args: '' },
+      workflow: { definition: resolveWorkflow(makeTestWorkflow({ name: 'deliver' })), args: '' },
     });
     mockHydrateResumableRun.mockResolvedValueOnce({
       preCreatedRun: { ...paused, status: 'running' },
@@ -370,7 +371,7 @@ describe('workflow continuation scanner', () => {
     mockResolveRunContinuation.mockResolvedValueOnce({
       ok: true,
       workflowName: 'deliver',
-      workflow: { definition: makeTestWorkflow({ name: 'deliver' }), args: '' },
+      workflow: { definition: resolveWorkflow(makeTestWorkflow({ name: 'deliver' })), args: '' },
     });
     mockHydrateResumableRun.mockResolvedValueOnce({
       preCreatedRun: { ...paused, status: 'running' },


### PR DESCRIPTION
## Problem and outcome

Dev's Test Suite went red at `65d32c898`: two independently green merges collided — PR #3089 made server test files visible to tsc while PR #3081 narrowed the resume path's parameter from `WorkflowDefinition` to `ResolvedWorkflow`. Four fixture sites in `workflow-resume-service.test.ts` fail type-check on the merge result; each PR's own CI predated the other's merge.

- **Outcome:** dev type-checks green again.
- **Scope boundary:** the four test fixture sites only, wrapped through `resolveWorkflow`; no production change.

## Validation

- `bun x tsc --noEmit` in `packages/server` and `packages/providers` — exit 0 (exit codes captured directly, not through a pipe).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated workflow resume test setup to use resolved workflow definitions, improving coverage reliability for continuation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->