### PR TITLE
Derive authored exec fields from their owner

### DIFF
--- a/packages/web/src/lib/api.generated.d.ts
+++ b/packages/web/src/lib/api.generated.d.ts
@@ -3749,6 +3749,7 @@ export interface components {
       command?: string;
       prompt?: string;
       bash?: string;
+      timeout?: number;
       loop?: {
         until?: string;
         max_iterations: number;
@@ -3816,12 +3817,18 @@ export interface components {
          */
         join: 'all_success' | 'all_done' | 'first_success';
       };
-      with?: unknown;
       script?: string;
       /** @enum {string} */
       runtime?: 'bun' | 'uv';
       deps?: string[];
-      timeout?: number;
+      with?: {
+        [key: string]:
+          | unknown
+          | {
+              from: string;
+              if_skipped?: unknown;
+            };
+      };
     };
     /** @enum {string} */
     WorkflowSource: 'project' | 'bundled' | 'global';

--- a/packages/web/src/lib/api.generated.d.ts
+++ b/packages/web/src/lib/api.generated.d.ts
@@ -3821,14 +3821,7 @@ export interface components {
       /** @enum {string} */
       runtime?: 'bun' | 'uv';
       deps?: string[];
-      with?: {
-        [key: string]:
-          | unknown
-          | {
-              from: string;
-              if_skipped?: unknown;
-            };
-      };
+      with?: unknown;
     };
     /** @enum {string} */
     WorkflowSource: 'project' | 'bundled' | 'global';

--- a/packages/workflows/src/loader.test.ts
+++ b/packages/workflows/src/loader.test.ts
@@ -8564,8 +8564,7 @@ description: with on bash is dropped with a visible warning
 nodes:
   - id: run
     bash: echo hi
-    with:
-      v: x
+    with: [ignored]
 `);
     expect(workflow.nodes).toHaveLength(1);
     expect(

--- a/packages/workflows/src/schemas.test.ts
+++ b/packages/workflows/src/schemas.test.ts
@@ -840,11 +840,7 @@ describe('dagNodeSchema — per-node Pi posture (pi:)', () => {
 
 describe('dagNodeSchema — ExecNode', () => {
   test('derives authored exec fields from the resolved ExecNode owner', () => {
-    expect(dagNodeFlatSchema.shape.bash.unwrap()).toBe(execNodeSchema.shape.script);
-    expect(dagNodeFlatSchema.shape.script.unwrap()).toBe(execNodeSchema.shape.script);
     expect(dagNodeFlatSchema.shape.deps.unwrap()).toBe(execNodeSchema.shape.deps);
-    expect(dagNodeFlatSchema.shape.timeout.unwrap()).toBe(execNodeSchema.shape.timeout);
-    expect(dagNodeFlatSchema.shape.with.unwrap()).toBe(execNodeSchema.shape.with);
     expect(KNOWN_DAG_NODE_KEYS).toEqual(new Set(Object.keys(dagNodeFlatSchema.shape)));
 
     const authoredRuntime = dagNodeFlatSchema.shape.runtime.unwrap();
@@ -852,13 +848,16 @@ describe('dagNodeSchema — ExecNode', () => {
       execNodeSchema.shape.runtime.options.filter(runtime => runtime !== 'sh')
     );
 
-    const authored = dagNodeSchema.safeParse({ id: 's', script: '   ', runtime: 'bun' });
+    const raw = { id: 's', script: '   ', runtime: 'bun' };
+    const flat = dagNodeFlatSchema.safeParse(raw);
+    const authored = dagNodeSchema.safeParse(raw);
     const resolved = execNodeSchema.safeParse({
       id: 's',
       kind: 'exec',
       script: '   ',
       runtime: 'bun',
     });
+    expect(flat.success).toBe(true);
     expect(authored.success).toBe(false);
     expect(resolved.success).toBe(false);
     if (!authored.success && !resolved.success) {
@@ -970,6 +969,143 @@ describe('dagNodeSchema — ExecNode', () => {
         script: 'echo hi',
         runtime: 'sh',
       });
+    }
+  });
+
+  test('ignores deferred exec fields on every mode that does not select them', () => {
+    const cases: readonly {
+      name: string;
+      node: Record<string, unknown>;
+      ignored: Record<string, unknown>;
+    }[] = [
+      {
+        name: 'command',
+        node: { id: 'command', command: 'review' },
+        ignored: { bash: '   ', script: '   ', timeout: 0 },
+      },
+      {
+        name: 'prompt',
+        node: { id: 'prompt', prompt: 'Review this.' },
+        ignored: { bash: '   ', script: '   ', timeout: 0 },
+      },
+      {
+        name: 'loop',
+        node: {
+          id: 'loop',
+          loop: { prompt: 'Review this.', until: 'DONE', max_iterations: 1 },
+        },
+        ignored: { bash: '   ', script: '   ', timeout: 0 },
+      },
+      {
+        name: 'loop_group',
+        node: {
+          id: 'loop-group',
+          loop_group: {
+            until: 'DONE',
+            max_iterations: 1,
+            nodes: [{ id: 'review', prompt: 'Review this.' }],
+          },
+        },
+        ignored: { bash: '   ', script: '   ', timeout: 0 },
+      },
+      {
+        name: 'approval',
+        node: { id: 'approval', approval: { message: 'Continue?' } },
+        ignored: { bash: '   ', script: '   ', timeout: 0 },
+      },
+      {
+        name: 'wait',
+        node: { id: 'wait', wait: { duration_ms: 1 } },
+        ignored: { bash: '   ', script: '   ', timeout: 0 },
+      },
+      {
+        name: 'cancel',
+        node: { id: 'cancel', cancel: 'Stop.' },
+        ignored: { bash: '   ', script: '   ', timeout: 0 },
+      },
+      {
+        name: 'include',
+        node: { id: 'include', include: 'child' },
+        ignored: { bash: '   ', script: '   ', timeout: 0 },
+      },
+      {
+        name: 'workflow',
+        node: { id: 'workflow', workflow: 'child' },
+        ignored: { bash: '   ', script: '   ', timeout: 0 },
+      },
+      {
+        name: 'bash',
+        node: { id: 'bash', bash: 'echo hi' },
+        ignored: { script: '   ' },
+      },
+      {
+        name: 'script',
+        node: { id: 'script', script: 'console.log("hi")', runtime: 'bun' },
+        ignored: { bash: '   ' },
+      },
+    ];
+
+    for (const { name, node, ignored } of cases) {
+      const baseline = dagNodeSchema.safeParse(node);
+      const withIgnoredFields = dagNodeSchema.safeParse({ ...node, ...ignored });
+      expect(baseline.success, `${name} baseline`).toBe(true);
+      expect(withIgnoredFields.success, name).toBe(true);
+      if (baseline.success && withIgnoredFields.success) {
+        expect(withIgnoredFields.data, name).toEqual(baseline.data);
+      }
+    }
+  });
+
+  test('ignores unsupported with values on every mode that drops with', () => {
+    const cases: readonly { name: string; node: Record<string, unknown> }[] = [
+      { name: 'bash', node: { id: 'bash', bash: 'echo hi' } },
+      { name: 'prompt', node: { id: 'prompt', prompt: 'Review this.' } },
+      {
+        name: 'loop',
+        node: {
+          id: 'loop',
+          loop: { prompt: 'Review this.', until: 'DONE', max_iterations: 1 },
+        },
+      },
+      {
+        name: 'loop_group',
+        node: {
+          id: 'loop-group',
+          loop_group: {
+            until: 'DONE',
+            max_iterations: 1,
+            nodes: [{ id: 'review', prompt: 'Review this.' }],
+          },
+        },
+      },
+      { name: 'approval', node: { id: 'approval', approval: { message: 'Continue?' } } },
+      { name: 'wait', node: { id: 'wait', wait: { duration_ms: 1 } } },
+      { name: 'cancel', node: { id: 'cancel', cancel: 'Stop.' } },
+    ];
+
+    for (const { name, node } of cases) {
+      const baseline = dagNodeSchema.safeParse(node);
+      const withIgnoredValue = dagNodeSchema.safeParse({ ...node, with: ['ignored'] });
+      expect(baseline.success, `${name} baseline`).toBe(true);
+      expect(withIgnoredValue.success, name).toBe(true);
+      if (baseline.success && withIgnoredValue.success) {
+        expect(withIgnoredValue.data, name).toEqual(baseline.data);
+      }
+    }
+  });
+
+  test('validates with against the exec owner after script mode is selected', () => {
+    const result = dagNodeSchema.safeParse({
+      id: 'script',
+      script: 'console.log("hi")',
+      runtime: 'bun',
+      with: ['not-a-map'],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe(
+        "'with' on script nodes must be an object mapping input names to values"
+      );
     }
   });
 

--- a/packages/workflows/src/schemas.test.ts
+++ b/packages/workflows/src/schemas.test.ts
@@ -1109,6 +1109,35 @@ describe('dagNodeSchema — ExecNode', () => {
     }
   });
 
+  // The command and script paths must reject the same authored input names. They
+  // reached one validator before the owner-derived split; a script path that skips
+  // validateWithShape silently widens the accepted key grammar for scripts only.
+  test('rejects an invalid input name on script with, exactly as command does', () => {
+    const script = dagNodeSchema.safeParse({
+      id: 'script',
+      script: 'console.log("hi")',
+      runtime: 'bun',
+      with: { '1bad': 'value' },
+    });
+    const command = dagNodeSchema.safeParse({
+      id: 'command',
+      command: 'thing',
+      with: { '1bad': 'value' },
+    });
+    expect(script.success).toBe(false);
+    expect(command.success).toBe(false);
+    if (!script.success && !command.success) {
+      const nameIssue = (issues: readonly { message: string }[]) =>
+        issues.find(i => /invalid (script|command) input name/.test(i.message))?.message;
+      expect(nameIssue(script.error.issues)).toBe(
+        "invalid script input name '1bad'; use letters, numbers, underscores, or hyphens and start with a letter or underscore"
+      );
+      expect(nameIssue(command.error.issues)).toBe(
+        "invalid command input name '1bad'; use letters, numbers, underscores, or hyphens and start with a letter or underscore"
+      );
+    }
+  });
+
   test('rejects empty script string', () => {
     const result = dagNodeSchema.safeParse({ id: 's', script: '', runtime: 'bun' });
     expect(result.success).toBe(false);

--- a/packages/workflows/src/schemas.test.ts
+++ b/packages/workflows/src/schemas.test.ts
@@ -13,11 +13,14 @@ import {
   LOOP_NODE_AI_FIELDS,
   LOOP_GROUP_NODE_AI_FIELDS,
   INCLUDE_NODE_IGNORED_FIELDS,
+  KNOWN_DAG_NODE_KEYS,
   WAIT_NODE_IGNORED_FIELDS,
   WORKFLOW_NODE_IGNORED_FIELDS,
   BASH_NODE_AI_FIELDS,
   approvalOnRejectSchema,
+  dagNodeFlatSchema,
   dagNodeSchema,
+  execNodeSchema,
   MAX_DURABLE_WAIT_MS,
   waitConfigSchema,
   inputEnvKey,
@@ -836,6 +839,33 @@ describe('dagNodeSchema — per-node Pi posture (pi:)', () => {
 // ---------------------------------------------------------------------------
 
 describe('dagNodeSchema — ExecNode', () => {
+  test('derives authored exec fields from the resolved ExecNode owner', () => {
+    expect(dagNodeFlatSchema.shape.bash.unwrap()).toBe(execNodeSchema.shape.script);
+    expect(dagNodeFlatSchema.shape.script.unwrap()).toBe(execNodeSchema.shape.script);
+    expect(dagNodeFlatSchema.shape.deps.unwrap()).toBe(execNodeSchema.shape.deps);
+    expect(dagNodeFlatSchema.shape.timeout.unwrap()).toBe(execNodeSchema.shape.timeout);
+    expect(dagNodeFlatSchema.shape.with.unwrap()).toBe(execNodeSchema.shape.with);
+    expect(KNOWN_DAG_NODE_KEYS).toEqual(new Set(Object.keys(dagNodeFlatSchema.shape)));
+
+    const authoredRuntime = dagNodeFlatSchema.shape.runtime.unwrap();
+    expect(authoredRuntime.options).toEqual(
+      execNodeSchema.shape.runtime.options.filter(runtime => runtime !== 'sh')
+    );
+
+    const authored = dagNodeSchema.safeParse({ id: 's', script: '   ', runtime: 'bun' });
+    const resolved = execNodeSchema.safeParse({
+      id: 's',
+      kind: 'exec',
+      script: '   ',
+      runtime: 'bun',
+    });
+    expect(authored.success).toBe(false);
+    expect(resolved.success).toBe(false);
+    if (!authored.success && !resolved.success) {
+      expect(authored.error.issues[0]?.message).toBe(resolved.error.issues[0]?.message);
+    }
+  });
+
   test('parses a bun script node with inline script', () => {
     const result = dagNodeSchema.safeParse({
       id: 'fetch',
@@ -922,6 +952,25 @@ describe('dagNodeSchema — ExecNode', () => {
       runtime: 'node',
     });
     expect(result.success).toBe(false);
+  });
+
+  test("keeps the internal 'sh' runtime behind the authored bash projection", () => {
+    const authoredScript = dagNodeSchema.safeParse({
+      id: 's',
+      script: 'echo hi',
+      runtime: 'sh',
+    });
+    expect(authoredScript.success).toBe(false);
+
+    const authoredBash = dagNodeSchema.safeParse({ id: 's', bash: 'echo hi' });
+    expect(authoredBash.success).toBe(true);
+    if (authoredBash.success) {
+      expect(authoredBash.data).toMatchObject({
+        kind: 'exec',
+        script: 'echo hi',
+        runtime: 'sh',
+      });
+    }
   });
 
   test('rejects empty script string', () => {

--- a/packages/workflows/src/schemas/dag-node.ts
+++ b/packages/workflows/src/schemas/dag-node.ts
@@ -31,7 +31,6 @@ import {
   parseWholeInputsRef,
   OUTPUT_REF_SOURCE,
   INPUT_NAME_SOURCE,
-  type JsonValue,
 } from '../output-ref';
 import {
   BASE_COMPLETION_CHANNELS,
@@ -299,6 +298,8 @@ export const bindingDirectiveSchema = z.strictObject({
 
 export type BindingDirective = z.infer<typeof bindingDirectiveSchema>;
 
+const nodeBindingsSchema = z.record(z.string(), z.union([jsonValueSchema, bindingDirectiveSchema]));
+
 /**
  * Runtime guard for a command/script `with:` value: loader-validated maps only ever
  * hold a directive in object position, but programmatic definitions bypass the
@@ -331,7 +332,7 @@ export const promptSourceSchema = z.discriminatedUnion('kind', [
     // `$INPUTS.<name>` surface. Strings may hold refs/templates; a whole
     // `$node.output[.field]` ref passes the logical value; objects are binding
     // directives ({ from, if_skipped }) — validated in dagNodeSchema's superRefine.
-    with: z.record(z.string(), z.union([jsonValueSchema, bindingDirectiveSchema])).optional(),
+    with: nodeBindingsSchema.optional(),
   }),
 ]);
 
@@ -383,26 +384,25 @@ export type AgentNode = z.infer<typeof agentNodeSchema>;
  * drift, not evidence for merging — they're filed as their own fixes, #2725 and
  * #2726, rather than folded into this call.
  */
+const execScriptInputSchema = z.string();
+const execTimeoutInputSchema = z.number();
+
 export const execNodeSchema = dagNodeBaseSchema.extend({
   kind: z.literal('exec'),
-  script: z
-    .string()
-    .trim()
-    .min(1, {
-      error: issue =>
-        issue.path?.at(-1) === 'bash' ? 'bash script cannot be empty' : 'script cannot be empty',
-    }),
+  script: execScriptInputSchema.trim().min(1, {
+    error: issue =>
+      issue.path?.at(-1) === 'bash' ? 'bash script cannot be empty' : 'script cannot be empty',
+  }),
   runtime: z.enum(['sh', 'bun', 'uv']),
   deps: z.array(z.string().min(1, 'each dep must be a non-empty string')).optional(),
-  timeout: z
-    .number()
+  timeout: execTimeoutInputSchema
     .positive("'timeout' must be a positive number (ms)")
     .finite("'timeout' must be a positive number (ms)")
     .optional(),
   // Node-local named bindings (#2637): delivered as INPUTS_<UPPER_SNAKE> env vars.
   // Same value grammar as an agent node's command-sourced `with:`. Only meaningful
   // (and only ever populated) when `runtime !== 'sh'`.
-  with: z.record(z.string(), z.union([jsonValueSchema, bindingDirectiveSchema])).optional(),
+  with: nodeBindingsSchema.optional(),
 });
 
 /** DAG node that runs a shell script, or a TypeScript/Python script via bun or uv, without AI */
@@ -424,6 +424,20 @@ const scriptExecAuthoringSchema = execNodeSchema
   .extend({
     runtime: execNodeSchema.shape.runtime.exclude(['sh']),
   });
+
+// The flat schema must accept legacy ignored values until a node mode is known.
+// Selected bash/script nodes are validated against the strict projections in
+// dagNodeSchema; other modes keep dropping these fields as they did before.
+const bashExecFlatSchema = bashExecAuthoringSchema.extend({
+  bash: execScriptInputSchema,
+  timeout: execTimeoutInputSchema.optional(),
+} satisfies Partial<Record<keyof typeof bashExecAuthoringSchema.shape, z.ZodType>>);
+
+const scriptExecFlatSchema = scriptExecAuthoringSchema.extend({
+  script: execScriptInputSchema,
+  timeout: execTimeoutInputSchema.optional(),
+  with: z.unknown().optional(),
+} satisfies Partial<Record<keyof typeof scriptExecAuthoringSchema.shape, z.ZodType>>);
 
 type BashExecAuthoring = z.infer<typeof bashExecAuthoringSchema>;
 type ScriptExecAuthoring = z.infer<typeof scriptExecAuthoringSchema>;
@@ -1070,7 +1084,7 @@ export const dagNodeFlatSchema = dagNodeBaseSchema.extend({
   // Mode fields (exactly one required)
   command: z.string().optional(),
   prompt: z.string().optional(),
-  ...bashExecAuthoringSchema.partial().shape,
+  ...bashExecFlatSchema.partial().shape,
   loop: loopNodeConfigSchema.optional(),
   loop_group: loopGroupNodeConfigSchema.optional(),
   approval: approvalConfigSchema.optional(),
@@ -1091,10 +1105,7 @@ export const dagNodeFlatSchema = dagNodeBaseSchema.extend({
   // `workflow:` node it multiplies child runs (#2121 slice 2); on an `include:` node it
   // multiplies the composed body inside this run (#2512). Guarded in superRefine.
   fan_out: fanOutConfigSchema.optional(),
-  // `bash:` and `script:` are authored projections of the resolved ExecNode contract.
-  // The projection keeps the authored runtime vocabulary narrower: shell execution is
-  // selected by `bash:`, while `script:` admits only the non-shell runtimes.
-  ...scriptExecAuthoringSchema.partial().shape,
+  ...scriptExecFlatSchema.partial().shape,
 });
 
 // ---------------------------------------------------------------------------
@@ -1134,6 +1145,17 @@ export const dagNodeSchema = z
   .preprocess(rejectRetiredThinking, dagNodeFlatSchema)
   .superRefine((data, ctx) => {
     const id = data.id.trim();
+    const addSchemaIssues = (
+      issues: readonly { message: string; path?: readonly PropertyKey[] }[]
+    ): void => {
+      for (const issue of issues) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: issue.message,
+          ...(issue.path !== undefined ? { path: [...issue.path] } : {}),
+        });
+      }
+    };
 
     // id must be non-empty
     if (!id) {
@@ -1185,6 +1207,32 @@ export const dagNodeSchema = z
           "'command', 'prompt', 'bash', 'loop', 'loop_group', 'approval', 'wait', 'cancel', 'script', 'include', and 'workflow' are mutually exclusive",
       });
       return z.NEVER;
+    }
+
+    const bashAuthoring = hasBash ? bashExecAuthoringSchema.partial().safeParse(data) : undefined;
+    if (bashAuthoring && !bashAuthoring.success) {
+      addSchemaIssues(bashAuthoring.error.issues);
+    }
+
+    const scriptAuthoring = hasScript
+      ? scriptExecAuthoringSchema.partial().safeParse(data)
+      : undefined;
+    if (scriptAuthoring && !scriptAuthoring.success) {
+      for (const issue of scriptAuthoring.error.issues) {
+        if (issue.path[0] === 'with') {
+          const key = issue.path.at(1);
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message:
+              typeof key === 'string'
+                ? `script input '${key}' must be a JSON-compatible value (string, number, boolean, null, array, or object)`
+                : "'with' on script nodes must be an object mapping input names to values",
+            path: ['with'],
+          });
+        } else {
+          addSchemaIssues([issue]);
+        }
+      }
     }
 
     // 'decisions' (#2707 step 1, the new authoring surface) and 'on_reject' (the
@@ -1240,17 +1288,41 @@ export const dagNodeSchema = z
     // `with:` is an identifier-keyed JSON-value map on include and workflow nodes
     // (#2470, values widened from string-only in #2637). For includes it inlines at
     // load time (applyInputsMacro); for sub-runs it becomes `$INPUTS.<name>` runtime
-    // variables on the child. Its value type comes from the ExecNode projection above;
-    // mode-specific key and binding-directive rules remain contextual here.
+    // variables on the child. The flat field remains unknown until a mode is selected,
+    // so node types that historically ignored `with:` keep accepting and dropping it.
     const validateWithShape = (
       kind: 'include' | 'workflow' | 'command' | 'script'
-    ): NonNullable<typeof data.with> => {
-      const map = data.with ?? {};
-      for (const key of Object.keys(map)) {
+    ): Record<string, unknown> | undefined => {
+      const prototype =
+        typeof data.with === 'object' && data.with !== null
+          ? Object.getPrototypeOf(data.with)
+          : undefined;
+      if (
+        typeof data.with !== 'object' ||
+        data.with === null ||
+        Array.isArray(data.with) ||
+        (prototype !== Object.prototype && prototype !== null)
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `'with' on ${kind} nodes must be an object mapping input names to values`,
+          path: ['with'],
+        });
+        return undefined;
+      }
+      const map = data.with as Record<string, unknown>;
+      for (const [key, value] of Object.entries(map)) {
         if (!INPUT_NAME_PATTERN.test(key)) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             message: `invalid ${kind} input name '${key}'; use letters, numbers, underscores, or hyphens and start with a letter or underscore`,
+            path: ['with'],
+          });
+        }
+        if (!jsonValueSchema.safeParse(value).success) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `${kind} input '${key}' must be a JSON-compatible value (string, number, boolean, null, array, or object)`,
             path: ['with'],
           });
         }
@@ -1260,9 +1332,10 @@ export const dagNodeSchema = z
     // Node-local bindings on command/script nodes (#2637): same key/value grammar as
     // include/workflow `with:`, plus the object position is RESERVED for the binding
     // directive — any other object shape is rejected naming both accepted forms.
-    const validateNodeBindings = (kind: 'command' | 'script'): void => {
-      const map = validateWithShape(kind);
-      if (map === undefined) return;
+    const validateNodeBindings = (
+      kind: 'command' | 'script',
+      map: Record<string, unknown>
+    ): void => {
       // Two names folding to one INPUTS_<UPPER_SNAKE> env key would silently clobber
       // each other on script env delivery — same rule the loader enforces for a
       // workflow's declared `inputs:` block, applied here where the map is visible.
@@ -1313,8 +1386,13 @@ export const dagNodeSchema = z
     };
     if (hasInclude && data.with !== undefined) validateWithShape('include');
     if (hasWorkflow && data.with !== undefined) validateWithShape('workflow');
-    if (hasCommand && data.with !== undefined) validateNodeBindings('command');
-    if (hasScript && data.with !== undefined) validateNodeBindings('script');
+    if (hasCommand && data.with !== undefined) {
+      const bindings = validateWithShape('command');
+      if (bindings !== undefined) validateNodeBindings('command', bindings);
+    }
+    if (scriptAuthoring?.success && scriptAuthoring.data.with !== undefined) {
+      validateNodeBindings('script', scriptAuthoring.data.with);
+    }
     // A `workflow:` node has ONE input channel per invocation: either the untyped
     // `input:` string ($ARGUMENTS) or the named `with:` map ($INPUTS.<name>). Accepting
     // both would require a precedence rule between two overlapping channels — the exact
@@ -1448,12 +1526,26 @@ export const dagNodeSchema = z
     }
 
     if (modeCount === 0) {
+      if (typeof data.bash === 'string') {
+        const result = bashExecAuthoringSchema.pick({ bash: true }).safeParse(data);
+        if (!result.success) {
+          addSchemaIssues(result.error.issues);
+        }
+        return z.NEVER;
+      }
       if (typeof data.prompt === 'string') {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: 'prompt cannot be empty',
           path: ['prompt'],
         });
+        return z.NEVER;
+      }
+      if (typeof data.script === 'string') {
+        const result = scriptExecAuthoringSchema.pick({ script: true }).safeParse(data);
+        if (!result.success) {
+          addSchemaIssues(result.error.issues);
+        }
         return z.NEVER;
       }
       ctx.addIssue({
@@ -1651,10 +1743,6 @@ export const dagNodeSchema = z
       ...(data.persist_session !== undefined ? { persist_session: data.persist_session } : {}),
     };
 
-    // Node-local bindings (#2637) — validated by validateNodeBindings above; carried
-    // only by the command/script variants (other modes keep stripping the field).
-    const nodeBindings = data.with !== undefined ? { with: data.with } : {};
-
     if (data.command !== undefined && data.command.trim().length > 0) {
       return {
         ...base,
@@ -1664,7 +1752,7 @@ export const dagNodeSchema = z
         source: {
           kind: 'command',
           name: data.command.trim(),
-          ...nodeBindings,
+          ...(data.with !== undefined ? { with: nodeBindingsSchema.parse(data.with) } : {}),
         },
       } as AgentNode;
     }
@@ -1753,7 +1841,9 @@ export const dagNodeSchema = z
           ...structuralBase,
           kind: 'compose_fan_out',
           include: data.include.trim(),
-          ...(data.with !== undefined ? { with: data.with as Record<string, JsonValue> } : {}),
+          ...(data.with !== undefined
+            ? { with: composeFanOutNodeSchema.shape.with.unwrap().parse(data.with) }
+            : {}),
           fan_out: data.fan_out,
         } as ComposeFanOutNode;
       }
@@ -1767,7 +1857,9 @@ export const dagNodeSchema = z
         ...structuralBase,
         kind: 'include',
         include: data.include.trim(),
-        ...(data.with !== undefined ? { with: data.with as Record<string, JsonValue> } : {}),
+        ...(data.with !== undefined
+          ? { with: includeDirectiveSchema.shape.with.unwrap().parse(data.with) }
+          : {}),
       } as IncludeDirective;
     }
     if (data.workflow !== undefined && data.workflow.trim().length > 0) {
@@ -1787,7 +1879,9 @@ export const dagNodeSchema = z
         // `with:` supplies named $INPUTS to the child sub-run (#2470), validated in shape
         // by the superRefine above and mutually exclusive with `input:`. Mirrors the
         // include transform's `with` assembly.
-        ...(data.with !== undefined ? { with: data.with as Record<string, JsonValue> } : {}),
+        ...(data.with !== undefined
+          ? { with: workflowNodeSchema.shape.with.unwrap().parse(data.with) }
+          : {}),
         // Isolation is EXPLICIT-ONLY — never inferred, including from `fan_out`. How many
         // children a node spawns says nothing about whether they write; N review or
         // research children over the shared checkout is the common case. A shared-checkout

--- a/packages/workflows/src/schemas/dag-node.ts
+++ b/packages/workflows/src/schemas/dag-node.ts
@@ -385,10 +385,20 @@ export type AgentNode = z.infer<typeof agentNodeSchema>;
  */
 export const execNodeSchema = dagNodeBaseSchema.extend({
   kind: z.literal('exec'),
-  script: z.string().min(1, 'script cannot be empty'),
+  script: z
+    .string()
+    .trim()
+    .min(1, {
+      error: issue =>
+        issue.path?.at(-1) === 'bash' ? 'bash script cannot be empty' : 'script cannot be empty',
+    }),
   runtime: z.enum(['sh', 'bun', 'uv']),
   deps: z.array(z.string().min(1, 'each dep must be a non-empty string')).optional(),
-  timeout: z.number().optional(),
+  timeout: z
+    .number()
+    .positive("'timeout' must be a positive number (ms)")
+    .finite("'timeout' must be a positive number (ms)")
+    .optional(),
   // Node-local named bindings (#2637): delivered as INPUTS_<UPPER_SNAKE> env vars.
   // Same value grammar as an agent node's command-sourced `with:`. Only meaningful
   // (and only ever populated) when `runtime !== 'sh'`.
@@ -397,6 +407,51 @@ export const execNodeSchema = dagNodeBaseSchema.extend({
 
 /** DAG node that runs a shell script, or a TypeScript/Python script via bun or uv, without AI */
 export type ExecNode = z.infer<typeof execNodeSchema>;
+
+const bashExecAuthoringSchema = z.object({
+  bash: execNodeSchema.shape.script,
+  timeout: execNodeSchema.shape.timeout,
+});
+
+const scriptExecAuthoringSchema = execNodeSchema
+  .pick({
+    script: true,
+    runtime: true,
+    deps: true,
+    timeout: true,
+    with: true,
+  })
+  .extend({
+    runtime: execNodeSchema.shape.runtime.exclude(['sh']),
+  });
+
+type BashExecAuthoring = z.infer<typeof bashExecAuthoringSchema>;
+type ScriptExecAuthoring = z.infer<typeof scriptExecAuthoringSchema>;
+type ResolvedExecAuthoring = Pick<ExecNode, 'script' | 'runtime' | 'deps' | 'timeout' | 'with'>;
+
+function resolveBashExecAuthoring({ bash, timeout }: BashExecAuthoring): ResolvedExecAuthoring {
+  return {
+    script: bash,
+    runtime: 'sh',
+    ...(timeout !== undefined ? { timeout } : {}),
+  };
+}
+
+function resolveScriptExecAuthoring({
+  script,
+  runtime,
+  deps,
+  timeout,
+  with: bindings,
+}: ScriptExecAuthoring): ResolvedExecAuthoring {
+  return {
+    script,
+    runtime,
+    ...(deps !== undefined ? { deps } : {}),
+    ...(timeout !== undefined ? { timeout } : {}),
+    ...(bindings !== undefined ? { with: bindings } : {}),
+  };
+}
 
 /**
  * Loop node schema — extends base with `loop` config.
@@ -1015,7 +1070,7 @@ export const dagNodeFlatSchema = dagNodeBaseSchema.extend({
   // Mode fields (exactly one required)
   command: z.string().optional(),
   prompt: z.string().optional(),
-  bash: z.string().optional(),
+  ...bashExecAuthoringSchema.partial().shape,
   loop: loopNodeConfigSchema.optional(),
   loop_group: loopGroupNodeConfigSchema.optional(),
   approval: approvalConfigSchema.optional(),
@@ -1036,17 +1091,10 @@ export const dagNodeFlatSchema = dagNodeBaseSchema.extend({
   // `workflow:` node it multiplies child runs (#2121 slice 2); on an `include:` node it
   // multiplies the composed body inside this run (#2512). Guarded in superRefine.
   fan_out: fanOutConfigSchema.optional(),
-  // Raw (not `z.record(z.string(), z.string())`) so each relevant node mode validates it
-  // contextually. Include and workflow nodes both accept the same identifier-keyed string
-  // map, validate it in superRefine, and retain it in their transform. Other node modes
-  // strip it with the rest of their unsupported surface.
-  with: z.unknown().optional(),
-  // Script-only
-  script: z.string().optional(),
-  runtime: z.enum(['bun', 'uv']).optional(),
-  deps: z.array(z.string().min(1, 'each dep must be a non-empty string')).optional(),
-  // Bash/Script shared
-  timeout: z.number().optional(),
+  // `bash:` and `script:` are authored projections of the resolved ExecNode contract.
+  // The projection keeps the authored runtime vocabulary narrower: shell execution is
+  // selected by `bash:`, while `script:` admits only the non-shell runtimes.
+  ...scriptExecAuthoringSchema.partial().shape,
 });
 
 // ---------------------------------------------------------------------------
@@ -1192,42 +1240,17 @@ export const dagNodeSchema = z
     // `with:` is an identifier-keyed JSON-value map on include and workflow nodes
     // (#2470, values widened from string-only in #2637). For includes it inlines at
     // load time (applyInputsMacro); for sub-runs it becomes `$INPUTS.<name>` runtime
-    // variables on the child. The flat field stays `z.unknown()` so other node
-    // variants validate it contextually. Returns the validated plain-object map, or
-    // undefined when the surrounding shape is wrong (issues already added).
+    // variables on the child. Its value type comes from the ExecNode projection above;
+    // mode-specific key and binding-directive rules remain contextual here.
     const validateWithShape = (
       kind: 'include' | 'workflow' | 'command' | 'script'
-    ): Record<string, unknown> | undefined => {
-      const prototype =
-        typeof data.with === 'object' && data.with !== null
-          ? Object.getPrototypeOf(data.with)
-          : undefined;
-      if (
-        typeof data.with !== 'object' ||
-        data.with === null ||
-        Array.isArray(data.with) ||
-        (prototype !== Object.prototype && prototype !== null)
-      ) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `'with' on ${kind} nodes must be an object mapping input names to values`,
-          path: ['with'],
-        });
-        return undefined;
-      }
-      const map = data.with as Record<string, unknown>;
-      for (const [key, value] of Object.entries(map)) {
+    ): NonNullable<typeof data.with> => {
+      const map = data.with ?? {};
+      for (const key of Object.keys(map)) {
         if (!INPUT_NAME_PATTERN.test(key)) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             message: `invalid ${kind} input name '${key}'; use letters, numbers, underscores, or hyphens and start with a letter or underscore`,
-            path: ['with'],
-          });
-        }
-        if (!jsonValueSchema.safeParse(value).success) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: `${kind} input '${key}' must be a JSON-compatible value (string, number, boolean, null, array, or object)`,
             path: ['with'],
           });
         }
@@ -1425,27 +1448,11 @@ export const dagNodeSchema = z
     }
 
     if (modeCount === 0) {
-      if (typeof data.bash === 'string') {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: 'bash script cannot be empty',
-          path: ['bash'],
-        });
-        return z.NEVER;
-      }
       if (typeof data.prompt === 'string') {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: 'prompt cannot be empty',
           path: ['prompt'],
-        });
-        return z.NEVER;
-      }
-      if (typeof data.script === 'string') {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: 'script cannot be empty',
-          path: ['script'],
         });
         return z.NEVER;
       }
@@ -1466,17 +1473,6 @@ export const dagNodeSchema = z
       });
     }
 
-    // Bash node validations
-    if (hasBash) {
-      if (data.timeout !== undefined && (data.timeout <= 0 || !isFinite(data.timeout))) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: "'timeout' must be a positive number (ms)",
-          path: ['timeout'],
-        });
-      }
-    }
-
     // Script node validations
     if (hasScript) {
       if (data.runtime === undefined) {
@@ -1484,13 +1480,6 @@ export const dagNodeSchema = z
           code: z.ZodIssueCode.custom,
           message: "'runtime' is required for script nodes ('bun' or 'uv')",
           path: ['runtime'],
-        });
-      }
-      if (data.timeout !== undefined && (data.timeout <= 0 || !isFinite(data.timeout))) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: "'timeout' must be a positive number (ms)",
-          path: ['timeout'],
         });
       }
     }
@@ -1664,10 +1653,7 @@ export const dagNodeSchema = z
 
     // Node-local bindings (#2637) — validated by validateNodeBindings above; carried
     // only by the command/script variants (other modes keep stripping the field).
-    const nodeBindings =
-      data.with !== undefined
-        ? { with: data.with as Record<string, JsonValue | BindingDirective> }
-        : {};
+    const nodeBindings = data.with !== undefined ? { with: data.with } : {};
 
     if (data.command !== undefined && data.command.trim().length > 0) {
       return {
@@ -1696,24 +1682,16 @@ export const dagNodeSchema = z
         ...base,
         ...shared,
         kind: 'exec',
-        script: data.bash.trim(),
-        runtime: 'sh',
-        ...(data.timeout !== undefined ? { timeout: data.timeout } : {}),
-      } as ExecNode;
+        ...resolveBashExecAuthoring(bashExecAuthoringSchema.parse(data)),
+      } satisfies ExecNode;
     }
     if (data.script !== undefined && data.script.trim().length > 0) {
-      // runtime is guaranteed by superRefine to be defined at this point
-      if (!data.runtime) throw new Error('unreachable: runtime must be defined for script nodes');
       return {
         ...base,
         ...shared,
         kind: 'exec',
-        script: data.script.trim(),
-        runtime: data.runtime,
-        ...(data.deps !== undefined ? { deps: data.deps } : {}),
-        ...(data.timeout !== undefined ? { timeout: data.timeout } : {}),
-        ...nodeBindings,
-      } as ExecNode;
+        ...resolveScriptExecAuthoring(scriptExecAuthoringSchema.parse(data)),
+      } satisfies ExecNode;
     }
     if (data.approval !== undefined) {
       // Two mechanisms, mutually exclusive (enforced by the superRefine below):

--- a/packages/workflows/src/schemas/dag-node.ts
+++ b/packages/workflows/src/schemas/dag-node.ts
@@ -1391,7 +1391,11 @@ export const dagNodeSchema = z
       if (bindings !== undefined) validateNodeBindings('command', bindings);
     }
     if (scriptAuthoring?.success && scriptAuthoring.data.with !== undefined) {
-      validateNodeBindings('script', scriptAuthoring.data.with);
+      // Shape, input-name, and JSON-value checks live in validateWithShape; the
+      // command path above calls it for the same reason. Skipping it here would
+      // accept a script `with:` key that command rejects.
+      const bindings = validateWithShape('script');
+      if (bindings !== undefined) validateNodeBindings('script', bindings);
     }
     // A `workflow:` node has ONE input channel per invocation: either the untyped
     // `input:` string ($ARGUMENTS) or the named `with:` map ($INPUTS.<name>). Accepting


### PR DESCRIPTION
## Problem and outcome

The authored flat DAG-node schema independently restated fields owned by the resolved `ExecNode` schema, and the copies had drifted. This made constraints and generated API types depend on two declarations.

- **Outcome:** Authored `bash:` and `script:` fields now project from the owning exec schema while retaining authored YAML's `bash:` to `runtime: 'sh'` mapping and `script:` restriction to `bun|uv`.
- **Invariant:** Existing authored nodes resolve to the same `DagNode` values, invalid mode combinations remain rejected, and `KNOWN_DAG_NODE_KEYS` remains derived from the flat schema.
- **Scope boundary:** This does not add YAML fields, expression capabilities, topology behavior, or #2937's template-slot classification work.

## Review guidance

- **Feedback requested:** Confirm the authored-to-resolved projections preserve the intended YAML/runtime boundary.
- **Start here:** `packages/workflows/src/schemas/dag-node.ts:411` — the typed authored projections derive shared fields from `execNodeSchema` and explicitly resolve them to `ExecNode` values.
- **Review order:** Review the projections and transforms, then the focused schema evidence, then the regenerated API declaration.
- **Lower-attention areas:** `packages/web/src/lib/api.generated.d.ts` is generated by `bun run --cwd packages/server generate:api-types`; repository validation checks it is current.
- **Known risk or uncertainty:** None.

## Solution

The flat schema spreads partial typed authoring projections instead of declaring exec fields again. The bash projection shares the resolved script and timeout constraints; the script projection picks the resolved fields and narrows only runtime to exclude internal `sh`. Transform helpers make both authored forms resolve to `ExecNode`-checked values. Contextual binding-name rules remain mode-specific.

## Validation

- `bun test packages/workflows/src/schemas.test.ts` — passed (199 tests); proves shared schema ownership, authored/runtime projection, and derived known keys.
- `bun test packages/workflows/src/subrun.test.ts --test-name-pattern "late resolution is a deliberate affordance"` — passed (9 tests); preserves spawn-time validation of runtime-authored child workflows.
- `bun run --cwd packages/workflows test` — passed.
- `bun run validate` — passed, including generated API types, type checks, lint, format, installer tests, and repository tests.
- **Not verified:** Nothing material; the full repository validation and focused regression coverage passed.

## Links

- Closes #3125


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workflow validation for command and script nodes.
  - Ensured scripts contain non-empty content and use valid, positive timeouts.
  - Standardized binding validation across prompts, commands, and scripts, including environment keys and JSON values.
  - Improved handling of unsupported fields and bindings, with ignored values reported through visible warnings instead of workflow errors.
  - Ensured script-specific fields are validated only for applicable execution modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->