### PR TITLE
fix(observability): expose concurrent active workflow nodes

### DIFF
--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -450,6 +450,26 @@ const mockCreateWorkflowRun = mock((data: { workflow_name: string; conversation_
   })
 );
 
+const EMPTY_STATUS_COUNTS = {
+  all: 0,
+  running: 0,
+  completed: 0,
+  failed: 0,
+  cancelled: 0,
+  pending: 0,
+  paused: 0,
+};
+const mockListDashboardRuns = mock(() =>
+  Promise.resolve({ runs: [] as unknown[], total: 0, counts: EMPTY_STATUS_COUNTS })
+);
+function statusRuns(runs: unknown[]): {
+  runs: unknown[];
+  total: number;
+  counts: typeof EMPTY_STATUS_COUNTS;
+} {
+  return { runs, total: runs.length, counts: EMPTY_STATUS_COUNTS };
+}
+
 mock.module('@archon/core/db/workflows', () => ({
   createWorkflowRun: mockCreateWorkflowRun,
   getActiveWorkflowRun: mock(() => Promise.resolve(null)),
@@ -468,13 +488,7 @@ mock.module('@archon/core/db/workflows', () => ({
   resolveApprovalGate: mock(() => Promise.resolve({ resolved: true })),
   resolveAndCancelApprovalGate: mock(() => Promise.resolve({ resolved: true })),
   listWorkflowRuns: mock(() => Promise.resolve([])),
-  listDashboardRuns: mock(() =>
-    Promise.resolve({
-      runs: [],
-      total: 0,
-      counts: { all: 0, running: 0, completed: 0, failed: 0, cancelled: 0, pending: 0, paused: 0 },
-    })
-  ),
+  listDashboardRuns: mockListDashboardRuns,
   deleteOldWorkflowRuns: mock(() => Promise.resolve({ count: 0 })),
 }));
 
@@ -4041,8 +4055,7 @@ describe('workflowStatusCommand', () => {
   });
 
   it('should print message when no active runs', async () => {
-    const workflowDb = await import('@archon/core/db/workflows');
-    (workflowDb.listWorkflowRuns as ReturnType<typeof mock>).mockResolvedValueOnce([]);
+    mockListDashboardRuns.mockResolvedValueOnce(statusRuns([]));
 
     await workflowStatusCommand();
 
@@ -4050,16 +4063,18 @@ describe('workflowStatusCommand', () => {
   });
 
   it('should list active runs with ID, name, path, status, and age', async () => {
-    const workflowDb = await import('@archon/core/db/workflows');
-    (workflowDb.listWorkflowRuns as ReturnType<typeof mock>).mockResolvedValueOnce([
-      {
-        id: 'run-abc',
-        workflow_name: 'implement',
-        working_path: '/path/to/worktree',
-        status: 'running',
-        started_at: new Date(Date.now() - 5 * 60 * 1000), // 5 minutes ago
-      },
-    ]);
+    mockListDashboardRuns.mockResolvedValueOnce(
+      statusRuns([
+        {
+          id: 'run-abc',
+          workflow_name: 'implement',
+          working_path: '/path/to/worktree',
+          status: 'running',
+          started_at: new Date(Date.now() - 5 * 60 * 1000), // 5 minutes ago
+          active_nodes: ['parallel-a', 'parallel-b'],
+        },
+      ])
+    );
 
     await workflowStatusCommand();
 
@@ -4068,20 +4083,23 @@ describe('workflowStatusCommand', () => {
     expect(calls.some(c => c.includes('implement'))).toBe(true);
     expect(calls.some(c => c.includes('/path/to/worktree'))).toBe(true);
     expect(calls.some(c => c.includes('running'))).toBe(true);
+    expect(calls.some(c => c.includes('Active nodes: parallel-a, parallel-b'))).toBe(true);
   });
 
   it('should label authored outcome separately from active execution status', async () => {
-    const workflowDb = await import('@archon/core/db/workflows');
-    (workflowDb.listWorkflowRuns as ReturnType<typeof mock>).mockResolvedValueOnce([
-      {
-        id: 'run-paused',
-        workflow_name: 'review',
-        working_path: '/path/to/worktree',
-        status: 'paused',
-        outcome: 'succeeded',
-        started_at: new Date(),
-      },
-    ]);
+    mockListDashboardRuns.mockResolvedValueOnce(
+      statusRuns([
+        {
+          id: 'run-paused',
+          workflow_name: 'review',
+          working_path: '/path/to/worktree',
+          status: 'paused',
+          outcome: 'succeeded',
+          started_at: new Date(),
+          active_nodes: ['parallel-a', 'parallel-b'],
+        },
+      ])
+    );
 
     await workflowStatusCommand();
 
@@ -4090,8 +4108,7 @@ describe('workflowStatusCommand', () => {
   });
 
   it('should output JSON when json=true', async () => {
-    const workflowDb = await import('@archon/core/db/workflows');
-    (workflowDb.listWorkflowRuns as ReturnType<typeof mock>).mockResolvedValueOnce([]);
+    mockListDashboardRuns.mockResolvedValueOnce(statusRuns([]));
 
     await workflowStatusCommand(true);
 
@@ -4101,19 +4118,43 @@ describe('workflowStatusCommand', () => {
     );
   });
 
+  it('keeps parallel active nodes in non-verbose JSON', async () => {
+    mockListDashboardRuns.mockResolvedValueOnce(
+      statusRuns([
+        {
+          id: 'run-parallel',
+          workflow_name: 'implement',
+          working_path: '/path/to/worktree',
+          status: 'running',
+          started_at: new Date(),
+          active_nodes: ['parallel-a', 'parallel-b'],
+        },
+      ])
+    );
+
+    await workflowStatusCommand(true);
+
+    const parsed = JSON.parse(firstJsonPayload(stdoutSpy)) as {
+      runs: Array<{ active_nodes: string[] }>;
+    };
+    expect(parsed.runs[0]?.active_nodes).toEqual(['parallel-a', 'parallel-b']);
+  });
+
   it('should show node summaries in verbose mode', async () => {
-    const workflowDb = await import('@archon/core/db/workflows');
     const workflowEventsDb = await import('@archon/core/db/workflow-events');
 
-    (workflowDb.listWorkflowRuns as ReturnType<typeof mock>).mockResolvedValueOnce([
-      {
-        id: 'run-verbose',
-        workflow_name: 'implement',
-        working_path: '/path/to/worktree',
-        status: 'running',
-        started_at: new Date(Date.now() - 30 * 1000),
-      },
-    ]);
+    mockListDashboardRuns.mockResolvedValueOnce(
+      statusRuns([
+        {
+          id: 'run-verbose',
+          workflow_name: 'implement',
+          working_path: '/path/to/worktree',
+          status: 'running',
+          started_at: new Date(Date.now() - 30 * 1000),
+          active_nodes: ['plan'],
+        },
+      ])
+    );
 
     const startTime = new Date(Date.now() - 25 * 1000).toISOString();
     const endTime = new Date(Date.now() - 15 * 1000).toISOString();
@@ -4147,18 +4188,20 @@ describe('workflowStatusCommand', () => {
   });
 
   it('should show error message for failed node in verbose mode', async () => {
-    const workflowDb = await import('@archon/core/db/workflows');
     const workflowEventsDb = await import('@archon/core/db/workflow-events');
 
-    (workflowDb.listWorkflowRuns as ReturnType<typeof mock>).mockResolvedValueOnce([
-      {
-        id: 'run-failed',
-        workflow_name: 'implement',
-        working_path: '/path/to/worktree',
-        status: 'running',
-        started_at: new Date(Date.now() - 30 * 1000),
-      },
-    ]);
+    mockListDashboardRuns.mockResolvedValueOnce(
+      statusRuns([
+        {
+          id: 'run-failed',
+          workflow_name: 'implement',
+          working_path: '/path/to/worktree',
+          status: 'running',
+          started_at: new Date(Date.now() - 30 * 1000),
+          active_nodes: ['implement'],
+        },
+      ])
+    );
 
     const startTime = new Date(Date.now() - 20 * 1000).toISOString();
     const endTime = new Date(Date.now() - 10 * 1000).toISOString();
@@ -4191,18 +4234,20 @@ describe('workflowStatusCommand', () => {
   });
 
   it('should not show nodes section when no events in verbose mode', async () => {
-    const workflowDb = await import('@archon/core/db/workflows');
     const workflowEventsDb = await import('@archon/core/db/workflow-events');
 
-    (workflowDb.listWorkflowRuns as ReturnType<typeof mock>).mockResolvedValueOnce([
-      {
-        id: 'run-empty',
-        workflow_name: 'implement',
-        working_path: '/path/to/worktree',
-        status: 'running',
-        started_at: new Date(Date.now() - 5 * 1000),
-      },
-    ]);
+    mockListDashboardRuns.mockResolvedValueOnce(
+      statusRuns([
+        {
+          id: 'run-empty',
+          workflow_name: 'implement',
+          working_path: '/path/to/worktree',
+          status: 'running',
+          started_at: new Date(Date.now() - 5 * 1000),
+          active_nodes: [],
+        },
+      ])
+    );
     (workflowEventsDb.listWorkflowEvents as ReturnType<typeof mock>).mockResolvedValueOnce([]);
 
     await workflowStatusCommand(false, true);
@@ -4212,18 +4257,20 @@ describe('workflowStatusCommand', () => {
   });
 
   it('emits the shared ordered node summaries in verbose JSON by default', async () => {
-    const workflowDb = await import('@archon/core/db/workflows');
     const workflowEventsDb = await import('@archon/core/db/workflow-events');
 
-    (workflowDb.listWorkflowRuns as ReturnType<typeof mock>).mockResolvedValueOnce([
-      {
-        id: 'run-verbose-json',
-        workflow_name: 'implement',
-        working_path: '/path/to/worktree',
-        status: 'running',
-        started_at: new Date(),
-      },
-    ]);
+    mockListDashboardRuns.mockResolvedValueOnce(
+      statusRuns([
+        {
+          id: 'run-verbose-json',
+          workflow_name: 'implement',
+          working_path: '/path/to/worktree',
+          status: 'running',
+          started_at: new Date(),
+          active_nodes: ['beta'],
+        },
+      ])
+    );
     (workflowEventsDb.listWorkflowEvents as ReturnType<typeof mock>).mockResolvedValueOnce(
       VERBOSE_EVENTS_FIXTURE
     );
@@ -4274,17 +4321,19 @@ describe('workflowStatusCommand', () => {
   });
 
   it('emits raw events in verbose JSON when events=true', async () => {
-    const workflowDb = await import('@archon/core/db/workflows');
     const workflowEventsDb = await import('@archon/core/db/workflow-events');
-    (workflowDb.listWorkflowRuns as ReturnType<typeof mock>).mockResolvedValueOnce([
-      {
-        id: 'run-verbose-json',
-        workflow_name: 'implement',
-        working_path: '/path/to/worktree',
-        status: 'running',
-        started_at: new Date(),
-      },
-    ]);
+    mockListDashboardRuns.mockResolvedValueOnce(
+      statusRuns([
+        {
+          id: 'run-verbose-json',
+          workflow_name: 'implement',
+          working_path: '/path/to/worktree',
+          status: 'running',
+          started_at: new Date(),
+          active_nodes: ['beta'],
+        },
+      ])
+    );
     (workflowEventsDb.listWorkflowEvents as ReturnType<typeof mock>).mockResolvedValueOnce(
       VERBOSE_EVENTS_FIXTURE
     );
@@ -4299,17 +4348,19 @@ describe('workflowStatusCommand', () => {
   });
 
   it('degrades a verbose JSON event-query failure to an empty node payload', async () => {
-    const workflowDb = await import('@archon/core/db/workflows');
     const workflowEventsDb = await import('@archon/core/db/workflow-events');
-    (workflowDb.listWorkflowRuns as ReturnType<typeof mock>).mockResolvedValueOnce([
-      {
-        id: 'run-unavailable',
-        workflow_name: 'implement',
-        working_path: '/path/to/worktree',
-        status: 'running',
-        started_at: new Date(),
-      },
-    ]);
+    mockListDashboardRuns.mockResolvedValueOnce(
+      statusRuns([
+        {
+          id: 'run-unavailable',
+          workflow_name: 'implement',
+          working_path: '/path/to/worktree',
+          status: 'running',
+          started_at: new Date(),
+          active_nodes: ['beta'],
+        },
+      ])
+    );
     (workflowEventsDb.listWorkflowEvents as ReturnType<typeof mock>).mockRejectedValueOnce(
       new Error('events unavailable')
     );
@@ -5513,6 +5564,7 @@ describe('workflowRunsCommand', () => {
           workflow_name: 'assist',
           status: 'completed',
           outcome: 'failed',
+          active_nodes: ['parallel-a', 'parallel-b'],
           current_step_name: null,
           total_steps: null,
           started_at: new Date(),
@@ -5526,13 +5578,14 @@ describe('workflowRunsCommand', () => {
 
     expect(stdoutSpy).toHaveBeenCalledTimes(1);
     const parsed = JSON.parse(firstJsonPayload(stdoutSpy)) as {
-      runs: Array<{ status: string; outcome: string | null }>;
+      runs: Array<{ status: string; outcome: string | null; active_nodes: string[] }>;
       total: number;
       scopeFallback: boolean;
     };
     expect(parsed.total).toBe(1);
     expect(parsed.runs).toHaveLength(1);
     expect(parsed.runs[0]).toMatchObject({ status: 'completed', outcome: 'failed' });
+    expect(parsed.runs[0]?.active_nodes).toEqual(['parallel-a', 'parallel-b']);
     // codebase did not resolve → result is a global fallback, flagged for agents
     expect(parsed.scopeFallback).toBe(true);
   });
@@ -5552,6 +5605,7 @@ describe('workflowRunsCommand', () => {
           workflow_name: 'review',
           status: 'completed',
           outcome: 'failed',
+          active_nodes: ['parallel-a', 'parallel-b'],
           current_step_name: null,
           total_steps: null,
           started_at: new Date(),
@@ -5566,6 +5620,7 @@ describe('workflowRunsCommand', () => {
     const output = consoleSpy.mock.calls.map(call => String(call[0])).join('\n');
     expect(output).toContain('completed');
     expect(output).toContain('authored outcome: failed');
+    expect(output).toContain('active node(s): parallel-a, parallel-b');
   });
 
   it('marks scopeFallback false in --json when the project scope resolves', async () => {

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -139,6 +139,7 @@ import * as codebaseDb from '@archon/core/db/codebases';
 import * as isolationDb from '@archon/core/db/isolation-environments';
 import * as messageDb from '@archon/core/db/messages';
 import * as workflowDb from '@archon/core/db/workflows';
+import type { DashboardWorkflowRun } from '@archon/core/db/workflows';
 import * as workflowEventsDb from '@archon/core/db/workflow-events';
 import type { WorkflowEventRow } from '@archon/core/db/workflow-events';
 import * as userDb from '@archon/core/db/users';
@@ -3520,7 +3521,7 @@ export async function workflowStatusCommand(
   verbose?: boolean,
   rawEvents?: boolean
 ): Promise<void> {
-  let runs: WorkflowRun[];
+  let runs: DashboardWorkflowRun[];
   try {
     const result = await getWorkflowStatus();
     runs = result.runs;
@@ -3561,6 +3562,11 @@ export async function workflowStatusCommand(
     console.log(`  Status: ${run.status}`);
     if (run.outcome) console.log(`  Authored outcome: ${run.outcome}`);
     console.log(`  Age:    ${age}`);
+    if (run.active_nodes.length > 0) {
+      console.log(
+        `  Active node${run.active_nodes.length === 1 ? '' : 's'}: ${run.active_nodes.join(', ')}`
+      );
+    }
 
     if (verbose) {
       const { events, failed } = await fetchVerboseEvents(run.id);
@@ -4231,13 +4237,11 @@ export async function workflowRunsCommand(
 
   console.log(`\nRecent runs (${result.runs.length} of ${result.total}):\n`);
   for (const run of result.runs) {
-    const step =
-      run.current_step_name !== null
-        ? ` · ${run.current_step_name}${run.total_steps !== null ? `/${String(run.total_steps)}` : ''}`
-        : '';
+    const activeNodes =
+      run.active_nodes.length > 0 ? ` · active node(s): ${run.active_nodes.join(', ')}` : '';
     const outcome = run.outcome ? ` · authored outcome: ${run.outcome}` : '';
     console.log(
-      `  ${run.id.slice(0, 8)}  ${run.status.padEnd(9)}  ${run.workflow_name}${step}${outcome}  (${formatAge(run.started_at)})`
+      `  ${run.id.slice(0, 8)}  ${run.status.padEnd(9)}  ${run.workflow_name}${activeNodes}${outcome}  (${formatAge(run.started_at)})`
     );
   }
   console.log('');

--- a/packages/core/src/db/workflow-events.test.ts
+++ b/packages/core/src/db/workflow-events.test.ts
@@ -315,6 +315,28 @@ describe('workflow-events', () => {
       );
     });
 
+    test('preserves activation order when a terminal node retries', async () => {
+      mockQuery.mockResolvedValueOnce(
+        createQueryResult([
+          { workflow_run_id: 'run-active', step_name: 'zeta', event_type: 'node_started' },
+          { workflow_run_id: 'run-active', step_name: 'alpha', event_type: 'node_started' },
+          { workflow_run_id: 'run-retry', step_name: 'zeta', event_type: 'node_started' },
+          { workflow_run_id: 'run-retry', step_name: 'alpha', event_type: 'node_started' },
+          { workflow_run_id: 'run-retry', step_name: 'zeta', event_type: 'node_failed' },
+          { workflow_run_id: 'run-retry', step_name: 'zeta', event_type: 'node_started' },
+        ])
+      );
+
+      const result = await listActiveWorkflowNodeIds(['run-active', 'run-retry']);
+
+      expect(result).toEqual(
+        new Map([
+          ['run-active', ['zeta', 'alpha']],
+          ['run-retry', ['alpha', 'zeta']],
+        ])
+      );
+    });
+
     test('returns an empty map without querying for an empty run list', async () => {
       expect(await listActiveWorkflowNodeIds([])).toEqual(new Map());
       expect(mockQuery).not.toHaveBeenCalled();

--- a/packages/core/src/db/workflow-events.test.ts
+++ b/packages/core/src/db/workflow-events.test.ts
@@ -40,6 +40,7 @@ import {
   persistWorkflowEventIfRunning,
   listWorkflowEvents,
   listRecentEvents,
+  listActiveWorkflowNodeIds,
   getDagResumeSnapshot,
 } from './workflow-events';
 
@@ -264,6 +265,68 @@ describe('workflow-events', () => {
     });
   });
 
+  describe('listActiveWorkflowNodeIds', () => {
+    test('folds parallel, terminal, skipped, duplicate, and retry lifecycle rows in order', async () => {
+      mockQuery.mockResolvedValueOnce(
+        createQueryResult([
+          { workflow_run_id: 'run-a', step_name: 'alpha', event_type: 'node_started' },
+          { workflow_run_id: 'run-a', step_name: 'alpha', event_type: 'node_started' },
+          { workflow_run_id: 'run-a', step_name: 'completed', event_type: 'node_started' },
+          { workflow_run_id: 'run-a', step_name: 'completed', event_type: 'node_completed' },
+          { workflow_run_id: 'run-a', step_name: 'alpha', event_type: 'node_failed' },
+          { workflow_run_id: 'run-a', step_name: 'alpha', event_type: 'node_started' },
+          { workflow_run_id: 'run-a', step_name: 'skipped', event_type: 'node_started' },
+          { workflow_run_id: 'run-a', step_name: 'skipped', event_type: 'node_skipped' },
+          { workflow_run_id: 'run-a', step_name: 'cached', event_type: 'node_started' },
+          {
+            workflow_run_id: 'run-a',
+            step_name: 'cached',
+            event_type: 'node_skipped_prior_success',
+          },
+          { workflow_run_id: 'run-b', step_name: 'parallel-a', event_type: 'node_started' },
+          { workflow_run_id: 'run-b', step_name: 'parallel-b', event_type: 'node_started' },
+          { workflow_run_id: 'run-b', step_name: null, event_type: 'node_started' },
+        ])
+      );
+
+      const result = await listActiveWorkflowNodeIds(['run-a', 'run-b', 'run-c']);
+
+      expect(result).toEqual(
+        new Map([
+          ['run-a', ['alpha']],
+          ['run-b', ['parallel-a', 'parallel-b']],
+          ['run-c', []],
+        ])
+      );
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'ORDER BY workflow_run_id, created_at ASC, COALESCE(event_order, 0) ASC, id ASC'
+        ),
+        [
+          'run-a',
+          'run-b',
+          'run-c',
+          'node_started',
+          'node_completed',
+          'node_failed',
+          'node_skipped',
+          'node_skipped_prior_success',
+        ]
+      );
+    });
+
+    test('returns an empty map without querying for an empty run list', async () => {
+      expect(await listActiveWorkflowNodeIds([])).toEqual(new Map());
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+
+    test('propagates query failures', async () => {
+      mockQuery.mockRejectedValueOnce(new Error('connection refused'));
+
+      await expect(listActiveWorkflowNodeIds(['run-a'])).rejects.toThrow('connection refused');
+    });
+  });
+
   describe('getDagResumeSnapshot', () => {
     test('returns outputs and summed tokens from node_completed events', async () => {
       mockQuery.mockResolvedValueOnce(
@@ -301,9 +364,10 @@ describe('workflow-events', () => {
         cacheRead: 50,
         cacheWrite: 5,
       });
-      expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining('node_completed'), [
-        'run-123',
-      ]);
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('event_type IN'),
+        expect.arrayContaining(['run-123', 'node_completed'])
+      );
     });
 
     test('carries structured_output back out; rows without it stay text-only (#2637)', async () => {
@@ -467,9 +531,10 @@ describe('workflow-events', () => {
         cacheWrite: 0,
         cachePartial: true,
       });
-      expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining("'node_failed'"), [
-        'run-failed-usage',
-      ]);
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('event_type IN'),
+        expect.arrayContaining(['run-failed-usage', 'node_failed'])
+      );
     });
 
     test('a later node_failed row supersedes an earlier node_completed row for the same step (#2705 R2)', async () => {
@@ -588,8 +653,8 @@ describe('workflow-events', () => {
       expect(result.completedNodeOutputs.get('node-b')).toEqual({ output: 'output B' });
       expect(result.tokens).toEqual({ input: 40, output: 4 });
       expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringContaining('node_skipped_prior_success'),
-        ['run-resume']
+        expect.stringContaining('event_type IN'),
+        expect.arrayContaining(['run-resume', 'node_skipped_prior_success'])
       );
     });
 

--- a/packages/core/src/db/workflow-events.ts
+++ b/packages/core/src/db/workflow-events.ts
@@ -1,7 +1,7 @@
 /**
  * Database operations for workflow events (lean UI-relevant events).
  *
- * Stores step transitions, parallel agent status, artifacts, and errors.
+ * Stores node lifecycle, parallel agent status, artifacts, and errors.
  * Verbose assistant/tool content stays in JSONL logs only.
  *
  * Ordinary observability writes are fire-and-forget. Correctness-critical lifecycle
@@ -15,7 +15,11 @@ import { createLogger } from '@archon/paths';
 import { mergeTokenUsage, type TokenUsage } from '@archon/providers/types';
 import { readFile } from 'node:fs/promises';
 import type { FanOutInstanceSnapshot } from '@archon/workflows/fan-out-identity';
-import type { WorkflowEventType } from '@archon/workflows/store';
+import {
+  NODE_LIFECYCLE_EVENT_TYPES,
+  type NodeLifecycleEventType,
+  type WorkflowEventType,
+} from '@archon/workflows/store';
 
 /** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
 let cachedLog: ReturnType<typeof createLogger> | undefined;
@@ -350,6 +354,51 @@ function parseFanOutSnapshots(value: unknown): FanOutInstanceSnapshot[] | undefi
   return snapshots;
 }
 
+interface NodeLifecycleEvent {
+  step_name: string | null;
+  event_type: NodeLifecycleEventType;
+}
+
+interface NodeLifecycleEventRow extends NodeLifecycleEvent {
+  workflow_run_id: string;
+}
+
+function foldActiveNodeIds(activeNodeIds: Set<string>, row: NodeLifecycleEvent): void {
+  if (!row.step_name) return;
+  if (row.event_type === 'node_started') {
+    activeNodeIds.add(row.step_name);
+  } else {
+    activeNodeIds.delete(row.step_name);
+  }
+}
+
+export async function listActiveWorkflowNodeIds(
+  workflowRunIds: readonly string[]
+): Promise<Map<string, string[]>> {
+  if (workflowRunIds.length === 0) return new Map();
+
+  const activeByRun = new Map(workflowRunIds.map(id => [id, new Set<string>()]));
+  const runPlaceholders = workflowRunIds.map((_, index) => `$${String(index + 1)}`);
+  const eventPlaceholders = NODE_LIFECYCLE_EVENT_TYPES.map(
+    (_, index) => `$${String(workflowRunIds.length + index + 1)}`
+  );
+  const result = await pool.query<NodeLifecycleEventRow>(
+    `SELECT workflow_run_id, step_name, event_type
+     FROM remote_agent_workflow_events
+     WHERE workflow_run_id IN (${runPlaceholders.join(', ')})
+       AND event_type IN (${eventPlaceholders.join(', ')})
+     ORDER BY workflow_run_id, created_at ASC, COALESCE(event_order, 0) ASC, id ASC`,
+    [...workflowRunIds, ...NODE_LIFECYCLE_EVENT_TYPES]
+  );
+
+  for (const row of result.rows) {
+    const activeNodeIds = activeByRun.get(row.workflow_run_id);
+    if (activeNodeIds) foldActiveNodeIds(activeNodeIds, row);
+  }
+
+  return new Map([...activeByRun].map(([runId, activeNodeIds]) => [runId, [...activeNodeIds]]));
+}
+
 export async function getDagResumeSnapshot(workflowRunId: string): Promise<{
   completedNodeOutputs: Map<string, { output: string; structuredOutput?: unknown }>;
   fanOutSnapshots: Map<string, readonly FanOutInstanceSnapshot[]>;
@@ -359,19 +408,15 @@ export async function getDagResumeSnapshot(workflowRunId: string): Promise<{
 }> {
   const result = await pool.query<{
     step_name: string | null;
-    event_type:
-      | 'node_started'
-      | 'node_completed'
-      | 'node_failed'
-      | 'node_skipped'
-      | 'node_skipped_prior_success'
-      | 'fan_out_instances';
+    event_type: NodeLifecycleEventType | 'fan_out_instances';
     data: string | Record<string, unknown>;
   }>(
     `SELECT step_name, event_type, data FROM remote_agent_workflow_events
-     WHERE workflow_run_id = $1 AND event_type IN ('node_started', 'node_completed', 'node_failed', 'node_skipped', 'node_skipped_prior_success', 'fan_out_instances')
+     WHERE workflow_run_id = $1 AND event_type IN (${NODE_LIFECYCLE_EVENT_TYPES.map(
+       (_, index) => `$${String(index + 2)}`
+     ).join(', ')}, $${String(NODE_LIFECYCLE_EVENT_TYPES.length + 2)})
      ORDER BY created_at ASC, COALESCE(event_order, 0) ASC, id ASC`,
-    [workflowRunId]
+    [workflowRunId, ...NODE_LIFECYCLE_EVENT_TYPES, 'fan_out_instances']
   );
   const completedNodeOutputs = new Map<string, { output: string; structuredOutput?: unknown }>();
   const fanOutSnapshots = new Map<string, readonly FanOutInstanceSnapshot[]>();
@@ -382,15 +427,8 @@ export async function getDagResumeSnapshot(workflowRunId: string): Promise<{
   const authoritativeInstanceScopes = new Set<string>();
   for (const row of result.rows) {
     if (!row.step_name) continue;
-    if (row.event_type === 'node_started') {
-      unresolvedNodeStarts.add(row.step_name);
-    } else if (
-      row.event_type === 'node_completed' ||
-      row.event_type === 'node_failed' ||
-      row.event_type === 'node_skipped' ||
-      row.event_type === 'node_skipped_prior_success'
-    ) {
-      unresolvedNodeStarts.delete(row.step_name);
+    if (row.event_type !== 'fan_out_instances') {
+      foldActiveNodeIds(unresolvedNodeStarts, row);
     }
     let data: Record<string, unknown>;
     try {

--- a/packages/core/src/db/workflow-events.ts
+++ b/packages/core/src/db/workflow-events.ts
@@ -363,12 +363,16 @@ interface NodeLifecycleEventRow extends NodeLifecycleEvent {
   workflow_run_id: string;
 }
 
-function foldActiveNodeIds(activeNodeIds: Set<string>, row: NodeLifecycleEvent): void {
-  if (!row.step_name) return;
-  if (row.event_type === 'node_started') {
-    activeNodeIds.add(row.step_name);
+function foldActiveNodeIds(
+  activeNodeIds: Set<string>,
+  stepName: string | null,
+  eventType: NodeLifecycleEventType
+): void {
+  if (!stepName) return;
+  if (eventType === 'node_started') {
+    activeNodeIds.add(stepName);
   } else {
-    activeNodeIds.delete(row.step_name);
+    activeNodeIds.delete(stepName);
   }
 }
 
@@ -393,7 +397,7 @@ export async function listActiveWorkflowNodeIds(
 
   for (const row of result.rows) {
     const activeNodeIds = activeByRun.get(row.workflow_run_id);
-    if (activeNodeIds) foldActiveNodeIds(activeNodeIds, row);
+    if (activeNodeIds) foldActiveNodeIds(activeNodeIds, row.step_name, row.event_type);
   }
 
   return new Map([...activeByRun].map(([runId, activeNodeIds]) => [runId, [...activeNodeIds]]));
@@ -428,7 +432,7 @@ export async function getDagResumeSnapshot(workflowRunId: string): Promise<{
   for (const row of result.rows) {
     if (!row.step_name) continue;
     if (row.event_type !== 'fan_out_instances') {
-      foldActiveNodeIds(unresolvedNodeStarts, row);
+      foldActiveNodeIds(unresolvedNodeStarts, row.step_name, row.event_type);
     }
     let data: Record<string, unknown>;
     try {

--- a/packages/core/src/db/workflows.test.ts
+++ b/packages/core/src/db/workflows.test.ts
@@ -192,7 +192,7 @@ describe('workflows database', () => {
   });
 
   describe('listDashboardRuns', () => {
-    test('derives active nodes from canonical node lifecycle events', async () => {
+    test('derives active nodes from canonical retries and skip terminals', async () => {
       mockQuery
         .mockResolvedValueOnce(
           createQueryResult([
@@ -215,6 +215,36 @@ describe('workflows database', () => {
               workflow_run_id: mockWorkflowRun.id,
               step_name: 'implement',
               event_type: 'node_started',
+            },
+            {
+              workflow_run_id: mockWorkflowRun.id,
+              step_name: 'implement',
+              event_type: 'node_failed',
+            },
+            {
+              workflow_run_id: mockWorkflowRun.id,
+              step_name: 'implement',
+              event_type: 'node_started',
+            },
+            {
+              workflow_run_id: mockWorkflowRun.id,
+              step_name: 'conditional',
+              event_type: 'node_started',
+            },
+            {
+              workflow_run_id: mockWorkflowRun.id,
+              step_name: 'conditional',
+              event_type: 'node_skipped',
+            },
+            {
+              workflow_run_id: mockWorkflowRun.id,
+              step_name: 'cached',
+              event_type: 'node_started',
+            },
+            {
+              workflow_run_id: mockWorkflowRun.id,
+              step_name: 'cached',
+              event_type: 'node_skipped_prior_success',
             },
           ])
         );

--- a/packages/core/src/db/workflows.test.ts
+++ b/packages/core/src/db/workflows.test.ts
@@ -44,6 +44,7 @@ import {
   findChildRuns,
   getRunAncestry,
   listWorkflowRuns,
+  listDashboardRuns,
   findOpenWorkRuns,
   findAdoptingRuns,
   deleteOldWorkflowRuns,
@@ -187,6 +188,150 @@ describe('workflows database', () => {
       const result = await getWorkflowRun('non-existent');
 
       expect(result).toBeNull();
+    });
+  });
+
+  describe('listDashboardRuns', () => {
+    test('derives active nodes from canonical node lifecycle events', async () => {
+      mockQuery
+        .mockResolvedValueOnce(
+          createQueryResult([
+            {
+              ...mockWorkflowRun,
+              codebase_name: 'Archon',
+              platform_type: 'web',
+              worker_platform_id: 'worker-1',
+              parent_platform_id: null,
+              agents_completed: 0,
+              agents_failed: 0,
+              agents_total: null,
+            },
+          ])
+        )
+        .mockResolvedValueOnce(createQueryResult([{ status: 'running', cnt: '1' }]))
+        .mockResolvedValueOnce(
+          createQueryResult([
+            {
+              workflow_run_id: mockWorkflowRun.id,
+              step_name: 'implement',
+              event_type: 'node_started',
+            },
+          ])
+        );
+
+      const result = await listDashboardRuns({ status: 'running' });
+
+      expect(result.runs[0]).toMatchObject({
+        active_nodes: ['implement'],
+        current_step_name: 'implement',
+        current_step_status: 'running',
+        total_steps: null,
+      });
+      const listSql = String(mockQuery.mock.calls[0]?.[0]);
+      expect(listSql).not.toContain('step_started');
+      expect(listSql).not.toContain('step_completed');
+      expect(listSql).not.toContain('step_failed');
+    });
+
+    test('does not collapse parallel active nodes into the singular compatibility fields', async () => {
+      mockQuery
+        .mockResolvedValueOnce(
+          createQueryResult([
+            {
+              ...mockWorkflowRun,
+              codebase_name: 'Archon',
+              platform_type: 'web',
+              worker_platform_id: 'worker-1',
+              parent_platform_id: null,
+              agents_completed: 0,
+              agents_failed: 0,
+              agents_total: null,
+            },
+          ])
+        )
+        .mockResolvedValueOnce(createQueryResult([{ status: 'running', cnt: '1' }]))
+        .mockResolvedValueOnce(
+          createQueryResult([
+            {
+              workflow_run_id: mockWorkflowRun.id,
+              step_name: 'parallel-a',
+              event_type: 'node_started',
+            },
+            {
+              workflow_run_id: mockWorkflowRun.id,
+              step_name: 'parallel-b',
+              event_type: 'node_started',
+            },
+          ])
+        );
+
+      const result = await listDashboardRuns();
+
+      expect(result.runs[0]).toMatchObject({
+        active_nodes: ['parallel-a', 'parallel-b'],
+        current_step_name: null,
+        current_step_status: null,
+        total_steps: null,
+      });
+    });
+
+    test('returns empty active state when all observed nodes are terminal', async () => {
+      mockQuery
+        .mockResolvedValueOnce(
+          createQueryResult([
+            {
+              ...mockWorkflowRun,
+              codebase_name: 'Archon',
+              platform_type: 'web',
+              worker_platform_id: 'worker-1',
+              parent_platform_id: null,
+              agents_completed: 0,
+              agents_failed: 0,
+              agents_total: null,
+            },
+          ])
+        )
+        .mockResolvedValueOnce(createQueryResult([{ status: 'running', cnt: '1' }]))
+        .mockResolvedValueOnce(
+          createQueryResult([
+            {
+              workflow_run_id: mockWorkflowRun.id,
+              step_name: 'plan',
+              event_type: 'node_started',
+            },
+            {
+              workflow_run_id: mockWorkflowRun.id,
+              step_name: 'plan',
+              event_type: 'node_completed',
+            },
+          ])
+        );
+
+      const result = await listDashboardRuns();
+
+      expect(result.runs[0]).toMatchObject({
+        active_nodes: [],
+        current_step_name: null,
+        current_step_status: null,
+        total_steps: null,
+      });
+    });
+
+    test('filters by multiple statuses and totals their counts', async () => {
+      mockQuery.mockResolvedValueOnce(createQueryResult([])).mockResolvedValueOnce(
+        createQueryResult([
+          { status: 'running', cnt: '2' },
+          { status: 'paused', cnt: '3' },
+          { status: 'completed', cnt: '4' },
+        ])
+      );
+
+      const result = await listDashboardRuns({ status: ['running', 'paused'] });
+
+      expect(result.total).toBe(5);
+      expect(String(mockQuery.mock.calls[0]?.[0])).toContain('r.status IN ($1, $2)');
+      expect(mockQuery.mock.calls[0]?.[1]).toEqual(['running', 'paused', 50, 0]);
+      expect(mockQuery).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/core/src/db/workflows.ts
+++ b/packages/core/src/db/workflows.ts
@@ -2,7 +2,7 @@
  * Database operations for workflow runs
  */
 import { pool, getDialect, getDatabaseType, getDatabase } from './connection';
-import { insertWorkflowEvent } from './workflow-events';
+import { insertWorkflowEvent, listActiveWorkflowNodeIds } from './workflow-events';
 import { toHydratedTimestamp } from './timestamps';
 import type { IDatabase, SqlDialect } from './adapters/types';
 import type {
@@ -1755,6 +1755,12 @@ export type {
   DashboardRunsResult,
 } from '../schemas/workflow-run';
 
+function dashboardStatuses(
+  status: NonNullable<ListDashboardRunsOptions['status']>
+): WorkflowRunStatus[] {
+  return [...new Set(Array.isArray(status) ? status : [status])];
+}
+
 /**
  * Build WHERE clauses shared between the list and count queries.
  * Returns the clauses array and values array (mutated in place).
@@ -1766,8 +1772,11 @@ function buildDashboardWhereClauses(
   const whereClauses: string[] = [];
 
   if (options?.status) {
-    values.push(options.status);
-    whereClauses.push(`r.status = $${String(values.length)}`);
+    const placeholders = dashboardStatuses(options.status).map(status => {
+      values.push(status);
+      return `$${String(values.length)}`;
+    });
+    whereClauses.push(`r.status IN (${placeholders.join(', ')})`);
   }
   if (options?.codebaseId) {
     values.push(options.codebaseId);
@@ -1835,30 +1844,17 @@ export async function listDashboardRuns(
 
   try {
     const [listResult, countResult] = await Promise.all([
-      pool.query<DashboardWorkflowRun>(
+      pool.query<
+        Omit<
+          DashboardWorkflowRun,
+          'active_nodes' | 'current_step_name' | 'current_step_status' | 'total_steps'
+        >
+      >(
         `SELECT r.*,
                 c.platform_type,
                 c.platform_conversation_id AS worker_platform_id,
                 pc.platform_conversation_id AS parent_platform_id,
                 cb.name AS codebase_name,
-                (SELECT e.step_name
-                 FROM remote_agent_workflow_events e
-                 WHERE e.workflow_run_id = r.id AND e.event_type = 'step_started'
-                 ORDER BY e.created_at DESC LIMIT 1) AS current_step_name,
-                (SELECT ${jsonIntExtract('e.data', 'total_steps')}
-                 FROM remote_agent_workflow_events e
-                 WHERE e.workflow_run_id = r.id AND e.event_type = 'step_started'
-                 ORDER BY e.created_at DESC LIMIT 1) AS total_steps,
-                CASE (SELECT e2.event_type
-                      FROM remote_agent_workflow_events e2
-                      WHERE e2.workflow_run_id = r.id
-                        AND e2.event_type IN ('step_completed','step_failed','step_started')
-                      ORDER BY e2.created_at DESC LIMIT 1)
-                  WHEN 'step_completed' THEN 'completed'
-                  WHEN 'step_failed' THEN 'failed'
-                  WHEN 'step_started' THEN 'running'
-                  ELSE NULL
-                END AS current_step_status,
                 (SELECT COUNT(*) FROM remote_agent_workflow_events e
                  WHERE e.workflow_run_id = r.id AND e.event_type = 'parallel_agent_completed') AS agents_completed,
                 (SELECT COUNT(*) FROM remote_agent_workflow_events e
@@ -1904,10 +1900,23 @@ export async function listDashboardRuns(
 
     // Total for the current filter (with status applied)
     const total = options?.status
-      ? (counts[options.status as keyof typeof counts] ?? 0)
+      ? dashboardStatuses(options.status).reduce((sum, status) => sum + counts[status], 0)
       : counts.all;
 
-    return { runs: listResult.rows.map(normalizeWorkflowRun), total, counts };
+    const activeByRun = await listActiveWorkflowNodeIds(listResult.rows.map(run => run.id));
+    const runs = listResult.rows.map(run => {
+      const activeNodes = activeByRun.get(run.id) ?? [];
+      const hasSingleActiveNode = activeNodes.length === 1;
+      return normalizeWorkflowRun({
+        ...run,
+        active_nodes: activeNodes,
+        current_step_name: hasSingleActiveNode ? (activeNodes[0] ?? null) : null,
+        current_step_status: hasSingleActiveNode ? ('running' as const) : null,
+        total_steps: null,
+      });
+    });
+
+    return { runs, total, counts };
   } catch (error) {
     const err = error as Error;
     getLog().error({ err }, 'list_dashboard_runs_failed');

--- a/packages/core/src/handlers/command-handler.test.ts
+++ b/packages/core/src/handlers/command-handler.test.ts
@@ -13,6 +13,7 @@ import { createMockLogger } from '../test/mocks/logger';
 import { makeTestWorkflowWithSource } from '@archon/workflows/test-utils';
 import type { Codebase, Conversation, Session } from '../types';
 import type { WorkflowRun } from '@archon/workflows/schemas/workflow-run';
+import type { DashboardWorkflowRun } from '../schemas/workflow-run';
 import type { IsolationEnvironmentRow } from '@archon/isolation';
 import { join } from 'path';
 import * as fsPromises from 'fs/promises';
@@ -104,6 +105,34 @@ function makeWorkflowRun(overrides: Partial<WorkflowRun> = {}): WorkflowRun {
   };
 }
 
+const EMPTY_DASHBOARD_COUNTS = {
+  all: 0,
+  running: 0,
+  completed: 0,
+  failed: 0,
+  cancelled: 0,
+  pending: 0,
+  paused: 0,
+};
+
+function makeDashboardRun(overrides: Partial<DashboardWorkflowRun> = {}): DashboardWorkflowRun {
+  return {
+    ...makeWorkflowRun(),
+    codebase_name: 'Archon',
+    platform_type: 'cli',
+    worker_platform_id: null,
+    parent_platform_id: null,
+    active_nodes: [],
+    current_step_name: null,
+    total_steps: null,
+    current_step_status: null,
+    agents_completed: null,
+    agents_failed: null,
+    agents_total: null,
+    ...overrides,
+  };
+}
+
 function makeIsolationEnvironment(
   overrides: Partial<IsolationEnvironmentRow> = {}
 ): IsolationEnvironmentRow {
@@ -156,7 +185,9 @@ const mockCancelWorkflowRun = mock<typeof WorkflowDb.cancelWorkflowRun>(() =>
 const mockCancelResumableRunsForConversation = mock<
   typeof WorkflowDb.cancelResumableRunsForConversation
 >(() => Promise.resolve([]));
-const mockListWorkflowRuns = mock<typeof WorkflowDb.listWorkflowRuns>(() => Promise.resolve([]));
+const mockListDashboardRuns = mock<typeof WorkflowDb.listDashboardRuns>(() =>
+  Promise.resolve({ runs: [], total: 0, counts: EMPTY_DASHBOARD_COUNTS })
+);
 const mockGetWorkflowRun = mock<typeof WorkflowDb.getWorkflowRun>(() => Promise.resolve(null));
 const mockResumeWorkflowRun = mock<typeof WorkflowDb.resumeWorkflowRun>(() =>
   Promise.resolve(makeWorkflowRun({ id: 'run-id' }))
@@ -231,7 +262,7 @@ mock.module('../db/workflows', () => ({
   getActiveWorkflowRun: mockGetActiveWorkflowRun,
   cancelWorkflowRun: mockCancelWorkflowRun,
   cancelResumableRunsForConversation: mockCancelResumableRunsForConversation,
-  listWorkflowRuns: mockListWorkflowRuns,
+  listDashboardRuns: mockListDashboardRuns,
   getWorkflowRun: mockGetWorkflowRun,
   findChildRuns: mockFindChildRuns,
   resumeWorkflowRun: mockResumeWorkflowRun,
@@ -391,7 +422,7 @@ function clearAllMocks(): void {
   mockGetActiveWorkflowRun.mockClear();
   mockCancelWorkflowRun.mockClear();
   mockCancelResumableRunsForConversation.mockClear();
-  mockListWorkflowRuns.mockClear();
+  mockListDashboardRuns.mockClear();
   mockGetWorkflowRun.mockClear();
   mockResumeWorkflowRun.mockClear();
   mockFailWorkflowRun.mockClear();
@@ -1860,17 +1891,22 @@ describe('CommandHandler', () => {
     describe('/workflow status', () => {
       test('should show all running workflows', async () => {
         const startedAt = new Date(Date.now() - 2 * 60 * 1000);
-        mockListWorkflowRuns.mockResolvedValueOnce([
-          makeWorkflowRun({
-            id: 'run-abc123',
-            workflow_name: 'implement',
-            conversation_id: 'conv-1',
-            user_message: 'add feature',
-            started_at: startedAt,
-            last_activity_at: startedAt,
-            working_path: '/workspace/worktrees/feat-auth',
-          }),
-        ]);
+        mockListDashboardRuns.mockResolvedValueOnce({
+          runs: [
+            makeDashboardRun({
+              id: 'run-abc123',
+              workflow_name: 'implement',
+              conversation_id: 'conv-1',
+              user_message: 'add feature',
+              started_at: startedAt,
+              last_activity_at: startedAt,
+              working_path: '/workspace/worktrees/feat-auth',
+              active_nodes: ['parallel-a', 'parallel-b'],
+            }),
+          ],
+          total: 1,
+          counts: { ...EMPTY_DASHBOARD_COUNTS, all: 1, running: 1 },
+        });
 
         const result = await handleCommand(baseConversation, '/workflow status');
 
@@ -1878,17 +1914,22 @@ describe('CommandHandler', () => {
         expect(result.message).toContain('implement');
         expect(result.message).toContain('run-abc123');
         expect(result.message).toContain('/workspace/worktrees/feat-auth');
+        expect(result.message).toContain('Active nodes: parallel-a, parallel-b');
       });
 
       test('should show authored outcome independently for an active workflow', async () => {
-        mockListWorkflowRuns.mockResolvedValueOnce([
-          makeWorkflowRun({
-            id: 'run-paused',
-            workflow_name: 'review',
-            status: 'paused',
-            outcome: 'succeeded',
-          }),
-        ]);
+        mockListDashboardRuns.mockResolvedValueOnce({
+          runs: [
+            makeDashboardRun({
+              id: 'run-paused',
+              workflow_name: 'review',
+              status: 'paused',
+              outcome: 'succeeded',
+            }),
+          ],
+          total: 1,
+          counts: { ...EMPTY_DASHBOARD_COUNTS, all: 1, paused: 1 },
+        });
 
         const result = await handleCommand(baseConversation, '/workflow status');
 
@@ -1898,7 +1939,11 @@ describe('CommandHandler', () => {
       });
 
       test('should show no-active message when no workflows running', async () => {
-        mockListWorkflowRuns.mockResolvedValueOnce([]);
+        mockListDashboardRuns.mockResolvedValueOnce({
+          runs: [],
+          total: 0,
+          counts: EMPTY_DASHBOARD_COUNTS,
+        });
 
         const result = await handleCommand(baseConversation, '/workflow status');
 
@@ -1907,7 +1952,7 @@ describe('CommandHandler', () => {
       });
 
       test('should handle database errors gracefully', async () => {
-        mockListWorkflowRuns.mockRejectedValueOnce(new Error('Database connection error'));
+        mockListDashboardRuns.mockRejectedValueOnce(new Error('Database connection error'));
 
         const result = await handleCommand(baseConversation, '/workflow status');
 
@@ -1917,16 +1962,20 @@ describe('CommandHandler', () => {
 
       test('should show working_path as (unknown) when null', async () => {
         const startedAt = new Date();
-        mockListWorkflowRuns.mockResolvedValueOnce([
-          makeWorkflowRun({
-            id: 'run-xyz',
-            workflow_name: 'assist',
-            conversation_id: 'conv-1',
-            user_message: 'help',
-            started_at: startedAt,
-            working_path: null,
-          }),
-        ]);
+        mockListDashboardRuns.mockResolvedValueOnce({
+          runs: [
+            makeDashboardRun({
+              id: 'run-xyz',
+              workflow_name: 'assist',
+              conversation_id: 'conv-1',
+              user_message: 'help',
+              started_at: startedAt,
+              working_path: null,
+            }),
+          ],
+          total: 1,
+          counts: { ...EMPTY_DASHBOARD_COUNTS, all: 1, running: 1 },
+        });
 
         const result = await handleCommand(baseConversation, '/workflow status');
 

--- a/packages/core/src/handlers/command-handler.ts
+++ b/packages/core/src/handlers/command-handler.ts
@@ -886,6 +886,9 @@ async function handleWorkflowCommand(
           if (run.outcome !== null) msg += `  Authored outcome: ${run.outcome}\n`;
           msg += `  ID: ${run.id}\n`;
           msg += `  Path: ${run.working_path ?? '(unknown)'}\n`;
+          if (run.active_nodes.length > 0) {
+            msg += `  Active node${run.active_nodes.length === 1 ? '' : 's'}: ${run.active_nodes.join(', ')}\n`;
+          }
           msg += `  Started: ${new Date(run.started_at).toISOString()}\n\n`;
         }
 

--- a/packages/core/src/operations/workflow-operations.test.ts
+++ b/packages/core/src/operations/workflow-operations.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, mock, beforeEach } from 'bun:test';
 import type { WorkflowRun } from '@archon/workflows/schemas/workflow-run';
+import type { DashboardWorkflowRun } from '../schemas/workflow-run';
 import type * as WorkflowDb from '../db/workflows';
 import type * as WorkflowEventDb from '../db/workflow-events';
 import type * as WorkflowNodeSessionDb from '../db/workflow-node-sessions';
@@ -10,7 +11,18 @@ import type * as CleanupService from '../services/cleanup-service';
 // ---------------------------------------------------------------------------
 
 const mockGetWorkflowRun = mock<typeof WorkflowDb.getWorkflowRun>(() => Promise.resolve(null));
-const mockListWorkflowRuns = mock<typeof WorkflowDb.listWorkflowRuns>(() => Promise.resolve([]));
+const EMPTY_COUNTS = {
+  all: 0,
+  running: 0,
+  completed: 0,
+  failed: 0,
+  cancelled: 0,
+  pending: 0,
+  paused: 0,
+};
+const mockListDashboardRuns = mock<typeof WorkflowDb.listDashboardRuns>(() =>
+  Promise.resolve({ runs: [], total: 0, counts: EMPTY_COUNTS })
+);
 const mockUpdateWorkflowRun = mock<typeof WorkflowDb.updateWorkflowRun>(() => Promise.resolve());
 const mockCancelWorkflowRun = mock<typeof WorkflowDb.cancelWorkflowRun>(() =>
   Promise.resolve({ cancelled: true })
@@ -32,7 +44,7 @@ const mockResolveAndCancelApprovalGate = mock<typeof WorkflowDb.resolveAndCancel
 
 mock.module('../db/workflows', () => ({
   getWorkflowRun: mockGetWorkflowRun,
-  listWorkflowRuns: mockListWorkflowRuns,
+  listDashboardRuns: mockListDashboardRuns,
   updateWorkflowRun: mockUpdateWorkflowRun,
   cancelWorkflowRun: mockCancelWorkflowRun,
   cancelResumableRunsForConversation: mockCancelResumableRunsForConversation,
@@ -123,6 +135,24 @@ function makePausedRun(overrides: Partial<WorkflowRun> = {}): WorkflowRun {
     parent_run_id: null,
     adopted_from_run_id: null,
     output_root: null,
+    ...overrides,
+  };
+}
+
+function makeDashboardRun(overrides: Partial<DashboardWorkflowRun> = {}): DashboardWorkflowRun {
+  return {
+    ...makePausedRun(),
+    codebase_name: 'Archon',
+    platform_type: 'cli',
+    worker_platform_id: null,
+    parent_platform_id: null,
+    active_nodes: [],
+    current_step_name: null,
+    total_steps: null,
+    current_step_status: null,
+    agents_completed: null,
+    agents_failed: null,
+    agents_total: null,
     ...overrides,
   };
 }
@@ -1197,20 +1227,25 @@ describe('assertApprovable / assertRejectable — shared precondition gate', () 
 
 describe('getWorkflowStatus', () => {
   beforeEach(() => {
-    mockListWorkflowRuns.mockClear();
+    mockListDashboardRuns.mockClear();
   });
 
   test('returns running and paused runs', async () => {
     const runs = [
-      makePausedRun({ status: 'running' }),
-      makePausedRun({ id: 'run-2', status: 'paused' }),
+      makeDashboardRun({ status: 'running', active_nodes: ['plan', 'implement'] }),
+      makeDashboardRun({ id: 'run-2', status: 'paused' }),
     ];
-    mockListWorkflowRuns.mockResolvedValueOnce(runs);
+    mockListDashboardRuns.mockResolvedValueOnce({
+      runs,
+      total: 2,
+      counts: { ...EMPTY_COUNTS, all: 2, running: 1, paused: 1 },
+    });
 
     const result = await getWorkflowStatus();
 
     expect(result.runs).toHaveLength(2);
-    expect(mockListWorkflowRuns).toHaveBeenCalledWith({
+    expect(result.runs[0]?.active_nodes).toEqual(['plan', 'implement']);
+    expect(mockListDashboardRuns).toHaveBeenCalledWith({
       status: ['running', 'paused'],
       limit: 50,
     });

--- a/packages/core/src/operations/workflow-operations.ts
+++ b/packages/core/src/operations/workflow-operations.ts
@@ -18,6 +18,7 @@ import type {
   LoopGateRunMetadata,
   RunAttention,
 } from '@archon/workflows/schemas/workflow-run';
+import type { DashboardWorkflowRun } from '../schemas/workflow-run';
 import * as workflowDb from '../db/workflows';
 import * as workflowNodeSessionDb from '../db/workflow-node-sessions';
 
@@ -33,7 +34,7 @@ function getLog(): ReturnType<typeof createLogger> {
 // ---------------------------------------------------------------------------
 
 export interface WorkflowStatusData {
-  runs: WorkflowRun[];
+  runs: DashboardWorkflowRun[];
 }
 
 export interface ApprovalOperationResult {
@@ -381,7 +382,7 @@ export function assertRejectable(run: WorkflowRun): ApprovalContext | undefined 
  * List all running and paused workflow runs.
  */
 export async function getWorkflowStatus(): Promise<WorkflowStatusData> {
-  const runs = await workflowDb.listWorkflowRuns({
+  const { runs } = await workflowDb.listDashboardRuns({
     status: ['running', 'paused'],
     limit: 50,
   });

--- a/packages/core/src/orchestrator/manage-run-tool.test.ts
+++ b/packages/core/src/orchestrator/manage-run-tool.test.ts
@@ -189,15 +189,14 @@ describe('manage_run — reads', () => {
           id: 'abcdef1234',
           workflow_name: 'wf',
           status: 'running',
-          current_step_name: 'plan',
-          total_steps: 3,
+          active_nodes: ['plan', 'implement'],
         },
       ],
     });
     const tool = buildManageRunTool({ codebaseId: CODEBASE_ID });
     const out = await tool.handler({ action: 'list' });
     expect(out).toContain('abcdef12');
-    expect(out).toContain('plan/3');
+    expect(out).toContain('active node(s): plan, implement');
     expect(mockListDashboardRuns).toHaveBeenCalledWith({ codebaseId: CODEBASE_ID, limit: 20 });
   });
 
@@ -209,8 +208,7 @@ describe('manage_run — reads', () => {
           workflow_name: 'wf',
           status: 'completed',
           outcome: 'failed',
-          current_step_name: null,
-          total_steps: 3,
+          active_nodes: [],
         },
       ],
     });

--- a/packages/core/src/orchestrator/manage-run-tool.ts
+++ b/packages/core/src/orchestrator/manage-run-tool.ts
@@ -132,7 +132,7 @@ const HELP_OVERVIEW = [
   'manage_run — inspect and operate this project’s workflow runs.',
   '',
   'Actions (call action=help subtool=<name> for details):',
-  '  list     — recent runs in this project (id, workflow, status, authored outcome, step). No params.',
+  '  list     — recent runs in this project (id, workflow, status, authored outcome, active nodes). No params.',
   '  get      — one run’s detail. Params: runId.',
   '  start    — launch a workflow in the background. Params: workflow, message.',
   '  resume   — check a failed/paused run can resume from completed nodes. Params: runId.',
@@ -147,7 +147,7 @@ const HELP_OVERVIEW = [
 ].join('\n');
 
 const HELP_BY_ACTION: Record<Exclude<Action, 'help'>, string> = {
-  list: 'list — recent runs for this project, most recent first. No parameters. Returns id · workflow · status · authored outcome when declared · current step.',
+  list: 'list — recent runs for this project, most recent first. No parameters. Returns id · workflow · status · authored outcome when declared · active node(s).',
   get: 'get — full detail for one run. Required: runId (short or full). Returns status, authored outcome when declared, start/finish times, and error if any. Scoped to this project.',
   start:
     'start — launch a workflow in the background. Required: workflow (name). Recommended: message (what it should do). It appears in the runs list and the workflow dock.',
@@ -246,12 +246,10 @@ async function handleList(ctx: ManageRunContext): Promise<string> {
   if (runs.length === 0) return 'No workflow runs for this project yet.';
 
   const lines = runs.map(r => {
-    const step =
-      r.current_step_name !== null
-        ? ` · ${r.current_step_name}${r.total_steps !== null ? `/${r.total_steps.toString()}` : ''}`
-        : '';
+    const activeNodes =
+      r.active_nodes.length > 0 ? ` · active node(s): ${r.active_nodes.join(', ')}` : '';
     const outcome = r.outcome ? ` · authored outcome: ${r.outcome}` : '';
-    return `- ${r.id.slice(0, 8)} · ${r.workflow_name} · ${r.status}${outcome}${step}`;
+    return `- ${r.id.slice(0, 8)} · ${r.workflow_name} · ${r.status}${outcome}${activeNodes}`;
   });
   return `${runs.length.toString()} run(s) (most recent first):\n${lines.join('\n')}`;
 }

--- a/packages/core/src/schemas/index.test.ts
+++ b/packages/core/src/schemas/index.test.ts
@@ -39,6 +39,7 @@ const validDashboardWorkflowRun = {
   platform_type: 'web',
   worker_platform_id: null,
   parent_platform_id: null,
+  active_nodes: [],
   current_step_name: null,
   total_steps: null,
   current_step_status: null,
@@ -267,6 +268,23 @@ describe('core schemas', () => {
     }
   });
 
+  test('dashboardWorkflowRunSchema requires non-empty active node identifiers', () => {
+    expect(
+      dashboardWorkflowRunSchema.safeParse({
+        ...validDashboardWorkflowRun,
+        active_nodes: ['plan', 'implement'],
+      }).success
+    ).toBe(true);
+    expect(
+      dashboardWorkflowRunSchema.safeParse({
+        ...validDashboardWorkflowRun,
+        active_nodes: [''],
+      }).success
+    ).toBe(false);
+    const { active_nodes: _, ...withoutActiveNodes } = validDashboardWorkflowRun;
+    expect(dashboardWorkflowRunSchema.safeParse(withoutActiveNodes).success).toBe(false);
+  });
+
   test('dashboardWorkflowRunSchema preserves nullable authored outcomes and rejects unknown values', () => {
     expect(
       dashboardWorkflowRunSchema.safeParse({
@@ -300,6 +318,13 @@ describe('core schemas', () => {
       offset: 0,
     });
     expect(result.success).toBe(true);
+  });
+
+  test('listDashboardRunsOptionsSchema accepts a non-empty status array', () => {
+    expect(
+      listDashboardRunsOptionsSchema.safeParse({ status: ['running', 'paused'] }).success
+    ).toBe(true);
+    expect(listDashboardRunsOptionsSchema.safeParse({ status: [] }).success).toBe(false);
   });
 
   test('listDashboardRunsOptionsSchema rejects invalid status', () => {

--- a/packages/core/src/schemas/workflow-run.ts
+++ b/packages/core/src/schemas/workflow-run.ts
@@ -3,6 +3,7 @@
  */
 import { z } from '@hono/zod-openapi';
 import { workflowRunSchema, workflowRunStatusSchema } from '@archon/workflows/schemas/workflow-run';
+import type { WorkflowRunStatus } from '@archon/workflows/schemas/workflow-run';
 
 // ---------------------------------------------------------------------------
 // DashboardWorkflowRun
@@ -38,7 +39,11 @@ export const listDashboardRunsOptionsSchema = z.object({
   offset: z.number().optional(),
 });
 
-export type ListDashboardRunsOptions = z.infer<typeof listDashboardRunsOptionsSchema>;
+type ParsedListDashboardRunsOptions = z.infer<typeof listDashboardRunsOptionsSchema>;
+
+export type ListDashboardRunsOptions = Omit<ParsedListDashboardRunsOptions, 'status'> & {
+  status?: WorkflowRunStatus | [WorkflowRunStatus, ...WorkflowRunStatus[]];
+};
 
 // ---------------------------------------------------------------------------
 // DashboardRunsResult

--- a/packages/core/src/schemas/workflow-run.ts
+++ b/packages/core/src/schemas/workflow-run.ts
@@ -13,6 +13,7 @@ export const dashboardWorkflowRunSchema = workflowRunSchema.extend({
   platform_type: z.string().nullable(),
   worker_platform_id: z.string().nullable(),
   parent_platform_id: z.string().nullable(),
+  active_nodes: z.array(z.string().min(1)),
   current_step_name: z.string().nullable(),
   total_steps: z.number().nullable(),
   current_step_status: z.enum(['running', 'completed', 'failed']).nullable(),
@@ -28,7 +29,7 @@ export type DashboardWorkflowRun = z.infer<typeof dashboardWorkflowRunSchema>;
 // ---------------------------------------------------------------------------
 
 export const listDashboardRunsOptionsSchema = z.object({
-  status: workflowRunStatusSchema.optional(),
+  status: z.union([workflowRunStatusSchema, z.array(workflowRunStatusSchema).min(1)]).optional(),
   codebaseId: z.string().optional(),
   search: z.string().optional(),
   after: z.string().optional(),

--- a/packages/core/src/schemas/workflow-run.ts
+++ b/packages/core/src/schemas/workflow-run.ts
@@ -3,7 +3,6 @@
  */
 import { z } from '@hono/zod-openapi';
 import { workflowRunSchema, workflowRunStatusSchema } from '@archon/workflows/schemas/workflow-run';
-import type { WorkflowRunStatus } from '@archon/workflows/schemas/workflow-run';
 
 // ---------------------------------------------------------------------------
 // DashboardWorkflowRun
@@ -30,7 +29,9 @@ export type DashboardWorkflowRun = z.infer<typeof dashboardWorkflowRunSchema>;
 // ---------------------------------------------------------------------------
 
 export const listDashboardRunsOptionsSchema = z.object({
-  status: z.union([workflowRunStatusSchema, z.array(workflowRunStatusSchema).min(1)]).optional(),
+  status: z
+    .union([workflowRunStatusSchema, z.tuple([workflowRunStatusSchema], workflowRunStatusSchema)])
+    .optional(),
   codebaseId: z.string().optional(),
   search: z.string().optional(),
   after: z.string().optional(),
@@ -39,11 +40,7 @@ export const listDashboardRunsOptionsSchema = z.object({
   offset: z.number().optional(),
 });
 
-type ParsedListDashboardRunsOptions = z.infer<typeof listDashboardRunsOptionsSchema>;
-
-export type ListDashboardRunsOptions = Omit<ParsedListDashboardRunsOptions, 'status'> & {
-  status?: WorkflowRunStatus | [WorkflowRunStatus, ...WorkflowRunStatus[]];
-};
+export type ListDashboardRunsOptions = z.infer<typeof listDashboardRunsOptionsSchema>;
 
 // ---------------------------------------------------------------------------
 // DashboardRunsResult

--- a/packages/docs-web/src/content/docs/adapters/web.md
+++ b/packages/docs-web/src/content/docs/adapters/web.md
@@ -134,7 +134,7 @@ Workflows with `interactive: true` in their YAML definition run in the foregroun
 While a workflow runs, a progress card appears in the conversation showing:
 
 - Current status (running, completed, failed, paused)
-- Which DAG node is currently executing
+- Every DAG node currently executing; parallel active nodes are shown together
 - Per-node status indicators
 - Elapsed time
 

--- a/packages/docs-web/src/content/docs/reference/api.md
+++ b/packages/docs-web/src/content/docs/reference/api.md
@@ -415,6 +415,13 @@ Returns `{ commands: [{ name, source: "bundled" | "project" }] }`.
 
 Query parameters include status filters, date ranges, and pagination. Used by the Command Center UI.
 
+Each run includes `active_nodes`, ordered by unresolved `node_started` event order. Completion,
+failure, and both skip lifecycle events remove a node; a retrying start adds it again. Concurrent
+nodes remain separate entries. The compatibility fields `current_step_name` and
+`current_step_status` are populated only when exactly one node is active, and are `null` for zero
+or multiple active nodes. `total_steps` is `null`; observed lifecycle events do not define the
+workflow's total node count. This state describes node lifecycle, not process-owner liveness.
+
 ---
 
 ## Configuration

--- a/packages/docs-web/src/content/docs/reference/cli.md
+++ b/packages/docs-web/src/content/docs/reference/cli.md
@@ -434,6 +434,12 @@ archon workflow status --verbose   # add a per-node summary for each run
 archon workflow status --json --verbose
 ```
 
+The normal human and JSON views include every active node without fetching each run's event
+history. In JSON, `active_nodes` is the ordered list of unresolved node starts: `node_started` adds
+an identifier, while `node_completed`, `node_failed`, `node_skipped`, and
+`node_skipped_prior_success` remove it. Retries re-add the node in their new start position. This
+is node lifecycle state, not evidence that a process owner is alive.
+
 ### `workflow runs`
 
 List recent runs of **every** status (completed, failed, cancelled, running, paused) for the current project. The project is resolved from `cwd` the same way `workflow run` does. Complements `workflow status` (which is active-only).
@@ -447,6 +453,11 @@ archon workflow runs --all             # list across all projects (ignore cwd sc
 ```
 
 If `cwd` is not a registered project, the command falls back to a global list and says so — `--json` carries this as a `scopeFallback: true` field so a consuming agent never mistakes a global result for a project-scoped one.
+
+The run-list JSON uses the same `active_nodes` contract as `workflow status`. The retained singular
+fields are compatibility fields: `current_step_name` and `current_step_status` are populated only
+when exactly one node is active, and are `null` for zero or concurrent active nodes. `total_steps`
+is always `null` because lifecycle events do not own a truthful declared DAG total.
 
 The listing shows short 8-character run ids. Every `<run-id>` command below (`get`, `logs`, `wait`, `resume`, `cancel`, `abandon`, `approve`, `reject`) accepts these short ids when run from the project directory: a unique prefix resolves to the full id, an ambiguous prefix errors, and full ids keep working from any directory. Short ids from `--all` rows belonging to *other* projects can't be resolved — use the full id from `--json` for those.
 

--- a/packages/server/src/adapters/web/dashboard-event-poller.test.ts
+++ b/packages/server/src/adapters/web/dashboard-event-poller.test.ts
@@ -13,7 +13,7 @@ mock.module('@archon/core/db/workflow-events', () => ({
 
 import { DashboardEventPoller } from './dashboard-event-poller';
 import type { DashboardTransport } from './dashboard-event-poller';
-import { mapWorkflowEventRow } from './workflow-bridge';
+import { DASHBOARD_SOURCE_EVENT_TYPES, mapWorkflowEventRow } from './workflow-bridge';
 
 function row(over: Partial<WorkflowEventRow>): WorkflowEventRow {
   return {
@@ -84,11 +84,11 @@ describe('mapWorkflowEventRow', () => {
     expect(e).toMatchObject({ type: 'dag_node', status: 'failed', error: 'boom' });
   });
 
-  test('step_started → dag_node running (drives the dock current step)', () => {
-    const e = JSON.parse(
-      mapWorkflowEventRow(row({ event_type: 'step_started', step_name: 'plan' })) as string
-    );
-    expect(e).toMatchObject({ type: 'dag_node', status: 'running', nodeId: 'plan' });
+  test('obsolete step transitions are not interpreted or polled', () => {
+    for (const eventType of ['step_started', 'step_completed', 'step_failed']) {
+      expect(mapWorkflowEventRow(row({ event_type: eventType, step_name: 'plan' }))).toBeNull();
+      expect(DASHBOARD_SOURCE_EVENT_TYPES).not.toContain(eventType);
+    }
   });
 
   test('loop_iteration_started → dag_node running', () => {

--- a/packages/server/src/adapters/web/workflow-bridge.ts
+++ b/packages/server/src/adapters/web/workflow-bridge.ts
@@ -226,10 +226,8 @@ const ROW_WORKFLOW_STATUS: Record<string, 'running' | 'completed' | 'failed' | '
 /** DB event_type → node-level status, emitted as a `dag_node` SSE event. */
 const ROW_NODE_STATUS: Record<string, 'running' | 'completed' | 'failed' | 'skipped'> = {
   node_started: 'running',
-  step_started: 'running',
   loop_iteration_started: 'running',
   node_completed: 'completed',
-  step_completed: 'completed',
   loop_iteration_completed: 'completed',
   node_failed: 'failed',
   loop_iteration_failed: 'failed',

--- a/packages/server/src/routes/api.workflow-runs.test.ts
+++ b/packages/server/src/routes/api.workflow-runs.test.ts
@@ -438,6 +438,7 @@ function makeDashboardWorkflowRun(run: WorkflowRun): DashboardWorkflowRun {
     platform_type: null,
     worker_platform_id: null,
     parent_platform_id: null,
+    active_nodes: [],
     current_step_name: null,
     total_steps: null,
     current_step_status: null,
@@ -1492,7 +1493,10 @@ describe('GET /api/dashboard/runs', () => {
     mockListDashboardRuns.mockImplementationOnce(async () =>
       makeDashboardRunsResult({
         runs: [
-          makeDashboardWorkflowRun(MOCK_RUNNING_RUN),
+          {
+            ...makeDashboardWorkflowRun(MOCK_RUNNING_RUN),
+            active_nodes: ['parallel-a', 'parallel-b'],
+          },
           makeDashboardWorkflowRun(MOCK_COMPLETED_RUN),
         ],
         total: 2,
@@ -1505,12 +1509,13 @@ describe('GET /api/dashboard/runs', () => {
     expect(response.status).toBe(200);
 
     const body = (await response.json()) as {
-      runs: Array<{ status: string; outcome: string | null }>;
+      runs: Array<{ status: string; outcome: string | null; active_nodes: string[] }>;
       total: number;
       counts: { all: number };
     };
     expect(Array.isArray(body.runs)).toBe(true);
     expect(body.runs.length).toBe(2);
+    expect(body.runs[0]?.active_nodes).toEqual(['parallel-a', 'parallel-b']);
     expect(body.runs[1]).toMatchObject({ status: 'completed', outcome: 'failed' });
     expect(body.total).toBe(2);
     expect(body.counts.all).toBe(5);

--- a/packages/web/src/components/dashboard/WorkflowRunCard.test.tsx
+++ b/packages/web/src/components/dashboard/WorkflowRunCard.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { MemoryRouter } from 'react-router';
 import type { DashboardRunResponse } from '@/lib/api';
+import { useWorkflowStore } from '@/stores/workflow-store';
 import { WorkflowRunCard } from './WorkflowRunCard';
 
 const parallelRun: DashboardRunResponse = {
@@ -45,5 +46,34 @@ describe('WorkflowRunCard', () => {
 
     expect(html).toContain('Active nodes:');
     expect(html).toContain('parallel-a, parallel-b');
+  });
+
+  test('does not fall back to stale REST nodes after live lifecycle events finish them', () => {
+    const serverWorkflows = useWorkflowStore.getInitialState().workflows;
+    serverWorkflows.set(parallelRun.id, {
+      runId: parallelRun.id,
+      workflowName: parallelRun.workflow_name,
+      status: 'running',
+      dagNodes: [
+        { nodeId: 'parallel-a', name: 'parallel-a', status: 'completed' },
+        { nodeId: 'parallel-b', name: 'parallel-b', status: 'failed' },
+      ],
+      artifacts: [],
+      startedAt: Date.now(),
+      currentTool: null,
+    });
+
+    try {
+      const html = renderToStaticMarkup(
+        <MemoryRouter>
+          <WorkflowRunCard run={parallelRun} onCancel={() => undefined} />
+        </MemoryRouter>
+      );
+
+      expect(html).not.toContain('Active node');
+      expect(html).not.toContain('parallel-a, parallel-b');
+    } finally {
+      serverWorkflows.delete(parallelRun.id);
+    }
   });
 });

--- a/packages/web/src/components/dashboard/WorkflowRunCard.test.tsx
+++ b/packages/web/src/components/dashboard/WorkflowRunCard.test.tsx
@@ -54,6 +54,7 @@ describe('WorkflowRunCard', () => {
       runId: parallelRun.id,
       workflowName: parallelRun.workflow_name,
       status: 'running',
+      activeNodeIds: [],
       dagNodes: [
         { nodeId: 'parallel-a', name: 'parallel-a', status: 'completed' },
         { nodeId: 'parallel-b', name: 'parallel-b', status: 'failed' },

--- a/packages/web/src/components/dashboard/WorkflowRunCard.test.tsx
+++ b/packages/web/src/components/dashboard/WorkflowRunCard.test.tsx
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { MemoryRouter } from 'react-router';
+import type { DashboardRunResponse } from '@/lib/api';
+import { WorkflowRunCard } from './WorkflowRunCard';
+
+const parallelRun: DashboardRunResponse = {
+  id: 'run-parallel',
+  workflow_name: 'implement',
+  conversation_id: 'conv-1',
+  parent_conversation_id: null,
+  codebase_id: 'codebase-1',
+  status: 'running',
+  outcome: null,
+  user_message: 'Implement the change',
+  metadata: {},
+  started_at: '2026-09-01T10:00:00.000Z',
+  completed_at: null,
+  last_activity_at: '2026-09-01T10:01:00.000Z',
+  working_path: '/workspace/archon',
+  user_id: null,
+  parent_run_id: null,
+  adopted_from_run_id: null,
+  output_root: null,
+  codebase_name: 'Archon',
+  platform_type: 'cli',
+  worker_platform_id: null,
+  parent_platform_id: null,
+  active_nodes: ['parallel-a', 'parallel-b'],
+  current_step_name: null,
+  total_steps: null,
+  current_step_status: null,
+  agents_completed: null,
+  agents_failed: null,
+  agents_total: null,
+};
+
+describe('WorkflowRunCard', () => {
+  test('renders every active node from the initial dashboard response', () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <WorkflowRunCard run={parallelRun} onCancel={() => undefined} />
+      </MemoryRouter>
+    );
+
+    expect(html).toContain('Active nodes:');
+    expect(html).toContain('parallel-a, parallel-b');
+  });
+});

--- a/packages/web/src/components/dashboard/WorkflowRunCard.tsx
+++ b/packages/web/src/components/dashboard/WorkflowRunCard.tsx
@@ -55,7 +55,7 @@ function StepProgress({
 }): React.ReactElement | null {
   const dagNodes = liveState?.dagNodes ?? [];
   const runningNodeNames = dagNodes.filter(n => n.status === 'running').map(n => n.name);
-  const activeNodeNames = runningNodeNames.length > 0 ? runningNodeNames : run.active_nodes;
+  const activeNodeNames = liveState === undefined ? run.active_nodes : runningNodeNames;
   const completedCount = dagNodes.filter(n => n.status === 'completed').length;
   const totalNodes = run.total_steps ?? 0;
   const currentTool = liveState?.currentTool ?? null;

--- a/packages/web/src/components/dashboard/WorkflowRunCard.tsx
+++ b/packages/web/src/components/dashboard/WorkflowRunCard.tsx
@@ -54,8 +54,7 @@ function StepProgress({
   liveState: WorkflowState | undefined;
 }): React.ReactElement | null {
   const dagNodes = liveState?.dagNodes ?? [];
-  const runningNodeNames = dagNodes.filter(n => n.status === 'running').map(n => n.name);
-  const activeNodeNames = liveState === undefined ? run.active_nodes : runningNodeNames;
+  const activeNodeNames = liveState?.activeNodeIds ?? run.active_nodes;
   const completedCount = dagNodes.filter(n => n.status === 'completed').length;
   const totalNodes = run.total_steps ?? 0;
   const currentTool = liveState?.currentTool ?? null;

--- a/packages/web/src/components/dashboard/WorkflowRunCard.tsx
+++ b/packages/web/src/components/dashboard/WorkflowRunCard.tsx
@@ -54,26 +54,27 @@ function StepProgress({
   liveState: WorkflowState | undefined;
 }): React.ReactElement | null {
   const dagNodes = liveState?.dagNodes ?? [];
-  const runningNode = dagNodes
-    .slice()
-    .reverse()
-    .find(n => n.status === 'running');
+  const runningNodeNames = dagNodes.filter(n => n.status === 'running').map(n => n.name);
+  const activeNodeNames = runningNodeNames.length > 0 ? runningNodeNames : run.active_nodes;
   const completedCount = dagNodes.filter(n => n.status === 'completed').length;
-  const totalNodes = dagNodes.length || run.total_steps || 0;
-  const stepName = runningNode?.name ?? run.current_step_name;
+  const totalNodes = run.total_steps ?? 0;
   const currentTool = liveState?.currentTool ?? null;
 
-  const hasProgress = runningNode != null || totalNodes > 0;
+  const hasProgress = activeNodeNames.length > 0 || totalNodes > 0;
   if (!hasProgress && !currentTool) return null;
 
   return (
     <div className="rounded-md bg-surface-elevated px-3 py-2 space-y-1">
       {hasProgress && (
         <div className="flex items-center gap-2 text-sm text-text-primary">
-          <span className="font-medium">
-            {`${String(completedCount)}${totalNodes ? `/${String(totalNodes)}` : ''} nodes`}
-          </span>
-          {stepName && <span className="text-text-secondary">{stepName}</span>}
+          {totalNodes > 0 && (
+            <span className="font-medium">{`${String(completedCount)}/${String(totalNodes)} nodes`}</span>
+          )}
+          {activeNodeNames.length > 0 && (
+            <span className="text-text-secondary">
+              Active node{activeNodeNames.length === 1 ? '' : 's'}: {activeNodeNames.join(', ')}
+            </span>
+          )}
         </div>
       )}
       {currentTool && (

--- a/packages/web/src/experiments/console/components/ActiveRunCard.test.tsx
+++ b/packages/web/src/experiments/console/components/ActiveRunCard.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { MemoryRouter } from 'react-router';
+import type { Run } from '../primitives/run';
+import { ActiveRunCard } from './ActiveRunCard';
+
+const parallelRun: Run = {
+  id: 'run-parallel',
+  projectId: null,
+  projectName: 'Archon',
+  costUsd: null,
+  conversationId: null,
+  conversationPlatformId: null,
+  workerPlatformId: null,
+  workflow: 'implement',
+  origin: 'cli',
+  status: 'running',
+  outcome: null,
+  startedAt: '2026-09-01T10:00:00.000Z',
+  finishedAt: null,
+  workingPath: null,
+  userMessage: 'Implement the change',
+  activeNodes: ['parallel-a', 'parallel-b'],
+  currentNode: null,
+  lastTool: null,
+};
+
+describe('ActiveRunCard', () => {
+  test('renders every active node for a parallel run', () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <ActiveRunCard run={parallelRun} />
+      </MemoryRouter>
+    );
+
+    expect(html).toContain('nodes');
+    expect(html).toContain('parallel-a, parallel-b');
+  });
+});

--- a/packages/web/src/experiments/console/components/ActiveRunCard.tsx
+++ b/packages/web/src/experiments/console/components/ActiveRunCard.tsx
@@ -158,10 +158,12 @@ export function ActiveRunCard({
                 </span>
               </>
             ) : null}
-            {run.status === 'running' && hasValue(run.currentNode) ? (
+            {run.status === 'running' && run.activeNodes.length > 0 ? (
               <>
-                <span className="font-mono text-text-tertiary">node</span>
-                <span className="font-mono text-text-primary">{run.currentNode}</span>
+                <span className="font-mono text-text-tertiary">
+                  {run.activeNodes.length === 1 ? 'node' : 'nodes'}
+                </span>
+                <span className="font-mono text-text-primary">{run.activeNodes.join(', ')}</span>
               </>
             ) : null}
             {run.status === 'running' && hasValue(run.lastTool) ? (

--- a/packages/web/src/experiments/console/components/WorkflowDock.test.tsx
+++ b/packages/web/src/experiments/console/components/WorkflowDock.test.tsx
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { MemoryRouter } from 'react-router';
+import type { Run } from '../primitives/run';
+import { set } from '../store/cache';
+import { K } from '../store/keys';
+import { WorkflowDock } from './WorkflowDock';
+
+const parallelRun: Run = {
+  id: 'run-parallel',
+  projectId: 'project-parallel',
+  projectName: 'Archon',
+  costUsd: null,
+  conversationId: null,
+  conversationPlatformId: null,
+  workerPlatformId: null,
+  workflow: 'implement',
+  origin: 'cli',
+  status: 'running',
+  outcome: null,
+  startedAt: '2026-09-01T10:00:00.000Z',
+  finishedAt: null,
+  workingPath: null,
+  userMessage: 'Implement the change',
+  activeNodes: ['parallel-a', 'parallel-b'],
+  currentNode: null,
+  lastTool: null,
+};
+
+describe('WorkflowDock', () => {
+  test('renders every active node for a parallel run', () => {
+    set(K.runs('project-parallel'), {
+      runs: [parallelRun],
+      counts: {
+        all: 1,
+        running: 1,
+        paused: 0,
+        failed: 0,
+        completed: 0,
+        cancelled: 0,
+        pending: 0,
+      },
+      total: 1,
+    });
+
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <WorkflowDock projectId="project-parallel" />
+      </MemoryRouter>
+    );
+
+    expect(html).toContain('nodes:');
+    expect(html).toContain('parallel-a, parallel-b');
+  });
+});

--- a/packages/web/src/experiments/console/components/WorkflowDock.test.tsx
+++ b/packages/web/src/experiments/console/components/WorkflowDock.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { MemoryRouter } from 'react-router';
 import type { Run } from '../primitives/run';
-import { set } from '../store/cache';
+import { invalidate, set } from '../store/cache';
 import { K } from '../store/keys';
 import { WorkflowDock } from './WorkflowDock';
 
@@ -29,7 +29,8 @@ const parallelRun: Run = {
 
 describe('WorkflowDock', () => {
   test('renders every active node for a parallel run', () => {
-    set(K.runs('project-parallel'), {
+    const cacheKey = K.runs('project-parallel');
+    set(cacheKey, {
       runs: [parallelRun],
       counts: {
         all: 1,
@@ -43,13 +44,17 @@ describe('WorkflowDock', () => {
       total: 1,
     });
 
-    const html = renderToStaticMarkup(
-      <MemoryRouter>
-        <WorkflowDock projectId="project-parallel" />
-      </MemoryRouter>
-    );
+    try {
+      const html = renderToStaticMarkup(
+        <MemoryRouter>
+          <WorkflowDock projectId="project-parallel" />
+        </MemoryRouter>
+      );
 
-    expect(html).toContain('nodes:');
-    expect(html).toContain('parallel-a, parallel-b');
+      expect(html).toContain('nodes:');
+      expect(html).toContain('parallel-a, parallel-b');
+    } finally {
+      invalidate(cacheKey);
+    }
   });
 });

--- a/packages/web/src/experiments/console/components/WorkflowDock.tsx
+++ b/packages/web/src/experiments/console/components/WorkflowDock.tsx
@@ -143,7 +143,7 @@ function ApprovalDockCard({ run }: { run: Run }): ReactElement {
 function DockCard({ run }: { run: Run }): ReactElement {
   const navigate = useNavigate();
   const elapsed = formatElapsed(elapsedSince(run.startedAt));
-  const node = run.currentNode !== null && run.currentNode !== undefined ? run.currentNode : null;
+  const activeNodes = run.activeNodes;
 
   return (
     <button
@@ -166,10 +166,12 @@ function DockCard({ run }: { run: Run }): ReactElement {
         <span className="mt-0.5 flex items-center gap-2 font-mono text-[11px] text-text-tertiary">
           <span className="text-text-secondary">{runStatusLabel(run)}</span>
           <RunOutcomeBadge outcome={run.outcome} />
-          {node !== null ? (
+          {activeNodes.length > 0 ? (
             <>
               <span aria-hidden>·</span>
-              <span className="truncate">{node}</span>
+              <span className="truncate">
+                {activeNodes.length === 1 ? 'node' : 'nodes'}: {activeNodes.join(', ')}
+              </span>
             </>
           ) : null}
         </span>

--- a/packages/web/src/experiments/console/console-open-questions.md
+++ b/packages/web/src/experiments/console/console-open-questions.md
@@ -120,8 +120,8 @@ flaky) deserves hardening.
 - **Provider/model per conversation** — not selectable in chat.
 - **Keyboard shortcuts** for chat (new chat, focus composer, approve) — the rest
   of the console is keyboard-driven; chat isn't.
-- **`currentNode` only, no `n/total`** in the dock — the dashboard run has step
-  counts the `Run` primitive doesn't capture; add for a real progress sense.
+- ~~**Concurrent active nodes in the dock**~~ — shipped. A declared `n/total` remains unavailable;
+  observed lifecycle events do not define a truthful total for active or dynamic workflows.
 - **Working-pill `· <activity>`** depends on the last tool call landing in the
   message metadata mid-turn; verify it populates for fast/parallel tool use.
 - **Responsive / mobile** — unconsidered.

--- a/packages/web/src/experiments/console/lib/sse.ts
+++ b/packages/web/src/experiments/console/lib/sse.ts
@@ -39,8 +39,8 @@ function parse(raw: string): ParsedEvent | null {
  *
  * Events we care about:
  *   workflow_status   — run created / status changed / completed / failed
- *   dag_node          — currently-executing-node changes (current_step_name)
- *                       which is rendered on each ActiveRunCard
+ *   dag_node          — active-node lifecycle changes, rendered together on
+ *                       each ActiveRunCard
  */
 export function useDashboardSSE(): void {
   useEffect(() => {

--- a/packages/web/src/experiments/console/primitives/run.test.ts
+++ b/packages/web/src/experiments/console/primitives/run.test.ts
@@ -35,6 +35,38 @@ describe('normalizeOrigin', () => {
 });
 
 describe('toRun — provenance', () => {
+  test('keeps parallel active nodes without inventing a singular representative', () => {
+    const parallel = toRun(
+      raw({
+        id: 'r-parallel',
+        workflow_name: 'implement',
+        status: 'running',
+        active_nodes: ['parallel-a', 'parallel-b'],
+        current_step_name: 'parallel-a',
+      })
+    );
+    const singular = toRun(
+      raw({
+        id: 'r-singular',
+        workflow_name: 'implement',
+        status: 'running',
+        active_nodes: ['plan'],
+      })
+    );
+
+    expect(parallel.activeNodes).toEqual(['parallel-a', 'parallel-b']);
+    expect(parallel.currentNode).toBeNull();
+    expect(singular.activeNodes).toEqual(['plan']);
+    expect(singular.currentNode).toBe('plan');
+  });
+
+  test('detail responses without active_nodes normalize to empty active state', () => {
+    const detail = toRun(raw({ id: 'r-detail', workflow_name: 'plan', status: 'running' }));
+
+    expect(detail.activeNodes).toEqual([]);
+    expect(detail.currentNode).toBeNull();
+  });
+
   test('keeps authored outcome independent from execution status', () => {
     const completedWithSucceededOutcome = toRun(
       raw({

--- a/packages/web/src/experiments/console/primitives/run.ts
+++ b/packages/web/src/experiments/console/primitives/run.ts
@@ -35,7 +35,8 @@ export interface Run {
   /** workflow_runs.working_path — used to join against worktrees. */
   workingPath: string | null;
   userMessage: string;
-  /** Derived from metadata/events at runtime; initially undefined. */
+  activeNodes: string[];
+  /** Singular compatibility view, populated only when exactly one node is active. */
   currentNode?: string | null;
   lastTool?: string | null;
   /**
@@ -101,6 +102,7 @@ interface RawWorkflowRun {
   /** Only present on dashboard runs — enriched by server-side join. */
   codebase_name?: string | null;
   platform_type?: string | null;
+  active_nodes?: string[];
   current_step_name?: string | null;
   /** Run-tree parent id (#2121 Phase 2); null/absent for top-level runs. */
   parent_run_id?: string | null;
@@ -156,6 +158,9 @@ export function runMessageConversationId(run: Run | undefined): string | null {
 }
 
 export function toRun(raw: RawWorkflowRun): Run {
+  const activeNodes = Array.isArray(raw.active_nodes)
+    ? raw.active_nodes.filter(nodeId => typeof nodeId === 'string' && nodeId.length > 0)
+    : [];
   const approval = raw.metadata?.approval;
   const isApprovalShape =
     approval !== null &&
@@ -235,7 +240,8 @@ export function toRun(raw: RawWorkflowRun): Run {
     finishedAt: raw.completed_at ?? null,
     workingPath: raw.working_path ?? null,
     userMessage: raw.user_message ?? '',
-    currentNode: raw.current_step_name ?? null,
+    activeNodes,
+    currentNode: activeNodes.length === 1 ? (activeNodes[0] ?? null) : null,
     lastTool: null,
     approval: parsedApproval,
     wait: parsedWait,

--- a/packages/web/src/experiments/console/routes/PreviewPage.tsx
+++ b/packages/web/src/experiments/console/routes/PreviewPage.tsx
@@ -26,6 +26,7 @@ const baseRun: Omit<Run, 'id' | 'workflow' | 'status'> = {
   finishedAt: null,
   workingPath: null,
   userMessage: '',
+  activeNodes: [],
 };
 
 const SAMPLE_RUNS: Run[] = [
@@ -34,6 +35,7 @@ const SAMPLE_RUNS: Run[] = [
     id: 'a4f2c918-running',
     workflow: 'plan',
     status: 'running',
+    activeNodes: ['plan/draft'],
     currentNode: 'plan/draft',
     lastTool: 'read_file',
   },

--- a/packages/web/src/experiments/console/routes/RunsPage.tsx
+++ b/packages/web/src/experiments/console/routes/RunsPage.tsx
@@ -52,6 +52,7 @@ function buildDemoRuns(scope: Scope, projectName: string | null): Run[] {
     outcome: null,
     workingPath: null,
     userMessage: '',
+    activeNodes: [] as string[],
     finishedAt: null as string | null,
   };
   return [
@@ -62,6 +63,7 @@ function buildDemoRuns(scope: Scope, projectName: string | null): Run[] {
       origin: 'cli',
       status: 'running',
       startedAt: iso(4 * 60 + 12),
+      activeNodes: ['plan/draft'],
       currentNode: 'plan/draft',
       lastTool: 'read_file',
     },
@@ -72,6 +74,7 @@ function buildDemoRuns(scope: Scope, projectName: string | null): Run[] {
       origin: 'web',
       status: 'running',
       startedAt: iso(9 * 60 + 38),
+      activeNodes: ['implement/loop'],
       currentNode: 'implement/loop',
       lastTool: 'edit_file',
     },

--- a/packages/web/src/lib/api.generated.d.ts
+++ b/packages/web/src/lib/api.generated.d.ts
@@ -3867,6 +3867,7 @@ export interface components {
       platform_type: string | null;
       worker_platform_id: string | null;
       parent_platform_id: string | null;
+      active_nodes: string[];
       current_step_name: string | null;
       total_steps: number | null;
       /** @enum {string|null} */

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -373,6 +373,8 @@ export interface WorkflowState {
   runId: string;
   workflowName: string;
   status: WorkflowRunStatus;
+  /** Complete dashboard snapshot; absent until the run-list projection has been hydrated. */
+  activeNodeIds?: string[];
   dagNodes: DagNodeState[];
   artifacts: WorkflowArtifact[];
   currentIteration?: number;

--- a/packages/web/src/routes/DashboardPage.tsx
+++ b/packages/web/src/routes/DashboardPage.tsx
@@ -187,8 +187,7 @@ export function DashboardPage(): React.ReactElement {
     paused: 0,
   };
 
-  // Hydrate Zustand store from REST-polled data for active runs.
-  // Only sets initial state if the run isn't already tracked by SSE.
+  // Refresh the authoritative active-node snapshot while the store keeps richer SSE details.
   useEffect(() => {
     for (const run of runs) {
       if (run.status === 'running' || run.status === 'pending' || run.status === 'paused') {
@@ -196,11 +195,8 @@ export function DashboardPage(): React.ReactElement {
           runId: run.id,
           workflowName: run.workflow_name,
           status: run.status,
-          dagNodes: run.active_nodes.map(nodeId => ({
-            nodeId,
-            name: nodeId,
-            status: 'running',
-          })),
+          activeNodeIds: run.active_nodes,
+          dagNodes: [],
           artifacts: [],
           startedAt: new Date(ensureUtc(run.started_at)).getTime(),
           currentTool: null,

--- a/packages/web/src/routes/DashboardPage.tsx
+++ b/packages/web/src/routes/DashboardPage.tsx
@@ -196,7 +196,11 @@ export function DashboardPage(): React.ReactElement {
           runId: run.id,
           workflowName: run.workflow_name,
           status: run.status,
-          dagNodes: [],
+          dagNodes: run.active_nodes.map(nodeId => ({
+            nodeId,
+            name: nodeId,
+            status: 'running',
+          })),
           artifacts: [],
           startedAt: new Date(ensureUtc(run.started_at)).getTime(),
           currentTool: null,

--- a/packages/web/src/stores/workflow-store.test.ts
+++ b/packages/web/src/stores/workflow-store.test.ts
@@ -122,6 +122,26 @@ describe('handleDagNode', () => {
     expect(wf!.dagNodes).toHaveLength(1);
     expect(wf!.dagNodes[0].status).toBe('completed');
   });
+
+  test('updates a hydrated active-node snapshot from lifecycle events', () => {
+    useWorkflowStore.getState().hydrateWorkflow({
+      runId: 'run-d3',
+      workflowName: 'dag-wf',
+      status: 'running',
+      activeNodeIds: ['node-a', 'node-b'],
+      dagNodes: [],
+      artifacts: [],
+      startedAt: 1000,
+    });
+    useWorkflowStore
+      .getState()
+      .handleDagNode(dagNodeEvent({ runId: 'run-d3', nodeId: 'node-a', status: 'completed' }));
+    useWorkflowStore
+      .getState()
+      .handleDagNode(dagNodeEvent({ runId: 'run-d3', nodeId: 'node-b', status: 'failed' }));
+
+    expect(useWorkflowStore.getState().workflows.get('run-d3')?.activeNodeIds).toEqual([]);
+  });
 });
 
 describe('handleWorkflowArtifact', () => {
@@ -245,6 +265,23 @@ describe('hydrateWorkflow', () => {
       .hydrateWorkflow(makeWorkflow({ runId: 'run-h2', status: 'running', startedAt: 500 }));
     const wf = useWorkflowStore.getState().workflows.get('run-h2');
     expect(wf!.startedAt).toBe(1000);
+  });
+
+  test('reconciles active nodes from REST into existing SSE state', () => {
+    useWorkflowStore.getState().handleWorkflowStatus(statusEvent({ runId: 'run-h6' }));
+    useWorkflowStore
+      .getState()
+      .handleDagNode(dagNodeEvent({ runId: 'run-h6', nodeId: 'stale-node' }));
+    useWorkflowStore.getState().hydrateWorkflow(
+      makeWorkflow({
+        runId: 'run-h6',
+        activeNodeIds: ['zeta', 'alpha'],
+      })
+    );
+
+    const workflow = useWorkflowStore.getState().workflows.get('run-h6');
+    expect(workflow?.activeNodeIds).toEqual(['zeta', 'alpha']);
+    expect(workflow?.dagNodes.map(node => node.nodeId)).toEqual(['stale-node']);
   });
 
   test('DOES override stale running with terminal REST data', () => {

--- a/packages/web/src/stores/workflow-store.ts
+++ b/packages/web/src/stores/workflow-store.ts
@@ -62,6 +62,22 @@ function deriveActiveId(workflows: Map<string, WorkflowState>): string | null {
   return (running ?? newest)?.runId ?? null;
 }
 
+function updateActiveNodeIds(
+  activeNodeIds: string[] | undefined,
+  nodeId: string,
+  status: DagNodeEvent['status']
+): string[] | undefined {
+  if (activeNodeIds === undefined || status === 'pending') return activeNodeIds;
+  if (status === 'running') {
+    return activeNodeIds.includes(nodeId) ? activeNodeIds : [...activeNodeIds, nodeId];
+  }
+  return activeNodeIds.filter(activeNodeId => activeNodeId !== nodeId);
+}
+
+function sameNodeIds(left: string[] | undefined, right: string[]): boolean {
+  return left?.length === right.length && left.every((nodeId, index) => nodeId === right[index]);
+}
+
 // --- Polling infrastructure ---
 
 let pollingInterval: ReturnType<typeof setInterval> | null = null;
@@ -194,6 +210,7 @@ export const useWorkflowStore = create<WorkflowStoreState>()(
                 runId: event.runId,
                 workflowName: event.workflowName,
                 status: event.status,
+                ...(isTerminalStatus(event.status) ? { activeNodeIds: [] } : {}),
                 dagNodes: [],
                 artifacts: [],
                 startedAt: event.timestamp,
@@ -210,6 +227,7 @@ export const useWorkflowStore = create<WorkflowStoreState>()(
               next.set(event.runId, {
                 ...existing,
                 status: event.status,
+                ...(isTerminalStatus(event.status) ? { activeNodeIds: [] } : {}),
                 error: event.error,
                 completedAt: isTerminalStatus(event.status) ? event.timestamp : undefined,
                 approval: event.status === 'paused' ? event.approval : undefined,
@@ -269,7 +287,13 @@ export const useWorkflowStore = create<WorkflowStoreState>()(
                 dagNodes.push(nodeState);
               }
 
-              return { ...wf, dagNodes };
+              const activeNodeIds = updateActiveNodeIds(
+                wf.activeNodeIds,
+                event.nodeId,
+                event.status
+              );
+
+              return { ...wf, dagNodes, activeNodeIds };
             }),
           undefined,
           'workflow/dagNode'
@@ -508,10 +532,21 @@ export const useWorkflowStore = create<WorkflowStoreState>()(
           state => {
             const existing = state.workflows.get(incoming.runId);
             if (existing) {
-              if (
-                !isTerminalStatus(incoming.status) ||
-                (existing.status !== 'running' && existing.status !== 'pending')
-              ) {
+              if (!isTerminalStatus(incoming.status)) {
+                if (isTerminalStatus(existing.status) || incoming.activeNodeIds === undefined) {
+                  return state;
+                }
+                if (sameNodeIds(existing.activeNodeIds, incoming.activeNodeIds)) {
+                  return state;
+                }
+                const next = new Map(state.workflows);
+                next.set(incoming.runId, {
+                  ...existing,
+                  activeNodeIds: incoming.activeNodeIds,
+                });
+                return { workflows: next, activeWorkflowId: deriveActiveId(next) };
+              }
+              if (existing.status !== 'running' && existing.status !== 'pending') {
                 return state;
               }
             }

--- a/packages/workflows/src/store.ts
+++ b/packages/workflows/src/store.ts
@@ -64,6 +64,16 @@ export interface WorkflowNodeSessionKey {
   provider: string;
 }
 
+export const NODE_LIFECYCLE_EVENT_TYPES = [
+  'node_started',
+  'node_completed',
+  'node_failed',
+  'node_skipped',
+  'node_skipped_prior_success',
+] as const;
+
+export type NodeLifecycleEventType = (typeof NODE_LIFECYCLE_EVENT_TYPES)[number];
+
 export const WORKFLOW_EVENT_TYPES = [
   'workflow_started',
   'workflow_completed',
@@ -77,11 +87,7 @@ export const WORKFLOW_EVENT_TYPES = [
   // Between-run continuation (#2747) — written on the ADOPTING run's log when it
   // starts with `--adopt`/`--supersedes`, so the chain renders from events alone.
   'workflow.run_adopted',
-  'node_started',
-  'node_completed',
-  'node_failed',
-  'node_skipped',
-  'node_skipped_prior_success',
+  ...NODE_LIFECYCLE_EVENT_TYPES,
   // #2402 — written when a cached prior-success node is invalidated because a
   // dependency re-executed during the current resume (e.g. an `always_run: true`
   // upstream, or any dep that re-ran with fresh output). `data.prior_output` is the

--- a/packages/workflows/src/utils/idle-timeout.ts
+++ b/packages/workflows/src/utils/idle-timeout.ts
@@ -8,7 +8,7 @@
  * This is the primary defense against subprocess hangs where the AI process
  * completes its work but fails to exit (stuck MCP connection, dangling child
  * process, etc.). Without this, the `for await` loop blocks indefinitely and
- * `step_completed` / `node_completed` is never recorded.
+ * `node_completed` is never recorded.
  */
 
 /**


### PR DESCRIPTION
## Problem and outcome

Run-list consumers received no current execution state even when the event stream showed a running node. The projection still interpreted obsolete `step_*` events, so it could not truthfully represent canonical lifecycle events or concurrent DAG nodes.

- **Outcome:** CLI, `manage_run`, API/dashboard, and Web consumers expose ordered active node IDs derived from canonical node lifecycle events.
- **Invariant:** Parallel active nodes remain explicit; singular compatibility fields are set only when exactly one node is active, and `total_steps` remains `null` when no truthful DAG total exists.
- **Scope boundary:** No database migration, persisted-column rewrite, event-writer change, or liveness-policy change.
- **Root cause:** The shared dashboard projection queried an obsolete event vocabulary with no production writer instead of the canonical `node_*` lifecycle stream.

## Review guidance

- **Feedback requested:** Validate lifecycle folding, compatibility semantics for the additive API shape, and the REST/SSE authority boundary.
- **Start here:** `packages/core/src/db/workflow-events.ts` — batches lifecycle rows and folds them into ordered active-node collections.
- **Review order:** lifecycle fold and dashboard projection; schema and CLI/API consumers; Web live-state rendering.
- **Lower-attention areas:** Generated Web API declaration and docs follow the owning schema/API path and are covered by API generation and repository validation.
- **Known risk or uncertainty:** None.

## Solution

The dashboard projection uses one batched lifecycle-event query for all listed runs. It exposes `active_nodes` as the truthful multi-node contract, derives legacy singular current-node fields only for a single active node, and stops assigning an invented total-step count.

The existing schema carries the additive contract through CLI, `manage_run`, the server API, and generated Web types. The Web dashboard and console render all active nodes. REST polling refreshes the active-node snapshot without replacing richer SSE node details, and later lifecycle events update that snapshot. The obsolete `step_started`, `step_completed`, and `step_failed` current-execution interpretation is removed while generic historical event reads stay intact.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Run lists reported null current-step state despite persisted `node_started` events. | Supported JSON and UI surfaces report ordered active node IDs, including concurrent nodes. |
| **Failure behavior** | Terminal lifecycle events could leave the projection without canonical current-state semantics. | Completed, failed, and skipped lifecycle events remove the node from the active collection; retry starts it again. |

## Architecture

```mermaid
flowchart LR
  E[Canonical node lifecycle events] --> F[Lifecycle fold]
  F --> P[Dashboard run projection]
  P --> C[CLI and manage_run]
  P --> A[API and generated Web types]
  A --> W[Dashboard and console]
  S[Live SSE lifecycle state] --> W
```

### Changed seams

| Boundary or contract | Change | Evidence |
|---|---|---|
| Event log → dashboard projection | `node_*` lifecycle events now own active-node derivation; obsolete `step_*` transition interpretation is gone. | `packages/core/src/db/workflow-events.ts`, `packages/core/src/db/workflows.test.ts` |
| Projection → supported clients | Adds required `active_nodes`; retains singular fields only for a single active node. | `packages/core/src/schemas/workflow-run.ts`, `packages/cli/src/commands/workflow.test.ts` |
| REST snapshot/SSE → Web rendering | REST polling refreshes the active-node snapshot without replacing richer SSE node details; later lifecycle events update it. | `packages/web/src/components/dashboard/WorkflowRunCard.test.tsx` |

## Validation

- `bun install --frozen-lockfile` — passed.
- Focused workflow-event, dashboard-projection, schema, CLI, server route/poller, and Web component/normalizer tests — passed; cover running, terminal, skipped, retry, parallel-node, and stale-live-state cases.
- Complete package test suites and type-checks for workflows, core, CLI, server, and Web — passed.
- `bun run generate:api-types` in `packages/server` — passed.
- `bun run validate` — passed after the final commit; covers generated artifacts, API and package type-checks, lint, formatting, installer tests, and package/script tests.
- **Not verified:** Nothing material; repository validation completed successfully after the final commit.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | Shipped fields remain; `active_nodes` is additive and `total_steps` stays null rather than fabricating a dynamic-DAG total. | `packages/core/src/schemas/workflow-run.ts` |
| Observability | Concurrent active work is visible in the supported list projections and Web surfaces. | CLI, API, and component tests |
| Documentation / communication | CLI, API, and Web adapter docs describe the active-node collection. | `packages/docs-web/src/content/docs/reference/cli.md`, `packages/docs-web/src/content/docs/reference/api.md` |

## Links

- Closes #3108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow status, run lists, dashboards, and console views now display all currently active nodes, including parallel nodes.
  * Added support for filtering workflow runs by multiple statuses.
  * Active-node data now updates accurately as nodes start, complete, retry, or fail.
* **Bug Fixes**
  * Prevented stale active-node information from appearing after live workflow events complete.
  * Improved active-node handling for concurrent and retried executions.
* **Documentation**
  * Updated CLI, API, and web documentation to describe active-node reporting and compatibility fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->