### PR TITLE
fix(workflows): redact successful stderr broadcasts

### DIFF
--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -25382,7 +25382,7 @@ describe('subprocess credential redaction', () => {
   });
 
   afterEach(async () => {
-    await rm(testDir, { recursive: true, force: true });
+    await removeTempTree(testDir);
   });
 
   it('removes exact injected credentials from every rejection field before persistence', async () => {
@@ -25603,6 +25603,136 @@ describe('subprocess credential redaction', () => {
       }
     }
   });
+
+  it.each([
+    [
+      'bash',
+      'sh',
+      `printf 'node output\\n'; printf 'visible before %s visible after\\nsecond unchanged line\\n' "$NODE_SECRET" >&2`,
+      'Bash',
+    ],
+    [
+      'script',
+      'bun',
+      `console.log("node output"); console.error("visible before " + process.env.NODE_SECRET + " visible after\\nsecond unchanged line")`,
+      'Script',
+    ],
+  ] as const)(
+    "redacts a successful %s node's stderr broadcast exactly like its retained copy",
+    async (_kind, runtime, script, nodeLabel) => {
+      const secret = `successful-${runtime}-credential`;
+      const nodeId = `${runtime}-leaky-stderr`;
+      const workflowRun = makeWorkflowRun(`success-${runtime}-broadcast-redaction`, {
+        workflow_name: `success-${runtime}-broadcast-redaction`,
+        conversation_id: `conv-success-${runtime}-broadcast-redaction`,
+      });
+      const platform = createMockPlatform();
+      const logDir = join(testDir, `success-${runtime}-broadcast-logs`);
+
+      await executeDagWorkflow(
+        dagOptions({
+          deps: createMockDeps(),
+          platform,
+          conversationId: workflowRun.conversation_id,
+          cwd: testDir,
+          workflow: {
+            name: workflowRun.workflow_name,
+            nodes: [{ id: nodeId, kind: 'exec', runtime, script }],
+          },
+          workflowRun,
+          artifactsDir: join(testDir, `success-${runtime}-broadcast-artifacts`),
+          stateDir: join(testDir, `success-${runtime}-broadcast-state`),
+          logDir,
+          config: {
+            ...minimalConfig,
+            envVars: { NODE_SECRET: secret, BASE_BRANCH: 'main' },
+          },
+        })
+      );
+
+      const expectedStderr = 'visible before [REDACTED] visible after\nsecond unchanged line';
+      const stderrMessages = platform.sendMessage.mock.calls
+        .map(([, message]) => message)
+        .filter(message => message.includes(`${nodeLabel} node '${nodeId}' stderr:`));
+      expect(stderrMessages).toEqual([
+        `${nodeLabel} node '${nodeId}' stderr:\n\`\`\`\n${expectedStderr}\n\`\`\``,
+      ]);
+
+      const row = (await readTranscript(logDir, workflowRun.id)).find(
+        candidate => candidate.type === 'exec_output' && candidate.step === nodeId
+      );
+      expect(row?.stdout_tail).toBe('node output');
+      expect(row?.stderr_tail).toBe(expectedStderr);
+    }
+  );
+
+  it.each([
+    [
+      'bash',
+      'sh',
+      `printf 'failure before %s failure after\\nsecond unchanged failure line\\n' "$NODE_SECRET" >&2; exit 7`,
+    ],
+    [
+      'script',
+      'bun',
+      `console.error("failure before " + process.env.NODE_SECRET + " failure after\\nsecond unchanged failure line"); process.exit(7)`,
+    ],
+  ] as const)(
+    "keeps a failed %s node's stderr redacted when the workflow broadcasts its error",
+    async (_kind, runtime, script) => {
+      const secret = `failed-${runtime}-credential`;
+      const nodeId = `${runtime}-failed-stderr`;
+      const workflowRun = makeWorkflowRun(`failed-${runtime}-broadcast-redaction`, {
+        workflow_name: `failed-${runtime}-broadcast-redaction`,
+        conversation_id: `conv-failed-${runtime}-broadcast-redaction`,
+      });
+      const platform = createMockPlatform();
+      const logDir = join(testDir, `failed-${runtime}-broadcast-logs`);
+
+      await executeDagWorkflow(
+        dagOptions({
+          deps: createMockDeps(),
+          platform,
+          conversationId: workflowRun.conversation_id,
+          cwd: testDir,
+          workflow: {
+            name: workflowRun.workflow_name,
+            nodes: [
+              { id: 'completed-first', kind: 'exec', runtime: 'sh', script: 'true' },
+              {
+                id: nodeId,
+                kind: 'exec',
+                runtime,
+                script,
+                depends_on: ['completed-first'],
+              },
+            ],
+          },
+          workflowRun,
+          artifactsDir: join(testDir, `failed-${runtime}-broadcast-artifacts`),
+          stateDir: join(testDir, `failed-${runtime}-broadcast-state`),
+          logDir,
+          config: {
+            ...minimalConfig,
+            envVars: { NODE_SECRET: secret, BASE_BRANCH: 'main' },
+          },
+        })
+      );
+
+      const expectedStderr =
+        'failure before [REDACTED] failure after\nsecond unchanged failure line';
+      const failureMessage = platform.sendMessage.mock.calls
+        .map(([, message]) => message)
+        .find(message => message.includes('completed with failures'));
+      expect(failureMessage).toContain(expectedStderr);
+      expect(JSON.stringify(platform.sendMessage.mock.calls)).not.toContain(secret);
+
+      const row = (await readTranscript(logDir, workflowRun.id)).find(
+        candidate => candidate.type === 'exec_output' && candidate.step === nodeId
+      );
+      expect(row?.stderr_tail).toBe(expectedStderr);
+    }
+  );
 
   it('removes a credential a SUCCESSFUL subprocess echoed, before it reaches the retained evidence', async () => {
     // The failure path has been redacting since #2431. Retention (#2967) writes on the

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -25734,7 +25734,7 @@ describe('subprocess credential redaction', () => {
     }
   );
 
-  it('removes a credential a SUCCESSFUL subprocess echoed, before it reaches the retained evidence', async () => {
+  it('redacts successful subprocess evidence while preserving raw stdout for dependent nodes', async () => {
     // The failure path has been redacting since #2431. Retention (#2967) writes on the
     // success path too, and a node that echoes a token while exiting 0 is the ordinary
     // case (`set -x`, a remote URL, a debug print) — so the evidence copy has to be
@@ -25747,10 +25747,12 @@ describe('subprocess credential redaction', () => {
       conversation_id: 'conv-success-redaction',
     });
     const store = createMockStore();
+    const platform = createMockPlatform();
 
     await executeDagWorkflow(
       dagOptions({
         deps: createMockDeps(store),
+        platform,
         conversationId: workflowRun.conversation_id,
         cwd: testDir,
         workflow: {
@@ -25762,6 +25764,13 @@ describe('subprocess credential redaction', () => {
               runtime: 'sh',
               // Real subprocess, both streams, exit 0.
               script: 'printf "%s\\n" "$OPENAI_API_KEY"; printf "%s\\n" "$SIDECAR_AUTH" >&2',
+            },
+            {
+              id: 'consumer',
+              kind: 'exec',
+              runtime: 'sh',
+              script: 'value=$leaky.output; printf "%s" "$value"',
+              depends_on: ['leaky'],
             },
           ],
         },
@@ -25792,6 +25801,20 @@ describe('subprocess credential redaction', () => {
     );
     expect(row?.stdout_tail).toBe('[REDACTED]');
     expect(row?.stderr_tail).toBe('[REDACTED]');
+
+    const stderrMessage = platform.sendMessage.mock.calls
+      .map(([, message]) => message)
+      .find(message => message.includes("Bash node 'leaky' stderr:"));
+    expect(stderrMessage).toBe("Bash node 'leaky' stderr:\n```\n[REDACTED]\n```");
+
+    const consumerEvent = (
+      store.createWorkflowEvent as Mock<IWorkflowStore['createWorkflowEvent']>
+    ).mock.calls.find(
+      ([event]) => event.event_type === 'node_completed' && event.step_name === 'consumer'
+    );
+    expect((consumerEvent?.[0].data as { node_output: string }).node_output).toBe(
+      suffixNamedSecret
+    );
   });
 });
 

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -3409,15 +3409,20 @@ async function runSubprocess(
             env: subprocessEnv,
           });
 
+    const redactedStreams = {
+      stdout: redactCredentialValues(result.stdout, credentialValues),
+      stderr: redactCredentialValues(result.stderr, credentialValues),
+    };
     // Retention is the EVIDENCE copy, taken from a redacted-then-capped copy of the
-    // streams. `result` itself is returned untouched: the caller's `stdout` is the
-    // node's value channel and keeps its full-fidelity semantics (#2726).
+    // streams. The caller's `stdout` remains the node's full-fidelity value channel
+    // (#2726), while `stderr` shares the exact redacted copy used for retention because
+    // callers broadcast it to the operator.
     await logExecOutput(logDir, workflowRunId, nodeId, label, {
-      stdoutTail: retainStreamTail(redactCredentialValues(result.stdout, credentialValues)),
-      stderrTail: retainStreamTail(redactCredentialValues(result.stderr, credentialValues)),
+      stdoutTail: retainStreamTail(redactedStreams.stdout),
+      stderrTail: retainStreamTail(redactedStreams.stderr),
       exitCode: 0,
     });
-    return result;
+    return { stdout: result.stdout, stderr: redactedStreams.stderr };
   } catch (err) {
     const rejection = redactSubprocessError(err as RawSubprocessRejection, credentialValues);
     // `redactSubprocessError` already scrubbed these fields in place, so retention reads

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -3409,20 +3409,17 @@ async function runSubprocess(
             env: subprocessEnv,
           });
 
-    const redactedStreams = {
-      stdout: redactCredentialValues(result.stdout, credentialValues),
-      stderr: redactCredentialValues(result.stderr, credentialValues),
-    };
+    const redactedStderr = redactCredentialValues(result.stderr, credentialValues);
     // Retention is the EVIDENCE copy, taken from a redacted-then-capped copy of the
     // streams. The caller's `stdout` remains the node's full-fidelity value channel
     // (#2726), while `stderr` shares the exact redacted copy used for retention because
     // callers broadcast it to the operator.
     await logExecOutput(logDir, workflowRunId, nodeId, label, {
-      stdoutTail: retainStreamTail(redactedStreams.stdout),
-      stderrTail: retainStreamTail(redactedStreams.stderr),
+      stdoutTail: retainStreamTail(redactCredentialValues(result.stdout, credentialValues)),
+      stderrTail: retainStreamTail(redactedStderr),
       exitCode: 0,
     });
-    return { stdout: result.stdout, stderr: redactedStreams.stderr };
+    return { stdout: result.stdout, stderr: redactedStderr };
   } catch (err) {
     const rejection = redactSubprocessError(err as RawSubprocessRejection, credentialValues);
     // `redactSubprocessError` already scrubbed these fields in place, so retention reads

--- a/scripts/check-test-cleanup-drift.ts
+++ b/scripts/check-test-cleanup-drift.ts
@@ -373,7 +373,7 @@ export const LEGACY_RECURSIVE_CLEANUP: ReadonlyMap<string, number> = buildLedger
   ['packages/server/src/routes/api.workflow-runs.test.ts', 2],
   ['packages/server/src/routes/api.workflows.test.ts', 29],
   ['packages/workflows/src/artifacts-index.test.ts', 1],
-  ['packages/workflows/src/dag-executor.test.ts', 56],
+  ['packages/workflows/src/dag-executor.test.ts', 55],
   ['packages/workflows/src/defaults/generate-bundled-defaults.test.ts', 6],
   ['packages/workflows/src/dry-run.test.ts', 1],
   ['packages/workflows/src/executor-preamble.test.ts', 1],


### PR DESCRIPTION
## Problem and outcome

Successful bash and script nodes could send credentials written to stderr directly to the operator chat, even though the retained transcript redacted the same stream. This made the live and durable copies of subprocess output disagree.

- **Outcome:** Successful stderr broadcasts now contain the same redacted content as their retained transcript rows.
- **Invariant:** Credential values are collected once and the same redacted stderr copy is used for retention and every operator-facing broadcast; raw stdout remains the node value channel.
- **Scope boundary:** This does not change stdout value semantics or add a separate redaction mechanism. Existing failure-path redaction remains at its shared rejection boundary.
- **Root cause:** On success, `runSubprocess` redacted only the retained stream tails and returned raw stderr to the callers that broadcast it.

## Review guidance

- **Feedback requested:** Confirm the shared success-path boundary preserves the single-redaction and raw-stdout invariants.
- **Start here:** `packages/workflows/src/dag-executor.ts:3412` — derives the redacted stderr used by broadcasts.
- **Review order:** Read the subprocess success return path, then the parameterized success and failure broadcast tests.
- **Lower-attention areas:** `scripts/check-test-cleanup-drift.ts` updates the recorded legacy cleanup count after this test suite adopts `removeTempTree`.
- **Known risk or uncertainty:** None. Full review completed across code, seams, simplify, and tests lenses — all four returned no findings. See the review comment on this PR for the complete report.

## Solution

`runSubprocess` now computes credential-redacted stderr once after a successful command. It retains capped redacted tails as before, returns raw stdout for node values, and returns that same redacted stderr to the existing bash and script message paths. Failed subprocesses continue to use the existing redacted rejection fields.

The regression tests run successful bash and script nodes that place a credential between unchanged stderr text, then compare both chat and transcript output with the expected redaction. Matching failure cases prove the sibling error broadcasts remain redacted.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Successful stderr broadcasts could include a credential verbatim. | Successful stderr broadcasts replace the credential with `[REDACTED]` while preserving surrounding output. |
| **Failure behavior** | Failure broadcasts already used redacted rejection data. | Failure broadcasts remain redacted and are explicitly covered for bash and script nodes. |

## Validation

- `bun test src/dag-executor.test.ts --test-name-pattern "subprocess credential redaction"` (from `packages/workflows`) — 7 pass / 0 fail — covers successful and failed bash/script broadcasts plus retained output.
- `bun run validate` (repository root) — exit 0. Covers generated-file checks, API type check, per-package type-check, lint (`--max-warnings 0`), format check, installer tests, package tests, and script tests.
- CI (`gh pr checks 3120`) — 9 checks, all pass (Test Suite, docker-build, test ubuntu/windows, schema-upgrade, postgres-parity, changes, workflow-fixtures, CodeRabbit).
- **Not verified:** Nothing material; the regression was observed failing on the unmodified success broadcast before this change, then passing afterward.

## Links

- Closes #2989
