### PR TITLE
Fix landing page logo and add community video section

### DIFF
--- a/packages/docs-web/src/pages/index.astro
+++ b/packages/docs-web/src/pages/index.astro
@@ -9,6 +9,26 @@
 // magenta → violet → teal gradient drawn from the shield logo.
 const GITHUB = 'https://github.com/coleam00/Archon';
 
+// Community videos. Swap an entry to change what the "See Archon in action"
+// section embeds — nothing else references these ids.
+const videos = [
+  {
+    id: 'fC_BvySeIhY',
+    title: 'Archon vs GitHub Workflows: The AI Pipeline Game Changer!',
+    creator: 'DIY Smart Code',
+  },
+  {
+    id: 'dumoyEGjhD4',
+    title: 'Better Models Or Better Harnesses? The 2026 Developer Debate',
+    creator: 'DIY Smart Code',
+  },
+  {
+    id: 'Jp5mxkAc_Mk',
+    title: 'How Archon V3 catches its own mistakes',
+    creator: 'DIY Smart Code',
+  },
+];
+
 const features = [
   {
     label: 'Parallel by default',
@@ -77,29 +97,7 @@ const steps = [
   <nav class="nav">
     <div class="nav-inner">
       <a href="/" class="nav-logo" aria-label="Archon home">
-        <svg class="nav-mark" viewBox="0 0 360 480" width="22" height="29" aria-hidden="true">
-          <defs>
-            <linearGradient id="navg" x1="0" y1="0" x2="1" y2="1">
-              <stop offset="0%" stop-color="#ED10EC" />
-              <stop offset="50%" stop-color="#8E40C8" />
-              <stop offset="100%" stop-color="#06CE94" />
-            </linearGradient>
-          </defs>
-          <g
-            fill="none"
-            stroke="url(#navg)"
-            stroke-width="22"
-            stroke-linejoin="round"
-            stroke-linecap="round"
-          >
-            <path d="M180 8 C108 8 30 22 8 36 L8 220 C8 340 78 432 180 470 C282 432 352 340 352 220 L352 36 C330 22 252 8 180 8 Z" />
-            <path d="M180 92 L210 122 L180 152 L150 122 Z" />
-            <path d="M180 152 L180 218" />
-            <path d="M124 226 C124 270 148 290 180 290 C212 290 236 270 236 226" />
-            <circle cx="180" cy="294" r="12" fill="url(#navg)" stroke="none" />
-            <path d="M180 308 L180 410" />
-          </g>
-        </svg>
+        <img class="nav-mark" src="/favicon.png" alt="" width="28" height="28" />
         <span>Archon</span>
       </a>
       <div class="nav-links">
@@ -121,29 +119,7 @@ const steps = [
     <section class="hero">
       <div class="hero-glow" aria-hidden="true"></div>
       <div class="hero-inner">
-        <svg class="hero-mark" viewBox="0 0 360 480" aria-hidden="true">
-          <defs>
-            <linearGradient id="herog" x1="0" y1="0" x2="1" y2="1">
-              <stop offset="0%" stop-color="#ED10EC" />
-              <stop offset="50%" stop-color="#8E40C8" />
-              <stop offset="100%" stop-color="#06CE94" />
-            </linearGradient>
-          </defs>
-          <g
-            fill="none"
-            stroke="url(#herog)"
-            stroke-width="22"
-            stroke-linejoin="round"
-            stroke-linecap="round"
-          >
-            <path d="M180 8 C108 8 30 22 8 36 L8 220 C8 340 78 432 180 470 C282 432 352 340 352 220 L352 36 C330 22 252 8 180 8 Z" />
-            <path d="M180 92 L210 122 L180 152 L150 122 Z" />
-            <path d="M180 152 L180 218" />
-            <path d="M124 226 C124 270 148 290 180 290 C212 290 236 270 236 226" />
-            <circle cx="180" cy="294" r="12" fill="url(#herog)" stroke="none" />
-            <path d="M180 308 L180 410" />
-          </g>
-        </svg>
+        <img class="hero-mark" src="/favicon.png" alt="" width="76" height="76" />
 
         <p class="eyebrow">The command layer for your AI coding agents</p>
         <h1 class="hero-title">
@@ -204,6 +180,32 @@ const steps = [
             <h3 class="step-title">{s.title}</h3>
             <p class="step-body">{s.body}</p>
           </div>
+        ))}
+      </div>
+    </section>
+
+    <!-- VIDEOS -->
+    <section class="videos">
+      <header class="section-head">
+        <span class="section-kicker">From the community</span>
+        <h2 class="section-title">See Archon in action.</h2>
+      </header>
+      <div class="video-grid">
+        {videos.map((v) => (
+          <article class="video-card">
+            <div class="video-frame">
+              <iframe
+                src={`https://www.youtube-nocookie.com/embed/${v.id}`}
+                title={`${v.creator} — ${v.title}`}
+                loading="lazy"
+                allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                referrerpolicy="strict-origin-when-cross-origin"
+                allowfullscreen
+              ></iframe>
+            </div>
+            <h3 class="video-title">{v.title}</h3>
+            <span class="video-creator">{v.creator}</span>
+          </article>
         ))}
       </div>
     </section>
@@ -572,6 +574,38 @@ const steps = [
     }
     .step-body { font-size: 0.94rem; color: var(--text-secondary); line-height: 1.6; }
 
+    /* ---- VIDEOS ---- */
+    .videos { max-width: 1080px; margin: 0 auto; padding: 2rem 1.5rem 4rem; }
+    .video-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 1.5rem;
+    }
+    .video-card { min-width: 0; }
+    .video-frame {
+      aspect-ratio: 16 / 9;
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      overflow: hidden;
+      background: var(--surface);
+    }
+    .video-frame iframe { display: block; width: 100%; height: 100%; border: 0; }
+    .video-title {
+      font-size: 1.02rem;
+      font-weight: 600;
+      letter-spacing: -0.02em;
+      color: var(--text);
+      margin: 0.9rem 0 0.3rem;
+    }
+    .video-creator {
+      font-family: var(--font-mono);
+      font-size: 0.76rem;
+      font-weight: 500;
+      letter-spacing: 0.07em;
+      text-transform: uppercase;
+      color: var(--brand-teal);
+    }
+
     /* ---- AWE ---- */
     .awe {
       position: relative;
@@ -638,6 +672,7 @@ const steps = [
     @media (max-width: 820px) {
       .features { grid-template-columns: 1fr; }
       .steps { grid-template-columns: 1fr; }
+      .video-grid { grid-template-columns: 1fr; }
     }
     @media (max-width: 640px) {
       .nav-links a:not(.nav-github) { padding: 0.4rem 0.5rem; font-size: 0.82rem; }


### PR DESCRIPTION
## Problem and outcome

The landing page (`packages/docs-web/src/pages/index.astro`) drew the Archon logo as a hand-approximated inline SVG (nav + hero marks) that didn't match the canonical shield mark — an upward-opening cup instead of the real pen-nib shape — while every other docs page (`roadmap`, `workflows`) and Starlight already used the correct shared PNG. The page also had no social proof despite creator videos existing.

- **Outcome:** Landing page nav and hero logos now render the same `/favicon.png` used everywhere else on the site, and a new "See Archon in action" section embeds two community YouTube videos as responsive, privacy-friendly (`youtube-nocookie.com`) iframes.
- **Invariant:** Only `packages/docs-web` changed; no new dependencies; no external scripts; `public/brand/*` untouched; existing content, links, and sections preserved.
- **Scope boundary:** No new logo asset was added — `public/favicon.png`, `public/brand/assets/archon-logo.png`, and `src/assets/logo.png` are already byte-identical (verified by hash), so the fix is pointing the two inline SVGs at the existing canonical PNG rather than introducing a new file or a hand-derived SVG.

## Review guidance

- **Feedback requested:** Correctness of the logo swap and whether the video section styling matches the design tokens well enough.
- **Start here:** `packages/docs-web/src/pages/index.astro:80` — the nav logo swap; same pattern repeats at the hero mark and the new video section below.
- **Review order:** Logo swap (`nav-mark`, `hero-mark`) → `videos` data array near the top of frontmatter → new `.videos` section markup → matching CSS block.
- **Lower-attention areas:** CSS additions reuse existing tokens (`--surface`, `--border`, `--brand-teal`, `--font-mono`) and the existing 820px breakpoint — mechanical, verified against built HTML.
- **Known risk or uncertainty:** The `--sl-color-text-accent` override is now scoped to `.sidebar-content`, an internal Starlight class; re-check after Starlight upgrades.

## Solution

Both inline SVGs (`.nav-mark` at line ~80, `.hero-mark` at line ~124) are replaced with `<img src="/favicon.png">`, matching the exact idiom already used by `roadmap.astro:29`, `workflows/index.astro:33`, and `workflows/[slug].astro:41`. The brand source (`public/brand/logo.jsx`) states the PNG "carries the multi-color gradient cleanly at any size" and is canonical, while the SVG glyph is explicitly "not pixel-perfect" — so a shared PNG was chosen over deriving a new vector, avoiding reintroducing an approximation.

The video section adds a `videos` array (`id`, `title`, `creator`) at the top of the component frontmatter so swapping the current placeholder videos later is a one-line-per-video change. The section is rendered by mapping over that array into `youtube-nocookie.com/embed/<id>` iframes with `loading="lazy"`, `allowfullscreen`, and a descriptive `title`, styled with the page's existing surface/border/gradient tokens and placed between "How it works" and the awe band.

### Follow-up commits

- Final video picks: Cole Medin's "Full Archon Guide" livestream (`srx9iwnjK2M`) and DIY Smart Code's "What Is Archon?" explainer (`uvLW0sPEZ_k`); grid widened to two columns.
- Dark-mode docs pages (`/docs/` and every Starlight page) rendered the site title, the primary "Get Started" button, and links at 25% opacity. Cause: #1869 declared `--sl-color-text-accent: rgba(168, 85, 247, 0.25)` on the whole dark theme for the mobile sidebar active-link background, but Starlight derives title, button, and link colors from the same variable. `src/styles/custom.css` now scopes that override to `.sidebar-content`; the sidebar active link keeps its white-on-purple treatment.

## Validation

- `cd packages/docs-web && bun run build` — pass (85 pages) — proves the page builds and iframes/logo render into static HTML.
- `cd packages/docs-web && bun run type-check` — pass.
- `bun run lint` — pass.
- `bun run validate` — `check:api-types`, `type-check` (all 12 packages), `lint --max-warnings 0`, `format:check` all pass. `test:install` fails in this environment only because `scripts/test-install.sh` refuses to run outside WSL2/Linux (`[ERROR] Windows is not supported`) and never touches `packages/docs-web`; `bun run test` was run directly since `validate` short-circuits on that step.
- `bun run test` — 2 pre-existing failures in `@archon/adapters` (`SlackAdapter` FIFO eviction and seed-post error tests), proven unrelated by stashing this diff and re-running: identical failures with the change absent.
- Built-HTML check: `dist/index.html` shows `<img class="nav-mark" src="/favicon.png">` and `<img class="hero-mark" src="/favicon.png">`, `grep -c "360 480" dist/index.html` returns `0` (no hand-drawn SVG path remains), and `dist/roadmap/index.html` / `dist/workflows/index.html` both reference the same `/favicon.png`. All three video embeds are present in `dist/index.html` with correct `youtube-nocookie.com` ids and titles.
- Visual check via headless Playwright against `astro preview` of the built site: `/` at 1280px and 390px (logo, two-column video grid, single column on mobile, no horizontal scroll); `/docs/` in dark and light mode and at 390px (site title `rgb(147,197,253)`, "Get Started" readable); mobile sidebar active link on `/getting-started/installation/` still white text on the purple gradient.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a community videos section featuring three embedded YouTube videos with titles and creator labels.
  - Added responsive video-grid layout that adapts to smaller screens.

- **Style**
  - Updated navigation and hero branding to use the site favicon image instead of inline shield graphics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
