### PR TITLE
Fork-PR launches no longer fail on concurrent Git ref-lock races

### DIFF
--- a/packages/git/src/git.test.ts
+++ b/packages/git/src/git.test.ts
@@ -2547,6 +2547,90 @@ branch refs/heads/feature/auth
     });
   });
 
+  describe('fetchWithRefLockRetry', () => {
+    let execSpy: Mock<typeof git.execFileAsync>;
+
+    beforeEach(() => {
+      execSpy = spyOn(git, 'execFileAsync');
+    });
+
+    afterEach(() => {
+      execSpy.mockRestore();
+    });
+
+    test('retries the ref-lock race and succeeds on a later attempt', async () => {
+      const raceError = new Error(
+        "error: cannot lock ref 'refs/heads/pr-42-review': is at de581e24 but expected 8eaa8d42\n" +
+          '! 8eaa8d420..de581e24b pr-42-review -> pr-42-review (unable to update local ref)'
+      );
+      let fetchCalls = 0;
+
+      execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
+        expect(args).toEqual([
+          '-C',
+          '/workspace/repo',
+          'fetch',
+          'origin',
+          'pull/42/head:pr-42-review',
+        ]);
+        fetchCalls++;
+        if (fetchCalls === 1) {
+          throw raceError;
+        }
+        return { stdout: '', stderr: '' };
+      });
+
+      await expect(
+        git.fetchWithRefLockRetry(repo('/workspace/repo'), 'origin', 'pull/42/head:pr-42-review')
+      ).resolves.toEqual({ stdout: '', stderr: '' });
+
+      expect(fetchCalls).toBe(2);
+    });
+
+    test('rethrows the original error object after exhausting the budget', async () => {
+      const raceText =
+        "error: cannot lock ref 'refs/heads/pr-42-review': is at de581e24 but expected 8eaa8d42\n" +
+        '! 8eaa8d420..de581e24b pr-42-review -> pr-42-review (unable to update local ref)';
+      const raceError = Object.assign(new Error(raceText), { stderr: 'original stderr evidence' });
+      let fetchCalls = 0;
+
+      execSpy.mockImplementation(async () => {
+        fetchCalls++;
+        throw raceError;
+      });
+
+      let caught: unknown;
+      try {
+        await git.fetchWithRefLockRetry(
+          repo('/workspace/repo'),
+          'origin',
+          'pull/42/head:pr-42-review'
+        );
+      } catch (error) {
+        caught = error;
+      }
+
+      // Original object identity: stderr evidence survives for callers
+      expect(caught).toBe(raceError);
+      expect(fetchCalls).toBe(4); // 1 initial + 3 retries
+    });
+
+    test('attempts non-race errors exactly once', async () => {
+      let fetchCalls = 0;
+
+      execSpy.mockImplementation(async () => {
+        fetchCalls++;
+        throw new Error("fatal: 'origin' does not appear to be a git repository");
+      });
+
+      await expect(
+        git.fetchWithRefLockRetry(repo('/workspace/repo'), 'origin', 'main')
+      ).rejects.toThrow("fatal: 'origin' does not appear to be a git repository");
+
+      expect(fetchCalls).toBe(1);
+    });
+  });
+
   describe('getDefaultRemote', () => {
     let execSpy: Mock<typeof git.execFileAsync>;
 

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -59,6 +59,7 @@ export {
   getRemoteUrl,
   listChildRepos,
   syncWorkspace,
+  fetchWithRefLockRetry,
   cloneRepository,
   validateCloneUrl,
   syncRepository,

--- a/packages/git/src/repo.ts
+++ b/packages/git/src/repo.ts
@@ -127,6 +127,52 @@ export async function getRemoteUrl(repoPath: RepoPath, remote = 'origin'): Promi
   }
 }
 
+const MAX_FETCH_RETRIES = 3;
+
+/**
+ * Run `git fetch <remote> <refspec>` with bounded retry on Git's ref-lock race.
+ *
+ * Two concurrent fetches that write the same named ref — a remote-tracking ref,
+ * or a local branch via a `pull/N/head:branch` refspec — collide on Git's shared
+ * lock file and fail transiently with `cannot lock ref ... unable to update local
+ * ref`. This helper owns the single ref-lock classifier and backoff budget for
+ * the codebase: race failures are retried up to MAX_FETCH_RETRIES times with
+ * 50ms doubling backoff, then the original error object is rethrown untouched
+ * (stderr preserved for callers). Any other failure is rethrown immediately —
+ * unrelated git errors are attempted once and stay loud.
+ */
+export async function fetchWithRefLockRetry(
+  repoPath: RepoPath,
+  remote: string,
+  refspec: string,
+  options?: { timeoutMs?: number }
+): Promise<{ stdout: string; stderr: string }> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await execFileAsync('git', ['-C', repoPath, 'fetch', remote, refspec], {
+        timeout: options?.timeoutMs,
+      });
+    } catch (error) {
+      const err = error as Error;
+      const errorMessage = err.message.toLowerCase();
+      const isRefLockRace =
+        errorMessage.includes('cannot lock ref') &&
+        errorMessage.includes('unable to update local ref');
+
+      if (!isRefLockRace || attempt >= MAX_FETCH_RETRIES) {
+        throw error;
+      }
+
+      const backoffMs = 50 * Math.pow(2, attempt);
+      getLog().debug(
+        { err, attempt: attempt + 1, backoffMs, remote, refspec },
+        'git.fetch_ref_lock_retry'
+      );
+      await new Promise(resolve => setTimeout(resolve, backoffMs));
+    }
+  }
+}
+
 /**
  * Sync workspace with its remote.
  * Fetches the base branch from the remote, then updates local state according to mode.
@@ -160,49 +206,27 @@ export async function syncWorkspace(
   const branchToSync = baseBranch ?? (await getDefaultBranch(workspacePath, remote));
 
   // Fetch from the remote to ensure <remote>/<branchToSync> is up-to-date.
-  // Retry on transient ref-lock races — two concurrent fetches of the same
-  // remote-tracking ref collide on Git's shared lock file.
-  const MAX_FETCH_RETRIES = 3;
+  // Concurrent fetches of the same remote-tracking ref can collide on Git's
+  // shared ref lock; fetchWithRefLockRetry owns the bounded retry.
+  try {
+    await fetchWithRefLockRetry(workspacePath, remote, branchToSync, { timeoutMs: 60000 });
+  } catch (error) {
+    const err = error as Error;
+    const errorMessage = err.message.toLowerCase();
 
-  for (let attempt = 0; attempt <= MAX_FETCH_RETRIES; attempt++) {
-    try {
-      await execFileAsync('git', ['-C', workspacePath, 'fetch', remote, branchToSync], {
-        timeout: 60000,
-      });
-      break;
-    } catch (error) {
-      const err = error as Error;
-      const errorMessage = err.message.toLowerCase();
-
-      // If configured branch doesn't exist on remote, provide actionable error
-      if (
-        baseBranch &&
-        (errorMessage.includes("couldn't find remote ref") || errorMessage.includes('not found'))
-      ) {
-        throw new Error(
-          `Configured base branch '${baseBranch}' not found on remote '${remote}'. ` +
-            'Either create the branch, update worktree.baseBranch in .archon/config.yaml, ' +
-            'or remove the setting to use the auto-detected default branch.'
-        );
-      }
-
-      // Retry transient ref-lock races from concurrent fetch calls
-      if (
-        attempt < MAX_FETCH_RETRIES &&
-        errorMessage.includes('cannot lock ref') &&
-        errorMessage.includes('unable to update local ref')
-      ) {
-        const backoffMs = 50 * Math.pow(2, attempt);
-        getLog().debug(
-          { err, attempt: attempt + 1, backoffMs, remote, branch: branchToSync },
-          'workspace.fetch_ref_lock_retry'
-        );
-        await new Promise(resolve => setTimeout(resolve, backoffMs));
-        continue;
-      }
-
-      throw new Error(`Sync fetch from ${remote}/${branchToSync} failed: ${err.message}`);
+    // If configured branch doesn't exist on remote, provide actionable error
+    if (
+      baseBranch &&
+      (errorMessage.includes("couldn't find remote ref") || errorMessage.includes('not found'))
+    ) {
+      throw new Error(
+        `Configured base branch '${baseBranch}' not found on remote '${remote}'. ` +
+          'Either create the branch, update worktree.baseBranch in .archon/config.yaml, ' +
+          'or remove the setting to use the auto-detected default branch.'
+      );
     }
+
+    throw new Error(`Sync fetch from ${remote}/${branchToSync} failed: ${err.message}`);
   }
 
   const previousHead = await readShortSha(workspacePath, 'HEAD');

--- a/packages/isolation/src/providers/worktree.test.ts
+++ b/packages/isolation/src/providers/worktree.test.ts
@@ -1296,6 +1296,115 @@ describe('WorktreeProvider', () => {
       );
     });
 
+    test('absorbs ref-lock race on concurrent fork-PR launches', async () => {
+      // Two concurrent fork-PR launches race on the local branch refspec's
+      // ref lock (refs/heads/pr-42-review). The first attempt per launch fails
+      // with the lock-race error; the bounded retry absorbs it.
+      const request: IsolationRequest = {
+        ...baseRequest,
+        workflowType: 'pr',
+        identifier: '42',
+        prBranch: git.toBranchName('feature/auth'),
+        isForkPR: true,
+      };
+
+      const raceText =
+        "error: cannot lock ref 'refs/heads/pr-42-review': is at de581e24 but expected 8eaa8d42\n" +
+        '! 8eaa8d420..de581e24b pr-42-review -> pr-42-review (unable to update local ref)';
+      const raceError = new Error(raceText) as Error & { stderr?: string };
+      raceError.stderr = raceText;
+      let fetchCalls = 0;
+
+      execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
+        if (args.includes('fetch') && args.some(a => a.includes('pull/42/head:pr-42-review'))) {
+          fetchCalls++;
+          if (fetchCalls <= 2) {
+            throw raceError;
+          }
+        }
+        return { stdout: '', stderr: '' };
+      });
+
+      await Promise.all([provider.create(request), provider.create(request)]);
+
+      expect(fetchCalls).toBeGreaterThan(2);
+      expect(execSpy).toHaveBeenCalledWith(
+        'git',
+        expect.arrayContaining([
+          '-C',
+          '/workspace/repo',
+          'worktree',
+          'add',
+          expect.any(String),
+          'pr-42-review',
+        ]),
+        expect.any(Object)
+      );
+    });
+
+    test('exhausts the bounded budget on persistent fork-PR fetch lock-race and fails before worktree creation', async () => {
+      const request: IsolationRequest = {
+        ...baseRequest,
+        workflowType: 'pr',
+        identifier: '42',
+        prBranch: git.toBranchName('feature/auth'),
+        isForkPR: true,
+      };
+
+      const raceText =
+        "error: cannot lock ref 'refs/heads/pr-42-review': is at de581e24 but expected 8eaa8d42\n" +
+        '! 8eaa8d420..de581e24b pr-42-review -> pr-42-review (unable to update local ref)';
+      const raceError = new Error(raceText) as Error & { stderr?: string };
+      raceError.stderr = raceText;
+      let fetchCalls = 0;
+
+      execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
+        if (args.includes('fetch') && args.some(a => a.includes('pull/42/head:pr-42-review'))) {
+          fetchCalls++;
+          throw raceError;
+        }
+        return { stdout: '', stderr: '' };
+      });
+
+      await expect(provider.create(request)).rejects.toThrow(
+        'Failed to create worktree for PR #42: Fetch origin pull/42/head:pr-42-review failed: error: cannot lock ref'
+      );
+
+      expect(fetchCalls).toBe(4); // 1 initial + 3 retries
+
+      const addCalls = execSpy.mock.calls.filter((call: unknown[]) => {
+        const args = call[1] as string[];
+        return args.includes('add');
+      });
+      expect(addCalls).toHaveLength(0);
+    });
+
+    test('does not retry non-race fork-PR fetch errors', async () => {
+      const request: IsolationRequest = {
+        ...baseRequest,
+        workflowType: 'pr',
+        identifier: '42',
+        prBranch: git.toBranchName('feature/auth'),
+        isForkPR: true,
+      };
+
+      let fetchCalls = 0;
+
+      execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
+        if (args.includes('fetch') && args.some(a => a.includes('pull/42/head:pr-42-review'))) {
+          fetchCalls++;
+          throw new Error("fatal: 'origin' does not appear to be a git repository");
+        }
+        return { stdout: '', stderr: '' };
+      });
+
+      await expect(provider.create(request)).rejects.toThrow(
+        'Failed to create worktree for PR #42'
+      );
+
+      expect(fetchCalls).toBe(1);
+    });
+
     test('propagates permission error when workspace sync fails during creation', async () => {
       const request: IsolationRequest = {
         codebaseId: 'cb-123',

--- a/packages/isolation/src/providers/worktree.ts
+++ b/packages/isolation/src/providers/worktree.ts
@@ -11,6 +11,7 @@ import { isAbsolute, join, normalize as normalizePath, resolve, sep } from 'path
 import { createLogger } from '@archon/paths';
 import {
   execFileAsync,
+  fetchWithRefLockRetry,
   findWorktreeByBranch,
   getCanonicalRepoPath,
   getCurrentBranchStrict,
@@ -1153,7 +1154,8 @@ export class WorktreeProvider implements IIsolationProvider {
    * Create worktree for fork PR using synthetic review branch
    *
    * Handles stale branches: If a branch already exists from a previous worktree
-   * that was deleted, we delete the stale branch and retry.
+   * that was deleted, we delete the stale branch and retry. The no-SHA fetch
+   * retries transient ref-lock races via fetchWithRefLockRetry.
    */
   private async createFromForkPR(
     repoPath: string,
@@ -1165,7 +1167,9 @@ export class WorktreeProvider implements IIsolationProvider {
     const reviewBranch = `pr-${prNumber}-review`;
 
     if (prSha) {
-      // SHA provided: create at specific commit for reproducible reviews
+      // SHA provided: create at specific commit for reproducible reviews.
+      // No colon refspec: git writes only FETCH_HEAD and locks no named ref,
+      // so this fetch cannot hit the ref-lock race and needs no retry.
       await execFileAsync('git', ['-C', repoPath, 'fetch', remote, `pull/${prNumber}/head`], {
         timeout: GIT_OPERATION_TIMEOUT_MS,
       });
@@ -1184,15 +1188,29 @@ export class WorktreeProvider implements IIsolationProvider {
         reviewBranch
       );
     } else {
-      // No SHA: fetch and create review branch
+      // No SHA: fetch and create review branch. The refspec's destination is the
+      // local branch refs/heads/pr-<n>-review, so concurrent fork-PR launches
+      // race on its ref lock; fetchWithRefLockRetry owns the bounded retry.
       await this.createBranchWithStaleRetry(
         repoPath,
-        () =>
-          execFileAsync(
-            'git',
-            ['-C', repoPath, 'fetch', remote, `pull/${prNumber}/head:${reviewBranch}`],
-            { timeout: GIT_OPERATION_TIMEOUT_MS }
-          ),
+        async () => {
+          try {
+            return await fetchWithRefLockRetry(
+              toRepoPath(repoPath),
+              remote,
+              `pull/${prNumber}/head:${reviewBranch}`,
+              { timeoutMs: GIT_OPERATION_TIMEOUT_MS }
+            );
+          } catch (error) {
+            const err = error as Error & { stderr?: string };
+            const wrapped = new Error(
+              `Fetch ${remote} pull/${prNumber}/head:${reviewBranch} failed: ${err.message}`
+            ) as Error & { stderr?: string };
+            // createBranchWithStaleRetry keys on stderr for its stale-branch retry
+            wrapped.stderr = err.stderr;
+            throw wrapped;
+          }
+        },
         reviewBranch
       );
 


### PR DESCRIPTION
## Problem and outcome

`createFromForkPR` performs fetches that #3065 and #3091 already protected on the `syncWorkspace` and same-repo PR paths, but its no-SHA fork fetch branch was unguarded: two concurrent fork-PR launches against the same upstream both write the local branch `refs/heads/pr-<n>-review` via the `pull/<n>/head:pr-<n>-review` refspec and collide on Git's shared ref lock, failing with `cannot lock ref ... unable to update local ref`.

- **Outcome:** Concurrent fork-PR launches no longer fail transiently; the no-SHA fetch absorbs the race with the same bounded retry that already protected `syncWorkspace`. The codebase now has exactly one ref-lock classifier and one backoff budget, in `@archon/git`.
- **Invariant:** Unrelated git failures are attempted once and stay loud; a persistent contention failure exhausts the bounded budget (4 attempts total) and reports the original error; every failure path still fails before an isolation environment or worktree is created.
- **Scope boundary:** The with-SHA fork fetch is intentionally left unguarded (evidence below), and `syncWorkspace`'s public signature is unchanged.
- **Root cause:** The no-SHA refspec writes a named local ref, so concurrent fetches contend on Git's shared lock file for `refs/heads/pr-<n>-review`. This matches the issue body's error signature, but corrects its claim of a shared remote-tracking ref: the contended ref is the local review branch.

### The with-SHA form cannot exhibit this race

`git fetch <remote> pull/<n>/head` (no colon refspec) updates only `FETCH_HEAD` and touches no named ref, so there is no ref lock to contend on. The issue's second fetch branch therefore needs no retry, and the call site carries a comment explaining why. This PR does not silently drop that acceptance item — it resolves it by evidence.

## Review guidance

- **Feedback requested:** Correctness of the retry composition with stale-branch handling, and whether the shared-helper extraction (vs. generalizing `syncWorkspace`) is the right seam.
- **Start here:** `packages/git/src/repo.ts:130` — `fetchWithRefLockRetry` is the single owner of the classifier (`cannot lock ref` + `unable to update local ref`) and the backoff budget (3 retries, 50ms doubling). On exhaustion it rethrows the original error object, preserving stderr.
- **Review order:** `packages/git/src/repo.ts` → `packages/isolation/src/providers/worktree.ts` (`createFromForkPR`) → the two test files.
- **Lower-attention areas:** `packages/git/src/index.ts` (one export line).
- **Known risk or uncertainty:** None. `syncWorkspace`'s branch-not-found mapping, error wrapping, and public signature are unchanged; the only behavioral delta there is the debug log tag (`workspace.fetch_ref_lock_retry` → `git.fetch_ref_lock_retry`).

## Solution

The issue required reusing the bounded-retry owner established by #3087 rather than adding a second copy of the classifier or budget. Two options existed: generalize `syncWorkspace` to accept a refspec, or extract a shared helper. This PR extracts `fetchWithRefLockRetry(repoPath, remote, refspec)` in `@archon/git` and has both callers use it:

- `syncWorkspace` deletes its inline retry loop and calls the helper; its post-fetch body (branch-state classification, ff-only merge, reset) is entirely branch-shaped, so a refspec mode would bypass nearly all of it and would change a public signature consumed by the orchestrator.
- `createFromForkPR`'s no-SHA branch wraps the helper call inside the existing `createBranchWithStaleRetry` closure. On failure it wraps the message as `Fetch <remote> pull/<n>/head:pr-<n>-review failed: ...` and copies `stderr` through, so the stale-branch detection (which keys on `already exists` in stderr) still composes.

## Validation

- `cd packages/isolation && bun test src/providers/worktree.test.ts` — the two new contention tests were observed **red** against the unguarded path first (race absorbed on concurrent launches; persistent contention exhausts the budget and rejects with zero `worktree add` calls), then green after the fix: 170 pass, 0 fail.
- `cd packages/git && bun test src/git.test.ts` — 218 pass, 0 fail, including the pre-existing `syncWorkspace` race/exhaustion/no-retry/branch-not-found tests passing verbatim after the refactor, plus new helper unit tests (retry-then-succeed; original error object identity and stderr preserved after 4 attempts; non-race error attempted exactly once).
- `bun run validate` — exit 0.

## Links

- Closes #3124
- Relates to #3065, #3091, #3087, #3112


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workspace synchronization reliability when Git encounters temporary reference-lock conflicts.
  - Fork pull request creation now retries transient local reference-lock failures before reporting an error.
  - Non-transient Git errors continue to fail immediately with clearer contextual information.
  - Existing handling for missing base branches and stale-branch scenarios is preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->