### PR TITLE
test(cli): pin --full as scoped flag in workflow list --help

### DIFF
--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -515,6 +515,20 @@ Examples:
     expect(result.stdout).toContain('--node');
     expect(result.stdout).toContain('--yes');
   });
+
+  it('renders --full in workflow list --help', () => {
+    const result = spawnSync(process.execPath, [CLI_ENTRY, 'workflow', 'list', '--help'], {
+      encoding: 'utf8',
+      env: { ...process.env, ARCHON_TELEMETRY_DISABLED: '1' },
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('--full');
+    // Unlike its siblings, `--full` is also mentioned in the Commands spec and
+    // description, so `toContain('--full')` alone would pass even without a
+    // scopedFlags entry. The scoped description is the unique contribution —
+    // guard it so deleting scopedFlags trips this test.
+    expect(result.stdout).toContain('exact description instead of the compact preview');
+  });
 });
 
 describe('removed continue command', () => {


### PR DESCRIPTION
## Problem and outcome

`archon workflow list --help` renders its `Options` block from the `scopedFlags` array at `packages/cli/src/cli.ts:216-222`, but no test pinned it. The three siblings from #3118 — `isolation cleanup --merged/--include-closed`, `workflow reject --reason`, `workflow reset-sessions --scope/--node/--yes` — each had assertions; this one slipped the partition. A future refactor that drops the `scopedFlags` entry would land without a red CI.

- **Outcome:** `workflow list --help` now has the same scoped-flag coverage as its siblings, completing the partition.
- **Invariant:** every flag in a command's `scopedFlags` array must be reachable through that command's scoped `--help` output. `archon --help` must stay byte-identical to the frozen `PRE_REFACTOR_GLOBAL_HELP` template.
- **Scope boundary:** only the one `it(...)` block in `packages/cli/src/cli.test.ts`. No source change, no helper, no new file. The `archon --help` path and the global template are untouched.

## Review guidance

- **Feedback requested:** correctness of the test shape (matches the three siblings in the same `describe` block).
- **Start here:** `packages/cli/src/cli.test.ts:519-531` — the new `it(...)` block.
- **Review order:** read the three sibling scoped-flag tests immediately above (lines ~483-518) to confirm the shape parity, then read the new block.
- **Lower-attention areas:** none beyond the single test block.
- **Known risk or uncertainty:** the bare `expect(result.stdout).toContain('--full')` would always pass because `--full` also appears in the Commands spec (`workflow list [name] [--full] [--json]`) and the wrapping description. The second `toContain` against `'exact description instead of the compact preview'` is the guard that actually fails when `scopedFlags` is deleted. An inline comment explains the trade-off so a future maintainer doesn't collapse both expectations. Both `toContain` calls are required to honour the issue's "asserts --full is present in stdout" intent and to make the guard observable.

## Solution

Added one `it(...)` block immediately after the `workflow reset-sessions --scope/--node/--yes` sibling (lines 519-531), reusing the established `spawnSync(process.execPath, [CLI_ENTRY, '<cmd>', '--help'], { env: { ...process.env, ARCHON_TELEMETRY_DISABLED: '1' } })` + `toContain` shape verbatim. A second `toContain` against the scoped description was added because `--full` is also referenced outside the `Options` block, so the literal assertion alone would not have failed on `scopedFlags` deletion.

This is the smallest coherent change that closes the partition: one block, one file, one invariant pinned.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | `archon workflow list --help` renders `--full` from `scopedFlags`, untested. | Same render; `--full` is now asserted by CI. |
| **Failure behavior** | A drop of the `scopedFlags` entry would ship silently. | That drop now fails the targeted test before merging. |

## Validation

- `bun run validate` from the repo root — green: lint, format, type-check, all package tests, and the aggregate checks (`check:bundled`, `check:bundled-skill`, `check:bundled-schema`, `check:pi-vendor-map`, `check:capability-matrix`, `check:api-types`, `test:install`) all pass.
- `cd packages/cli && bun run test` — green; the new `it(...)` (`renders --full in workflow list --help`) passes against current source.
- Red-on-deletion check: temporarily deleted the `scopedFlags` array at `packages/cli/src/cli.ts:216-222` and re-ran the targeted test — failed on the second `toContain` (`expected to contain: "exact description instead of the compact preview"`); restored the entry and re-ran — green.
- **Not verified:** nothing material. The changed behavior is one test assertion in a partition already covered by its siblings.

## Links

- Closes #3139


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage verifying that the workflow listing help text documents the `--full` option and its exact-description behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->