### PR TITLE
fix(adapters/slack): treat a bare reset as /reset

### DIFF
--- a/packages/adapters/src/chat/slack/adapter.test.ts
+++ b/packages/adapters/src/chat/slack/adapter.test.ts
@@ -242,6 +242,17 @@ describe('SlackAdapter', () => {
         )
       ).toBe('compare https://github.com/a and https://github.com/b');
     });
+
+    test('should map a bare reset to /reset', () => {
+      expect(adapter.stripBotMention('reset')).toBe('/reset');
+      expect(adapter.stripBotMention('RESET')).toBe('/reset');
+      expect(adapter.stripBotMention('<@U1234ABCD> reset')).toBe('/reset');
+    });
+
+    test('should leave /reset and longer reset text unchanged', () => {
+      expect(adapter.stripBotMention('/reset')).toBe('/reset');
+      expect(adapter.stripBotMention('reset please')).toBe('reset please');
+    });
   });
 
   describe('parent conversation ID', () => {

--- a/packages/adapters/src/chat/slack/adapter.ts
+++ b/packages/adapters/src/chat/slack/adapter.ts
@@ -356,6 +356,12 @@ export class SlackAdapter implements IPlatformAdapter {
     // Also handles URLs with labels: <https://example.com|example.com> -> https://example.com
     result = result.replace(/<(https?:\/\/[^|>]+)(?:\|[^>]+)?>/g, '$1');
 
+    // Slack intercepts `/reset` as a workspace slash command, so that text
+    // never reaches the bot. Accept a bare `reset` in this adapter only.
+    if (result.toLowerCase() === 'reset') {
+      return '/reset';
+    }
+
     return result;
   }
 


### PR DESCRIPTION
Slack intercepts `/reset` as a workspace slash command, so the bot never sees that text. Map a bare `reset` (exact match, case-insensitive, after mention/URL strip) to `/reset` in the Slack adapter only.

Fixes #2198


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Slack now correctly interprets a standalone “reset” command, regardless of capitalization, as `/reset`.
  - Existing `/reset` commands and longer messages such as “reset please” remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->