### PR TITLE
test: derive WorkflowDefinition-as-ResolvedWorkflow test mocks from their owner functions

### DIFF
--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -36,9 +36,11 @@ import {
 } from '@archon/paths/archon-paths';
 import type { WorkflowEmitterEvent } from '@archon/workflows/event-emitter';
 import type * as WorkflowDiscovery from '@archon/workflows/workflow-discovery';
+import type * as WorkflowExecutor from '@archon/workflows/executor';
 import type * as DetachedRunControl from '../utils/detached-run-control';
 import {
   makeTestComposedWorkflow,
+  makeTestResolvedWorkflow,
   makeTestWorkflow,
   makeTestWorkflowWithSource,
   withObservableCapturedSource,
@@ -281,6 +283,28 @@ mock.module('@archon/workflows/fixture-runner', () => ({
  * the owner would let a dropped `adopt()` — which deletes a live run's source — pass here.
  */
 const capturedSourceOwnerCalls: string[] = [];
+/** The full owned roots shape a continuation carries — shared between the prepare and
+ *  continuation mocks so the two cannot drift on which fields a `ResolvedContinuation`
+ *  promises its consumer. */
+const CAPTURED_SOURCE_ROOTS: WorkflowExecutor.WorkflowSourceRoots = {
+  project: '/test/capture/project',
+  globalWorkflows: '/test/capture/global/workflows',
+  globalCommands: '/test/capture/global/commands',
+  globalScripts: '/test/capture/global/scripts',
+  bundledWorkflows: '/test/capture/bundled',
+  bundledCommands: '/test/capture/bundled/commands/defaults',
+  kind: 'captured',
+  config: {
+    load_default_workflows: true,
+    load_default_commands: true,
+  },
+};
+const mockResolveContinuationWorkflow = mock<typeof WorkflowExecutor.resolveContinuationWorkflow>(
+  // Default: the run predates captures, so the caller keeps live discovery — what the
+  // resume tests below already assume. Tests that care about the frozen graph override
+  // it per invocation.
+  () => Promise.resolve(undefined)
+);
 
 mock.module('@archon/workflows/executor', () => ({
   // Mirrors the real executor's adopt site (#2690): rename happens, then the wrap's
@@ -303,7 +327,7 @@ mock.module('@archon/workflows/executor', () => ({
   // Every resume form reaches this now, including `run <name> --resume`. Default: the run
   // predates captures, so the caller keeps live discovery — what the resume tests below
   // already assume. Tests that care about the frozen graph override it per invocation.
-  resolveContinuationWorkflow: mock(() => Promise.resolve(undefined)),
+  resolveContinuationWorkflow: mockResolveContinuationWorkflow,
   // Source capture is real filesystem work the run path now performs BEFORE discovery.
   // Stubbed so these tests keep exercising flag validation and gating rather than disk.
   prepareWorkflowSource: mock(() =>
@@ -1764,10 +1788,9 @@ describe('workflowRunCommand — continuation and capture ownership (#2646)', ()
   beforeEach(async () => {
     consoleSpy = spyOn(console, 'log').mockImplementation(() => {});
     capturedSourceOwnerCalls.length = 0;
-    const { executeWorkflow, resolveContinuationWorkflow } =
-      await import('@archon/workflows/executor');
+    const { executeWorkflow } = await import('@archon/workflows/executor');
     (executeWorkflow as ReturnType<typeof mock>).mockClear();
-    (resolveContinuationWorkflow as ReturnType<typeof mock>).mockClear();
+    mockResolveContinuationWorkflow.mockClear();
   });
 
   afterEach(() => {
@@ -1779,14 +1802,13 @@ describe('workflowRunCommand — continuation and capture ownership (#2646)', ()
     // after the graph was already chosen from live discovery — while the executor still
     // fed that graph the frozen commands and scripts. Two vintages in one run, on the one
     // resume form that never carried a run object.
-    const { executeWorkflow, hydrateResumableRun, resolveContinuationWorkflow } =
-      await import('@archon/workflows/executor');
+    const { executeWorkflow, hydrateResumableRun } = await import('@archon/workflows/executor');
     const conversationDb = await import('@archon/core/db/conversations');
     const codebaseDb = await import('@archon/core/db/codebases');
     const workflowDb = await import('@archon/core/db/workflows');
     const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
 
-    const frozen = makeTestWorkflow({ name: 'review-block', description: 'frozen' });
+    const frozen = makeTestResolvedWorkflow({ name: 'review-block', description: 'frozen' });
     // What the checkout holds NOW: same name, edited since the run paused. Set as the
     // standing answer rather than a queued one — a continuation must never consume it, and
     // a queued value nothing consumes leaks into the next test.
@@ -1796,9 +1818,9 @@ describe('workflowRunCommand — continuation and capture ownership (#2646)', ()
       workflows: [makeTestWorkflowWithSource({ name: 'review-block', description: 'edited' })],
       errors: [],
     });
-    (resolveContinuationWorkflow as ReturnType<typeof mock>).mockResolvedValueOnce({
+    mockResolveContinuationWorkflow.mockResolvedValueOnce({
       workflow: frozen,
-      roots: { project: '/test/capture/project', kind: 'captured' },
+      roots: CAPTURED_SOURCE_ROOTS,
       workflows: [{ workflow: frozen, source: 'project' }],
       errors: [],
     });
@@ -1833,9 +1855,10 @@ describe('workflowRunCommand — continuation and capture ownership (#2646)', ()
     // Live discovery never even runs: the continuation carries the discovery it paid for.
     expect(discoverMock).not.toHaveBeenCalled();
     // The row is resolved before discovery and handed to the shared entry point...
-    expect(resolveContinuationWorkflow).toHaveBeenCalledTimes(1);
-    const continuedRun = (resolveContinuationWorkflow as ReturnType<typeof mock>).mock
-      .calls[0][1] as { id: string };
+    expect(mockResolveContinuationWorkflow).toHaveBeenCalledTimes(1);
+    const continuedRun = mockResolveContinuationWorkflow.mock.calls[0]?.[1] as unknown as {
+      id: string;
+    };
     expect(continuedRun.id).toBe('run-prior');
     // ...and its answer, not the edited checkout, is what runs.
     const executed = (executeWorkflow as ReturnType<typeof mock>).mock.calls[0][4] as {

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -345,13 +345,7 @@ mock.module('@archon/workflows/executor', () => ({
         byte_count: 0,
         scopes: [],
       },
-      roots: {
-        project: '/test/capture/project',
-        globalWorkflows: '/test/capture/global/workflows',
-        globalCommands: '/test/capture/global/commands',
-        globalScripts: '/test/capture/global/scripts',
-        bundledWorkflows: '/test/capture/bundled',
-      },
+      roots: CAPTURED_SOURCE_ROOTS,
     })
   ),
   recordSelectedWorkflow: mock(() => Promise.resolve()),

--- a/packages/core/src/orchestrator/orchestrator-agent.test.ts
+++ b/packages/core/src/orchestrator/orchestrator-agent.test.ts
@@ -236,6 +236,19 @@ const mockInspectResumableRun = mock<typeof WorkflowExecutor.inspectResumableRun
     priorUsage: { costUsd: 0 },
   })
 );
+const CAPTURED_SOURCE_ROOTS: WorkflowExecutor.WorkflowSourceRoots = {
+  project: '/capture/project',
+  globalWorkflows: '/capture/global/workflows',
+  globalCommands: '/capture/global/commands',
+  globalScripts: '/capture/global/scripts',
+  bundledWorkflows: '/capture/bundled',
+  bundledCommands: '/capture/bundled/commands/defaults',
+  kind: 'captured',
+  config: {
+    load_default_workflows: true,
+    load_default_commands: true,
+  },
+};
 const mockPrepareWorkflowSource = mock<typeof WorkflowExecutor.prepareWorkflowSource>(() =>
   Promise.resolve({
     runId: 'prepared-run-id',
@@ -255,20 +268,11 @@ const mockPrepareWorkflowSource = mock<typeof WorkflowExecutor.prepareWorkflowSo
         load_default_commands: true,
       },
     },
-    roots: {
-      project: '/capture/project',
-      globalWorkflows: '/capture/global/workflows',
-      globalCommands: '/capture/global/commands',
-      globalScripts: '/capture/global/scripts',
-      bundledWorkflows: '/capture/bundled',
-      bundledCommands: '/capture/bundled/commands/defaults',
-      kind: 'captured',
-      config: {
-        load_default_workflows: true,
-        load_default_commands: true,
-      },
-    },
+    roots: CAPTURED_SOURCE_ROOTS,
   })
+);
+const mockResolveContinuationWorkflow = mock<typeof WorkflowExecutor.resolveContinuationWorkflow>(
+  () => Promise.resolve(undefined)
 );
 /** Ownership calls the dispatch path makes on its capture, in order. */
 const capturedSourceOwnerCalls: string[] = [];
@@ -283,7 +287,7 @@ mock.module('@archon/workflows/executor', () => ({
   prepareWorkflowSource: mockPrepareWorkflowSource,
   recordSelectedWorkflow: mock(() => Promise.resolve()),
   disposeWorkflowSource: mock(() => Promise.resolve()),
-  resolveContinuationWorkflow: mock(() => Promise.resolve(undefined)),
+  resolveContinuationWorkflow: mockResolveContinuationWorkflow,
   withCapturedSource: mock((body: Parameters<typeof withObservableCapturedSource>[1]) =>
     withObservableCapturedSource(capturedSourceOwnerCalls, body)
   ),
@@ -6389,21 +6393,17 @@ describe('continueResolvedGateRun — chat gate continuation source (#2646)', ()
 
   beforeEach(async () => {
     mockExecuteWorkflow.mockClear();
-    const { resolveContinuationWorkflow } = await import('@archon/workflows/executor');
     // Reset, not clear: a queued `…Once` value that a test never consumes would otherwise
     // leak into the next one. Restores the factory default — a run predating captures.
-    (resolveContinuationWorkflow as ReturnType<typeof mock>).mockReset();
-    (resolveContinuationWorkflow as ReturnType<typeof mock>).mockImplementation(() =>
-      Promise.resolve(undefined)
-    );
+    mockResolveContinuationWorkflow.mockReset();
+    mockResolveContinuationWorkflow.mockImplementation(() => Promise.resolve(undefined));
   });
 
   test("continues with the graph the run froze, not the chat turn's discovery list", async () => {
-    const { resolveContinuationWorkflow } = await import('@archon/workflows/executor');
-    const frozen = makeTestWorkflow({ name: 'gated', description: 'frozen' });
-    (resolveContinuationWorkflow as ReturnType<typeof mock>).mockResolvedValueOnce({
+    const frozen = makeTestResolvedWorkflow({ name: 'gated', description: 'frozen' });
+    mockResolveContinuationWorkflow.mockResolvedValueOnce({
       workflow: frozen,
-      roots: { kind: 'captured' },
+      roots: CAPTURED_SOURCE_ROOTS,
       workflows: [{ workflow: frozen, source: 'project' }],
       errors: [],
     });
@@ -6430,11 +6430,10 @@ describe('continueResolvedGateRun — chat gate continuation source (#2646)', ()
     // The refusal this replaces was a false one: the chat turn's list describes the
     // checkout, and a workflow deleted or renamed since the run started is missing from
     // it — while the run's own captured source still holds exactly what it was running.
-    const { resolveContinuationWorkflow } = await import('@archon/workflows/executor');
-    const frozen = makeTestWorkflow({ name: 'gated', description: 'frozen' });
-    (resolveContinuationWorkflow as ReturnType<typeof mock>).mockResolvedValueOnce({
+    const frozen = makeTestResolvedWorkflow({ name: 'gated', description: 'frozen' });
+    mockResolveContinuationWorkflow.mockResolvedValueOnce({
       workflow: frozen,
-      roots: { kind: 'captured' },
+      roots: CAPTURED_SOURCE_ROOTS,
       workflows: [{ workflow: frozen, source: 'project' }],
       errors: [],
     });
@@ -6478,8 +6477,7 @@ describe('continueResolvedGateRun — chat gate continuation source (#2646)', ()
   });
 
   test('an unreadable captured source refuses instead of running something else', async () => {
-    const { resolveContinuationWorkflow } = await import('@archon/workflows/executor');
-    (resolveContinuationWorkflow as ReturnType<typeof mock>).mockRejectedValueOnce(
+    mockResolveContinuationWorkflow.mockRejectedValueOnce(
       new Error('captured source digest mismatch')
     );
 

--- a/packages/server/src/routes/api.workflow-runs.test.ts
+++ b/packages/server/src/routes/api.workflow-runs.test.ts
@@ -5,7 +5,9 @@ import { join, sep } from 'path';
 import { OpenAPIHono } from '@hono/zod-openapi';
 import type { ConversationLockManager } from '@archon/core';
 import type { DashboardWorkflowRun } from '@archon/core/db/workflows';
+import type { resolveRunContinuation } from '@archon/core/handlers';
 import type { WorkflowRun } from '@archon/workflows/schemas/workflow-run';
+import { makeTestResolvedWorkflow } from '@archon/workflows/test-utils';
 import type { WebAdapter } from '../adapters/web';
 import { validationErrorHook } from './openapi-defaults';
 import {
@@ -350,14 +352,12 @@ mock.module('@archon/core/utils/commands', () => ({
 
 // resumeRunHeadless (#2008) — the direct in-process resume fallback used when
 // a run has no parent conversation to dispatch a chat message through.
-type MockContinuationResult =
-  | { ok: true; workflowName: string; workflow: { definition: unknown } }
-  | { ok: false; message: string };
+type RunContinuationResult = Awaited<ReturnType<typeof resolveRunContinuation>>;
 const mockResolveRunContinuation = mock(
-  async (_runId: string, _cwd: string): Promise<MockContinuationResult> => ({
+  async (_runId: string, _cwd: string): Promise<RunContinuationResult> => ({
     ok: true,
     workflowName: 'deploy',
-    workflow: { definition: { name: 'deploy', nodes: [] } },
+    workflow: { definition: makeTestResolvedWorkflow({ name: 'deploy' }), args: '' },
   })
 );
 mock.module('@archon/core/handlers', () => ({


### PR DESCRIPTION
## Problem and outcome

Three test-side seams still let a bare `WorkflowDefinition` shape pass where `ResolvedWorkflow` is expected, the same collision class PR #3099 fixed for four sites in `workflow-resume-service.test.ts`. Two slipped through that review; the validating run for this PR surfaced the third.

- **Outcome:** All three continuation mocks now derive their return type from the owner function. A future change that hands back the wrong shape fails to compile on the exact assignment site, not later in a runtime assertion.
- **Invariant:** No hand-declared mock contract types for `ResolvedContinuation` or `RunContinuationResult` remain. `makeTestResolvedWorkflow` is the only fixture building continuation payloads, and the full owned `WorkflowSourceRoots` literal lives in one named constant per file.
- **Scope boundary:** Test files only. No production code changed, no new dependency added. Sibling mocks outside the named class (`discoverWorkflowsWithConfig`, the orchestrator typed prepare mock) were checked and left alone; the cli `prepareWorkflowSource` mock's `roots` now reuses `CAPTURED_SOURCE_ROOTS` so the one-constant-per-file invariant holds in that file too.

## Review guidance

- **Feedback requested:** Correctness of the type derivation against the owner functions, and whether the typed-mock + shared-roots widening on the orchestrator seam and CLI seam were load-bearing or scope creep.
- **Start here:** `packages/server/src/routes/api.workflow-runs.test.ts:355` — the typed `RunContinuationResult` is the smallest swap, the pattern PR #3099 set.
- **Review order:** server first, then `packages/core/src/orchestrator/orchestrator-agent.test.ts` (typed mock + shared `CAPTURED_SOURCE_ROOTS`), then `packages/cli/src/commands/workflow.test.ts` (the third seam this PR corrects).
- **Lower-attention areas:** Extracted `CAPTURED_SOURCE_ROOTS` constants and dropped dynamic `await import(...)` re-imports are mechanical cleanup on the same seam — the typed mock is what removes the escape hatch the old `as ReturnType<typeof mock>` cast provided.
- **Known risk or uncertainty:** None.

## Solution

For each seam, derive the mock type from the owner instead of declaring a looser contract by hand:

- `api.workflow-runs.test.ts`: replace the hand-declared `MockContinuationResult` (which typed `definition: unknown`) with `type RunContinuationResult = Awaited<ReturnType<typeof resolveRunContinuation>>`, and build the mock's `workflow.definition` with `makeTestResolvedWorkflow({ name: 'deploy' })`.
- `orchestrator-agent.test.ts`: promote `resolveContinuationWorkflow` to a typed module-level mock (`mock<typeof WorkflowExecutor.resolveContinuationWorkflow>`) and switch the two continuation sites from `makeTestWorkflow(...)` to `makeTestResolvedWorkflow(...)`. Extract `CAPTURED_SOURCE_ROOTS: WorkflowExecutor.WorkflowSourceRoots` so the prepare and continuation fixtures cannot drift on which fields a `ResolvedContinuation` promises. The typed mock also removes the per-test `await import(...)` re-imports the `as ReturnType<typeof mock>` cast required.
- `cli/commands/workflow.test.ts`: same pattern — type the mock against `typeof WorkflowExecutor.resolveContinuationWorkflow`, extract `CAPTURED_SOURCE_ROOTS`, build the resume test override through `makeTestResolvedWorkflow`, drop the three `as ReturnType<typeof mock>` casts on the continuation call sites. The typed mock is the load-bearing piece: without it, the `WorkflowDefinition` payload and the 2-of-7 partial roots literal would still compile. The module-level `prepareWorkflowSource` mock's `roots` now reuses `CAPTURED_SOURCE_ROOTS` instead of a hand-written five-field literal, closing the last partial-roots literal the comment on the constant claimed to prevent.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Mocks type-check with a hand-declared loose contract or a `as ReturnType<typeof mock>` escape hatch; a wrong shape compiles silently. | Mocks derive from the owner's return type; a wrong shape fails `TS2322` on the assignment. |
| **Failure behavior** | Latent: a future consumer that asserts on `ResolvedWorkflowIdentity` would compile fine here and only blow up at runtime. | The type-check is the failure; no runtime regression introduced. |

## Architecture

```mermaid
flowchart LR
  A[Owner function: resolveRunContinuation / WorkflowExecutor.resolveContinuationWorkflow] --> B[Derived mock type]
  B ==> C[Test mock body uses makeTestResolvedWorkflow + CAPTURED_SOURCE_ROOTS]
  C --> D[Wrong shape rejected at compile time]
```

### Changed seams

| Boundary or contract | Change | Evidence |
|---|---|---|
| `api.workflow-runs.test.ts → resolveRunContinuation mock` | Type derived from `Awaited<ReturnType<typeof resolveRunContinuation>>`; body uses `makeTestResolvedWorkflow` | `packages/server/src/routes/api.workflow-runs.test.ts:355-360` |
| `orchestrator-agent.test.ts → resolveContinuationWorkflow mock` | Typed against `WorkflowExecutor.resolveContinuationWorkflow`; two continuation sites use `makeTestResolvedWorkflow`; roots share `CAPTURED_SOURCE_ROOTS` | `packages/core/src/orchestrator/orchestrator-agent.test.ts:236-280, 6389-6480` |
| `cli/commands/workflow.test.ts → resolveContinuationWorkflow mock` | Typed against `WorkflowExecutor.resolveContinuationWorkflow`; resume test override builds through `makeTestResolvedWorkflow`; roots share `CAPTURED_SOURCE_ROOTS`; three `as ReturnType<typeof mock>` casts dropped | `packages/cli/src/commands/workflow.test.ts:286-307, 1788-1860` |

## Validation

- `bun run type-check` — 0 errors across 12 packages.
- `bun run lint` — clean, max-warnings 0.
- `bun run format:check` — clean.
- `bun run check:bundled && bun run check:bundled-skill && bun run check:bundled-schema && bun run check:pi-vendor-map && bun run check:capability-matrix && bun run check:api-types` — OK.
- `bash scripts/test-install.sh` — passed.
- `bun run test` — exit 0.
- `bun run validate` — exit 0.
- `bun test --cwd packages/core src/orchestrator/orchestrator-agent.test.ts` — 280 pass, 0 fail.
- `bun test --cwd packages/server src/routes/api.workflow-runs.test.ts` — 132 pass, 0 fail.
- `bun test --cwd packages/cli src/commands/workflow.test.ts` — 367 pass, 0 fail.
- T-test against the boundary itself (orchestrator + server):
  - Restoring either mock to the old shape fails type-check on `ResolvedWorkflowIdentity` at the exact assignment line.
  - Unused-import warning fires on `makeTestResolvedWorkflow` in the server file when reverted.
- T-test against the third (CLI) seam:
  - Reverting the typed mock to `mock(() => Promise.resolve(undefined))` fails with `TS2345` on the `mockResolvedValueOnce` body.
  - Reverting `makeTestResolvedWorkflow` back to `makeTestWorkflow` fails with `TS2322` (`WorkflowDefinition` not assignable to `ResolvedWorkflow`) on both the `workflow` and `workflows[0].workflow` assignments, plus an unused-import warning on `makeTestResolvedWorkflow`.
  - Reverting `CAPTURED_SOURCE_ROOTS` back to the 2-field literal fails with `TS2740`: missing `globalWorkflows, globalCommands, globalScripts, bundledWorkflows, bundledCommands, config` from `WorkflowSourceRoots`.
- Acceptance grep: `rg -n "definition: makeTestWorkflow\(" packages/ -g '*.test.ts'` → 0 hits. `rg -n "definition: { name:" packages/ -g '*.test.ts' | rg workflow-runs` → 0 hits.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | None — test-only change, no production behavior or schema touched. | Diff is restricted to three `*.test.ts` files. |
| Security / permissions / data | None — no production code path or credential surface changed. | n/a |
| Rollout / rollback | Trivial — revert three commits. | Three commits across three test files; +68 / −53 overall. |
| Observability | None — tests only. | n/a |
| Documentation / communication | None required. | n/a |

## Links

- Closes #3101


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved workflow continuation and resume test coverage.
  * Standardized test scenarios for resolved workflows and captured source roots.
  * Strengthened validation of workflow-run continuation behavior across server and CLI flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->