### PR TITLE
fix(git): route syncRepository's fetch through the ref-lock retry owner

### DIFF
--- a/packages/git/src/git.test.ts
+++ b/packages/git/src/git.test.ts
@@ -3067,8 +3067,7 @@ branch refs/heads/feature/auth
       const result = await git.syncRepository(repo('/workspace/repo'), branch('main'));
 
       expect(result).toEqual({ ok: true, value: undefined });
-      expect(execSpy).toHaveBeenCalledWith('git', ['fetch', 'origin'], {
-        cwd: '/workspace/repo',
+      expect(execSpy).toHaveBeenCalledWith('git', ['-C', '/workspace/repo', 'fetch', 'origin'], {
         timeout: 60000,
       });
       expect(execSpy).toHaveBeenCalledWith('git', ['reset', '--hard', 'origin/main'], {
@@ -3077,14 +3076,76 @@ branch refs/heads/feature/auth
       });
     });
 
+    // syncRepository is reachable concurrently from the forge adapters on PR
+    // events, and its bare fetch updates every configured remote-tracking ref —
+    // the same contention syncWorkspace and the fork-PR path already survive.
+    test('absorbs a ref-lock race on the bare fetch and still resets', async () => {
+      const raceError = Object.assign(
+        new Error(
+          "error: cannot lock ref 'refs/remotes/origin/main': is at aaa but expected bbb\n" +
+            ' ! aaa..bbb  main -> origin/main  (unable to update local ref)'
+        ),
+        { stderr: 'unable to update local ref' }
+      );
+      execSpy.mockRejectedValueOnce(raceError).mockResolvedValue({ stdout: '', stderr: '' });
+
+      const result = await git.syncRepository(repo('/workspace/repo'), branch('main'));
+
+      expect(result).toEqual({ ok: true, value: undefined });
+      const fetches = execSpy.mock.calls.filter(([, args]) => (args as string[])[2] === 'fetch');
+      expect(fetches).toHaveLength(2);
+      expect(execSpy).toHaveBeenCalledWith('git', ['reset', '--hard', 'origin/main'], {
+        cwd: '/workspace/repo',
+        timeout: 30000,
+      });
+    });
+
+    test('exhausts the shared budget on persistent contention and reports the original evidence', async () => {
+      const raceError = Object.assign(
+        new Error(
+          "error: cannot lock ref 'refs/remotes/origin/main'\n (unable to update local ref)"
+        ),
+        { stderr: 'unable to update local ref' }
+      );
+      execSpy.mockRejectedValue(raceError);
+
+      const result = await git.syncRepository(repo('/workspace/repo'), branch('main'));
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('unknown');
+        // The original git text survives the GitResult wrap.
+        expect(JSON.stringify(result.error)).toContain('cannot lock ref');
+      }
+      const fetches = execSpy.mock.calls.filter(([, args]) => (args as string[])[2] === 'fetch');
+      expect(fetches).toHaveLength(4);
+      const resets = execSpy.mock.calls.filter(([, args]) => (args as string[])[0] === 'reset');
+      expect(resets).toHaveLength(0);
+    });
+
+    test('attempts a non-contention fetch failure once and keeps its GitResult code', async () => {
+      const authError = Object.assign(new Error('fatal: Authentication failed for repo'), {
+        stderr: 'authentication failed',
+      });
+      execSpy.mockRejectedValue(authError);
+
+      const result = await git.syncRepository(repo('/workspace/repo'), branch('main'));
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('permission_denied');
+      }
+      const fetches = execSpy.mock.calls.filter(([, args]) => (args as string[])[2] === 'fetch');
+      expect(fetches).toHaveLength(1);
+    });
+
     test('fetches and resets using a custom remote', async () => {
       execSpy.mockResolvedValue({ stdout: '', stderr: '' });
 
       const result = await git.syncRepository(repo('/workspace/repo'), branch('main'), 'upstream');
 
       expect(result).toEqual({ ok: true, value: undefined });
-      expect(execSpy).toHaveBeenCalledWith('git', ['fetch', 'upstream'], {
-        cwd: '/workspace/repo',
+      expect(execSpy).toHaveBeenCalledWith('git', ['-C', '/workspace/repo', 'fetch', 'upstream'], {
         timeout: 60000,
       });
       expect(execSpy).toHaveBeenCalledWith('git', ['reset', '--hard', 'upstream/main'], {

--- a/packages/git/src/repo.ts
+++ b/packages/git/src/repo.ts
@@ -144,12 +144,16 @@ const MAX_FETCH_RETRIES = 3;
 export async function fetchWithRefLockRetry(
   repoPath: RepoPath,
   remote: string,
-  refspec: string,
+  refspec: string | undefined,
   options?: { timeoutMs?: number }
 ): Promise<{ stdout: string; stderr: string }> {
+  const args =
+    refspec === undefined
+      ? ['-C', repoPath, 'fetch', remote]
+      : ['-C', repoPath, 'fetch', remote, refspec];
   for (let attempt = 0; ; attempt++) {
     try {
-      return await execFileAsync('git', ['-C', repoPath, 'fetch', remote, refspec], {
+      return await execFileAsync('git', args, {
         timeout: options?.timeoutMs,
       });
     } catch (error) {
@@ -562,8 +566,8 @@ export async function cloneRepository(
  * Runs sequential fetch + reset --hard. If fetch fails, reset is skipped.
  * Uses execFileAsync (no shell interpolation) for safety.
  *
- * Note: Uses `cwd` option instead of `-C` flag. Both are functionally
- * equivalent; this style was chosen for readability with multi-arg commands.
+ * Note: the reset uses the `cwd` option; the fetch goes through
+ * fetchWithRefLockRetry, which uses `-C`. Both are functionally equivalent.
  *
  * @param repoPath - Path to the local repository
  * @param branch - Branch to sync to (e.g., 'main')
@@ -576,7 +580,7 @@ export async function syncRepository(
   remote = 'origin'
 ): Promise<GitResult<void>> {
   try {
-    await execFileAsync('git', ['fetch', remote], { cwd: repoPath, timeout: 60000 });
+    await fetchWithRefLockRetry(repoPath, remote, undefined, { timeoutMs: 60000 });
   } catch (error) {
     const err = error as Error & { stderr?: string };
     const errorText = `${err.message} ${err.stderr ?? ''}`.toLowerCase();


### PR DESCRIPTION
## Problem and outcome

`syncRepository` ran a bare `git fetch <remote>` with no retry. A bare fetch updates every configured remote-tracking ref, so it is exposed to the same `cannot lock ref … unable to update local ref` contention that #3065 fixed for `syncWorkspace` and #3091 fixed for the same-repository PR path — and the forge adapters reach it concurrently on PR events. After #3124 it was the last unguarded fetch route in the codebase.

- **Outcome:** a transient ref-lock collision no longer fails a repository sync; the fetch retries through the shared bounded owner and the reset still runs.
- **Invariant:** exactly one ref-lock classifier and one backoff budget in non-test code. Non-contention failures are attempted once, stay loud, and keep their existing `GitResult` error codes.
- **Scope boundary:** only `syncRepository`'s fetch. The reset, the error-code classification, and every other call site are unchanged. No new retry loop and no broad retry-everything wrapper.
- **Root cause:** `packages/git/src/repo.ts:579` called `execFileAsync` directly instead of the owner introduced by PR #3144.

## Review guidance

- **Feedback requested:** correctness of the optional-refspec change to the shared owner, and whether widening it is preferable to any alternative that keeps one classifier.
- **Start here:** `packages/git/src/repo.ts:583` — the one-line call-site change that closes the gap.
- **Review order:** `repo.ts` owner signature, then the `syncRepository` call site, then the three new tests in `git.test.ts`.
- **Lower-attention areas:** two existing `syncRepository` assertions moved from `['fetch', remote]` + `cwd` to `['-C', repoPath, 'fetch', remote]`, because the owner uses `-C`. Functionally equivalent; the stale note in `syncRepository`'s docstring is corrected in the same commit.
- **Known risk or uncertainty:** None.

## Solution

`fetchWithRefLockRetry` always appended a refspec, which a bare fetch has none of. Its `refspec` parameter is now `string | undefined` and the argv is built accordingly, so `syncRepository` reuses the existing classifier, budget, and backoff rather than growing a second copy — the constraint #3150 states as a requirement.

Everything after the fetch is untouched: the owner rethrows the original error object with `stderr` intact, so `syncRepository`'s existing `not_a_repo` / `permission_denied` / `no_space` / `unknown` classification keeps working on the same text it saw before.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | A concurrent ref-lock collision failed the sync outright | The fetch retries up to the shared budget and the sync completes |
| **Failure behavior** | Every fetch failure returned a `GitResult` error after one attempt | Contention exhausts the bounded budget then returns the same error with the original git text preserved; non-contention failures still fail on the first attempt |

## Validation

- `bun run validate` — exit 0 — proves the repository gate is green with the change.
- `cd packages/git && bun run test` — 236 pass, 0 fail — proves the owner's existing `syncWorkspace` coverage and the new `syncRepository` coverage hold together.
- Guards observed red before being trusted: reverting only the call site to the old `execFileAsync` line fails all five `syncRepository` tests (the three new ones plus the two updated invocation assertions); restoring it returns 236 pass / 0 fail.
- The three new tests prove retry-then-succeed with the reset still running, budget exhaustion at 4 fetch attempts with zero resets and `cannot lock ref` preserved in the returned error, and a single attempt for a non-contention auth failure that still maps to `permission_denied`.
- **Not verified:** the live race itself. It is timing-dependent; #3124's run reproduced this exact classifier signature against real git, and these tests drive the same message shape through the owner.

## Links

- Closes #3150
- Related #3124
- Related #3065
- Related #3091


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved repository synchronization when temporary Git reference-lock conflicts occur; fetch operations now retry automatically.
  - Prevented unnecessary resets when persistent reference-lock contention prevents synchronization.
  - Preserved meaningful error details and classifications for authentication failures and other fetch errors.
  - Improved handling of fetch operations that do not specify a refspec.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->