### PR TITLE
fix(isolation): reuse concurrent fork PR review worktree

### DIFF
--- a/packages/isolation/src/providers/worktree.test.ts
+++ b/packages/isolation/src/providers/worktree.test.ts
@@ -62,6 +62,7 @@ mock.module('@archon/paths', () => ({
 import * as git from '@archon/git';
 import * as worktreeCopy from '../worktree-copy';
 import type { IsolationRequest, PRIsolationRequest, RepoConfigLoader } from '../types';
+import type { IIsolationStore } from '../store';
 
 // Track sync function calls for testing
 let getDefaultBranchSpy: Mock<typeof git.getDefaultBranch>;
@@ -81,6 +82,7 @@ mock.module('node:fs/promises', () => ({
 }));
 
 import { WorktreeProvider } from './worktree';
+import { IsolationResolver } from '../resolver';
 
 describe('WorktreeProvider', () => {
   let provider: WorktreeProvider;
@@ -1415,15 +1417,20 @@ describe('WorktreeProvider', () => {
       const initialLookupsComplete = new Promise<void>(resolve => {
         releaseInitialLookups = resolve;
       });
-      const branchLookups: git.BranchName[] = [];
-      findWorktreeByBranchSpy.mockImplementation(async (_repoPath, branch) => {
-        branchLookups.push(branch);
-        if (branchLookups.length <= 2) {
-          if (branchLookups.length === 2) releaseInitialLookups();
+      let worktreeListCount = 0;
+      listWorktreesSpy.mockImplementation(async () => {
+        worktreeListCount++;
+        if (worktreeListCount <= 2) {
+          if (worktreeListCount === 2) releaseInitialLookups();
           await initialLookupsComplete;
-          return null;
+          return [];
         }
-        return git.toWorktreePath(winningPath);
+        return [
+          {
+            path: git.toWorktreePath(winningPath),
+            branch: git.toBranchName('pr-42-review'),
+          },
+        ];
       });
 
       let releaseWorktreeAdds!: () => void;
@@ -1453,12 +1460,118 @@ describe('WorktreeProvider', () => {
       expect(adopted.workingPath).toBe(winningPath);
       expect(adopted.branchName).toBe(git.toBranchName('pr-42-review'));
       expect(adopted.metadata).toMatchObject({ adopted: true, adoptedFrom: 'branch' });
-      expect(branchLookups).toEqual([
-        git.toBranchName('pr-42-review'),
-        git.toBranchName('pr-42-review'),
-        git.toBranchName('pr-42-review'),
-      ]);
+      expect(worktreeListCount).toBe(3);
+      expect(findWorktreeByBranchSpy).not.toHaveBeenCalled();
       expect(worktreeAddCount).toBe(2);
+    });
+
+    test('preserves a concurrently adopted review checkout when isolation persistence fails', async () => {
+      const request: PRIsolationRequest = {
+        codebaseId: 'cb-123',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
+        workflowType: 'pr',
+        identifier: '42',
+        prBranch: git.toBranchName('feature/auth'),
+        isForkPR: true,
+      };
+      const winningConfig = {
+        baseBranch: git.toBranchName('main'),
+        path: '.worktrees/winner',
+      };
+      const losingConfig = {
+        baseBranch: git.toBranchName('main'),
+        path: '.worktrees/loser',
+      };
+      const winningProvider = new WorktreeProvider(async () => winningConfig);
+      const losingProvider = new WorktreeProvider(async () => losingConfig);
+      const winningPath = winningProvider.getWorktreePath(
+        request,
+        winningProvider.generateBranchName(request),
+        winningConfig
+      );
+      const destroySpy = spyOn(losingProvider, 'destroy').mockResolvedValue({
+        worktreeRemoved: true,
+        branchDeleted: null,
+        remoteBranchDeleted: null,
+        directoryClean: true,
+        warnings: [],
+      });
+      const store: IIsolationStore = {
+        getById: async () => null,
+        findActiveByWorkflow: async () => null,
+        create: async () => {
+          throw new Error('DB constraint violation');
+        },
+        updateStatus: async () => undefined,
+        countActiveByCodebase: async () => 0,
+      };
+      const resolver = new IsolationResolver({ store, provider: losingProvider });
+
+      let releaseInitialLookups!: () => void;
+      const initialLookupsComplete = new Promise<void>(resolve => {
+        releaseInitialLookups = resolve;
+      });
+      let worktreeListCount = 0;
+      listWorktreesSpy.mockImplementation(async () => {
+        worktreeListCount++;
+        if (worktreeListCount <= 2) {
+          if (worktreeListCount === 2) releaseInitialLookups();
+          await initialLookupsComplete;
+          return [];
+        }
+        return [
+          {
+            path: git.toWorktreePath(winningPath),
+            branch: git.toBranchName('pr-42-review'),
+          },
+        ];
+      });
+
+      let releaseWorktreeAdds!: () => void;
+      const worktreeAddsComplete = new Promise<void>(resolve => {
+        releaseWorktreeAdds = resolve;
+      });
+      let worktreeAddCount = 0;
+      execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
+        if (args.includes('worktree') && args.includes('add')) {
+          worktreeAddCount++;
+          if (worktreeAddCount === 2) releaseWorktreeAdds();
+          await worktreeAddsComplete;
+          if (!args.includes(winningPath)) {
+            throw new Error('simulated concurrent worktree rejection');
+          }
+        }
+        return { stdout: '', stderr: '' };
+      });
+
+      const [winningResult, losingResult] = await Promise.allSettled([
+        winningProvider.create(request),
+        resolver.resolve({
+          existingEnvId: null,
+          codebase: {
+            id: 'cb-123',
+            defaultCwd: '/workspace/repo',
+            name: 'owner/repo',
+          },
+          hints: {
+            workflowType: 'pr',
+            workflowId: '42',
+            prBranch: git.toBranchName('feature/auth'),
+            isForkPR: true,
+          },
+          platformType: 'web',
+        }),
+      ]);
+
+      expect(winningResult.status).toBe('fulfilled');
+      expect(losingResult).toMatchObject({
+        status: 'rejected',
+        reason: expect.objectContaining({ message: 'DB constraint violation' }),
+      });
+      expect(destroySpy).not.toHaveBeenCalled();
+      expect(worktreeListCount).toBe(3);
+      expect(worktreeAddCount).toBe(2);
+      destroySpy.mockRestore();
     });
 
     test('keeps concurrent fork-PR launches for different PRs independent', async () => {
@@ -1488,14 +1601,67 @@ describe('WorktreeProvider', () => {
       });
       expect(worktreeAddRefs).toContain('pr-42-review');
       expect(worktreeAddRefs).toContain('pr-43-review');
-      expect(findWorktreeByBranchSpy).toHaveBeenCalledWith(
-        '/workspace/repo',
-        git.toBranchName('pr-42-review')
+      expect(listWorktreesSpy).toHaveBeenCalledTimes(2);
+      expect(findWorktreeByBranchSpy).not.toHaveBeenCalled();
+    });
+
+    test('does not adopt a slug-colliding branch for a fork-PR review checkout', async () => {
+      const request: PRIsolationRequest = {
+        codebaseId: 'cb-123',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
+        workflowType: 'pr',
+        identifier: '42',
+        prBranch: git.toBranchName('feature/auth'),
+        isForkPR: true,
+      };
+      const collidingPath = git.toWorktreePath('/workspace/worktrees/pr-42-review');
+      listWorktreesSpy.mockResolvedValue([
+        {
+          path: collidingPath,
+          branch: git.toBranchName('pr/42/review'),
+        },
+      ]);
+      findWorktreeByBranchSpy.mockResolvedValue(collidingPath);
+
+      const environment = await provider.create(request);
+
+      expect(environment.workingPath).not.toBe(collidingPath);
+      expect(environment.metadata.adopted).toBe(false);
+      expect(findWorktreeByBranchSpy).not.toHaveBeenCalled();
+    });
+
+    test('preserves worktree creation failure when only a slug-colliding branch is registered', async () => {
+      const request: PRIsolationRequest = {
+        codebaseId: 'cb-123',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
+        workflowType: 'pr',
+        identifier: '42',
+        prBranch: git.toBranchName('feature/auth'),
+        isForkPR: true,
+      };
+      const collidingPath = git.toWorktreePath('/workspace/worktrees/pr-42-review');
+      listWorktreesSpy.mockResolvedValue([
+        {
+          path: collidingPath,
+          branch: git.toBranchName('pr/42/review'),
+        },
+      ]);
+      let worktreeAddAttempted = false;
+      findWorktreeByBranchSpy.mockImplementation(async () =>
+        worktreeAddAttempted ? collidingPath : null
       );
-      expect(findWorktreeByBranchSpy).toHaveBeenCalledWith(
-        '/workspace/repo',
-        git.toBranchName('pr-43-review')
+      execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
+        if (args.includes('worktree') && args.includes('add')) {
+          worktreeAddAttempted = true;
+          throw new Error('simulated worktree add failure');
+        }
+        return { stdout: '', stderr: '' };
+      });
+
+      await expect(provider.create(request)).rejects.toThrow(
+        'Failed to create worktree for PR #42: simulated worktree add failure'
       );
+      expect(findWorktreeByBranchSpy).not.toHaveBeenCalled();
     });
 
     test('preserves a fork-PR worktree creation failure when no review checkout is registered', async () => {
@@ -1517,11 +1683,8 @@ describe('WorktreeProvider', () => {
       await expect(provider.create(request)).rejects.toThrow(
         'Failed to create worktree for PR #42: simulated worktree add failure'
       );
-      expect(findWorktreeByBranchSpy).toHaveBeenCalledTimes(2);
-      expect(findWorktreeByBranchSpy).toHaveBeenLastCalledWith(
-        '/workspace/repo',
-        git.toBranchName('pr-42-review')
-      );
+      expect(listWorktreesSpy).toHaveBeenCalledTimes(2);
+      expect(findWorktreeByBranchSpy).not.toHaveBeenCalled();
     });
 
     test('exhausts the bounded budget on persistent fork-PR fetch lock-race and fails before worktree creation', async () => {

--- a/packages/isolation/src/providers/worktree.test.ts
+++ b/packages/isolation/src/providers/worktree.test.ts
@@ -562,7 +562,9 @@ describe('WorktreeProvider', () => {
         isForkPR: false,
       };
 
-      await provider.create(request);
+      const environment = await provider.create(request);
+
+      expect(environment.branchName).toBe(git.toBranchName('feature/auth'));
 
       // PR branch fetch is delegated to syncWorkspace with fetch-only mode so
       // the bounded ref-lock retry lives in @archon/git.
@@ -612,7 +614,9 @@ describe('WorktreeProvider', () => {
         isForkPR: true,
       };
 
-      await provider.create(request);
+      const environment = await provider.create(request);
+
+      expect(environment.branchName).toBe(git.toBranchName('pr-42-review'));
 
       // Verify fetch with PR ref (fork PRs use pull/N/head)
       expect(execSpy).toHaveBeenCalledWith(
@@ -659,7 +663,9 @@ describe('WorktreeProvider', () => {
         isForkPR: true,
       };
 
-      await provider.create(request);
+      const environment = await provider.create(request);
+
+      expect(environment.branchName).toBe(git.toBranchName('pr-42-review'));
 
       // Verify fetch with PR ref and local branch creation
       expect(execSpy).toHaveBeenCalledWith(
@@ -731,6 +737,44 @@ describe('WorktreeProvider', () => {
         return args.includes('add');
       });
       expect(addCalls).toHaveLength(0);
+    });
+
+    test('adopts an expected-path fork-PR worktree by its synthetic review branch', async () => {
+      const request: PRIsolationRequest = {
+        codebaseId: 'cb-123',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
+        workflowType: 'pr',
+        identifier: '42',
+        prBranch: git.toBranchName('feature/auth'),
+        isForkPR: true,
+      };
+      worktreeExistsSpy.mockResolvedValue(true);
+      getCurrentBranchStrictSpy.mockResolvedValue(git.toBranchName('pr-42-review'));
+
+      const environment = await provider.create(request);
+
+      expect(getCurrentBranchStrictSpy).toHaveBeenCalledWith(environment.workingPath);
+      expect(environment.branchName).toBe(git.toBranchName('pr-42-review'));
+      expect(environment.metadata).toHaveProperty('adopted', true);
+      expect(findWorktreeByBranchSpy).not.toHaveBeenCalled();
+    });
+
+    test('refuses an expected-path fork-PR worktree on a different branch', async () => {
+      const request: PRIsolationRequest = {
+        codebaseId: 'cb-123',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
+        workflowType: 'pr',
+        identifier: '42',
+        prBranch: git.toBranchName('feature/auth'),
+        isForkPR: true,
+      };
+      worktreeExistsSpy.mockResolvedValue(true);
+      getCurrentBranchStrictSpy.mockResolvedValue(git.toBranchName('feature/auth'));
+
+      await expect(provider.create(request)).rejects.toThrow(
+        "expected branch 'pr-42-review', found 'feature/auth'"
+      );
+      expect(findWorktreeByBranchSpy).not.toHaveBeenCalled();
     });
 
     test('throws when worktree belongs to different repo root (cross-checkout)', async () => {
@@ -1339,6 +1383,144 @@ describe('WorktreeProvider', () => {
           'pr-42-review',
         ]),
         expect.any(Object)
+      );
+    });
+
+    test('adopts the registered review checkout when concurrent fork-PR worktree creation loses the race', async () => {
+      const request: PRIsolationRequest = {
+        codebaseId: 'cb-123',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
+        workflowType: 'pr',
+        identifier: '42',
+        prBranch: git.toBranchName('feature/auth'),
+        isForkPR: true,
+      };
+      const winningConfig = {
+        baseBranch: git.toBranchName('main'),
+        path: '.worktrees/winner',
+      };
+      const losingConfig = {
+        baseBranch: git.toBranchName('main'),
+        path: '.worktrees/loser',
+      };
+      const winningProvider = new WorktreeProvider(async () => winningConfig);
+      const losingProvider = new WorktreeProvider(async () => losingConfig);
+      const winningPath = winningProvider.getWorktreePath(
+        request,
+        winningProvider.generateBranchName(request),
+        winningConfig
+      );
+
+      let releaseInitialLookups!: () => void;
+      const initialLookupsComplete = new Promise<void>(resolve => {
+        releaseInitialLookups = resolve;
+      });
+      const branchLookups: git.BranchName[] = [];
+      findWorktreeByBranchSpy.mockImplementation(async (_repoPath, branch) => {
+        branchLookups.push(branch);
+        if (branchLookups.length <= 2) {
+          if (branchLookups.length === 2) releaseInitialLookups();
+          await initialLookupsComplete;
+          return null;
+        }
+        return git.toWorktreePath(winningPath);
+      });
+
+      let releaseWorktreeAdds!: () => void;
+      const worktreeAddsComplete = new Promise<void>(resolve => {
+        releaseWorktreeAdds = resolve;
+      });
+      let worktreeAddCount = 0;
+      execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
+        if (args.includes('worktree') && args.includes('add')) {
+          worktreeAddCount++;
+          if (worktreeAddCount === 2) releaseWorktreeAdds();
+          await worktreeAddsComplete;
+          if (!args.includes(winningPath)) {
+            throw new Error('simulated concurrent worktree rejection');
+          }
+        }
+        return { stdout: '', stderr: '' };
+      });
+
+      const [created, adopted] = await Promise.all([
+        winningProvider.create(request),
+        losingProvider.create(request),
+      ]);
+
+      expect(created.workingPath).toBe(winningPath);
+      expect(created.metadata).toHaveProperty('adopted', false);
+      expect(adopted.workingPath).toBe(winningPath);
+      expect(adopted.branchName).toBe(git.toBranchName('pr-42-review'));
+      expect(adopted.metadata).toMatchObject({ adopted: true, adoptedFrom: 'branch' });
+      expect(branchLookups).toEqual([
+        git.toBranchName('pr-42-review'),
+        git.toBranchName('pr-42-review'),
+        git.toBranchName('pr-42-review'),
+      ]);
+      expect(worktreeAddCount).toBe(2);
+    });
+
+    test('keeps concurrent fork-PR launches for different PRs independent', async () => {
+      const request42: PRIsolationRequest = {
+        codebaseId: 'cb-123',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
+        workflowType: 'pr',
+        identifier: '42',
+        prBranch: git.toBranchName('feature/auth'),
+        isForkPR: true,
+      };
+      const request43: PRIsolationRequest = {
+        ...request42,
+        identifier: '43',
+        prBranch: git.toBranchName('feature/billing'),
+      };
+
+      const environments = await Promise.all([
+        provider.create(request42),
+        provider.create(request43),
+      ]);
+
+      expect(environments.map(environment => environment.metadata.adopted)).toEqual([false, false]);
+      const worktreeAddRefs = execSpy.mock.calls.flatMap((call: unknown[]) => {
+        const args = call[1] as string[];
+        return args.includes('worktree') && args.includes('add') ? [args.at(-1)] : [];
+      });
+      expect(worktreeAddRefs).toContain('pr-42-review');
+      expect(worktreeAddRefs).toContain('pr-43-review');
+      expect(findWorktreeByBranchSpy).toHaveBeenCalledWith(
+        '/workspace/repo',
+        git.toBranchName('pr-42-review')
+      );
+      expect(findWorktreeByBranchSpy).toHaveBeenCalledWith(
+        '/workspace/repo',
+        git.toBranchName('pr-43-review')
+      );
+    });
+
+    test('preserves a fork-PR worktree creation failure when no review checkout is registered', async () => {
+      const request: PRIsolationRequest = {
+        codebaseId: 'cb-123',
+        canonicalRepoPath: git.toRepoPath('/workspace/repo'),
+        workflowType: 'pr',
+        identifier: '42',
+        prBranch: git.toBranchName('feature/auth'),
+        isForkPR: true,
+      };
+      execSpy.mockImplementation(async (_cmd: string, args: string[]) => {
+        if (args.includes('worktree') && args.includes('add')) {
+          throw new Error('simulated worktree add failure');
+        }
+        return { stdout: '', stderr: '' };
+      });
+
+      await expect(provider.create(request)).rejects.toThrow(
+        'Failed to create worktree for PR #42: simulated worktree add failure'
+      );
+      expect(findWorktreeByBranchSpy).toHaveBeenCalledTimes(2);
+      expect(findWorktreeByBranchSpy).toHaveBeenLastCalledWith(
+        '/workspace/repo',
+        git.toBranchName('pr-42-review')
       );
     });
 

--- a/packages/isolation/src/providers/worktree.ts
+++ b/packages/isolation/src/providers/worktree.ts
@@ -30,7 +30,7 @@ import {
 } from '@archon/git';
 import type { WorktreeBaseOverride } from '@archon/git';
 import { getArchonWorkspacesPath } from '@archon/paths';
-import type { RepoPath, WorktreeInfo } from '@archon/git';
+import type { BranchName, RepoPath, WorktreeInfo } from '@archon/git';
 import { copyWorktreeFiles } from '../worktree-copy';
 import type {
   DestroyResult,
@@ -62,6 +62,14 @@ function getLog(): ReturnType<typeof createLogger> {
 interface GitCommandAnchors {
   active: RepoPath;
   durable: RepoPath;
+}
+
+type WorktreeCreationResult =
+  | { kind: 'created'; warnings: string[] }
+  | { kind: 'adopted'; environment: WorktreeEnvironment };
+
+function getForkReviewBranch(prNumber: string): BranchName {
+  return toBranchName(`pr-${prNumber}-review`);
 }
 
 async function getGitCommandAnchors(path: string): Promise<GitCommandAnchors> {
@@ -184,21 +192,28 @@ export class WorktreeProvider implements IIsolationProvider {
     }
 
     // Create new worktree (re-uses the already-loaded repoConfig — no double load).
-    const { warnings } = await this.createWorktree(request, worktreePath, branchName, repoConfig);
+    const creation = await this.createWorktree(request, worktreePath, branchName, repoConfig);
+    if (creation.kind === 'adopted') {
+      return creation.environment;
+    }
 
     const existingTaskBranch =
       request.workflowType === 'task' && request.taskBranch?.kind === 'existing';
+    const checkedOutBranch =
+      isPRIsolationRequest(request) && request.isForkPR
+        ? getForkReviewBranch(request.identifier)
+        : branchName;
     return {
       id: envId,
       provider: 'worktree',
       workingPath: worktreePath,
-      branchName,
+      branchName: checkedOutBranch,
       status: 'active',
       createdAt: new Date(),
       metadata: existingTaskBranch
         ? { adopted: true, adoptedFrom: 'branch', request }
         : { adopted: false, request },
-      ...(warnings.length > 0 ? { warnings } : {}),
+      ...(creation.warnings.length > 0 ? { warnings: creation.warnings } : {}),
     };
   }
 
@@ -655,6 +670,11 @@ export class WorktreeProvider implements IIsolationProvider {
       request.workflowType === 'task' && request.taskBranch?.kind === 'existing'
         ? request.taskBranch.branch
         : undefined;
+    const exactBranch = isPRIsolationRequest(request)
+      ? request.isForkPR
+        ? getForkReviewBranch(request.identifier)
+        : request.prBranch
+      : exactTaskBranch;
     // Check if worktree already exists at expected path
     if (await worktreeExists(toWorktreePath(worktreePath))) {
       // Verify the existing worktree belongs to the same repo root before
@@ -679,58 +699,62 @@ export class WorktreeProvider implements IIsolationProvider {
         throw err;
       }
 
-      if (exactTaskBranch) {
+      if (exactBranch) {
         const actualBranch = await getCurrentBranchStrict(toWorktreePath(worktreePath));
-        if (actualBranch !== exactTaskBranch) {
+        if (actualBranch !== exactBranch) {
           throw new Error(
             `Cannot adopt worktree at '${worktreePath}': expected branch ` +
-              `'${exactTaskBranch}', found '${actualBranch ?? 'detached HEAD'}'.`
+              `'${exactBranch}', found '${actualBranch ?? 'detached HEAD'}'.`
           );
         }
       }
 
-      getLog().info({ worktreePath, branchName }, 'worktree_adopted');
-      return this.buildAdoptedEnvironment(worktreePath, branchName, request);
+      const adoptedBranch = exactBranch ?? toBranchName(branchName);
+      getLog().info({ worktreePath, branchName: adoptedBranch }, 'worktree_adopted');
+      return this.buildAdoptedEnvironment(worktreePath, adoptedBranch, request);
     }
 
     // Exact-branch requests also search Git's registered worktrees because an
     // external tool may have created the checkout at a non-Archon path.
-    const exactBranch = isPRIsolationRequest(request) ? request.prBranch : exactTaskBranch;
     if (exactBranch) {
-      const existingByBranch = exactTaskBranch
-        ? ((await listWorktrees(request.canonicalRepoPath)).find(
-            worktree => worktree.branch === exactTaskBranch
-          )?.path ?? null)
-        : await findWorktreeByBranch(request.canonicalRepoPath, exactBranch);
-      if (existingByBranch) {
-        // Same cross-clone guard as the primary adoption path above — a
-        // worktree matching the PR branch might still belong to a different
-        // clone of the same remote.
-        try {
-          await verifyWorktreeOwnership(existingByBranch, request.canonicalRepoPath);
-        } catch (err) {
-          getLog().warn(
-            {
-              worktreePath: existingByBranch,
-              branchName: exactBranch,
-              codebaseId: request.codebaseId,
-              canonicalRepoPath: request.canonicalRepoPath,
-              err: (err as Error).message,
-            },
-            'worktree.adoption_refused_cross_checkout'
-          );
-          throw err;
-        }
-
-        getLog().info(
-          { worktreePath: existingByBranch, branchName: exactBranch },
-          'worktree_adopted'
-        );
-        return this.buildAdoptedEnvironment(existingByBranch, exactBranch, request, 'branch');
-      }
+      return this.findRegisteredWorktree(request, exactBranch, Boolean(exactTaskBranch));
     }
 
     return null;
+  }
+
+  private async findRegisteredWorktree(
+    request: IsolationRequest,
+    branchName: BranchName,
+    requireExactBranch = false
+  ): Promise<WorktreeEnvironment | null> {
+    const worktreePath = requireExactBranch
+      ? ((await listWorktrees(request.canonicalRepoPath)).find(
+          worktree => worktree.branch === branchName
+        )?.path ?? null)
+      : await findWorktreeByBranch(request.canonicalRepoPath, branchName);
+    if (!worktreePath) {
+      return null;
+    }
+
+    try {
+      await verifyWorktreeOwnership(worktreePath, request.canonicalRepoPath);
+    } catch (err) {
+      getLog().warn(
+        {
+          worktreePath,
+          branchName,
+          codebaseId: request.codebaseId,
+          canonicalRepoPath: request.canonicalRepoPath,
+          err: (err as Error).message,
+        },
+        'worktree.adoption_refused_cross_checkout'
+      );
+      throw err;
+    }
+
+    getLog().info({ worktreePath, branchName }, 'worktree_adopted');
+    return this.buildAdoptedEnvironment(worktreePath, branchName, request, 'branch');
   }
 
   private buildAdoptedEnvironment(
@@ -752,7 +776,8 @@ export class WorktreeProvider implements IIsolationProvider {
 
   /**
    * Create the actual worktree.
-   * Returns warnings that should be surfaced to the user (non-fatal issues).
+   * Returns either the newly created worktree's warnings or a worktree adopted
+   * after a concurrent creator won the same branch.
    *
    * `repoConfig` is the already-loaded config from `create()`. Receiving it here
    * keeps the work of each public entrypoint tied to exactly one config load —
@@ -763,7 +788,7 @@ export class WorktreeProvider implements IIsolationProvider {
     worktreePath: string,
     branchName: string,
     worktreeConfig: WorktreeCreateConfig | null
-  ): Promise<{ warnings: string[] }> {
+  ): Promise<WorktreeCreationResult> {
     const repoPath = request.canonicalRepoPath;
 
     const override: WorktreeBaseOverride = {
@@ -795,7 +820,10 @@ export class WorktreeProvider implements IIsolationProvider {
 
       if (isPRIsolationRequest(request)) {
         // For PRs: fetch and checkout the PR branch (actual or synthetic)
-        await this.createFromPR(request, worktreePath, remote);
+        const adopted = await this.createFromPR(request, worktreePath, remote);
+        if (adopted) {
+          return { kind: 'adopted', environment: adopted };
+        }
       } else {
         // For issues, tasks, threads: create new branch
         await this.createNewBranch(request, repoPath, worktreePath, branchName, baseBranch, remote);
@@ -831,7 +859,7 @@ export class WorktreeProvider implements IIsolationProvider {
         'Config file could not be loaded — copyFiles configuration was not applied. Check your .archon/config.yaml for syntax errors.'
       );
     }
-    return { warnings };
+    return { kind: 'created', warnings };
   }
 
   /**
@@ -1064,7 +1092,7 @@ export class WorktreeProvider implements IIsolationProvider {
     request: PRIsolationRequest,
     worktreePath: string,
     remote = 'origin'
-  ): Promise<void> {
+  ): Promise<WorktreeEnvironment | null> {
     // Clean up any orphan directory before creating worktree
     await this.cleanOrphanDirectoryIfExists(worktreePath);
 
@@ -1077,8 +1105,9 @@ export class WorktreeProvider implements IIsolationProvider {
         await this.createFromSameRepoPR(repoPath, worktreePath, request.prBranch, remote);
       } else {
         // Fork PR: Use synthetic review branch
-        await this.createFromForkPR(repoPath, worktreePath, prNumber, remote, request.prSha);
+        return await this.createFromForkPR(request, worktreePath, remote);
       }
+      return null;
     } catch (error) {
       // Clean up orphaned git-registered worktree from partial failure
       // (e.g., worktree add succeeded but createBranchWithStaleRetry failed)
@@ -1158,13 +1187,14 @@ export class WorktreeProvider implements IIsolationProvider {
    * retries transient ref-lock races via fetchWithRefLockRetry.
    */
   private async createFromForkPR(
-    repoPath: string,
+    request: PRIsolationRequest,
     worktreePath: string,
-    prNumber: string,
-    remote = 'origin',
-    prSha?: string
-  ): Promise<void> {
-    const reviewBranch = `pr-${prNumber}-review`;
+    remote = 'origin'
+  ): Promise<WorktreeEnvironment | null> {
+    const repoPath = request.canonicalRepoPath;
+    const prNumber = request.identifier;
+    const reviewBranch = getForkReviewBranch(prNumber);
+    const prSha = request.prSha;
 
     if (prSha) {
       // SHA provided: create at specific commit for reproducible reviews.
@@ -1214,10 +1244,22 @@ export class WorktreeProvider implements IIsolationProvider {
         reviewBranch
       );
 
-      await execFileAsync('git', ['-C', repoPath, 'worktree', 'add', worktreePath, reviewBranch], {
-        timeout: GIT_OPERATION_TIMEOUT_MS,
-      });
+      try {
+        await execFileAsync(
+          'git',
+          ['-C', repoPath, 'worktree', 'add', worktreePath, reviewBranch],
+          { timeout: GIT_OPERATION_TIMEOUT_MS }
+        );
+      } catch (error) {
+        const adopted = await this.findRegisteredWorktree(request, reviewBranch);
+        if (adopted) {
+          return adopted;
+        }
+        throw error;
+      }
     }
+
+    return null;
   }
 
   /**

--- a/packages/isolation/src/providers/worktree.ts
+++ b/packages/isolation/src/providers/worktree.ts
@@ -717,7 +717,9 @@ export class WorktreeProvider implements IIsolationProvider {
     // Exact-branch requests also search Git's registered worktrees because an
     // external tool may have created the checkout at a non-Archon path.
     if (exactBranch) {
-      return this.findRegisteredWorktree(request, exactBranch, Boolean(exactTaskBranch));
+      const requireExactBranch =
+        exactTaskBranch !== undefined || (isPRIsolationRequest(request) && request.isForkPR);
+      return this.findRegisteredWorktree(request, exactBranch, requireExactBranch);
     }
 
     return null;
@@ -1251,7 +1253,7 @@ export class WorktreeProvider implements IIsolationProvider {
           { timeout: GIT_OPERATION_TIMEOUT_MS }
         );
       } catch (error) {
-        const adopted = await this.findRegisteredWorktree(request, reviewBranch);
+        const adopted = await this.findRegisteredWorktree(request, reviewBranch, true);
         if (adopted) {
           return adopted;
         }

--- a/packages/isolation/src/resolver.ts
+++ b/packages/isolation/src/resolver.ts
@@ -542,7 +542,7 @@ export class IsolationResolver {
     }
 
     // provider.create() succeeded — worktree exists on disk.
-    // If store.create() fails, we must clean up the orphaned worktree.
+    // If store.create() fails, clean up a worktree created by this call.
     let env: IsolationEnvironmentRow;
     try {
       env = await this.store.create({
@@ -570,28 +570,30 @@ export class IsolationResolver {
         'isolation_store_create_failed'
       );
 
-      // Clean up the orphaned worktree — best-effort, don't mask the original error
-      try {
-        await this.provider.destroy(isolatedEnv.workingPath, {
-          canonicalRepoPath: canonicalPath,
-          branchName: isolatedEnv.branchName,
-          force: true,
-        });
-        getLog().info(
-          { worktreePath: isolatedEnv.workingPath },
-          'isolation_orphan_cleanup_completed'
-        );
-      } catch (cleanupError) {
-        const cleanupErr =
-          cleanupError instanceof Error ? cleanupError : new Error(String(cleanupError));
-        getLog().error(
-          {
-            err: cleanupErr,
-            errorType: cleanupErr.constructor.name,
-            worktreePath: isolatedEnv.workingPath,
-          },
-          'isolation_orphan_cleanup_failed'
-        );
+      if (!isolatedEnv.metadata.adopted) {
+        // Clean up the orphaned worktree — best-effort, don't mask the original error
+        try {
+          await this.provider.destroy(isolatedEnv.workingPath, {
+            canonicalRepoPath: canonicalPath,
+            branchName: isolatedEnv.branchName,
+            force: true,
+          });
+          getLog().info(
+            { worktreePath: isolatedEnv.workingPath },
+            'isolation_orphan_cleanup_completed'
+          );
+        } catch (cleanupError) {
+          const cleanupErr =
+            cleanupError instanceof Error ? cleanupError : new Error(String(cleanupError));
+          getLog().error(
+            {
+              err: cleanupErr,
+              errorType: cleanupErr.constructor.name,
+              worktreePath: isolatedEnv.workingPath,
+            },
+            'isolation_orphan_cleanup_failed'
+          );
+        }
       }
 
       throw err; // Re-throw original store error — this is an unexpected failure


### PR DESCRIPTION
## Problem and outcome

Two concurrent fork-PR launches for the same PR can both reach `git worktree add` for the synthetic review branch. Git rejects the second checkout, and discovery previously searched the contributor branch rather than the contended `pr-<n>-review` branch, leaving the operator with a raw Git failure.

- **Outcome:** A losing no-SHA fork-PR launch re-reads Git's registered worktrees and adopts the existing `pr-<n>-review` checkout when it belongs to the same repository.
- **Invariant:** Adoption decisions use the registered worktree state and the synthetic branch Git checks out; they do not classify Git error text.
- **Scope boundary:** This does not add recovery for the distinct SHA-path `checkout -b` collision. It preserves the original creation failure when no registered review checkout exists.
- **Root cause:** Fork-PR adoption keyed on `request.prBranch`, while the fork path checks out `pr-<n>-review`; therefore it could not find the checkout that held the conflicting branch.

## Review guidance

- **Feedback requested:** Confirm that registered-worktree adoption is the correct defined outcome after a concurrent `worktree add` loss.
- **Start here:** `packages/isolation/src/providers/worktree.ts:673` — fork PRs now consistently identify their exact checked-out branch as `pr-<n>-review`.
- **Review order:** Review synthetic-branch discovery and adoption, then the post-failure structured-state lookup at `packages/isolation/src/providers/worktree.ts:1247`, followed by the concurrent-create coverage in `packages/isolation/src/providers/worktree.test.ts:1389`.
- **Lower-attention areas:** The remaining test additions cover expected-path adoption, different-PR independence, exact-match failure preservation, and preventing cleanup of a concurrently adopted checkout after persistence fails.
- **Known risk or uncertainty:** The fix deliberately covers the reported no-SHA `worktree add` race only; concurrent SHA-path branch creation is a separate failure shape.

## Solution

The provider derives the fork review branch once from the PR number and uses it for expected-path validation, registered-worktree discovery, and the environment's reported branch. When the no-SHA `git worktree add` fails, it looks up that branch through Git's worktree registry. A same-repository checkout is adopted through the existing ownership-checked helper; no checkout leaves the original failure intact.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Fork-PR discovery searches the contributor branch. | Discovery and environments use `pr-<n>-review`, the branch Git actually checks out. |
| **Failure behavior** | A concurrent second checkout can surface Git's raw "already used by worktree" error. | The second launch adopts the registered review checkout; an unregistered failure remains an explicit creation failure. |

## Validation

- `bun test src/providers/worktree.test.ts` from `packages/isolation` — 178 passing — exercises two simultaneous same-PR launches, expected-path validation, different PR numbers, exact-match failure preservation, and persistence failure after concurrent adoption.
- `bun run --cwd packages/isolation type-check` — passed.
- `bun run --cwd packages/isolation test` — passed.
- `bun run lint --max-warnings 0` — passed.
- `bun run validate` — passed, including generated-artifact checks, API types, package type-checks, lint, formatting, installer tests, and the repository test suite.
- **Not verified:** Nothing material; the concurrent state transition is covered directly by the deterministic provider test.

## Links

- Closes #3149



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pull request environment creation when multiple operations run concurrently.
  - Existing worktrees are now safely reused when they match the expected branch, preventing duplicate environments and unnecessary failures.
  - Fork pull request environments now correctly recognize and adopt matching review branches.
  - Environments created by another operation are preserved if a later registration step fails.
  - Worktrees on unexpected branches or with conflicting names continue to be rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->