### PR TITLE
fix(core): take the next free port when a worktree's hashed port is occupied

### DIFF
--- a/packages/core/src/utils/port-allocation.test.ts
+++ b/packages/core/src/utils/port-allocation.test.ts
@@ -1,5 +1,27 @@
 import { describe, it, expect, afterEach } from 'bun:test';
-import { calculatePortOffset, getPort } from './port-allocation';
+import { createServer, type Server } from 'node:net';
+import {
+  calculatePortOffset,
+  getPort,
+  isPortAvailable,
+  resolveWorktreePort,
+} from './port-allocation';
+
+const BASE_PORT = 3090;
+const HOSTNAME = '0.0.0.0';
+
+/** Hold a real listener so availability probes see a genuinely occupied port. */
+function occupy(port: number): Promise<Server> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once('error', reject);
+    server.listen(port, HOSTNAME, () => resolve(server));
+  });
+}
+
+function release(server: Server): Promise<void> {
+  return new Promise(resolve => server.close(() => resolve()));
+}
 
 // Test the exported hash calculation function directly
 describe('calculatePortOffset', () => {
@@ -44,16 +66,56 @@ describe('calculatePortOffset', () => {
   });
 });
 
+describe('isPortAvailable', () => {
+  const held: Server[] = [];
+
+  afterEach(async () => {
+    await Promise.all(held.splice(0).map(release));
+  });
+
+  it('reports an unbound port as available', async () => {
+    // Port 0 asks the OS for any free port; bind it, learn the number, release it.
+    const scout = await occupy(0);
+    const address = scout.address();
+    const port = typeof address === 'object' && address ? address.port : 0;
+    await release(scout);
+
+    expect(await isPortAvailable(port, HOSTNAME)).toBe(true);
+  });
+
+  it('reports a port held by a live listener as unavailable', async () => {
+    const server = await occupy(0);
+    held.push(server);
+    const address = server.address();
+    const port = typeof address === 'object' && address ? address.port : 0;
+
+    expect(await isPortAvailable(port, HOSTNAME)).toBe(false);
+  });
+
+  it('leaves the probed port bindable afterwards', async () => {
+    const scout = await occupy(0);
+    const address = scout.address();
+    const port = typeof address === 'object' && address ? address.port : 0;
+    await release(scout);
+
+    expect(await isPortAvailable(port, HOSTNAME)).toBe(true);
+    // The probe must not leak its own listener, or the second call would fail.
+    expect(await isPortAvailable(port, HOSTNAME)).toBe(true);
+  });
+});
+
 // Test getPort() behavior with mocked dependencies
 describe('getPort', () => {
   const originalEnv = process.env.PORT;
+  const held: Server[] = [];
 
-  afterEach(() => {
+  afterEach(async () => {
     if (originalEnv === undefined) {
       delete process.env.PORT;
     } else {
       process.env.PORT = originalEnv;
     }
+    await Promise.all(held.splice(0).map(release));
   });
 
   it('should return PORT env var when explicitly set to valid number', async () => {
@@ -62,21 +124,105 @@ describe('getPort', () => {
     expect(port).toBe(4000);
   });
 
+  it('returns an explicit PORT even when that port is already occupied', async () => {
+    const server = await occupy(0);
+    held.push(server);
+    const address = server.address();
+    const port = typeof address === 'object' && address ? address.port : 0;
+
+    // An explicit PORT is an instruction: probing must not move the operator off it.
+    process.env.PORT = String(port);
+    expect(await getPort()).toBe(port);
+  });
+
   it('should return a valid port when no PORT env is set', async () => {
     delete process.env.PORT;
     // Note: If running in a worktree, port will be auto-allocated (base 3090 + offset 100-999)
     // If running in main repo, port will be 3090
     const port = await getPort();
-    const basePort = 3090;
-    const maxPort = basePort + 999;
-    expect(port).toBeGreaterThanOrEqual(basePort);
+    const maxPort = BASE_PORT + 999;
+    expect(port).toBeGreaterThanOrEqual(BASE_PORT);
     expect(port).toBeLessThanOrEqual(maxPort);
+  });
+
+  it('returns the same port twice when nothing is holding it', async () => {
+    delete process.env.PORT;
+    // The deterministic-port promise still holds in the common case.
+    expect(await getPort()).toBe(await getPort());
+  });
+});
+
+// Driven directly rather than through getPort(): the worktree branch is only
+// reachable when the suite itself runs inside a worktree, which it does not in the
+// main repo or in CI. Calling the resolver is what makes the fallback actually run.
+describe('resolveWorktreePort', () => {
+  const CWD = '/Users/test/.archon/worktrees/owner/repo/issue-123';
+  const held: Server[] = [];
+
+  afterEach(async () => {
+    await Promise.all(held.splice(0).map(release));
+  });
+
+  const hold = async (port: number): Promise<void> => {
+    held.push(await occupy(port));
+  };
+
+  it('returns the hashed port when it is free', async () => {
+    const offset = calculatePortOffset(CWD);
+    expect(await resolveWorktreePort(offset, HOSTNAME, CWD)).toBe(BASE_PORT + offset);
+  });
+
+  it('advances to the next free port when the hashed one is taken', async () => {
+    const offset = calculatePortOffset(CWD);
+    await hold(BASE_PORT + offset);
+
+    const port = await resolveWorktreePort(offset, HOSTNAME, CWD);
+    expect(port).toBe(BASE_PORT + offset + 1);
+  });
+
+  it('skips a contiguous run of occupied ports', async () => {
+    const offset = calculatePortOffset(CWD);
+    await hold(BASE_PORT + offset);
+    await hold(BASE_PORT + offset + 1);
+    await hold(BASE_PORT + offset + 2);
+
+    const port = await resolveWorktreePort(offset, HOSTNAME, CWD);
+    expect(port).toBe(BASE_PORT + offset + 3);
+    expect(await isPortAvailable(port, HOSTNAME)).toBe(true);
+  });
+
+  it('returns to the hashed port once it is released again', async () => {
+    const offset = calculatePortOffset(CWD);
+    const preferred = BASE_PORT + offset;
+
+    await hold(preferred);
+    expect(await resolveWorktreePort(offset, HOSTNAME, CWD)).not.toBe(preferred);
+
+    await Promise.all(held.splice(0).map(release));
+    expect(await resolveWorktreePort(offset, HOSTNAME, CWD)).toBe(preferred);
+  });
+
+  it('wraps from the top of the range back to the bottom', async () => {
+    // Offset 999 is the last slot; the next candidate must be 100, not 1000.
+    const topOffset = 999;
+    await hold(BASE_PORT + topOffset);
+
+    expect(await resolveWorktreePort(topOffset, HOSTNAME, CWD)).toBe(BASE_PORT + 100);
+  });
+
+  it('stays inside the 3190-4089 range for every starting offset', async () => {
+    for (const offset of [100, 101, 500, 998, 999]) {
+      const port = await resolveWorktreePort(offset, HOSTNAME, CWD);
+      expect(port).toBeGreaterThanOrEqual(BASE_PORT + 100);
+      expect(port).toBeLessThanOrEqual(BASE_PORT + 999);
+    }
   });
 });
 
 // Integration test notes (manual verification):
-// 1. Run in main repo: `bun dev` → should use port 3000 with log "Using default port"
-// 2. Run in worktree: `bun dev` → should auto-allocate port 3XXX with "Worktree detected" log
+// 1. Run in main repo: `bun dev` → should use port 3090 with log "default_port_selected"
+// 2. Run in worktree: `bun dev` → should auto-allocate port 3XXX with "worktree_port_allocated"
 // 3. Override: `PORT=4000 bun dev` → should use 4000 (both contexts)
 // 4. Multiple worktrees: Start in 2+ worktrees → different ports
-// 5. Invalid PORT: `PORT=abc bun dev` → should exit with error message
+// 5. Colliding worktrees: occupy a worktree's hashed port, start it → "worktree_port_reallocated"
+// 6. Invalid PORT: `PORT=abc bun dev` → should exit with error message

--- a/packages/core/src/utils/port-allocation.ts
+++ b/packages/core/src/utils/port-allocation.ts
@@ -3,6 +3,7 @@
  * Separated from index.ts to allow testing without triggering app startup
  */
 import { createHash } from 'crypto';
+import { createServer } from 'node:net';
 import { isWorktreePath } from '@archon/git';
 import { createLogger } from '@archon/paths';
 
@@ -12,6 +13,13 @@ function getLog(): ReturnType<typeof createLogger> {
   if (!cachedLog) cachedLog = createLogger('port-allocation');
   return cachedLog;
 }
+
+/** Base port for the Hono server; also the Vite dev proxy's fallback target. */
+const BASE_PORT = 3090;
+/** Lowest worktree offset. Ports below this stay clear of the base port. */
+const MIN_OFFSET = 100;
+/** Number of distinct worktree offsets (100–999 → ports 3190–4089). */
+const OFFSET_SPAN = 900;
 
 /**
  * Calculate hash-based port offset for worktree paths.
@@ -23,13 +31,43 @@ function getLog(): ReturnType<typeof createLogger> {
 export function calculatePortOffset(path: string): number {
   const hash = createHash('md5').update(path).digest();
   // 100-999 range: offset starts at 100; produces ports 3190-4089 when added to basePort (3090)
-  return (hash.readUInt16BE(0) % 900) + 100;
+  return (hash.readUInt16BE(0) % OFFSET_SPAN) + MIN_OFFSET;
+}
+
+/**
+ * Report whether `port` can be bound on `hostname`.
+ *
+ * Binds and immediately closes rather than scanning a port list, so the answer
+ * reflects what `Bun.serve` will actually be allowed to do — a port held by
+ * another user, or blocked by a local policy, reads as unavailable here for the
+ * same reason it would fail at startup. `hostname` mirrors the server's own
+ * `process.env.HOST || '0.0.0.0'`, because availability is per-interface: a
+ * process bound to 127.0.0.1 does not block 0.0.0.0 on every platform.
+ *
+ * Exported for testing.
+ */
+export function isPortAvailable(port: number, hostname: string): Promise<boolean> {
+  return new Promise(resolve => {
+    const probe = createServer();
+    // Both listeners settle the same promise; `once` plus the immediate close
+    // below means whichever fires first wins and the other never runs.
+    probe.once('error', () => {
+      resolve(false);
+    });
+    probe.once('listening', () => {
+      probe.close(() => {
+        resolve(true);
+      });
+    });
+    probe.listen(port, hostname);
+  });
 }
 
 /**
  * Get the port for the Hono server
- * - If PORT env var is set: use it (explicit override, validated)
- * - If running in worktree: auto-allocate deterministic port based on path hash
+ * - If PORT env var is set: use it (explicit override, validated, never probed)
+ * - If running in worktree: deterministic port from the path hash, advanced to the
+ *   next free port in the range when that one is taken
  * - Otherwise: use default 3090 (matches the Vite proxy fallback in packages/web/vite.config.ts)
  *
  * Note: Exits process with code 1 if PORT env var is set but invalid (not 1-65535)
@@ -43,19 +81,82 @@ export async function getPort(): Promise<number> {
       getLog().fatal({ envPort }, 'invalid_port_env_var');
       process.exit(1);
     }
+    // Deliberately unprobed: an explicit PORT is an instruction, not a preference.
+    // Moving the operator off the port they named would break whatever they pointed
+    // at it; a bind failure here is the honest outcome.
     return parsedPort;
   }
 
-  const basePort = 3090;
   const cwd = process.cwd();
+  const hostname = process.env.HOST || '0.0.0.0';
 
   if (await isWorktreePath(cwd)) {
-    const offset = calculatePortOffset(cwd);
-    const port = basePort + offset;
-    getLog().info({ cwd, port, basePort, offset }, 'worktree_port_allocated');
+    return resolveWorktreePort(calculatePortOffset(cwd), hostname, cwd);
+  }
+
+  // The base port is NOT probed. Unlike a worktree port, 3090 is a value other
+  // things resolve independently — vite.config.ts falls back to it verbatim when
+  // PORT is unset — so silently serving from somewhere else would leave the dev
+  // proxy pointing at nothing. A collision here is the operator's to resolve, with
+  // PORT or by freeing the socket, and Bun.serve reports it.
+  getLog().info({ port: BASE_PORT }, 'default_port_selected');
+  return BASE_PORT;
+}
+
+/**
+ * Resolve a worktree's port: the hashed offset when it is free, otherwise the next
+ * free offset in the range.
+ *
+ * Exported for testing: reaching this through `getPort()` requires the suite itself to
+ * be running inside a worktree, so a collision test written against `getPort()` passes
+ * by skipping in the main repo — including in CI, where it would never once exercise
+ * the fallback it claims to cover.
+ *
+ * The hash is a convenience — "this worktree, this port, every time" — not a value
+ * anything else recomputes, so yielding it to a live listener costs nothing a caller
+ * can observe. 900 offsets is a small space: collisions between worktrees reach
+ * roughly even odds around 35 of them, and any unrelated local process holding a port
+ * in 3190–4089 collides too. Scanning forward from the hashed offset keeps the result
+ * stable for a given occupancy rather than reshuffling every worktree.
+ *
+ * Racy by construction: another process can take the port between this probe and
+ * `Bun.serve`. Closing that window means holding the socket from here to the server,
+ * which this function does not own. The probe removes the common case — a port
+ * already held when the server starts — and leaves the narrow one to the bind error.
+ */
+export async function resolveWorktreePort(
+  offset: number,
+  hostname: string,
+  cwd: string
+): Promise<number> {
+  for (let attempt = 0; attempt < OFFSET_SPAN; attempt += 1) {
+    const candidate = MIN_OFFSET + ((offset - MIN_OFFSET + attempt) % OFFSET_SPAN);
+    const port = BASE_PORT + candidate;
+    if (!(await isPortAvailable(port, hostname))) continue;
+
+    if (attempt === 0) {
+      getLog().info({ cwd, port, basePort: BASE_PORT, offset }, 'worktree_port_allocated');
+    } else {
+      getLog().info(
+        { cwd, port, basePort: BASE_PORT, offset: candidate, preferredOffset: offset, attempt },
+        'worktree_port_reallocated'
+      );
+    }
     return port;
   }
 
-  getLog().info({ port: basePort }, 'default_port_selected');
-  return basePort;
+  getLog().fatal(
+    {
+      cwd,
+      rangeStart: BASE_PORT + MIN_OFFSET,
+      rangeEnd: BASE_PORT + MIN_OFFSET + OFFSET_SPAN - 1,
+      hint: 'Free a port in the range, or set PORT to choose one explicitly.',
+    },
+    'worktree_port_range_exhausted'
+  );
+  throw new Error(
+    `No free port for this worktree in ${String(BASE_PORT + MIN_OFFSET)}-${String(
+      BASE_PORT + MIN_OFFSET + OFFSET_SPAN - 1
+    )}. Free one, or set PORT explicitly.`
+  );
 }

--- a/packages/docs-web/src/content/docs/contributing/dx-quirks.md
+++ b/packages/docs-web/src/content/docs/contributing/dx-quirks.md
@@ -51,6 +51,11 @@ Worktrees auto-allocate ports (3190–4089 range, hash-based on path). Same work
 - Main repo defaults to 3090
 - Override: `PORT=4000 bun dev`
 - Same worktree always gets same port (deterministic)
+- If that port is already taken — another worktree hashed to it, or any unrelated
+  process holds it — the server takes the next free port in the range and logs
+  `worktree_port_reallocated` with both the port it wanted and the one it got.
+  It returns to the hashed port once that frees up.
+- `PORT` is never moved: an explicit override binds where you said, or fails.
 
 ## `bun run test` vs `bun test`
 


### PR DESCRIPTION
## Problem and outcome

A worktree's server port is an MD5 hash of its path folded into 900 slots and returned without checking whether anything is listening on it. Two worktrees hashing to the same slot — or any unrelated process holding a port in 3190–4089 — makes the second server fail to bind with a bare `EADDRINUSE` that names neither the cause nor the `PORT` override that resolves it. Parallel worktrees are the workflow the README leads with, and 900 slots is a small space: collisions reach roughly even odds around 35 worktrees, and about 5% at ten.

- **Outcome:** A worktree whose hashed port is taken starts on the next free port in the range and logs `worktree_port_reallocated` with both the port it wanted and the one it got, instead of failing to start.
- **Invariant:** The hashed port is still what a worktree gets whenever it is free — "same worktree, same port" survives — and an explicit `PORT` is still bound verbatim or not at all.
- **Scope boundary:** The base port (3090) is deliberately still unprobed, and the Vite dev proxy is untouched. See *Known risk or uncertainty*.
- **Root cause:** `getPort()` computed a port and returned it. There was no availability check anywhere between the hash and `Bun.serve`.

## Review guidance

- **Feedback requested:** Correctness of the scan, and whether the base-port carve-out is the call you want.
- **Start here:** `packages/core/src/utils/port-allocation.ts` — `resolveWorktreePort()`. Everything else follows from it.
- **Review order:** `port-allocation.ts` (`isPortAvailable` → `getPort` → `resolveWorktreePort`), then `port-allocation.test.ts`, then the `dx-quirks.md` note.
- **Lower-attention areas:** The pre-existing `calculatePortOffset` tests are unchanged; the magic numbers they assert are now named constants (`BASE_PORT`, `MIN_OFFSET`, `OFFSET_SPAN`) with identical values.
- **Known risk or uncertainty:** Two, both deliberate and documented at the branch:

  1. **The probe is racy by construction.** Another process can take the port between `isPortAvailable()` and `Bun.serve`. Closing that window means holding the socket from allocation through to the server, which this function does not own. The probe removes the common case — a port already held when the server starts — and leaves the narrow one to the bind error, which is no worse than today.
  2. **The base port is not probed, on purpose.** Unlike a worktree port, 3090 is resolved independently elsewhere: `packages/web/vite.config.ts` falls back to it verbatim when `PORT` is unset. Silently serving from somewhere else would leave the dev proxy pointing at nothing. I think that carve-out is right, but it is the judgment call most worth a second opinion.

## Solution

`getPort()` gains one step on the worktree path: probe the hashed port, and if it is taken, walk forward through the 900-slot range (wrapping at 999 → 100) to the first free one.

Scanning forward from the hashed offset — rather than re-hashing or picking randomly — keeps the result stable for a given occupancy, so a worktree that lands on its second choice lands there again next time rather than reshuffling.

`isPortAvailable()` binds and immediately closes rather than consulting a list, so the answer reflects what `Bun.serve` will actually be allowed to do: a port held by another user or blocked by local policy reads as unavailable here for the same reason it would fail at startup. It probes on `process.env.HOST || '0.0.0.0'`, mirroring the server's own bind address, because availability is per-interface — a process bound to `127.0.0.1` does not block `0.0.0.0` on every platform.

Two paths deliberately keep their existing behavior:

- **Explicit `PORT`** returns unprobed. An explicit port is an instruction, not a preference; moving the operator off the port they named would break whatever they pointed at it, and a bind failure is the honest outcome.
- **The base port** returns unprobed, for the `vite.config.ts` reason above.

Range exhaustion — all 900 taken — fails loudly with a message naming `PORT`, rather than falling through to an arbitrary port.

`resolveWorktreePort` is exported for the same reason `calculatePortOffset` already is. My first draft tested the collision path through `getPort()`, which only reaches the worktree branch when the test process is itself running inside a worktree — so in the main repo, and therefore in CI, the test would have skipped its own assertion every single run and still reported green. Driving the resolver directly is what makes the fallback actually execute; the mutation check under Validation is what confirms it.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Worktree gets `3090 + hash(path)`, always | Worktree gets `3090 + hash(path)` when free; the next free port in 3190–4089 otherwise |
| **Failure behavior** | Server exits with a bare `EADDRINUSE` naming neither the cause nor `PORT` | Server starts on a neighbouring port and logs `worktree_port_reallocated`; only a fully exhausted range fails, with a message naming `PORT` |

### User flow

```mermaid
flowchart LR
  subgraph Before
    B1[Start server in worktree] --> B2["hash(path) → 3516"]
    B2 --> B3{3516 free?}
    B3 -- yes --> B4[Listening on 3516]
    B3 -- no --> B5[EADDRINUSE, server exits]
  end

  subgraph After
    A1[Start server in worktree] --> A2["hash(path) → 3516"]
    A2 --> A3{3516 free?}
    A3 -- yes --> A4["Listening on 3516<br/>worktree_port_allocated"]
    A3 -- no --> A5[Scan forward in 3190-4089]
    A5 --> A6["Listening on 3519<br/>worktree_port_reallocated"]
    A5 -- all 900 taken --> A7["Fatal, names PORT"]
  end
```

## Validation

- `bun test src/utils/port-allocation.test.ts` — **16 pass, 0 fail** — proves the hashed port is still returned when free, the scan advances past occupied ports, it wraps 999 → 100, it returns to the hashed port once released, and an explicit `PORT` is returned even when occupied.

- **Mutation check** — disabling the probe (`if (false && !(await isPortAvailable(...)))`) turns exactly the four collision tests red and leaves the other twelve green; restoring it returns all sixteen to green. This is the evidence that the new tests actually constrain the new behavior rather than passing alongside it.

- **Runtime evidence** from the test logs — the fallback genuinely executes, rather than the assertions being satisfied some other way:

  ```
  preferredOffset:426 → offset:427, attempt:1, port:3517   worktree_port_reallocated
  preferredOffset:426 → offset:429, attempt:3, port:3519   worktree_port_reallocated
  preferredOffset:999 → offset:100, attempt:1, port:3190   worktree_port_reallocated   (wrap)
  ```

- `bun run test` in `@archon/core` — **exit 0**, 44 test files, zero failures — proves nothing else in the package regressed.
- `bun --filter @archon/core type-check` — exit 0.
- `bun run lint --max-warnings 0` (whole repo) — exit 0. It caught two real `no-confusing-void-expression` errors in the first draft of `isPortAvailable`; both are fixed.
- `bun run format:check` — exit 0.
- `check:bundled`, `check:bundled-skill`, `check:bundled-schema`, `check:pi-vendor-map`, `check:capability-matrix` — all exit 0.

**Not verified:**

- `bun run validate` does not complete on my machine: `@archon/docs-web type-check` exits 1 with *"Node.js v20.12.2 is not supported by Astro! Please upgrade Node.js to >=22.12.0"*. I confirmed this reproduces on a clean stash of `dev`, so it is environmental and not caused by this change — but it does mean the aggregate `validate` gate is unproven here, and CI is its first real run.
- `@archon/cli` has two failing tests on my machine (`CLI startup import boundary`, and a caller-relative path test). Both reproduce on a clean stash of `dev` and both fail at ~5000ms, which looks like a Windows timeout rather than a real assertion failure. Pre-existing either way.
- One `@archon/providers` test (`PiProvider > sendQuery installs PI_PACKAGE_DIR shim`) failed once at 7392ms during the full `--parallel` run, but passes in isolation both with and without this change. Load-induced flake under parallel CPU contention, not a regression.
- Bun **1.4.0** locally; CI pins **1.3.11**. Within the `^1.3.0` engines range, but not the same runtime CI will use.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | None. The hashed port is unchanged whenever it is free, so every non-colliding setup behaves identically. Nothing persists or re-derives the port. | `grep` for `getPort`/`calculatePortOffset` finds one consumer, `packages/server/src/index.ts:688` |
| Observability | A moved port is visible as `worktree_port_reallocated` carrying `preferredOffset`, the chosen `offset`, and `attempt`; the existing `server_listening` line still reports the bound port | `port-allocation.ts`, `packages/server/src/index.ts:933` |
| Documentation / communication | `dx-quirks.md` documented "same worktree always gets same port" with no collision case; it now describes the fallback and the `PORT` guarantee | `packages/docs-web/src/content/docs/contributing/dx-quirks.md` |

---

## Adjacent finding, not fixed here

While tracing consumers I found what looks like a separate pre-existing bug, left untouched to keep this PR focused.

In a worktree with no `PORT` set, the server binds `3090 + offset` while the Vite dev proxy targets `3090` — `packages/web/vite.config.ts:11` reads `env.PORT ?? '3090'` and does not compute the worktree offset. So `bun dev` in a worktree appears to leave the web UI proxying to a port nothing is serving, unless the user sets `PORT` explicitly.

I have not reproduced this end-to-end (no Bun locally), so I am reporting it rather than claiming it. Happy to open a separate issue if it is not already known.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Worktree servers now automatically select the next available port when the preferred port is occupied.
  - Port selection stays within the supported range and returns to the preferred port when it becomes available.
  - Explicit `PORT` settings remain fixed and report an error if unavailable.

- **Documentation**
  - Added guidance describing worktree port collision handling and port assignment logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->