### PR TITLE
Final landing videos and readable dark-mode docs header

### DIFF
--- a/packages/docs-web/src/pages/index.astro
+++ b/packages/docs-web/src/pages/index.astro
@@ -13,18 +13,13 @@ const GITHUB = 'https://github.com/coleam00/Archon';
 // section embeds — nothing else references these ids.
 const videos = [
   {
-    id: 'fC_BvySeIhY',
-    title: 'Archon vs GitHub Workflows: The AI Pipeline Game Changer!',
-    creator: 'DIY Smart Code',
+    id: 'srx9iwnjK2M',
+    title: 'Full Archon Guide - Build AI Coding Harnesses That Actually Ship (LIVE)',
+    creator: 'Cole Medin',
   },
   {
-    id: 'dumoyEGjhD4',
-    title: 'Better Models Or Better Harnesses? The 2026 Developer Debate',
-    creator: 'DIY Smart Code',
-  },
-  {
-    id: 'Jp5mxkAc_Mk',
-    title: 'How Archon V3 catches its own mistakes',
+    id: 'uvLW0sPEZ_k',
+    title: 'What Is Archon? The Future of Workflow Control',
     creator: 'DIY Smart Code',
   },
 ];
@@ -578,7 +573,7 @@ const steps = [
     .videos { max-width: 1080px; margin: 0 auto; padding: 2rem 1.5rem 4rem; }
     .video-grid {
       display: grid;
-      grid-template-columns: repeat(3, 1fr);
+      grid-template-columns: repeat(2, 1fr);
       gap: 1.5rem;
     }
     .video-card { min-width: 0; }

--- a/packages/docs-web/src/styles/custom.css
+++ b/packages/docs-web/src/styles/custom.css
@@ -11,7 +11,13 @@
   --sl-color-bg-sidebar: #131825;
   --sl-color-bg-nav: #0f1219;
   --sl-color-hairline-light: #1e293b;
-  --sl-color-text-accent: rgba(168, 85, 247, 0.25); /* mobile sidebar active-link bg — re-test after Starlight upgrades */
+}
+
+/* Starlight uses --sl-color-text-accent for the site title, primary buttons, and
+   links as well as the mobile sidebar active-link background, so the override
+   stays scoped to the sidebar. Re-test after Starlight upgrades. */
+[data-theme='dark'] .sidebar-content {
+  --sl-color-text-accent: rgba(168, 85, 247, 0.25);
   --sl-color-text-invert: white;
 }
 


### PR DESCRIPTION
## Problem and outcome

Follow-up to #3141, which merged before two fixes landed on its branch.

1. The landing page shipped with three placeholder videos in a three-column grid. The final picks are two videos: Cole Medin's "Full Archon Guide" livestream (`srx9iwnjK2M`) and DIY Smart Code's condensed "What Is Archon?" explainer (`uvLW0sPEZ_k`).
2. Dark-mode docs pages (`/docs/` and every Starlight page) rendered the site title, the primary "Get Started" button, and links at 25% opacity, near-invisible on the dark background.

- **Outcome:** Landing page shows the two final videos in a two-column grid; Starlight title, buttons, and links are readable in dark mode again.
- **Invariant:** Only `packages/docs-web` changes; no new dependencies; the mobile sidebar active-link fix from #1869 keeps working.

## Solution

- `src/pages/index.astro`: swap the `videos` array entries and change `.video-grid` to `repeat(2, 1fr)`.
- `src/styles/custom.css`: #1869 declared `--sl-color-text-accent: rgba(168, 85, 247, 0.25)` on the whole dark theme to fix the mobile sidebar active-link background, but Starlight derives site title, button, and link colors from that same variable. The override is now scoped to `.sidebar-content`, the only place the semi-transparent value was meant for. `.sidebar-content` is an internal Starlight class already relied on by the existing active-link rule; re-check after Starlight upgrades.

## Validation

- `cd packages/docs-web && bun run build` passes.
- Headless Playwright against `astro preview` of the built site: `/` at 1280px and 390px (two-column grid, single column on mobile, no horizontal scroll); `/docs/` in dark and light mode and at 390px (site title computes to `rgb(147,197,253)`, "Get Started" readable); mobile sidebar active link on `/getting-started/installation/` still white text on the purple gradient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdN3WHnZBbCQodJEAU9SyG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Updated the community video section with two refreshed videos: “Full Archon Guide” and “What Is Archon?”
  * Adjusted the video layout to display two items per row for a cleaner presentation.

* **Style**
  * Refined dark-theme sidebar styling to improve text contrast and visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->