### PR TITLE
fix(workflows): node_failed events carry iteration for loop-group body agents

### DIFF
--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -23115,6 +23115,120 @@ describe('executeDagWorkflow -- loop_group node', () => {
     expect(written).toContain('final result v2');
     expect(written).not.toContain('draft v1');
   });
+
+  it('records iteration on node_failed for a failing loop_group body agent (#3080)', async () => {
+    let callCount = 0;
+    mockSendQueryDag.mockImplementation(async function* () {
+      callCount++;
+      if (callCount === 1) {
+        yield { type: 'assistant', content: 'iteration 1 done' };
+        yield { type: 'result', sessionId: 'lg-fail-1' };
+      } else {
+        throw new Error('Simulated provider failure on iteration 2');
+      }
+    });
+
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun('lg-fail-iter');
+
+    const nodes: DagNode[] = [
+      {
+        id: 'fixer',
+        kind: 'loop_group',
+        loop_group: {
+          until: 'DONE',
+          max_iterations: 3,
+          fresh_context: false,
+          nodes: [
+            {
+              id: 'work',
+              kind: 'agent',
+              source: { kind: 'inline', prompt: 'do work' },
+              depends_on: [],
+            },
+          ],
+        },
+        depends_on: [],
+      },
+    ];
+
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-lg-fail',
+        cwd: testDir,
+        workflow: { name: 'lg-fail-iter', nodes },
+        workflowRun,
+      })
+    );
+
+    expect(callCount).toBe(2);
+    const events = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls.map(
+      c => c[0] as { event_type: string; step_name: string; data?: Record<string, unknown> }
+    );
+
+    // Iteration 1 completed normally — started and completed carry iteration.
+    const iter1Started = events.find(
+      e => e.event_type === 'node_started' && e.step_name === 'fixer.work'
+    );
+    const iter1Completed = events.find(
+      e => e.event_type === 'node_completed' && e.step_name === 'fixer.work'
+    );
+    expect(iter1Started?.data?.iteration).toBe(1);
+    expect(iter1Completed?.data?.iteration).toBe(1);
+
+    // Iteration 2 failed — started and failed carry the same iteration.
+    const iter2Started = events.filter(
+      e => e.event_type === 'node_started' && e.step_name === 'fixer.work'
+    )[1];
+    const iter2Failed = events.find(
+      e => e.event_type === 'node_failed' && e.step_name === 'fixer.work'
+    );
+    expect(iter2Started?.data?.iteration).toBe(2);
+    expect(iter2Failed?.data?.iteration).toBe(2);
+    expect(iter2Failed?.data?.error).toContain('Simulated provider failure');
+  });
+
+  it('does not record iteration on node_failed for a non-loop agent (#3080)', async () => {
+    mockSendQueryDag.mockImplementation(async function* () {
+      throw new Error('Simulated provider failure');
+    });
+
+    const store = createMockStore();
+    const mockDeps = createMockDeps(store);
+    const platform = createMockPlatform();
+    const workflowRun = makeWorkflowRun('no-loop-fail');
+
+    await executeDagWorkflow(
+      dagOptions({
+        deps: mockDeps,
+        platform,
+        conversationId: 'conv-noloop',
+        cwd: testDir,
+        workflow: {
+          name: 'no-loop-fail',
+          nodes: [
+            {
+              id: 'agent',
+              kind: 'agent',
+              source: { kind: 'inline', prompt: 'do work' },
+            },
+          ],
+        },
+        workflowRun,
+      })
+    );
+
+    const events = (store.createWorkflowEvent as ReturnType<typeof mock>).mock.calls.map(
+      c => c[0] as { event_type: string; step_name: string; data?: Record<string, unknown> }
+    );
+    const failed = events.find(e => e.event_type === 'node_failed' && e.step_name === 'agent');
+    expect(failed).toBeDefined();
+    expect(failed?.data?.iteration).toBeUndefined();
+  });
 });
 
 // #2090: loop_group body lifecycle events must carry a namespaced persisted `step_name`

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -2132,6 +2132,7 @@ async function executeNodeInternal(
           duration_ms: Date.now() - nodeStartTime,
           ...usage,
           ...namedSessionAuditData,
+          ...iterationData,
           ...(extras.data ?? {}),
         },
       })


### PR DESCRIPTION
## Problem and outcome

A loop-group body agent's lifecycle events carry its iteration on `node_started` and `node_completed`, but the `node_failed` event omits it. A failed row therefore cannot be disaggregated by iteration — the one event that matters most says the least.

- **Outcome:** `node_failed` events from loop-group body agents carry an `iteration` key in `data`, matching its sibling lifecycle events.
- **Invariant:** Additive only — no existing `data` keys renamed or removed.
- **Scope boundary:** Non-loop `node_failed` events are unchanged; the `data` for those events contains no `iteration` key.
- **Root cause:** The `failAgentNode` closure (introduced by PR #3077) spread `error`, `duration_ms`, `usage`, `namedSessionAuditData`, and `extras.data` — but not `iterationData`, even though the same lexical-scope variable is already spread on `node_started` and `node_completed` in the same function.

## Review guidance

- **Feedback requested:** Correctness — one-line spread in the production code, two tests.
- **Start here:** `packages/workflows/src/dag-executor.ts:2135` — the single changed line.
- **Review order:** Read the production diff (one spread addition), then the two tests. The first test must be seen red against the production code before the fix.
- **Known risk or uncertainty:** None. The variable is defined at the same scope (line 2055), is already used identically for `node_started` and `node_completed`, and spreads `{}` when `iteration` is `undefined` (outside a loop-group body), so non-loop paths are unaffected.

## Solution

Add `...iterationData` to the `data` object in `failAgentNode` at the same position relative to the other spreads — after `namedSessionAuditData` and before `extras.data`. The variable `iterationData` is already in lexical scope (line 2055) and is already spread on `node_started` (line 2084) and `node_completed` (line 3156), so this restores parity as a one-line change inside the existing finalizer boundary.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | `node_failed` for a loop-group body agent has `data: { error, duration_ms, usage, ... }` | `node_failed` for a loop-group body agent has `data: { error, duration_ms, usage, iteration, ... }` |
| **Failure behavior** | A failed body iteration cannot be joined with its `node_started`/`node_completed` siblings | The same `iteration` value appears on all three lifecycle events, making them joinable |

### Changed seams

| Boundary or contract | Change | Evidence |
|---|---|---|
| `failAgentNode` closure → `workflow_events` row | `data` payload gains `iteration` when in a loop-group body | `dag-executor.ts:2135`, test `records iteration on node_failed for a failing loop_group body agent (#3080)` |

## Validation

- `bun test packages/workflows/src/dag-executor.test.ts` (712 tests) — all pass — proves the new tests and existing coverage.
- `bun run test` in workflows package — all pass — proves no regression in the broader workflow engine suite.
- `bun run type-check` in workflows package — clean.
- ESLint on the touched production file — clean.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | Additive schema extension; existing `workflow_events.data` consumers ignore unknown keys. | The `iteration` key joins existing `data`, no renames. |

## Links

- Closes #3080
- Depends on #3077

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workflow failure events now include the correct iteration for nodes running within loop groups.
  * Non-loop node failures continue to omit iteration details.
  * Error messages are preserved in failure events for improved troubleshooting.

* **Tests**
  * Added coverage for loop iteration failures and standard node failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->