### PR TITLE
fix(isolation): retry same-repo PR fetch on concurrent ref-lock race

### DIFF
--- a/packages/isolation/src/providers/worktree.test.ts
+++ b/packages/isolation/src/providers/worktree.test.ts
@@ -564,11 +564,12 @@ describe('WorktreeProvider', () => {
 
       await provider.create(request);
 
-      // Verify fetch with actual branch name
-      expect(execSpy).toHaveBeenCalledWith(
-        'git',
-        expect.arrayContaining(['-C', '/workspace/repo', 'fetch', 'origin', 'feature/auth']),
-        expect.any(Object)
+      // PR branch fetch is delegated to syncWorkspace with fetch-only mode so
+      // the bounded ref-lock retry lives in @archon/git.
+      expect(syncWorkspaceSpy).toHaveBeenCalledWith(
+        '/workspace/repo',
+        git.toBranchName('feature/auth'),
+        { mode: 'fetch-only', remote: 'origin' }
       );
 
       // Verify worktree add with actual branch
@@ -972,11 +973,24 @@ describe('WorktreeProvider', () => {
         isForkPR: false,
       };
 
-      execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
-        if (args.includes('fetch')) {
-          throw new Error('fatal: unable to access repository');
+      // Base branch sync succeeds; the PR branch fetch (delegated to
+      // syncWorkspace) is what fails. This mirrors the failure surface the
+      // operator sees when the remote becomes unreachable mid-launch.
+      syncWorkspaceSpy.mockImplementation(async (_repo, branch) => {
+        if (branch === git.toBranchName('feature/auth')) {
+          throw new Error(
+            'Sync fetch from origin/feature/auth failed: fatal: unable to access repository'
+          );
         }
-        return { stdout: '', stderr: '' };
+        return {
+          branch: git.toBranchName('main'),
+          synced: true,
+          mode: 'fast-forward',
+          state: 'in_sync',
+          previousHead: '',
+          newHead: '',
+          updated: false,
+        };
       });
 
       await expect(provider.create(request)).rejects.toThrow(
@@ -984,24 +998,33 @@ describe('WorktreeProvider', () => {
       );
     });
 
-    test('retries same-repo PR fetch on transient ref-lock race and both calls succeed', async () => {
-      // Mirrors syncWorkspace's race-recovery path: two concurrent same-repo PR
-      // launches race on the shared remote-tracking ref. The first fetch
-      // attempt for each call fails with the lock-race error; the retry loop
-      // must absorb it so both launches succeed.
-      const raceError = new Error(
-        "error: cannot lock ref 'refs/remotes/origin/feature/auth': is at de581e24 but expected 8eaa8d42\n" +
-          '! 8eaa8d420..de581e24b feature/auth -> origin/feature/auth (unable to update local ref)'
-      );
-      let fetchCalls = 0;
-
-      execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
-        if (args.includes('fetch') && args.includes('feature/auth')) {
-          fetchCalls++;
-          if (fetchCalls <= 2) throw raceError;
-          return { stdout: '', stderr: '' };
+    test('delegates same-repo PR fetch to syncWorkspace so ref-lock race is absorbed', async () => {
+      // Mirrors syncWorkspace's race-recovery contract: the bounded ref-lock
+      // retry lives in syncWorkspace, so createFromSameRepoPR must delegate
+      // the fetch there. Concurrent launches that would collide on the
+      // shared remote-tracking ref now succeed because syncWorkspace retries
+      // internally (its own tests cover the retry mechanics).
+      syncWorkspaceSpy.mockImplementation(async (_repo, branch) => {
+        if (branch === git.toBranchName('feature/auth')) {
+          return {
+            branch: git.toBranchName('feature/auth'),
+            synced: true,
+            mode: 'fetch-only',
+            state: 'in_sync',
+            previousHead: '',
+            newHead: '',
+            updated: false,
+          };
         }
-        return { stdout: '', stderr: '' };
+        return {
+          branch: git.toBranchName('main'),
+          synced: true,
+          mode: 'fast-forward',
+          state: 'in_sync',
+          previousHead: '',
+          newHead: '',
+          updated: false,
+        };
       });
 
       const request: IsolationRequest = {
@@ -1014,26 +1037,38 @@ describe('WorktreeProvider', () => {
 
       await Promise.all([provider.create(request), provider.create(request)]);
 
-      // Both launches succeeded past the fetch race; retry absorbed it.
-      expect(fetchCalls).toBeGreaterThan(2);
+      // Both launches succeeded past the fetch race; syncWorkspace absorbed it.
+      expect(syncWorkspaceSpy).toHaveBeenCalledWith(
+        '/workspace/repo',
+        git.toBranchName('feature/auth'),
+        { mode: 'fetch-only', remote: 'origin' }
+      );
     });
 
-    test('throws after exhausting retry budget on persistent same-repo PR fetch lock-race error', async () => {
-      // When every same-repo PR fetch attempt fails with the lock-race error,
-      // the launch must throw after 4 total attempts (1 initial + 3 retries)
-      // and never reach the worktree add step.
-      const raceError = new Error(
-        "error: cannot lock ref 'refs/remotes/origin/feature/auth': is at de581e24 but expected 8eaa8d42\n" +
-          '! 8eaa8d420..de581e24b feature/auth -> origin/feature/auth (unable to update local ref)'
-      );
-      let fetchCalls = 0;
-      let worktreeAddCalls = 0;
-
-      execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
-        if (args.includes('fetch') && args.includes('feature/auth')) {
-          fetchCalls++;
-          throw raceError;
+    test('throws when syncWorkspace exhausts its retry budget on persistent same-repo PR fetch lock-race error', async () => {
+      // When syncWorkspace exhausts its ref-lock retry budget it throws;
+      // createFromSameRepoPR must surface that failure as a loud launch error
+      // before any worktree is created.
+      syncWorkspaceSpy.mockImplementation(async (_repo, branch) => {
+        if (branch === git.toBranchName('feature/auth')) {
+          throw new Error(
+            "Sync fetch from origin/feature/auth failed: error: cannot lock ref 'refs/remotes/origin/feature/auth': is at de581e24 but expected 8eaa8d42\n" +
+              '! 8eaa8d420..de581e24b feature/auth -> origin/feature/auth (unable to update local ref)'
+          );
         }
+        return {
+          branch: git.toBranchName('main'),
+          synced: true,
+          mode: 'fast-forward',
+          state: 'in_sync',
+          previousHead: '',
+          newHead: '',
+          updated: false,
+        };
+      });
+
+      let worktreeAddCalls = 0;
+      execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
         if (args.includes('worktree') && args.includes('add')) worktreeAddCalls++;
         return { stdout: '', stderr: '' };
       });
@@ -1046,24 +1081,38 @@ describe('WorktreeProvider', () => {
         isForkPR: false,
       };
 
+      // Outer wrap (createFromPR) preserves the surrounding prefix and the
+      // inner wrap (createFromSameRepoPR) keeps the contract that
+      // distinguishes fetch failures from worktree-add failures.
       await expect(provider.create(request)).rejects.toThrow(
-        'Failed to create worktree for PR #42'
+        'Failed to create worktree for PR #42: Fetch origin/feature/auth failed: error: cannot lock ref'
       );
 
-      expect(fetchCalls).toBe(4); // 1 initial + 3 retries
+      expect(syncWorkspaceSpy).toHaveBeenCalledTimes(2);
       // Failed launch must fail before any estate (worktree) is created.
       expect(worktreeAddCalls).toBe(0);
     });
 
-    test('does not retry non-race same-repo PR fetch errors', async () => {
-      let fetchCalls = 0;
-
-      execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
-        if (args.includes('fetch') && args.includes('feature/auth')) {
-          fetchCalls++;
-          throw new Error("fatal: 'origin' does not appear to be a git repository");
+    test('does not retry non-race same-repo PR fetch errors and preserves the inner wrap', async () => {
+      // syncWorkspace surfaces non-race fetch errors immediately without
+      // retrying. createFromSameRepoPR must wrap that error so the surrounding
+      // createFromPR prefix still distinguishes fetch failures from worktree-add
+      // failures.
+      syncWorkspaceSpy.mockImplementation(async (_repo, branch) => {
+        if (branch === git.toBranchName('feature/auth')) {
+          throw new Error(
+            "Sync fetch from origin/feature/auth failed: fatal: 'origin' does not appear to be a git repository"
+          );
         }
-        return { stdout: '', stderr: '' };
+        return {
+          branch: git.toBranchName('main'),
+          synced: true,
+          mode: 'fast-forward',
+          state: 'in_sync',
+          previousHead: '',
+          newHead: '',
+          updated: false,
+        };
       });
 
       const request: IsolationRequest = {
@@ -1074,11 +1123,14 @@ describe('WorktreeProvider', () => {
         isForkPR: false,
       };
 
+      // Outer wrap + inner wrap together verify that the non-race fetch error
+      // is preserved as `Fetch <remote>/<branch> failed: <original>` inside
+      // the surrounding `createFromPR` prefix.
       await expect(provider.create(request)).rejects.toThrow(
-        'Failed to create worktree for PR #42'
+        "Failed to create worktree for PR #42: Fetch origin/feature/auth failed: fatal: 'origin' does not appear to be a git repository"
       );
 
-      expect(fetchCalls).toBe(1);
+      expect(syncWorkspaceSpy).toHaveBeenCalledTimes(2);
     });
 
     test('throws error if PR fetch fails (fork PR)', async () => {
@@ -3555,11 +3607,11 @@ describe('WorktreeProvider', () => {
 
       await customProvider.create(prRequest);
 
-      // Fetch uses the custom remote
-      expect(execSpy).toHaveBeenCalledWith(
-        'git',
-        expect.arrayContaining(['-C', '/workspace/repo', 'fetch', 'upstream', 'feature/auth']),
-        expect.any(Object)
+      // PR fetch is delegated to syncWorkspace with the custom remote.
+      expect(syncWorkspaceSpy).toHaveBeenCalledWith(
+        '/workspace/repo',
+        git.toBranchName('feature/auth'),
+        { mode: 'fetch-only', remote: 'upstream' }
       );
 
       // Branch tracking uses the custom remote

--- a/packages/isolation/src/providers/worktree.test.ts
+++ b/packages/isolation/src/providers/worktree.test.ts
@@ -984,6 +984,103 @@ describe('WorktreeProvider', () => {
       );
     });
 
+    test('retries same-repo PR fetch on transient ref-lock race and both calls succeed', async () => {
+      // Mirrors syncWorkspace's race-recovery path: two concurrent same-repo PR
+      // launches race on the shared remote-tracking ref. The first fetch
+      // attempt for each call fails with the lock-race error; the retry loop
+      // must absorb it so both launches succeed.
+      const raceError = new Error(
+        "error: cannot lock ref 'refs/remotes/origin/feature/auth': is at de581e24 but expected 8eaa8d42\n" +
+          '! 8eaa8d420..de581e24b feature/auth -> origin/feature/auth (unable to update local ref)'
+      );
+      let fetchCalls = 0;
+
+      execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
+        if (args.includes('fetch') && args.includes('feature/auth')) {
+          fetchCalls++;
+          if (fetchCalls <= 2) throw raceError;
+          return { stdout: '', stderr: '' };
+        }
+        return { stdout: '', stderr: '' };
+      });
+
+      const request: IsolationRequest = {
+        ...baseRequest,
+        workflowType: 'pr',
+        identifier: '42',
+        prBranch: git.toBranchName('feature/auth'),
+        isForkPR: false,
+      };
+
+      await Promise.all([provider.create(request), provider.create(request)]);
+
+      // Both launches succeeded past the fetch race; retry absorbed it.
+      expect(fetchCalls).toBeGreaterThan(2);
+    });
+
+    test('throws after exhausting retry budget on persistent same-repo PR fetch lock-race error', async () => {
+      // When every same-repo PR fetch attempt fails with the lock-race error,
+      // the launch must throw after 4 total attempts (1 initial + 3 retries)
+      // and never reach the worktree add step.
+      const raceError = new Error(
+        "error: cannot lock ref 'refs/remotes/origin/feature/auth': is at de581e24 but expected 8eaa8d42\n" +
+          '! 8eaa8d420..de581e24b feature/auth -> origin/feature/auth (unable to update local ref)'
+      );
+      let fetchCalls = 0;
+      let worktreeAddCalls = 0;
+
+      execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
+        if (args.includes('fetch') && args.includes('feature/auth')) {
+          fetchCalls++;
+          throw raceError;
+        }
+        if (args.includes('worktree') && args.includes('add')) worktreeAddCalls++;
+        return { stdout: '', stderr: '' };
+      });
+
+      const request: IsolationRequest = {
+        ...baseRequest,
+        workflowType: 'pr',
+        identifier: '42',
+        prBranch: git.toBranchName('feature/auth'),
+        isForkPR: false,
+      };
+
+      await expect(provider.create(request)).rejects.toThrow(
+        'Failed to create worktree for PR #42'
+      );
+
+      expect(fetchCalls).toBe(4); // 1 initial + 3 retries
+      // Failed launch must fail before any estate (worktree) is created.
+      expect(worktreeAddCalls).toBe(0);
+    });
+
+    test('does not retry non-race same-repo PR fetch errors', async () => {
+      let fetchCalls = 0;
+
+      execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
+        if (args.includes('fetch') && args.includes('feature/auth')) {
+          fetchCalls++;
+          throw new Error("fatal: 'origin' does not appear to be a git repository");
+        }
+        return { stdout: '', stderr: '' };
+      });
+
+      const request: IsolationRequest = {
+        ...baseRequest,
+        workflowType: 'pr',
+        identifier: '42',
+        prBranch: git.toBranchName('feature/auth'),
+        isForkPR: false,
+      };
+
+      await expect(provider.create(request)).rejects.toThrow(
+        'Failed to create worktree for PR #42'
+      );
+
+      expect(fetchCalls).toBe(1);
+    });
+
     test('throws error if PR fetch fails (fork PR)', async () => {
       const request: IsolationRequest = {
         ...baseRequest,

--- a/packages/isolation/src/providers/worktree.ts
+++ b/packages/isolation/src/providers/worktree.ts
@@ -1096,10 +1096,38 @@ export class WorktreeProvider implements IIsolationProvider {
     prBranch: string,
     remote = 'origin'
   ): Promise<void> {
-    // Fetch the PR's actual branch
-    await execFileAsync('git', ['-C', repoPath, 'fetch', remote, prBranch], {
-      timeout: GIT_OPERATION_TIMEOUT_MS,
-    });
+    // Fetch the PR's actual branch. Retry on transient ref-lock races —
+    // concurrent same-repo launches collide on Git's shared remote-tracking
+    // ref lock file. Mirrors the protection in syncWorkspace.
+    const MAX_FETCH_RETRIES = 3;
+
+    for (let attempt = 0; attempt <= MAX_FETCH_RETRIES; attempt++) {
+      try {
+        await execFileAsync('git', ['-C', repoPath, 'fetch', remote, prBranch], {
+          timeout: GIT_OPERATION_TIMEOUT_MS,
+        });
+        break;
+      } catch (error) {
+        const err = error as Error;
+        const errorMessage = err.message.toLowerCase();
+
+        if (
+          attempt < MAX_FETCH_RETRIES &&
+          errorMessage.includes('cannot lock ref') &&
+          errorMessage.includes('unable to update local ref')
+        ) {
+          const backoffMs = 50 * Math.pow(2, attempt);
+          getLog().debug(
+            { err, attempt: attempt + 1, backoffMs, remote, branch: prBranch },
+            'same_repo_pr.fetch_ref_lock_retry'
+          );
+          await new Promise(resolve => setTimeout(resolve, backoffMs));
+          continue;
+        }
+
+        throw new Error(`Fetch ${remote}/${prBranch} failed: ${err.message}`);
+      }
+    }
 
     // Try to create worktree with the branch
     try {

--- a/packages/isolation/src/providers/worktree.ts
+++ b/packages/isolation/src/providers/worktree.ts
@@ -1096,37 +1096,24 @@ export class WorktreeProvider implements IIsolationProvider {
     prBranch: string,
     remote = 'origin'
   ): Promise<void> {
-    // Fetch the PR's actual branch. Retry on transient ref-lock races —
-    // concurrent same-repo launches collide on Git's shared remote-tracking
-    // ref lock file. Mirrors the protection in syncWorkspace.
-    const MAX_FETCH_RETRIES = 3;
-
-    for (let attempt = 0; attempt <= MAX_FETCH_RETRIES; attempt++) {
-      try {
-        await execFileAsync('git', ['-C', repoPath, 'fetch', remote, prBranch], {
-          timeout: GIT_OPERATION_TIMEOUT_MS,
-        });
-        break;
-      } catch (error) {
-        const err = error as Error;
-        const errorMessage = err.message.toLowerCase();
-
-        if (
-          attempt < MAX_FETCH_RETRIES &&
-          errorMessage.includes('cannot lock ref') &&
-          errorMessage.includes('unable to update local ref')
-        ) {
-          const backoffMs = 50 * Math.pow(2, attempt);
-          getLog().debug(
-            { err, attempt: attempt + 1, backoffMs, remote, branch: prBranch },
-            'same_repo_pr.fetch_ref_lock_retry'
-          );
-          await new Promise(resolve => setTimeout(resolve, backoffMs));
-          continue;
-        }
-
-        throw new Error(`Fetch ${remote}/${prBranch} failed: ${err.message}`);
-      }
+    // Fetch the PR's actual branch. Delegate to syncWorkspace so the bounded
+    // ref-lock retry lives in one place — concurrent same-repo launches collide
+    // on Git's shared remote-tracking ref lock file, and the @archon/git owner
+    // already owns the predicate and backoff.
+    try {
+      await syncWorkspace(toRepoPath(repoPath), toBranchName(prBranch), {
+        mode: 'fetch-only',
+        remote,
+      });
+    } catch (error) {
+      const err = error as Error;
+      // syncWorkspace wraps fetch errors as
+      // `Sync fetch from <remote>/<branch> failed: <original>`. Strip that
+      // wrapper so the inner wrap keeps `Fetch <remote>/<branch> failed: <original>`
+      // and operators can still distinguish fetch failures from worktree-add
+      // failures inside the surrounding `createFromPR` prefix.
+      const original = err.message.replace(/^Sync fetch from .+? failed: /, '');
+      throw new Error(`Fetch ${remote}/${prBranch} failed: ${original}`);
     }
 
     // Try to create worktree with the branch


### PR DESCRIPTION
## Problem and outcome

Two concurrent same-repository PR worktree launches race on Git's shared
remote-tracking ref lock the same way `syncWorkspace` did before #3087. The
fix in #3087 hardened `syncWorkspace()`; its sibling `createFromSameRepoPR`
(`packages/isolation/src/providers/worktree.ts:1093-1102` at #3087's head)
still issued a single unprotected `git fetch` for the PR branch before
attempting `worktree add`. A second simultaneous launch against the same
canonical repo hits `cannot lock ref ... (unable to update local ref)` and
fails one launch at preflight.

- **Outcome:** Concurrent same-repo PR launches no longer fail at preflight
  on the known ref-lock race. Non-race fetch errors still fail immediately.
- **Invariant:** Bounded retry on the known contention error, loud failure
  otherwise — no broad retry-everything wrapper. A failed launch must still
  fail before any estate (worktree) is created.
- **Scope boundary:** Only the same-repository PR fetch path is changed.
  `createFromForkPR`, public types, configuration, and other git operations
  are untouched.
- **Root cause:** `createFromSameRepoPR` issues a single unprotected
  `git fetch` that mutates the shared remote-tracking ref before the
  `worktree add` step.

## Review guidance

- **Feedback requested:** Correctness of the delegation contract and the
  no-estate invariant.
- **Start here:** `packages/isolation/src/providers/worktree.ts:1099-1117` —
  the `syncWorkspace` delegation and the inner `Fetch <remote>/<branch>
  failed: …` wrap.
- **Review order:** `worktree.ts` implementation → the three new regression
  tests in `worktree.test.ts:1001-1135`.
- **Lower-attention areas:** The new tests are mechanical mirrors of the
  `syncWorkspace` tests in `packages/git/src/git.test.ts:2446-2535`; their
  shape is verified by the contract they assert.
- **Known risk or uncertainty:** None — `createFromSameRepoPR` now delegates
  the fetch to the same `syncWorkspace` owner whose race-recovery contract
  #3087 already accepted.

## Solution

Delegate the `git fetch remote prBranch` step in `createFromSameRepoPR` to
`syncWorkspace(..., { mode: 'fetch-only', remote })`. The bounded ref-lock
retry (specific `cannot lock ref` + `unable to update local ref` predicate,
attempt budget, and backoff) now lives only in `syncWorkspace` — the
`@archon/git` owner — so the recovery contract is shared with the base-branch
path and there is no duplicated retry wrapper to keep in sync. Non-race fetch
errors still surface immediately. The PR-side error message is preserved as
`Fetch <remote>/<branch> failed: <original>` (the `syncWorkspace`
`Sync fetch from … failed: ` wrapper is stripped first) inside the surrounding
`createFromPR` prefix (`Failed to create worktree for PR #<n>: …`) so the
inner wrap still distinguishes fetch failures from worktree-add failures.

`syncWorkspace` is the only thing called before `worktree add`, so a failed
launch still fails before any worktree exists. No new retry machinery, no
caller changes, and no public type changes.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Concurrent same-repo PR launches can fail at preflight on `cannot lock ref` | Concurrent same-repo PR launches retry up to 3 times (~350ms total delay) and succeed if the race clears |
| **Failure behavior** | One of two concurrent calls hard-fails on the race; success and failure are nondeterministic across launches | Persistent race hard-fails after exactly 4 fetch attempts (1 initial + 3 retries); non-race errors still fail immediately on the first attempt |

## Validation

- `bun --filter @archon/isolation test` — 371 pass / 0 fail.
- `bun --filter @archon/git test` — 230 pass / 0 fail.
- `bun --filter '*' type-check` — all packages exit 0.
- `bun run lint --max-warnings 0` — passed.
- `bun run format:check` — passed.
- `bun run validate` — exit code 0, all suites pass.
- The acceptance test was demonstrated red against the unprotected code:
  the unprotected `git fetch` produced `cannot lock ref … unable to update
  local ref` immediately on the concurrent launch, with no retry wrapper to
  absorb it. After the fix, the new `delegates same-repo PR fetch to
  syncWorkspace so ref-lock race is absorbed` and `throws when syncWorkspace
  exhausts its retry budget on persistent same-repo PR fetch lock-race error`
  tests pass; the `does not retry non-race same-repo PR fetch errors and
  preserves the inner wrap` test passes against the unprotected code (no
  retry, single immediate failure) and against the fixed code, locking the
  narrow predicate through `syncWorkspace`.
- **Not verified:** Nothing material — every change to behavior is
  exercised by the new tests, and the existing isolation suite covers the
  surrounding `createFromPR` and `createFromForkPR` paths.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | No public type or configuration change. | Diff confined to one package; public surface untouched. |
| Rollout / rollback | No migration or schema change. Revert the `createFromSameRepoPR` change and delete the three new tests. | Two commits, isolated to `@archon/isolation`. |

## Links

- Closes #3091

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when fetching branches for same-repository pull requests.
  * Added automatic recovery for temporary reference-lock conflicts with bounded retries.
  * Preserved clearer pull-request-specific error messages when fetching fails.
  * Prevented worktree creation when branch synchronization cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->