### PR TITLE
cli: resume refusal names the same-branch relaunch path

### DIFF
--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -1952,6 +1952,90 @@ describe('workflowRunCommand — --input declared inputs (#2554)', () => {
   });
 });
 
+describe('workflowRunCommand — resume with nothing completed (#3154)', () => {
+  let tempRoot: string;
+  let consoleSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(async () => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'archon-cli-resume-empty-'));
+    consoleSpy = spyOn(console, 'log').mockImplementation(() => {});
+    const { executeWorkflow, hydrateResumableRun } = await import('@archon/workflows/executor');
+    (executeWorkflow as ReturnType<typeof mock>).mockClear();
+    (hydrateResumableRun as ReturnType<typeof mock>).mockClear();
+  });
+
+  afterEach(async () => {
+    consoleSpy.mockRestore();
+    await removeTempTree(tempRoot);
+  });
+
+  /** Stub discovery and a dead prior run whose worktree and isolation record survive. */
+  async function stubFailedPriorRun(): Promise<void> {
+    const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
+    (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
+      workflows: [makeTestWorkflowWithSource({ name: 'archon-ship' }, 'project')],
+      errors: [],
+    });
+    const conversationDb = await import('@archon/core/db/conversations');
+    const codebaseDb = await import('@archon/core/db/codebases');
+    const workflowDb = await import('@archon/core/db/workflows');
+    const isolationDb = await import('@archon/core/db/isolation-environments');
+    (conversationDb.getOrCreateConversation as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'conv-resume',
+    });
+    (codebaseDb.findCodebaseByDefaultCwd as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'cb-resume',
+      default_cwd: '/repo/root',
+      default_branch: 'main',
+    });
+    (workflowDb.findResumableRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      id: 'run-dead',
+      working_path: tempRoot,
+      workflow_name: 'archon-ship',
+    });
+    (isolationDb.listByCodebase as ReturnType<typeof mock>).mockResolvedValueOnce([
+      {
+        id: 'env-1',
+        codebase_id: 'cb-resume',
+        working_path: tempRoot,
+        branch_name: 'fix/issue-3124',
+      },
+    ]);
+  }
+
+  it('refuses and names the same-branch relaunch with --supersedes', async () => {
+    const { executeWorkflow, hydrateResumableRun } = await import('@archon/workflows/executor');
+    await stubFailedPriorRun();
+    (hydrateResumableRun as ReturnType<typeof mock>).mockResolvedValueOnce(null);
+
+    await expect(
+      workflowRunCommand('/repo/root', 'archon-ship', 'go', { resume: true })
+    ).rejects.toThrow(
+      /no completed nodes and no interactive-loop state[\s\S]*archon workflow run archon-ship --branch fix\/issue-3124 --supersedes run-dead/
+    );
+
+    // The refusal is still a refusal: no run is started.
+    expect(executeWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('still resumes when the prior run has completed nodes', async () => {
+    const { executeWorkflow, hydrateResumableRun } = await import('@archon/workflows/executor');
+    await stubFailedPriorRun();
+    (hydrateResumableRun as ReturnType<typeof mock>).mockResolvedValueOnce({
+      preCreatedRun: { id: 'run-dead', workflow_name: 'archon-ship' },
+      priorCompletedNodes: new Map([['triage', 'done']]),
+    });
+    (executeWorkflow as ReturnType<typeof mock>).mockResolvedValueOnce({
+      success: true,
+      workflowRunId: 'run-dead',
+    });
+
+    await workflowRunCommand('/repo/root', 'archon-ship', 'go', { resume: true });
+
+    expect(executeWorkflow).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('workflowRunCommand — sparse model bindings (#2481)', () => {
   let consoleSpy: ReturnType<typeof spyOn>;
 

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -1969,8 +1969,22 @@ describe('workflowRunCommand — resume with nothing completed (#3154)', () => {
     await removeTempTree(tempRoot);
   });
 
-  /** Stub discovery and a dead prior run whose worktree and isolation record survive. */
-  async function stubFailedPriorRun(): Promise<void> {
+  /**
+   * Stub discovery and a dead prior run. `status` drives the run's terminality
+   * and `isolationEnvs` seeds the isolation records the resume path matches —
+   * empty for an in-place prior run, the surviving worktree record by default.
+   */
+  async function stubFailedPriorRun(
+    status: 'failed' | 'running' = 'failed',
+    isolationEnvs: Array<Record<string, unknown>> = [
+      {
+        id: 'env-1',
+        codebase_id: 'cb-resume',
+        working_path: tempRoot,
+        branch_name: 'fix/issue-3124',
+      },
+    ]
+  ): Promise<void> {
     const { discoverWorkflowsWithConfig } = await import('@archon/workflows/workflow-discovery');
     (discoverWorkflowsWithConfig as ReturnType<typeof mock>).mockResolvedValueOnce({
       workflows: [makeTestWorkflowWithSource({ name: 'archon-ship' }, 'project')],
@@ -1992,15 +2006,9 @@ describe('workflowRunCommand — resume with nothing completed (#3154)', () => {
       id: 'run-dead',
       working_path: tempRoot,
       workflow_name: 'archon-ship',
+      status,
     });
-    (isolationDb.listByCodebase as ReturnType<typeof mock>).mockResolvedValueOnce([
-      {
-        id: 'env-1',
-        codebase_id: 'cb-resume',
-        working_path: tempRoot,
-        branch_name: 'fix/issue-3124',
-      },
-    ]);
+    (isolationDb.listByCodebase as ReturnType<typeof mock>).mockResolvedValueOnce(isolationEnvs);
   }
 
   it('refuses and names the same-branch relaunch with --supersedes', async () => {
@@ -2015,6 +2023,36 @@ describe('workflowRunCommand — resume with nothing completed (#3154)', () => {
     );
 
     // The refusal is still a refusal: no run is started.
+    expect(executeWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('suggests a fresh in-place relaunch when no isolation record matched', async () => {
+    const { executeWorkflow, hydrateResumableRun } = await import('@archon/workflows/executor');
+    await stubFailedPriorRun('failed', []);
+    (hydrateResumableRun as ReturnType<typeof mock>).mockResolvedValueOnce(null);
+
+    // An in-place relaunch cannot carry --branch: the prior run's branch is the
+    // main checkout's own, so suggesting it would hand the operator a command
+    // this same CLI refuses.
+    await expect(
+      workflowRunCommand('/repo/root', 'archon-ship', 'go', { resume: true })
+    ).rejects.toThrow(
+      /^Cannot resume: the prior run for 'archon-ship' has no completed nodes and no interactive-loop state\.\nNothing can be skipped, so start a fresh run instead:\n  archon workflow run archon-ship --supersedes run-dead$/
+    );
+    expect(executeWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('names the abandon step for a stale-running orphan before the relaunch', async () => {
+    const { executeWorkflow, hydrateResumableRun } = await import('@archon/workflows/executor');
+    await stubFailedPriorRun('running');
+    (hydrateResumableRun as ReturnType<typeof mock>).mockResolvedValueOnce(null);
+
+    // --supersedes refuses a still-running run, so the message must first release it.
+    await expect(
+      workflowRunCommand('/repo/root', 'archon-ship', 'go', { resume: true })
+    ).rejects.toThrow(
+      /no completed nodes and no interactive-loop state[\s\S]*archon workflow abandon run-dead[\s\S]*archon workflow run archon-ship --branch fix\/issue-3124 --supersedes run-dead/
+    );
     expect(executeWorkflow).not.toHaveBeenCalled();
   });
 

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -122,7 +122,10 @@ import type {
   WorkflowRunStatus,
   ContinuationMode,
 } from '@archon/workflows/schemas/workflow-run';
-import { TERMINAL_WORKFLOW_STATUSES } from '@archon/workflows/schemas/workflow-run';
+import {
+  TERMINAL_WORKFLOW_STATUSES,
+  isTerminalRunStatus,
+} from '@archon/workflows/schemas/workflow-run';
 import {
   approveWorkflow,
   rejectWorkflow,
@@ -2484,8 +2487,8 @@ async function runWorkflowWithOwnedSource(
   // longer performs implicit resume detection on its own.
   let resumable: WorkflowRun | null = null;
   // Branch of the prior run's worktree, from the isolation record the resume path
-  // matches (or git in the worktree when no record does) — used only by the
-  // no-completed-nodes refusal to name the relaunch command (#3154).
+  // matches. Only a worktree-isolated run has one; the no-completed-nodes refusal
+  // names it in the relaunch command it suggests (#3154).
   let resumeBranch: string | undefined;
   if (options.resume) {
     if (!codebase) {
@@ -3113,32 +3116,28 @@ async function runWorkflowWithOwnedSource(
       );
     }
     if (!prepared) {
-      // Best-effort only: the message must still refuse when the branch cannot be
-      // determined, so a failed probe degrades to a <branch> placeholder.
-      if (!resumeBranch) {
-        try {
-          const { stdout } = await git.execFileAsync('git', [
-            '-C',
-            workingCwd,
-            'rev-parse',
-            '--abbrev-ref',
-            'HEAD',
-          ]);
-          const branch = stdout.trim();
-          if (branch && branch !== 'HEAD') resumeBranch = branch;
-        } catch (error) {
-          getLog().debug(
-            { err: error as Error, workingPath: workingCwd },
-            'cli.workflow_resume_branch_probe_failed'
-          );
-        }
-      }
-      const relaunch = resumeBranch
-        ? `archon workflow run ${workflowName} --branch ${resumeBranch} --supersedes ${resumable.id}`
-        : `archon workflow run ${workflowName} --branch <branch> --supersedes ${resumable.id}`;
+      // `--branch` is only runnable when the prior run used worktree isolation:
+      // folder projects reject worktree options outright, and an in-place repo run
+      // cannot be relaunched onto the branch its own checkout holds. A stale-running
+      // orphan cannot be superseded until it is released, so name that step first.
+      const worktreeBranch = isFolderCodebase ? undefined : resumeBranch;
+      const unblock = isTerminalRunStatus(resumable.status)
+        ? ''
+        : `The run is still marked ${resumable.status}; release it before relaunching:\n` +
+          `  archon workflow abandon ${resumable.id}\n`;
+      const relaunch = [
+        'archon workflow run',
+        workflowName,
+        ...(worktreeBranch ? ['--branch', worktreeBranch] : []),
+        '--supersedes',
+        resumable.id,
+      ].join(' ');
       throw new Error(
         `Cannot resume: the prior run for '${workflowName}' has no completed nodes and no interactive-loop state.\n` +
-          'Nothing can be skipped, so relaunch on the same branch instead:\n' +
+          unblock +
+          (worktreeBranch
+            ? 'Nothing can be skipped, so relaunch on the same branch instead:\n'
+            : 'Nothing can be skipped, so start a fresh run instead:\n') +
           `  ${relaunch}`
       );
     }

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -2483,6 +2483,10 @@ async function runWorkflowWithOwnedSource(
   // the resumed-run handle to executeWorkflow below via opts. The executor no
   // longer performs implicit resume detection on its own.
   let resumable: WorkflowRun | null = null;
+  // Branch of the prior run's worktree, from the isolation record the resume path
+  // matches (or git in the worktree when no record does) — used only by the
+  // no-completed-nodes refusal to name the relaunch command (#3154).
+  let resumeBranch: string | undefined;
   if (options.resume) {
     if (!codebase) {
       if (codebaseLookupError) {
@@ -2543,6 +2547,7 @@ async function runWorkflowWithOwnedSource(
     const matchingEnv = allEnvs.find(e => e.working_path === workingCwd);
     if (matchingEnv) {
       isolationEnvId = matchingEnv.id;
+      resumeBranch = matchingEnv.branch_name;
       getLog().info(
         { envId: isolationEnvId, workingPath: workingCwd },
         'workflow.resume_env_found'
@@ -3108,8 +3113,33 @@ async function runWorkflowWithOwnedSource(
       );
     }
     if (!prepared) {
+      // Best-effort only: the message must still refuse when the branch cannot be
+      // determined, so a failed probe degrades to a <branch> placeholder.
+      if (!resumeBranch) {
+        try {
+          const { stdout } = await git.execFileAsync('git', [
+            '-C',
+            workingCwd,
+            'rev-parse',
+            '--abbrev-ref',
+            'HEAD',
+          ]);
+          const branch = stdout.trim();
+          if (branch && branch !== 'HEAD') resumeBranch = branch;
+        } catch (error) {
+          getLog().debug(
+            { err: error as Error, workingPath: workingCwd },
+            'cli.workflow_resume_branch_probe_failed'
+          );
+        }
+      }
+      const relaunch = resumeBranch
+        ? `archon workflow run ${workflowName} --branch ${resumeBranch} --supersedes ${resumable.id}`
+        : `archon workflow run ${workflowName} --branch <branch> --supersedes ${resumable.id}`;
       throw new Error(
-        `Cannot resume: the prior run for '${workflowName}' has no completed nodes and no interactive-loop state.`
+        `Cannot resume: the prior run for '${workflowName}' has no completed nodes and no interactive-loop state.\n` +
+          'Nothing can be skipped, so relaunch on the same branch instead:\n' +
+          `  ${relaunch}`
       );
     }
   }


### PR DESCRIPTION
## Problem and outcome

When `archon workflow resume <run-id>` refuses because the prior run has no completed nodes and no interactive-loop state, the error stopped there. Nothing on a fresh clone or a fresh terminal tells the operator how to proceed, even though the branch and run id needed for the way forward are already in scope at that point. There is nothing to skip, so resume cannot work; the correct action is a fresh launch on the same branch.

- **Outcome:** The refusal now appends a runnable relaunch command, e.g. `archon workflow run archon-ship --branch fix/issue-3124 --supersedes run-dead`, using the branch and run id the resume path already matched.
- **Invariant:** The refusal itself does not change: the command still fails with a non-zero exit, creates no run, and `--resume` and `--supersedes` stay mutually exclusive.
- **Scope boundary:** No new flag, command, or exit-code change; the `--supersedes` suggestion reuses the existing fresh-lane flag.

## Review guidance

- **Feedback requested:** Correctness of the branch resolution (isolation record only, gated on worktree-capable codebases) and the branchless fresh-relaunch suggestion when no branch applies.
- **Start here:** `packages/cli/src/commands/workflow.ts:3118` — the refusal site; this is where the branch is resolved and the relaunch command is composed.
- **Review order:** The refusal site in `workflow.ts`, then the new `resume with nothing completed (#3154)` describe block in `workflow.test.ts`.
- **Lower-attention areas:** The companion test case asserting the unchanged happy-path resume; it guards against the message work leaking into normal resume behavior.
- **Known risk or uncertainty:** None.

## Solution

The branch comes from the isolation environment row the resume path already matches (`matchingEnv.branch_name`, lifted into a function-scoped `resumeBranch`). `--branch` is only suggested when that row exists and the codebase is not a folder project, since folder projects reject worktree options outright; otherwise the suggestion is the plain fresh relaunch `archon workflow run <name> --supersedes <run-id>`. When the prior run is still marked running, the message first names the unblock step `archon workflow abandon <run-id>`, because `--supersedes` refuses a run that has not reached a terminal status. The suggested command names the prior run id with `--supersedes`, which is the existing mechanism for superseding a dead run on the same branch.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | `Cannot resume: the prior run for 'archon-ship' has no completed nodes and no interactive-loop state.` | Same refusal, plus `Nothing can be skipped, so relaunch on the same branch instead:` followed by a runnable `archon workflow run ... --branch <branch> --supersedes <run-id>` line. |
| **Failure behavior** | Operator must work out the relaunch path from the docs. | Operator gets a copy-pasteable next step built from values already in scope; when no branch applies (no matching isolation record, or a folder project), the suggested relaunch omits `--branch`, and a stale-running prior run gets an `archon workflow abandon <run-id>` step first. |

## Validation

- `bun test src/commands/workflow.test.ts` (packages/cli) — 399 pass, 0 fail, including new tests that pin the message naming both `--branch fix/issue-3124` and `--supersedes run-dead`, the branchless relaunch when no isolation record matches, and that `executeWorkflow` was never called. The first test fails against the pre-fix message.
- `bun run validate` (repo root) — exit 0: bundled-artifact checks, api-types, type-check across all packages, lint (`--max-warnings 0`), format check, test:install, and the full workspace test suite.

## Links

- Closes #3154


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow resume handling when a previous run has no completed work.
  * Resume attempts now provide clearer guidance based on the run’s status and available worktree information.
  * Prevented resuming empty runs while preserving resume behavior for runs with completed nodes.
* **Tests**
  * Added coverage for refusing empty-run resumes, including stale, terminal, and worktree-specific scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->