### PR TITLE
test(workflows): enforce template slot completeness

### DIFF
--- a/packages/workflows/src/template-walker.test.ts
+++ b/packages/workflows/src/template-walker.test.ts
@@ -1,11 +1,460 @@
 import { expect, test } from 'bun:test';
+import { z } from '@hono/zod-openapi';
 import type { DagNode } from './schemas';
+import { bindingDirectiveSchema, dagNodeFlatSchema, dagNodeSchema } from './schemas';
 import type { TemplateSlotName, TemplateSurface } from './template-walker';
 import {
   mapNodeTemplateSlots,
   mapNodeTemplateValueSlots,
+  SLOT_SPEC,
   visitNodeTemplateSlots,
 } from './template-walker';
+
+type StringFieldClassification =
+  | { kind: 'template'; slots: readonly TemplateSlotName[] }
+  | { kind: 'literal'; reason: string };
+
+const HOOK_MATCHER_REASON = 'Hook matcher is an SDK regex, not execution template text';
+const HOOK_RESPONSE_REASON = 'Hook response is static provider configuration';
+
+const STRING_FIELD_CLASSIFICATIONS = {
+  id: { kind: 'literal', reason: 'Node identifier anchors graph edges and output references' },
+  description: { kind: 'literal', reason: 'Node documentation is not execution input' },
+  'depends_on.*': { kind: 'literal', reason: 'Dependency entries are node identifiers' },
+  when: { kind: 'template', slots: ['when'] },
+  trigger_rule: { kind: 'literal', reason: 'Trigger rule is a scheduling policy enum' },
+  model: { kind: 'literal', reason: 'Model is a provider model identifier' },
+  provider: { kind: 'literal', reason: 'Provider is an integration identifier' },
+  context: { kind: 'literal', reason: 'Context string selects a session policy' },
+  'context.resume': { kind: 'literal', reason: 'Resume target is a node identifier' },
+  'output_format.*': {
+    kind: 'literal',
+    reason: 'Output-format values declare a JSON schema rather than runtime template input',
+  },
+  'allowed_tools.*': { kind: 'literal', reason: 'Allowed-tool entries are capability names' },
+  'denied_tools.*': { kind: 'literal', reason: 'Denied-tool entries are capability names' },
+  'retry.on_error': { kind: 'literal', reason: 'Retry error class is an engine policy enum' },
+  'hooks.PreToolUse.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
+  'hooks.PreToolUse.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
+  'hooks.PostToolUse.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
+  'hooks.PostToolUse.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
+  'hooks.PostToolUseFailure.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
+  'hooks.PostToolUseFailure.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
+  'hooks.Notification.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
+  'hooks.Notification.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
+  'hooks.UserPromptSubmit.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
+  'hooks.UserPromptSubmit.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
+  'hooks.SessionStart.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
+  'hooks.SessionStart.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
+  'hooks.SessionEnd.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
+  'hooks.SessionEnd.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
+  'hooks.Stop.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
+  'hooks.Stop.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
+  'hooks.SubagentStart.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
+  'hooks.SubagentStart.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
+  'hooks.SubagentStop.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
+  'hooks.SubagentStop.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
+  'hooks.PreCompact.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
+  'hooks.PreCompact.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
+  'hooks.PermissionRequest.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
+  'hooks.PermissionRequest.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
+  'hooks.Setup.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
+  'hooks.Setup.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
+  'hooks.TeammateIdle.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
+  'hooks.TeammateIdle.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
+  'hooks.TaskCompleted.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
+  'hooks.TaskCompleted.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
+  'hooks.Elicitation.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
+  'hooks.Elicitation.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
+  'hooks.ElicitationResult.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
+  'hooks.ElicitationResult.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
+  'hooks.ConfigChange.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
+  'hooks.ConfigChange.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
+  'hooks.WorktreeCreate.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
+  'hooks.WorktreeCreate.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
+  'hooks.WorktreeRemove.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
+  'hooks.WorktreeRemove.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
+  'hooks.InstructionsLoaded.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
+  'hooks.InstructionsLoaded.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
+  mcp: { kind: 'literal', reason: 'MCP value is a configuration path' },
+  'skills.*': { kind: 'literal', reason: 'Skill entries are capability identifiers' },
+  'agents.*.description': { kind: 'template', slots: ['agents.*.description'] },
+  'agents.*.prompt': { kind: 'template', slots: ['agents.*.prompt'] },
+  'agents.*.model': { kind: 'literal', reason: 'Sub-agent model is a provider identifier' },
+  'agents.*.tools.*': { kind: 'literal', reason: 'Sub-agent tool entries are capability names' },
+  'agents.*.disallowedTools.*': {
+    kind: 'literal',
+    reason: 'Sub-agent denied-tool entries are capability names',
+  },
+  'agents.*.skills.*': {
+    kind: 'literal',
+    reason: 'Sub-agent skill entries are capability identifiers',
+  },
+  'pi.extensionFlags.*': { kind: 'literal', reason: 'Pi extension flag values configure plugins' },
+  effort: { kind: 'literal', reason: 'Effort is a provider reasoning-level enum' },
+  systemPrompt: { kind: 'template', slots: ['systemPrompt'] },
+  fallbackModel: { kind: 'literal', reason: 'Fallback model is a provider model identifier' },
+  'settingSources.*': { kind: 'literal', reason: 'Setting sources select provider config layers' },
+  'betas.*': { kind: 'literal', reason: 'Beta entries are provider feature identifiers' },
+  'sandbox.network.allowedDomains.*': {
+    kind: 'literal',
+    reason: 'Allowed domains are sandbox network rules',
+  },
+  'sandbox.network.allowUnixSockets.*': {
+    kind: 'literal',
+    reason: 'Allowed Unix sockets are sandbox paths',
+  },
+  'sandbox.filesystem.allowWrite.*': {
+    kind: 'literal',
+    reason: 'Allowed-write entries are sandbox filesystem paths',
+  },
+  'sandbox.filesystem.denyWrite.*': {
+    kind: 'literal',
+    reason: 'Denied-write entries are sandbox filesystem paths',
+  },
+  'sandbox.filesystem.denyRead.*': {
+    kind: 'literal',
+    reason: 'Denied-read entries are sandbox filesystem paths',
+  },
+  'sandbox.ignoreViolations.*.*': {
+    kind: 'literal',
+    reason: 'Ignored violations are provider sandbox rule names',
+  },
+  'sandbox.excludedCommands.*': {
+    kind: 'literal',
+    reason: 'Excluded commands are sandbox executable names',
+  },
+  'sandbox.ripgrep.command': {
+    kind: 'literal',
+    reason: 'Ripgrep command is a sandbox executable path',
+  },
+  'sandbox.ripgrep.args.*': {
+    kind: 'literal',
+    reason: 'Ripgrep arguments are static sandbox configuration',
+  },
+  'sandbox.*': {
+    kind: 'literal',
+    reason: 'Unmodelled sandbox values pass through as provider configuration',
+  },
+  output_type: { kind: 'literal', reason: 'Output type is an artifact classification tag' },
+  command: { kind: 'literal', reason: 'Resource identifier resolved before execution' },
+  prompt: { kind: 'template', slots: ['agent.prompt'] },
+  bash: { kind: 'template', slots: ['exec.bash'] },
+  'loop.until': { kind: 'literal', reason: 'Loop completion signal is matched verbatim' },
+  'loop.until_bash': { kind: 'template', slots: ['loop.until_bash'] },
+  'loop.gate_message': {
+    kind: 'literal',
+    reason: 'Interactive-loop gate message is operator display text',
+  },
+  'loop.prompt': { kind: 'template', slots: ['loop.prompt'] },
+  'loop.command': { kind: 'literal', reason: 'Loop command is a resource identifier' },
+  'loop.until_field': {
+    kind: 'literal',
+    reason: 'Loop completion field names an output-schema property',
+  },
+  'loop_group.until': {
+    kind: 'literal',
+    reason: 'Loop-group completion signal is matched verbatim',
+  },
+  'loop_group.until_bash': { kind: 'template', slots: ['loop_group.until_bash'] },
+  'loop_group.gate_message': {
+    kind: 'literal',
+    reason: 'Loop-group gate message is operator display text',
+  },
+  'approval.message': { kind: 'template', slots: ['approval.message'] },
+  'approval.decisions.*.id': {
+    kind: 'literal',
+    reason: 'Approval decision id is a response wire value',
+  },
+  'approval.decisions.*.label': {
+    kind: 'literal',
+    reason: 'Display text is not an execution template',
+  },
+  'approval.on_reject.prompt': { kind: 'template', slots: ['approval.on_reject.prompt'] },
+  'wait.until': { kind: 'template', slots: ['wait.until'] },
+  'wait.event': { kind: 'template', slots: ['wait.event'] },
+  'wait.attention': { kind: 'template', slots: ['wait.attention'] },
+  cancel: { kind: 'template', slots: ['cancel.reason'] },
+  include: { kind: 'literal', reason: 'Include target is a workflow resource identifier' },
+  workflow: { kind: 'literal', reason: 'Child target is a workflow resource identifier' },
+  input: { kind: 'template', slots: ['workflow.input'] },
+  isolation: { kind: 'literal', reason: 'Isolation is a child-run placement policy enum' },
+  'fan_out.items': {
+    kind: 'template',
+    slots: ['workflow.fan_out.items', 'compose_fan_out.fan_out.items'],
+  },
+  'fan_out.as': { kind: 'literal', reason: 'Fan-out alias is an input identifier' },
+  'fan_out.join': { kind: 'literal', reason: 'Fan-out join is an execution policy enum' },
+  'with.*': {
+    kind: 'template',
+    slots: ['binding.value', 'workflow.with.*', 'compose_fan_out.with.*'],
+  },
+  'with.*.from': { kind: 'template', slots: ['binding.from'] },
+  'with.*.if_skipped': { kind: 'template', slots: ['binding.if_skipped'] },
+  script: { kind: 'template', slots: ['exec.script'] },
+  runtime: { kind: 'literal', reason: 'Script runtime is an executor identifier' },
+  'deps.*': { kind: 'literal', reason: 'Script dependencies are package identifiers' },
+} satisfies Record<string, StringFieldClassification>;
+
+const ENGINE_PRIVATE_SLOT_REASONS = {
+  'loop.compiled_prompt': 'Loaded loop commands are compiled after authoring validation',
+  'composed.inputs.*': 'Materialized include inputs live only in engine metadata',
+} satisfies Partial<Record<TemplateSlotName, string>>;
+
+interface StringFieldInventory {
+  stringFields: readonly string[];
+  followedReferences: readonly string[];
+}
+
+interface CompletenessProblems {
+  unclassifiedStringFields: readonly string[];
+  classificationsWithoutStringFields: readonly string[];
+  templateSlotsMissingFromCatalogue: readonly string[];
+  schemaBackedSlotsWithoutClassification: readonly string[];
+  enginePrivateSlotsMissingFromCatalogue: readonly string[];
+  literalFieldsWithoutReasons: readonly string[];
+  enginePrivateSlotsWithoutReasons: readonly string[];
+}
+
+const EMPTY_COMPLETENESS_PROBLEMS: CompletenessProblems = {
+  unclassifiedStringFields: [],
+  classificationsWithoutStringFields: [],
+  templateSlotsMissingFromCatalogue: [],
+  schemaBackedSlotsWithoutClassification: [],
+  enginePrivateSlotsMissingFromCatalogue: [],
+  literalFieldsWithoutReasons: [],
+  enginePrivateSlotsWithoutReasons: [],
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function childPath(parent: string, child: string): string {
+  return parent === '' ? child : `${parent}.${child}`;
+}
+
+function resolveLocalReference(root: unknown, reference: string): unknown {
+  if (reference === '#') return root;
+  if (!reference.startsWith('#/'))
+    throw new Error(`Unsupported JSON Schema reference: ${reference}`);
+
+  let current = root;
+  for (const encodedToken of reference.slice(2).split('/')) {
+    if (!isRecord(current)) throw new Error(`JSON Schema reference does not resolve: ${reference}`);
+    const token = decodeURIComponent(encodedToken).replaceAll('~1', '/').replaceAll('~0', '~');
+    current = current[token];
+  }
+  if (current === undefined)
+    throw new Error(`JSON Schema reference does not resolve: ${reference}`);
+  return current;
+}
+
+function collectStringFields(
+  schema: z.ZodType,
+  options: { prefix?: string; opaqueRecordPaths?: ReadonlySet<string> } = {}
+): StringFieldInventory {
+  const root = z.toJSONSchema(schema, { io: 'input', unrepresentable: 'any' });
+  const rootPath = options.prefix ?? '';
+  const stringFields = new Set<string>();
+  const followedReferences = new Set<string>();
+
+  const addOpaquePosition = (path: string): void => {
+    if (path === '') return;
+    stringFields.add(options.opaqueRecordPaths?.has(path) === true ? `${path}.*` : path);
+  };
+
+  const walk = (value: unknown, path: string, activeReferences: ReadonlySet<string>): void => {
+    if (value === true) {
+      addOpaquePosition(path);
+      return;
+    }
+    if (!isRecord(value)) return;
+
+    const reference = value.$ref;
+    if (reference !== undefined) {
+      if (typeof reference !== 'string')
+        throw new Error(`Invalid JSON Schema reference at ${path}`);
+      followedReferences.add(path);
+      if (activeReferences.has(reference)) return;
+      const nextReferences = new Set(activeReferences);
+      nextReferences.add(reference);
+      walk(
+        resolveLocalReference(root, reference),
+        reference === '#' ? rootPath : path,
+        nextReferences
+      );
+      return;
+    }
+
+    if (Object.keys(value).length === 0) {
+      addOpaquePosition(path);
+      return;
+    }
+
+    const type = value.type;
+    if (type === 'string' || (Array.isArray(type) && type.includes('string'))) {
+      if (path !== '') stringFields.add(path);
+    }
+
+    for (const keyword of ['anyOf', 'oneOf', 'allOf'] as const) {
+      const variants = value[keyword];
+      if (variants === undefined) continue;
+      if (!Array.isArray(variants)) throw new Error(`Invalid JSON Schema ${keyword} at ${path}`);
+      for (const variant of variants) walk(variant, path, activeReferences);
+    }
+
+    const properties = value.properties;
+    if (properties !== undefined) {
+      if (!isRecord(properties)) throw new Error(`Invalid JSON Schema properties at ${path}`);
+      for (const [name, property] of Object.entries(properties)) {
+        walk(property, childPath(path, name), activeReferences);
+      }
+    }
+
+    const items = value.items;
+    if (Array.isArray(items)) {
+      for (const item of items) walk(item, childPath(path, '*'), activeReferences);
+    } else if (items !== undefined) {
+      walk(items, childPath(path, '*'), activeReferences);
+    }
+
+    const prefixItems = value.prefixItems;
+    if (prefixItems !== undefined) {
+      if (!Array.isArray(prefixItems))
+        throw new Error(`Invalid JSON Schema prefixItems at ${path}`);
+      for (const item of prefixItems) walk(item, childPath(path, '*'), activeReferences);
+    }
+
+    const additionalProperties = value.additionalProperties;
+    if (additionalProperties !== undefined && additionalProperties !== false) {
+      walk(additionalProperties, childPath(path, '*'), activeReferences);
+    }
+  };
+
+  walk(root, rootPath, new Set());
+  return {
+    stringFields: [...stringFields].sort(),
+    followedReferences: [...followedReferences].sort(),
+  };
+}
+
+function normalizeRecursiveNodePath(path: string): string {
+  const recursivePrefix = 'loop_group.nodes.*.';
+  let normalized = path;
+  while (normalized.startsWith(recursivePrefix)) {
+    normalized = normalized.slice(recursivePrefix.length);
+  }
+  return normalized === 'with' ? 'with.*' : normalized;
+}
+
+function authoredStringFields(schema: z.ZodType): StringFieldInventory {
+  // `with` stays opaque in the flat schema because node-mode-specific superRefine logic
+  // validates it as an identifier-keyed map. Its authored value position is `with.*`.
+  const nodeFields = collectStringFields(schema, { opaqueRecordPaths: new Set(['with']) });
+  const bindingFields = collectStringFields(bindingDirectiveSchema, { prefix: 'with.*' });
+  return {
+    stringFields: [
+      ...new Set([
+        ...nodeFields.stringFields.map(normalizeRecursiveNodePath),
+        ...bindingFields.stringFields,
+      ]),
+    ].sort(),
+    followedReferences: [
+      ...new Set([
+        ...nodeFields.followedReferences.map(normalizeRecursiveNodePath),
+        ...bindingFields.followedReferences,
+      ]),
+    ].sort(),
+  };
+}
+
+function completenessProblems(
+  schema: z.ZodType,
+  classifications: Readonly<
+    Record<string, StringFieldClassification>
+  > = STRING_FIELD_CLASSIFICATIONS,
+  catalogueSlots: ReadonlySet<string> = new Set(Object.keys(SLOT_SPEC)),
+  enginePrivateSlots: Readonly<Record<string, string>> = ENGINE_PRIVATE_SLOT_REASONS
+): CompletenessProblems {
+  const schemaFields = new Set(authoredStringFields(schema).stringFields);
+  const classificationFields = new Set(Object.keys(classifications));
+  const referencedSlots = new Set<string>();
+
+  for (const classification of Object.values(classifications)) {
+    if (classification.kind === 'template') {
+      for (const slot of classification.slots) referencedSlots.add(slot);
+    }
+  }
+
+  return {
+    unclassifiedStringFields: [...schemaFields].filter(field => !classificationFields.has(field)),
+    classificationsWithoutStringFields: [...classificationFields].filter(
+      field => !schemaFields.has(field)
+    ),
+    templateSlotsMissingFromCatalogue: [...referencedSlots]
+      .filter(slot => !catalogueSlots.has(slot))
+      .sort(),
+    schemaBackedSlotsWithoutClassification: [...catalogueSlots]
+      .filter(slot => !referencedSlots.has(slot) && !Object.hasOwn(enginePrivateSlots, slot))
+      .sort(),
+    enginePrivateSlotsMissingFromCatalogue: Object.keys(enginePrivateSlots)
+      .filter(slot => !catalogueSlots.has(slot))
+      .sort(),
+    literalFieldsWithoutReasons: Object.entries(classifications)
+      .filter(([, classification]) => {
+        return classification.kind === 'literal' && classification.reason.trim() === '';
+      })
+      .map(([field]) => field)
+      .sort(),
+    enginePrivateSlotsWithoutReasons: Object.entries(enginePrivateSlots)
+      .filter(([, reason]) => reason.trim() === '')
+      .map(([slot]) => slot)
+      .sort(),
+  };
+}
+
+test('the authored string-field classifications and template slot catalogue are complete', () => {
+  expect(completenessProblems(dagNodeSchema)).toEqual(EMPTY_COMPLETENESS_PROBLEMS);
+
+  const inventory = authoredStringFields(dagNodeSchema);
+  expect(inventory.stringFields).toContain('agents.*.prompt');
+  expect(inventory.stringFields).toContain('with.*');
+  expect(inventory.stringFields).toContain('with.*.from');
+  expect(inventory.followedReferences).toContain('loop_group.nodes.*');
+});
+
+test('a new authored string field stays unclassified until its template policy is explicit', () => {
+  const mutatedSchema = dagNodeFlatSchema.extend({ future_text: z.string() });
+
+  expect(completenessProblems(mutatedSchema).unclassifiedStringFields).toEqual(['future_text']);
+
+  const literalClassification = {
+    ...STRING_FIELD_CLASSIFICATIONS,
+    future_text: { kind: 'literal', reason: 'Future text is fixed protocol data' },
+  } satisfies Record<string, StringFieldClassification>;
+  expect(completenessProblems(mutatedSchema, literalClassification)).toEqual(
+    EMPTY_COMPLETENESS_PROBLEMS
+  );
+
+  const templateClassification = {
+    ...STRING_FIELD_CLASSIFICATIONS,
+    future_text: { kind: 'template', slots: ['when'] },
+  } satisfies Record<string, StringFieldClassification>;
+  expect(completenessProblems(mutatedSchema, templateClassification)).toEqual(
+    EMPTY_COMPLETENESS_PROBLEMS
+  );
+});
+
+test('a classification fails when its template slot leaves the catalogue', () => {
+  const incompleteCatalogue = new Set(Object.keys(SLOT_SPEC));
+  incompleteCatalogue.delete('when');
+
+  expect(
+    completenessProblems(dagNodeSchema, STRING_FIELD_CLASSIFICATIONS, incompleteCatalogue)
+      .templateSlotsMissingFromCatalogue
+  ).toEqual(['when']);
+});
 
 test('the slot catalogue rejects omitted fixed fields', () => {
   // @ts-expect-error approval.on_reject.prompt must remain catalogued

--- a/packages/workflows/src/template-walker.test.ts
+++ b/packages/workflows/src/template-walker.test.ts
@@ -1,7 +1,12 @@
 import { expect, test } from 'bun:test';
 import { z } from '@hono/zod-openapi';
 import type { DagNode } from './schemas';
-import { bindingDirectiveSchema, dagNodeFlatSchema, dagNodeSchema } from './schemas';
+import {
+  bindingDirectiveSchema,
+  dagNodeFlatSchema,
+  dagNodeSchema,
+  WORKFLOW_HOOK_EVENTS,
+} from './schemas';
 import type { TemplateSlotName, TemplateSurface } from './template-walker';
 import {
   mapNodeTemplateSlots,
@@ -16,6 +21,12 @@ type StringFieldClassification =
 
 const HOOK_MATCHER_REASON = 'Hook matcher is an SDK regex, not execution template text';
 const HOOK_RESPONSE_REASON = 'Hook response is static provider configuration';
+const HOOK_FIELD_CLASSIFICATIONS = Object.fromEntries(
+  WORKFLOW_HOOK_EVENTS.flatMap(event => [
+    [`hooks.${event}.*.matcher`, { kind: 'literal', reason: HOOK_MATCHER_REASON }] as const,
+    [`hooks.${event}.*.response.*`, { kind: 'literal', reason: HOOK_RESPONSE_REASON }] as const,
+  ])
+) satisfies Record<string, StringFieldClassification>;
 
 const STRING_FIELD_CLASSIFICATIONS = {
   id: { kind: 'literal', reason: 'Node identifier anchors graph edges and output references' },
@@ -34,48 +45,7 @@ const STRING_FIELD_CLASSIFICATIONS = {
   'allowed_tools.*': { kind: 'literal', reason: 'Allowed-tool entries are capability names' },
   'denied_tools.*': { kind: 'literal', reason: 'Denied-tool entries are capability names' },
   'retry.on_error': { kind: 'literal', reason: 'Retry error class is an engine policy enum' },
-  'hooks.PreToolUse.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
-  'hooks.PreToolUse.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
-  'hooks.PostToolUse.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
-  'hooks.PostToolUse.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
-  'hooks.PostToolUseFailure.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
-  'hooks.PostToolUseFailure.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
-  'hooks.Notification.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
-  'hooks.Notification.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
-  'hooks.UserPromptSubmit.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
-  'hooks.UserPromptSubmit.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
-  'hooks.SessionStart.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
-  'hooks.SessionStart.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
-  'hooks.SessionEnd.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
-  'hooks.SessionEnd.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
-  'hooks.Stop.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
-  'hooks.Stop.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
-  'hooks.SubagentStart.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
-  'hooks.SubagentStart.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
-  'hooks.SubagentStop.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
-  'hooks.SubagentStop.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
-  'hooks.PreCompact.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
-  'hooks.PreCompact.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
-  'hooks.PermissionRequest.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
-  'hooks.PermissionRequest.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
-  'hooks.Setup.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
-  'hooks.Setup.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
-  'hooks.TeammateIdle.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
-  'hooks.TeammateIdle.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
-  'hooks.TaskCompleted.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
-  'hooks.TaskCompleted.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
-  'hooks.Elicitation.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
-  'hooks.Elicitation.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
-  'hooks.ElicitationResult.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
-  'hooks.ElicitationResult.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
-  'hooks.ConfigChange.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
-  'hooks.ConfigChange.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
-  'hooks.WorktreeCreate.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
-  'hooks.WorktreeCreate.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
-  'hooks.WorktreeRemove.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
-  'hooks.WorktreeRemove.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
-  'hooks.InstructionsLoaded.*.matcher': { kind: 'literal', reason: HOOK_MATCHER_REASON },
-  'hooks.InstructionsLoaded.*.response.*': { kind: 'literal', reason: HOOK_RESPONSE_REASON },
+  ...HOOK_FIELD_CLASSIFICATIONS,
   mcp: { kind: 'literal', reason: 'MCP value is a configuration path' },
   'skills.*': { kind: 'literal', reason: 'Skill entries are capability identifiers' },
   'agents.*.description': { kind: 'template', slots: ['agents.*.description'] },
@@ -454,6 +424,42 @@ test('a classification fails when its template slot leaves the catalogue', () =>
     completenessProblems(dagNodeSchema, STRING_FIELD_CLASSIFICATIONS, incompleteCatalogue)
       .templateSlotsMissingFromCatalogue
   ).toEqual(['when']);
+});
+
+test('workflow and composed fan-out bindings use their classified slot names', () => {
+  const workflowNode = {
+    id: 'child',
+    kind: 'workflow',
+    workflow: 'child-workflow',
+    with: { topic: '$source.output' },
+  } satisfies DagNode;
+  const composedFanOutNode = {
+    id: 'fan',
+    kind: 'compose_fan_out',
+    include: 'worker-block',
+    with: { topic: '$source.output' },
+    fan_out: {
+      items: '$source.output',
+      as: 'topic',
+      max_parallel: 1,
+      join: 'all_done',
+    },
+  } satisfies DagNode;
+
+  const slotIdentity = (node: DagNode): { name: TemplateSlotName; path: string }[] => {
+    const slots: { name: TemplateSlotName; path: string }[] = [];
+    visitNodeTemplateSlots(node, ({ name, path }) => slots.push({ name, path }));
+    return slots;
+  };
+
+  expect(slotIdentity(workflowNode)).toContainEqual({
+    name: 'workflow.with.*',
+    path: 'with.topic',
+  });
+  expect(slotIdentity(composedFanOutNode)).toContainEqual({
+    name: 'compose_fan_out.with.*',
+    path: 'with.topic',
+  });
 });
 
 test('the slot catalogue rejects omitted fixed fields', () => {

--- a/packages/workflows/src/template-walker.ts
+++ b/packages/workflows/src/template-walker.ts
@@ -74,7 +74,7 @@ interface SlotDefinition {
 }
 
 /** The complete engine-owned template surface. */
-const SLOT_SPEC = {
+export const SLOT_SPEC = {
   when: { surface: 'condition', outputReference: true },
   systemPrompt: { surface: 'prompt', outputReference: true },
   'agents.*.prompt': { surface: 'prompt', outputReference: true },


### PR DESCRIPTION
## Problem and outcome

The template walker catalogue was checked against its TypeScript slot type, but newly authored string-capable node fields could still reach the schema without an explicit template or literal policy. This PR makes that omission fail in the existing workflow test suite.

- **Outcome:** Every string-capable path discovered from the node authoring schema and semantic `with:` binding schema now has one explicit classification, and every schema-backed walker slot is referenced.
- **Invariant:** Classifications are exact normalized schema paths; literal fields carry a field-specific reason, and engine-private slots are separately reasoned rather than treated as authored YAML.
- **Scope boundary:** This does not restructure `dagNodeFlatSchema` or `execNodeSchema`; issue #3125 owns that parallel work.
- **Root cause:** The previous guard proved that the catalogue covered declared slot names, but did not derive paths from the authoring schema and compare them back to the catalogue.

## Review guidance

- **Feedback requested:** Correctness of the schema traversal and completeness contract, especially normalization of recursive and record-shaped paths.
- **Start here:** `packages/workflows/src/template-walker.test.ts` — the classification map and completeness assertions establish the bidirectional guard.
- **Review order:** Read the schema-path collector, then `completenessProblems`, then the regression specimens; finally confirm the narrow `SLOT_SPEC` export in `packages/workflows/src/template-walker.ts`.
- **Lower-attention areas:** The literal classification entries are a mechanical inventory; the guard verifies that none become stale or omit a discovered path.
- **Known risk or uncertainty:** None.

## Solution

The test converts `dagNodeSchema` through Zod's public input JSON Schema API, recursively inventorying strings through object properties, arrays, records, unions, local references, and opaque values. It adds `bindingDirectiveSchema` under `with.*` for the semantic shape deliberately opaque in the flat authoring schema.

An exact classification map identifies each discovered path as either template-backed by runtime `SLOT_SPEC` entries or literal with a specific reason. The assertions reject missing and stale classifications, unreferenced schema-backed slots, catalogue references that no longer exist, and unreasoned engine-private slots. The runtime catalogue is exported solely so this test reads the owner rather than maintaining a copy.

## Behavior change

| | Before | After |
|---|---|---|
| **New authored string field** | Could be added without updating template traversal policy. | Fails the workflow test until explicitly classified as literal or template-backed. |
| **Catalogue drift** | Only declared slot-name coverage was tested. | Missing referenced slots and unreferenced schema-backed slots fail the completeness guard. |

## Validation

- `bun test src/template-walker.test.ts` in `packages/workflows` — passed (6 tests); proves the schema-derived completeness guard, mutation failure, literal/template clearing, recursion, wildcard paths, and missing catalogue entry.
- `bun run type-check` in `packages/workflows` — passed.
- `bun run lint --max-warnings 0` — passed.
- `bun run validate` — passed at committed HEAD; runs repository validation including generated-artifact checks, type checks, lint, formatting, installer tests, and the complete test suite.
- `git diff 900444f0980442675dc6330ec48bb2d12852b967..HEAD --check` — passed.
- **Not verified:** Nothing material; the permanent mutation specimen preserves the observed-red proof without leaving a schema mutation in production code.

## Links

- Closes #2937


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded validation to ensure template and literal string fields are fully classified.
  - Added checks that the template slot catalogue stays aligned with the workflow node schema.
  - Added diagnostics for missing classifications, invalid catalogue entries, and undocumented literal fields.

- **Developer Tools**
  - Made the template slot specification available for external inspection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->