### PR TITLE
fix(core): allow adopting runs whose isolation environment was created during execution

### DIFF
--- a/packages/core/src/db/isolation-environments.ts
+++ b/packages/core/src/db/isolation-environments.ts
@@ -103,7 +103,7 @@ export async function listByCodebase(
  *
  * Unlike operational environment lists, adoption needs the destroyed row: its
  * branch name is the durable route back to an estate after cleanup removed the
- * worktree. Scope by codebase, path, and the run's start time so neither an
+ * worktree. Scope by codebase, path, and the cutoff timestamp so neither an
  * unrelated project nor a later checkout that reused the path can cross the
  * ownership boundary.
  */

--- a/packages/core/src/db/workflows.adoption-timestamp.integration.test.ts
+++ b/packages/core/src/db/workflows.adoption-timestamp.integration.test.ts
@@ -70,23 +70,55 @@ await db.query(
   []
 );
 
+// Detached parent-created run (#2914 / #2935): run row is created at T_0 (started_at),
+// and the detached child creates the isolation environment shortly after at T_0 + 2s.
+await db.query(
+  `INSERT INTO remote_agent_workflow_runs
+     (id, workflow_name, conversation_id, codebase_id, user_message, status, metadata,
+      working_path, started_at, completed_at, last_activity_at)
+   VALUES ('run-detached', 'implement', 'conv-1', 'cb-1', 'detached pr', 'failed', '{}',
+     '/tmp/ops-client/.worktrees/run-detached', '2026-08-27 08:00:00', '2026-08-27 08:15:00',
+     '2026-08-27 08:15:00')`,
+  []
+);
+
 /** Seed an estate at the adopted run's working_path with its own cutoff relation. */
-async function seedEnv(id: string, createdAt: string, status: 'active' | 'destroyed') {
+async function seedEnv(
+  id: string,
+  createdAt: string,
+  status: 'active' | 'destroyed',
+  workingPath = '/tmp/ops-client/.worktrees/run-1'
+) {
   await db.query(
     `INSERT INTO remote_agent_isolation_environments
        (id, codebase_id, workflow_type, workflow_id, provider, working_path, branch_name, status, created_at)
      VALUES ($1, 'cb-1', 'task', $2, 'worktree',
-       '/tmp/ops-client/.worktrees/run-1', $3, $4, $5)`,
-    [id, `wf-${id}`, `impl-${id}`, status, createdAt]
+       $3, $4, $5, $6)`,
+    [id, `wf-${id}`, workingPath, `impl-${id}`, status, createdAt]
   );
 }
 
-// Two estates around the run's start: the one that OWNED the checkout before the
+// Two estates around run-1's start: the one that OWNED the checkout before the
 // run began (now destroyed — cleanup removed the worktree but the row survives),
-// and a later re-creation after the run had finished. Only the pre-cutoff row may
-// be selected as the adoption source.
+// and a later re-creation after the run had finished.
 await seedEnv('env-before', '2026-08-26 09:00:00', 'destroyed');
 await seedEnv('env-after', '2026-08-28 10:00:00', 'active');
+
+// Estates for detached run (#2935):
+// env-detached was created at T_0 + 2s during the run's execution (before completed_at).
+// env-detached-later was created after completed_at.
+await seedEnv(
+  'env-detached',
+  '2026-08-27 08:00:02',
+  'active',
+  '/tmp/ops-client/.worktrees/run-detached'
+);
+await seedEnv(
+  'env-detached-later',
+  '2026-08-27 09:00:00',
+  'active',
+  '/tmp/ops-client/.worktrees/run-detached'
+);
 
 describe('workflow-run adoption timestamp — real SQLite composition (#2845)', () => {
   test('getWorkflowRun hydrates SQLite TEXT timestamps into Dates', async () => {
@@ -137,5 +169,44 @@ describe('workflow-run adoption timestamp — real SQLite composition (#2845)', 
       new Date(Date.UTC(2026, 7, 25))
     );
     expect(env).toBeNull();
+  });
+
+  test('detached parent-created run adopts environment created during run execution (#2935)', async () => {
+    const resolved = await resolveWorkflowAdoption({
+      adoptedRunId: 'run-detached',
+      codebaseId: 'cb-1',
+      codebasePath: '/tmp/ops-client',
+      codebaseKind: 'repo',
+      deps: {
+        existsSync: p => p === '/tmp/ops-client/.worktrees/run-detached',
+        branchExists: async (_repoPath, branch) => branch === 'impl-env-detached',
+        currentBranch: async () => 'impl-env-detached',
+      },
+    });
+    expect(resolved.adoptedRun.id).toBe('run-detached');
+    expect(resolved.lane.kind).toBe('reuse-worktree');
+    if (resolved.lane.kind === 'reuse-worktree') {
+      expect(resolved.lane.workingPath).toBe('/tmp/ops-client/.worktrees/run-detached');
+      expect(resolved.lane.envId).toBe('env-detached');
+    }
+  });
+
+  test('detached parent-created run excludes environments created after completion (#2935)', async () => {
+    const resolved = await resolveWorkflowAdoption({
+      adoptedRunId: 'run-detached',
+      codebaseId: 'cb-1',
+      codebasePath: '/tmp/ops-client',
+      codebaseKind: 'repo',
+      deps: {
+        // Worktree gone, must checkout branch
+        existsSync: () => false,
+        branchExists: async (_repoPath, branch) => branch === 'impl-env-detached',
+      },
+    });
+    expect(resolved.adoptedRun.id).toBe('run-detached');
+    expect(resolved.lane.kind).toBe('checkout-branch');
+    if (resolved.lane.kind === 'checkout-branch') {
+      expect(resolved.lane.taskBranch.branch).toBe(toBranchName('impl-env-detached'));
+    }
   });
 });

--- a/packages/core/src/operations/workflow-adoption.test.ts
+++ b/packages/core/src/operations/workflow-adoption.test.ts
@@ -239,7 +239,7 @@ describe('resolveWorkflowAdoption', () => {
     });
   });
 
-  test("bounds estate history by the adopted run's start time", async () => {
+  test("bounds estate history by the adopted run's completion upper bound", async () => {
     const startedAt = new Date('2026-08-25T09:00:00.000Z');
     const completedAt = new Date('2026-08-25T12:00:00.000Z');
     const lookupCalls: Array<{ codebaseId: string; workingPath: string; cutoff: Date }> = [];
@@ -253,6 +253,47 @@ describe('resolveWorkflowAdoption', () => {
               working_path: '/ws/repo/.worktrees/vanished',
               started_at: startedAt,
               completed_at: completedAt,
+            }),
+          }),
+          findEnvironmentByPath: async (codebaseId, workingPath, cutoff) => {
+            lookupCalls.push({ codebaseId, workingPath, cutoff });
+            return envRow({
+              working_path: workingPath,
+              branch_name:
+                cutoff.getTime() === completedAt.getTime() ? 'alive-branch' : 'later-branch',
+              status: 'destroyed',
+            });
+          },
+        },
+      })
+    ).lane;
+
+    expect(lookupCalls).toEqual([
+      {
+        codebaseId: 'cb-1',
+        workingPath: '/ws/repo/.worktrees/vanished',
+        cutoff: completedAt,
+      },
+    ]);
+    expect(lane).toEqual({
+      kind: 'checkout-branch',
+      taskBranch: { kind: 'existing', branch: toBranchName('alive-branch') },
+    });
+  });
+
+  test('falls back to start time when completed_at is unset', async () => {
+    const startedAt = new Date('2026-08-25T09:00:00.000Z');
+    const lookupCalls: Array<{ codebaseId: string; workingPath: string; cutoff: Date }> = [];
+    const lane = (
+      await resolveWorkflowAdoption({
+        ...baseArgs,
+        adoptedRunId: 'run-1',
+        deps: {
+          ...makeDeps({
+            run: runRow({
+              working_path: '/ws/repo/.worktrees/vanished',
+              started_at: startedAt,
+              completed_at: null,
             }),
           }),
           findEnvironmentByPath: async (codebaseId, workingPath, cutoff) => {

--- a/packages/core/src/operations/workflow-adoption.ts
+++ b/packages/core/src/operations/workflow-adoption.ts
@@ -139,7 +139,11 @@ export async function resolveWorkflowAdoption(
   }
 
   const environment = adoptedRun.working_path
-    ? await findEnvironmentByPath(args.codebaseId, adoptedRun.working_path, adoptedRun.started_at)
+    ? await findEnvironmentByPath(
+        args.codebaseId,
+        adoptedRun.working_path,
+        adoptedRun.completed_at ?? adoptedRun.started_at
+      )
     : null;
 
   // Lane 2: the adopted run's worktree still exists — inherit it as-is, dirty


### PR DESCRIPTION
## Problem and outcome

Adopting a terminal run with `--adopt` failed when the run's isolation environment was created after the run record was persisted (such as in detached parent-created runs). `resolveWorkflowAdoption` previously queried the isolation environment cutoff at `adoptedRun.started_at`, excluding environments created during the run's lifecycle and falsely reporting that no isolation record exists.

- **Outcome:** Terminal runs whose isolation environments were created during run execution can now be adopted cleanly via `--adopt`.
- **Invariant:** Environments created after the adopted run's completion timestamp remain excluded so subsequent checkouts reusing the path cannot be mistakenly adopted.
- **Scope boundary:** Adoption lane resolution logic (worktree reuse, branch checkout, artifact inheritance) and the underlying isolation query remain unchanged.
- **Root cause:** `resolveWorkflowAdoption` passed `adoptedRun.started_at` as the cutoff upper bound to `findEnvironmentByPath`, causing environments with `created_at > started_at` to evaluate as `null`.

## Review guidance

- **Feedback requested:** Correctness of timestamp cutoff semantics across terminal and non-terminal run states.
- **Start here:** `packages/core/src/operations/workflow-adoption.ts:144` — upper-bound cutoff calculation passed to `findEnvironmentByPath`.
- **Review order:**
  1. `packages/core/src/operations/workflow-adoption.ts`
  2. `packages/core/src/db/isolation-environments.ts`
  3. `packages/core/src/db/workflows.adoption-timestamp.integration.test.ts`
  4. `packages/core/src/operations/workflow-adoption.test.ts`
- **Lower-attention areas:** None.
- **Known risk or uncertainty:** None.

## Solution

Updated `resolveWorkflowAdoption` to use `adoptedRun.completed_at ?? adoptedRun.started_at` as the cutoff upper bound when finding the isolation environment associated with the adopted run. This admits environments created while the run was executing while preserving the boundary against environments created after the run completed.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Adopting a detached run where the environment was created shortly after run start threw `WorkflowAdoptionError: Cannot adopt run '<id>': it has no isolation record`. | The run's isolation environment and worktree/branch are resolved and adopted successfully. |
| **Failure behavior** | Erroneously failed with missing isolation record error despite the environment existing in the database. | Only fails if no isolation environment exists for that path prior to the run's completion. |

## Changed seams

| Boundary or contract | Change | Evidence |
|---|---|---|
| `resolveWorkflowAdoption` → `findEnvironmentByPath` | Passes `completed_at ?? started_at` rather than `started_at` as the cutoff timestamp. | `packages/core/src/operations/workflow-adoption.ts:144` |

## Validation

- `bun test packages/core/src/db/workflows.adoption-timestamp.integration.test.ts` — passed (6 tests) — proves that detached runs with environments created at T0 + 2s are adopted and environments created after T1 are excluded.
- `bun test packages/core/src/operations/workflow-adoption.test.ts` — passed (15 tests) — proves unit-level cutoff parameter passing and fallback behavior.
- `bun run validate` — passed all checks (lint, types, formatting, and tests across all workspaces).
- **Not verified:** Nothing material. All adoption resolution paths and timestamp boundaries are covered by unit and integration suites.

## Links

- Closes #2935


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow adoption when reusing existing worktrees.
  * Correctly considers the workflow’s completion time when selecting an environment.
  * Prevents environments created after workflow completion from being reused.
  * Falls back to the workflow start time when completion information is unavailable.

* **Tests**
  * Added coverage for detached parent-created workflow runs and adoption fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->