### PR TITLE
fix(workflows): give fixture discovery a defined order

### DIFF
--- a/packages/workflows/src/fixture-runner.test.ts
+++ b/packages/workflows/src/fixture-runner.test.ts
@@ -769,17 +769,24 @@ describe('runFixtures', () => {
   // R1: this fixtures/ dir was already found by the walk, so a read failure is a real
   // fault, not an absence. Swallowing it would let a run exit 0 having skipped a
   // directory it was asked to certify.
-  it('propagates a fixtures-directory read failure instead of reporting no fixtures', async () => {
-    const cwd = makeTempProject();
-    writeWorkflowDirs(cwd, ['pack/locked']);
-    const fixturesDir = join(cwd, '.archon', 'workflows', 'pack', 'locked', 'fixtures');
-    chmodSync(fixturesDir, 0o000);
-    try {
-      await expect(runFixtures({ workflows: [], cwd })).rejects.toThrow();
-    } finally {
-      chmodSync(fixturesDir, 0o755);
+  //
+  // POSIX-only: the unreadable directory is created with chmod 000, which win32 does
+  // not enforce for directory reads — the precondition cannot be built there, so the
+  // test would assert nothing. Same treatment as the permission cases in git.test.ts.
+  it.skipIf(process.platform === 'win32')(
+    'propagates a fixtures-directory read failure instead of reporting no fixtures',
+    async () => {
+      const cwd = makeTempProject();
+      writeWorkflowDirs(cwd, ['pack/locked']);
+      const fixturesDir = join(cwd, '.archon', 'workflows', 'pack', 'locked', 'fixtures');
+      chmodSync(fixturesDir, 0o000);
+      try {
+        await expect(runFixtures({ workflows: [], cwd })).rejects.toThrow();
+      } finally {
+        chmodSync(fixturesDir, 0o755);
+      }
     }
-  });
+  );
 
   it('reports fixtures in label order, not filesystem order', async () => {
     const cwd = makeTempProject();

--- a/packages/workflows/src/fixture-runner.test.ts
+++ b/packages/workflows/src/fixture-runner.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeAll, afterAll, mock } from 'bun:test';
 import {
   cpSync,
   existsSync,
+  chmodSync,
   mkdirSync,
   mkdtempSync,
   readdirSync,
@@ -745,6 +746,41 @@ describe('runFixtures', () => {
   // `readdir` yields filesystem order, which varies by machine and filesystem. Two CI
   // runs on unrelated PRs failed here with the same fixtures in swapped order before
   // discovery defined one. Creation order below is deliberately reverse-alphabetical.
+  // R4: the sort in workflowNamesBeside only matters when one fixtures/ dir has two
+  // sibling workflow YAMLs — otherwise a single name hides any ordering. These names
+  // reach the operator in a "no discovered workflow matches" failure.
+  it('orders the sibling workflow names beside one fixtures dir', async () => {
+    const cwd = makeTempProject();
+    const dir = join(cwd, '.archon', 'workflows', 'pack', 'two');
+    mkdirSync(join(dir, 'fixtures'), { recursive: true });
+    // Created zulu-first so filesystem order is the wrong answer.
+    writeFileSync(join(dir, 'zulu-wf.yaml'), stubWorkflowYaml('zulu-wf'));
+    writeFileSync(join(dir, 'alfa-wf.yaml'), stubWorkflowYaml('alfa-wf'));
+    writeFileSync(join(dir, 'fixtures', 'two.stubs.yaml'), STUB_FIXTURE);
+
+    // No workflow is passed in, so the fixture matches nothing and the failure names
+    // every sibling candidate — the surface these names actually reach.
+    const report = await runFixtures({ workflows: [], cwd });
+
+    expect(report.results).toHaveLength(1);
+    expect(report.results[0].failureReason).toContain('alfa-wf, zulu-wf');
+  });
+
+  // R1: this fixtures/ dir was already found by the walk, so a read failure is a real
+  // fault, not an absence. Swallowing it would let a run exit 0 having skipped a
+  // directory it was asked to certify.
+  it('propagates a fixtures-directory read failure instead of reporting no fixtures', async () => {
+    const cwd = makeTempProject();
+    writeWorkflowDirs(cwd, ['pack/locked']);
+    const fixturesDir = join(cwd, '.archon', 'workflows', 'pack', 'locked', 'fixtures');
+    chmodSync(fixturesDir, 0o000);
+    try {
+      await expect(runFixtures({ workflows: [], cwd })).rejects.toThrow();
+    } finally {
+      chmodSync(fixturesDir, 0o755);
+    }
+  });
+
   it('reports fixtures in label order, not filesystem order', async () => {
     const cwd = makeTempProject();
     writeWorkflowDirs(cwd, ['pack/zulu', 'pack/mike', 'pack/alfa']);

--- a/packages/workflows/src/fixture-runner.test.ts
+++ b/packages/workflows/src/fixture-runner.test.ts
@@ -77,6 +77,27 @@ import {
 
 /** The file's one temp-root creator, so every fixture tree is tracked for teardown. */
 const trackTempRoot = trackTempRoots();
+const STUB_FIXTURE = ['fixture:', '  expect: completed', 'node-a: "stub output"', ''].join('\n');
+
+const stubWorkflowYaml = (name: string) =>
+  `name: ${name}\ndescription: test\nnodes:\n  - id: node-a\n    prompt: hello\n`;
+
+/**
+ * Write one workflow and its fixture per slash-separated path, so a tree is declared
+ * rather than assembled: `'sdlc/plan'` produces
+ * `.archon/workflows/sdlc/plan/plan-wf.yaml` and `.../fixtures/plan.stubs.yaml`.
+ */
+function writeWorkflowDirs(cwd: string, paths: readonly string[]): void {
+  for (const path of paths) {
+    const segments = path.split('/');
+    const leaf = segments[segments.length - 1];
+    const dir = join(cwd, '.archon', 'workflows', ...segments);
+    mkdirSync(join(dir, 'fixtures'), { recursive: true });
+    writeFileSync(join(dir, `${leaf}-wf.yaml`), stubWorkflowYaml(`${leaf}-wf`));
+    writeFileSync(join(dir, 'fixtures', `${leaf}.stubs.yaml`), STUB_FIXTURE);
+  }
+}
+
 function makeTempProject(prefix = 'fixture-runner-'): string {
   return trackTempRoot(mkdtempSync(join(tmpdir(), prefix)));
 }
@@ -717,30 +738,30 @@ describe('runFixtures', () => {
   /** Pack layout like the bundled SDLC pack: `<pack>/<workflow-folder>/fixtures/`, plus a sibling pack whose name extends `sdlc` so the path-containment anchor cannot drift. */
   function writeNestedPackProject(): { cwd: string } {
     const cwd = makeTempProject();
-    for (const folder of ['plan', 'ship']) {
-      const workflowDir = join(cwd, '.archon', 'workflows', 'sdlc', folder);
-      mkdirSync(join(workflowDir, 'fixtures'), { recursive: true });
-      writeFileSync(
-        join(workflowDir, `${folder}-wf.yaml`),
-        `name: ${folder}-wf\ndescription: test\nnodes:\n  - id: node-a\n    prompt: hello\n`
-      );
-      writeFileSync(
-        join(workflowDir, 'fixtures', `${folder}.stubs.yaml`),
-        ['fixture:', '  expect: completed', 'node-a: "stub output"', ''].join('\n')
-      );
-    }
-    const extDir = join(cwd, '.archon', 'workflows', 'sdlc-ext', 'ext');
-    mkdirSync(join(extDir, 'fixtures'), { recursive: true });
-    writeFileSync(
-      join(extDir, 'ext-wf.yaml'),
-      'name: ext-wf\ndescription: test\nnodes:\n  - id: node-a\n    prompt: hello\n'
-    );
-    writeFileSync(
-      join(extDir, 'fixtures', 'ext.stubs.yaml'),
-      ['fixture:', '  expect: completed', 'node-a: "stub output"', ''].join('\n')
-    );
+    writeWorkflowDirs(cwd, ['sdlc/plan', 'sdlc/ship', 'sdlc-ext/ext']);
     return { cwd };
   }
+
+  // `readdir` yields filesystem order, which varies by machine and filesystem. Two CI
+  // runs on unrelated PRs failed here with the same fixtures in swapped order before
+  // discovery defined one. Creation order below is deliberately reverse-alphabetical.
+  it('reports fixtures in label order, not filesystem order', async () => {
+    const cwd = makeTempProject();
+    writeWorkflowDirs(cwd, ['pack/zulu', 'pack/mike', 'pack/alfa']);
+    const workflows = [
+      ...workflowsOnDisk(cwd, ['zulu-wf'], 'pack/zulu'),
+      ...workflowsOnDisk(cwd, ['mike-wf'], 'pack/mike'),
+      ...workflowsOnDisk(cwd, ['alfa-wf'], 'pack/alfa'),
+    ];
+
+    const report = await runFixtures({ workflows, cwd });
+
+    expect(report.results.map(r => r.fixture)).toEqual([
+      'pack/alfa/fixtures/alfa.stubs.yaml',
+      'pack/mike/fixtures/mike.stubs.yaml',
+      'pack/zulu/fixtures/zulu.stubs.yaml',
+    ]);
+  });
 
   it('resolves a nested pack by name, workflow folder, and pack directory path', async () => {
     const { cwd } = writeNestedPackProject();

--- a/packages/workflows/src/fixture-runner.ts
+++ b/packages/workflows/src/fixture-runner.ts
@@ -161,7 +161,7 @@ interface DiscoveredFixture {
 async function workflowNamesBeside(fixturesDir: string): Promise<string[]> {
   const parent = join(fixturesDir, '..');
   const names: string[] = [];
-  for (const entry of (await readdir(parent)).sort()) {
+  for (const entry of await readdir(parent)) {
     if (!entry.endsWith('.yaml') && !entry.endsWith('.yml')) continue;
     try {
       const doc = Bun.YAML.parse(await Bun.file(join(parent, entry)).text());
@@ -179,6 +179,9 @@ async function workflowNamesBeside(fixturesDir: string): Promise<string[]> {
       );
     }
   }
+  // Sorted, not merely deduped: two sibling workflow YAMLs beside one fixtures/ dir
+  // would otherwise yield names in filesystem order, and these reach the operator in
+  // a no-matching-workflow failure. Covered by the two-sibling test.
   return [...new Set(names)].sort();
 }
 
@@ -192,7 +195,10 @@ async function fixturesInDir(
     .split(sep)
     .filter(segment => segment.length > 0);
   const workflowNames = await workflowNamesBeside(fixturesDir);
-  const files = await readdir(fixturesDir).catch(() => []);
+  // No catch: the walk already saw this directory, so a read failure here is a real
+  // fault (EACCES/EIO), not an absence. Swallowing it would let `workflow test` exit 0
+  // having silently skipped a directory instead of certifying it.
+  const files = await readdir(fixturesDir);
   return files
     .filter(file => file.endsWith(FIXTURE_SUFFIX))
     .map(file => ({

--- a/packages/workflows/src/fixture-runner.ts
+++ b/packages/workflows/src/fixture-runner.ts
@@ -154,11 +154,14 @@ interface DiscoveredFixture {
   readonly workflowNames: readonly string[];
 }
 
-/** Collect every `*.yaml` sibling of a `fixtures/` dir and read its declared workflow names. */
+/**
+ * Collect every `*.yaml` sibling of a `fixtures/` dir and read its declared workflow
+ * names. Sorted: these names reach the operator in a no-matching-workflow failure.
+ */
 async function workflowNamesBeside(fixturesDir: string): Promise<string[]> {
   const parent = join(fixturesDir, '..');
   const names: string[] = [];
-  for (const entry of await readdir(parent)) {
+  for (const entry of (await readdir(parent)).sort()) {
     if (!entry.endsWith('.yaml') && !entry.endsWith('.yml')) continue;
     try {
       const doc = Bun.YAML.parse(await Bun.file(join(parent, entry)).text());
@@ -176,42 +179,61 @@ async function workflowNamesBeside(fixturesDir: string): Promise<string[]> {
       );
     }
   }
-  return [...new Set(names)];
+  return [...new Set(names)].sort();
 }
 
+/** Every fixture file directly inside one `fixtures/` directory. */
+async function fixturesInDir(
+  scopeRoot: string,
+  workflowDir: string,
+  fixturesDir: string
+): Promise<DiscoveredFixture[]> {
+  const dirs = relative(scopeRoot, workflowDir)
+    .split(sep)
+    .filter(segment => segment.length > 0);
+  const workflowNames = await workflowNamesBeside(fixturesDir);
+  const files = await readdir(fixturesDir).catch(() => []);
+  return files
+    .filter(file => file.endsWith(FIXTURE_SUFFIX))
+    .map(file => ({
+      label: [...dirs, FIXTURES_DIR, file].join('/'),
+      dirs,
+      path: join(fixturesDir, file),
+      workflowNames,
+    }));
+}
+
+/** Depth-first walk below one scope root, in whatever order the filesystem yields. */
 async function walkForFixtures(
   scopeRoot: string,
-  root: string,
-  depth: number,
-  out: DiscoveredFixture[]
-): Promise<void> {
-  if (depth > MAX_WALK_DEPTH) return;
-  let entries;
-  try {
-    entries = await readdir(root, { withFileTypes: true });
-  } catch {
-    return;
-  }
+  dir: string,
+  depth: number
+): Promise<DiscoveredFixture[]> {
+  if (depth > MAX_WALK_DEPTH) return [];
+  const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
+  const found: DiscoveredFixture[] = [];
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
-    const dirPath = join(root, entry.name);
-    if (entry.name === FIXTURES_DIR) {
-      const dirs = relative(scopeRoot, root)
-        .split(sep)
-        .filter(segment => segment.length > 0);
-      for (const file of await readdir(dirPath)) {
-        if (!file.endsWith(FIXTURE_SUFFIX)) continue;
-        out.push({
-          label: [...dirs, FIXTURES_DIR, file].join('/'),
-          dirs,
-          path: join(dirPath, file),
-          workflowNames: await workflowNamesBeside(dirPath),
-        });
-      }
-      continue;
-    }
-    await walkForFixtures(scopeRoot, dirPath, depth + 1, out);
+    const path = join(dir, entry.name);
+    found.push(
+      ...(entry.name === FIXTURES_DIR
+        ? await fixturesInDir(scopeRoot, dir, path)
+        : await walkForFixtures(scopeRoot, path, depth + 1))
+    );
   }
+  return found;
+}
+
+/**
+ * Fixtures under one scope root, ordered by label.
+ *
+ * `readdir` yields filesystem order, which is not stable across machines or
+ * filesystems, and this order reaches the report a human reads. Sorting here is the
+ * single point that defines it; nothing downstream reorders.
+ */
+async function fixturesUnderScope(scopeRoot: string): Promise<DiscoveredFixture[]> {
+  const found = await walkForFixtures(scopeRoot, scopeRoot, 0);
+  return found.sort((a, b) => (a.label < b.label ? -1 : a.label > b.label ? 1 : 0));
 }
 
 async function discoverFixtures(roots: readonly string[]): Promise<DiscoveredFixture[]> {
@@ -223,21 +245,15 @@ async function discoverFixtures(roots: readonly string[]): Promise<DiscoveredFix
     // canonical spellings and a target spelled through a symlink still matches
     // (e.g. macOS /tmp → /private/tmp).
     const scopeRoot = await realpath(root).catch(() => root);
-    const before = found.length;
-    await walkForFixtures(scopeRoot, scopeRoot, 0, found);
-    for (let i = before; i < found.length; i++) {
+    for (const fixture of await fixturesUnderScope(scopeRoot)) {
       // Keyed on the scope-relative label, not the absolute path: an absolute path is
       // unique per scope by construction, so keying on it would never dedup anything and
       // a project copy of a bundled workflow would run both fixtures. The label is what
       // makes an override shadow the copy it overrides, matching how `workflow-discovery`
       // resolves the same scope chain for the workflow files themselves.
-      if (seen.has(found[i].label)) {
-        // Higher-precedence scope already discovered this fixture.
-        found.splice(i, 1);
-        i--;
-      } else {
-        seen.add(found[i].label);
-      }
+      if (seen.has(fixture.label)) continue;
+      seen.add(fixture.label);
+      found.push(fixture);
     }
   }
   return found;


### PR DESCRIPTION
## Problem and outcome

Fixture discovery had no defined order. `walkForFixtures` appended results in raw `readdir` order and nothing sorted afterwards, so `report.results` came back differently on different machines — and `fixture-runner.test.ts` asserts exact ordered labels against it. That assertion failed twice on 2 September on two unrelated PRs (#3144 and #3159, neither touching workflows), both times with the same two fixtures simply swapped.

- **Outcome:** the same tree always produces the same report, in label order, and the existing exact-label assertions are honest as written rather than accidentally passing.
- **Invariant:** scope precedence is unchanged — a higher-precedence scope still shadows a lower one, keyed on the scope-relative label. Discovery finds the same set of fixtures; only their order becomes defined.
- **Scope boundary:** no change to what is discovered, to target resolution, or to fixture execution.
- **Root cause:** `readdir` returns filesystem order, and `packages/workflows/src/fixture-runner.ts` passed it straight through to the report.

## Review guidance

- **Feedback requested:** whether sorting belongs at discovery (as here) or at the report boundary, and whether the rewritten dedup reads more clearly than the version it replaces.
- **Start here:** `packages/workflows/src/fixture-runner.ts` — `fixturesUnderScope`, the one place that now defines order.
- **Review order:** `fixturesUnderScope` and `walkForFixtures`, then `discoverFixtures`, then the new test and the `writeWorkflowDirs` helper.
- **Lower-attention areas:** `writeNestedPackProject` collapses from 26 lines to 5 by calling the new helper; the 50 existing tests in the file pass unchanged.
- **Known risk or uncertainty:** None.

## Solution

Sorting one line onto the end of the walk would have fixed the symptom. The reason the order was undefined in the first place is the shape, so this changes that instead — the fix is a consequence.

`walkForFixtures` **returns** its results rather than appending to a caller-owned `out` array, so a caller can no longer depend on append order. `discoverFixtures` then filters each scope's results through a seen-set instead of splicing the shared array while indexing it with a manual `i--`, which is what coupled the two functions through `before = found.length`. `fixturesUnderScope` sorts by label — one place, named, with the invariant written down.

Two smaller consequences fall out: `workflowNamesBeside` is now called once per `fixtures/` directory rather than once per fixture file in it, since the sibling YAML it parses is the same for every file in that directory; and its own result is sorted, because those names reach the operator in a "no discovered workflow matches" failure.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Fixture report order varied by machine and filesystem | Fixture report is ordered by label everywhere |
| **Failure behavior** | An exact-label assertion failed at random on unrelated PRs | The assertion pins a defined contract |

## Validation

- `bun run validate` — exit 0.
- `cd packages/workflows && bun run test` — 156 pass, 0 fail — the 50 existing fixture-runner tests pass unchanged alongside the new guard.
- The new guard was observed red before being trusted, and the state space closed around it: with the sort removed it fails on this machine naturally (this filesystem returns creation order, and the test creates `zulu`, `mike`, `alfa` in that deliberately reverse-alphabetical order); with the sort mutated to descending it also fails. It passes only on ascending label order.
- **Not verified:** that CI's filesystem returns a non-alphabetical order for this specific tree. It does not need to — the guard now pins the order the code defines rather than the order a filesystem happens to yield, which is the whole point.

## Links

- Closes #3161


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Workflow fixtures are now discovered and displayed in a consistent, deterministic order.
  - Duplicate fixture labels across workflow scopes are no longer reported multiple times.
  - Errors encountered while reading fixture directories are now surfaced instead of being treated as missing fixtures.
  - Workflow names in “no matching workflow” messages are listed alphabetically.

- **Tests**
  - Added coverage for fixture ordering, error handling, and shared workflow fixture setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->