### PR TITLE
Keep SQLite upgrade-path test fixtures out of the package directory

### DIFF
--- a/packages/core/src/db/adapters/sqlite.test.ts
+++ b/packages/core/src/db/adapters/sqlite.test.ts
@@ -5,6 +5,9 @@ import { APP_VERSION, readSchemaVersion } from '../schema-version';
 import { Database, type Statement } from 'bun:sqlite';
 import { unlinkSync } from 'fs';
 import { join } from 'path';
+import { tmpdir } from 'os';
+import { mkdtemp } from 'fs/promises';
+import { trackTempRoots } from '@archon/paths/test-utils';
 
 let currentDbPath = '';
 
@@ -25,6 +28,22 @@ async function insertCodebase(db: SqliteAdapter, id: string): Promise<void> {
   ]);
 }
 
+const trackTempRoot = trackTempRoots();
+
+/**
+ * A fresh on-disk database path for one upgrade fixture, reclaimed after the test.
+ *
+ * A real file, not a `file:...?mode=memory&cache=shared` URI: bun:sqlite opens without
+ * `SQLITE_OPEN_URI`, so SQLite reads such a URI as a literal filename and creates it in
+ * the process cwd — which is how these fixtures used to leave `file:archon-test-sqlite-*`
+ * files under `packages/core/`. The adapter has no URI requirement, and the fixture only
+ * needs a database that survives being reopened.
+ */
+async function upgradeFixturePath(): Promise<string> {
+  const root = trackTempRoot(await mkdtemp(join(tmpdir(), 'archon-core-sqlite-upgrade-')));
+  return join(root, 'archon.db');
+}
+
 /**
  * Produce a database in the state it had BEFORE event_order existed: current
  * schema in every other respect, with the column, its index and its trigger
@@ -32,31 +51,22 @@ async function insertCodebase(db: SqliteAdapter, id: string): Promise<void> {
  * the fixture realistic — the upgrade path that broke was an otherwise-current
  * database missing exactly this one column.
  */
-async function makeDbWithoutEventOrder(): Promise<{ uri: string; seed: SqliteAdapter }> {
-  const name = `archon-test-sqlite-legacy-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-  const uri = `file:${name}?mode=memory&cache=shared`;
-  // Plain :memory: cannot serve this fixture because each reopened connection
-  // would get an empty database. Keep the seed connection open so this named
-  // shared-cache database survives until the upgrade assertions finish.
-  const seed = new SqliteAdapter(uri); // writes the current schema
+async function makeDbWithoutEventOrder(): Promise<string> {
+  const path = await upgradeFixturePath();
+  await new SqliteAdapter(path).close(); // writes the current schema
+  const raw = new Database(path);
   try {
-    const raw = new Database(uri);
-    try {
-      raw.run('DROP TRIGGER IF EXISTS remote_agent_workflow_events_assign_order');
-      raw.run('DROP INDEX IF EXISTS idx_workflow_events_run_order');
-      raw.run('ALTER TABLE remote_agent_workflow_events DROP COLUMN event_order');
-    } finally {
-      raw.close();
-    }
-    return { uri, seed };
-  } catch (error) {
-    await seed.close();
-    throw error;
+    raw.run('DROP TRIGGER IF EXISTS remote_agent_workflow_events_assign_order');
+    raw.run('DROP INDEX IF EXISTS idx_workflow_events_run_order');
+    raw.run('ALTER TABLE remote_agent_workflow_events DROP COLUMN event_order');
+  } finally {
+    raw.close();
   }
+  return path;
 }
 
-function columnsOf(uri: string, table: string): string[] {
-  const raw = new Database(uri);
+function columnsOf(path: string, table: string): string[] {
+  const raw = new Database(path);
   const stmt = raw.prepare(`PRAGMA table_info('${table}')`);
   try {
     return (stmt.all() as { name: string }[]).map(c => c.name);
@@ -74,62 +84,50 @@ describe('SqliteAdapter upgrade path', () => {
   // column, never ran. Every existing SQLite install was bricked on upgrade,
   // and the migration that would fix it could never execute.
   test('converges a database that predates event_order', async () => {
-    const { uri, seed } = await makeDbWithoutEventOrder();
+    const path = await makeDbWithoutEventOrder();
+    expect(columnsOf(path, 'remote_agent_workflow_events')).not.toContain('event_order');
+
+    // Must not throw, and must converge.
+    const upgraded = new SqliteAdapter(path);
+    await upgraded.close();
+
+    expect(columnsOf(path, 'remote_agent_workflow_events')).toContain('event_order');
+
+    const raw = new Database(path);
+    const stmt = raw.prepare('SELECT name FROM sqlite_master WHERE name IN (?, ?)');
+    let objects: string[];
     try {
-      expect(columnsOf(uri, 'remote_agent_workflow_events')).not.toContain('event_order');
-
-      // Must not throw, and must converge.
-      const upgraded = new SqliteAdapter(uri);
-      await upgraded.close();
-
-      expect(columnsOf(uri, 'remote_agent_workflow_events')).toContain('event_order');
-
-      const raw = new Database(uri);
-      const stmt = raw.prepare('SELECT name FROM sqlite_master WHERE name IN (?, ?)');
-      let objects: string[];
-      try {
-        objects = (
-          stmt.all(
-            'idx_workflow_events_run_order',
-            'remote_agent_workflow_events_assign_order'
-          ) as {
-            name: string;
-          }[]
-        ).map(o => o.name);
-      } finally {
-        stmt.finalize();
-        raw.close();
-      }
-
-      expect(objects).toContain('idx_workflow_events_run_order');
-      expect(objects).toContain('remote_agent_workflow_events_assign_order');
+      objects = (
+        stmt.all('idx_workflow_events_run_order', 'remote_agent_workflow_events_assign_order') as {
+          name: string;
+        }[]
+      ).map(o => o.name);
     } finally {
-      await seed.close();
+      stmt.finalize();
+      raw.close();
     }
+
+    expect(objects).toContain('idx_workflow_events_run_order');
+    expect(objects).toContain('remote_agent_workflow_events_assign_order');
   });
 
   test('adds the authored outcome column idempotently to an existing workflow-runs table', async () => {
-    const name = `archon-test-sqlite-outcome-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-    const uri = `file:${name}?mode=memory&cache=shared`;
-    const seed = new SqliteAdapter(uri);
+    const path = await upgradeFixturePath();
+    await new SqliteAdapter(path).close();
+    const raw = new Database(path);
     try {
-      const raw = new Database(uri);
-      try {
-        raw.run('ALTER TABLE remote_agent_workflow_runs DROP COLUMN outcome');
-      } finally {
-        raw.close();
-      }
-      expect(columnsOf(uri, 'remote_agent_workflow_runs')).not.toContain('outcome');
-
-      const upgraded = new SqliteAdapter(uri);
-      await upgraded.close();
-      const reopened = new SqliteAdapter(uri);
-      await reopened.close();
-
-      expect(columnsOf(uri, 'remote_agent_workflow_runs')).toContain('outcome');
+      raw.run('ALTER TABLE remote_agent_workflow_runs DROP COLUMN outcome');
     } finally {
-      await seed.close();
+      raw.close();
     }
+    expect(columnsOf(path, 'remote_agent_workflow_runs')).not.toContain('outcome');
+
+    const upgraded = new SqliteAdapter(path);
+    await upgraded.close();
+    const reopened = new SqliteAdapter(path);
+    await reopened.close();
+
+    expect(columnsOf(path, 'remote_agent_workflow_runs')).toContain('outcome');
   });
 });
 


### PR DESCRIPTION
## Problem and outcome

Every run of the `@archon/core` suite left two files named `file:archon-test-sqlite-*?mode=memory&cache=shared` under `packages/core/`. The SQLite upgrade-path fixtures opened those names expecting a named in-memory database, but `bun:sqlite` opens without `SQLITE_OPEN_URI`, so SQLite read each URI as a literal filename and created it in the process cwd. The fixtures only ever worked because they were real files.

- **Outcome:** The two upgrade-path fixtures use a real database file under a tracked temp root that is removed after each test. Nothing is written into the source tree.
- **Invariant:** Both regression tests keep proving the same thing, on the real adapter: a database missing `event_order` converges on open, and the `outcome` column is added idempotently across reopen.
- **Scope boundary:** The adapter is unchanged. It has no URI requirement, so nothing gains `SQLITE_OPEN_URI`.
- **Root cause:** `new Database(uri)` in both the adapter and the test's raw connection, with no URI flag.

## Review guidance

- **Feedback requested:** Whether a file-backed fixture is the right replacement, or whether the adapter should learn URI opening.
- **Start here:** `packages/core/src/db/adapters/sqlite.test.ts` — `upgradeFixturePath` and the comment above it.
- **Review order:** The two fixture helpers, then the two tests that consume them.
- **Lower-attention areas:** The tests drop their held-open "seed" connection because a file does not need one to survive reopen.
- **Known risk or uncertainty:** None.

## Solution

Each fixture gets `<mkdtemp>/archon.db` from `trackTempRoots`, the suite's standard cleanup primitive. The seed adapter writes the current schema and closes; the raw connection strips the column; the assertions reopen the same file. A file-backed fixture is the honest version of what the URI was already doing by accident.

## Validation

- `cd packages/core && bun test src/db/adapters/sqlite.test.ts` — 28 pass — and `git status` shows no stray files afterwards, where before the run left two.
- `bun run lint` — the test-cleanup drift check passes.
- **Not verified:** Nothing material.

## Links

- Related #3132 (found while validating it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nv3rzN6mfBHrmHrtHJ4Vq8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nv3rzN6mfBHrmHrtHJ4Vq8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated database upgrade tests to use temporary on-disk database files instead of shared in-memory databases.
  * Simplified test fixture setup and cleanup for more reliable upgrade-path testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->