### PR TITLE
fix(cli): doctor fails on retired skill roots

### DIFF
--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -28,6 +28,7 @@ import {
   checkTelegram,
   checkTelemetry,
   checkFolderProject,
+  checkArchonSkill,
   defaultLoadClaudeBinaryDeps,
   doctorCommand,
   type ClaudeBinaryDeps,
@@ -908,6 +909,47 @@ describe('checkTelemetry', () => {
     const result = await checkTelemetry();
     expect(result.status).toBe('skip');
     expect(result.message).toContain('ARCHON_TELEMETRY_DISABLED');
+  });
+});
+
+describe('checkArchonSkill', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'archon-doctor-skill-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('skips when no skill trees are present', () => {
+    const result = checkArchonSkill(tmp);
+    expect(result.status).toBe('skip');
+    expect(result.label).toBe('Archon skill');
+  });
+
+  it('fails when a retired skill root is still on disk', () => {
+    mkdirSync(join(tmp, '.claude', 'skills', 'archon'), { recursive: true });
+    const result = checkArchonSkill(tmp);
+    expect(result.status).toBe('fail');
+    expect(result.message).toContain('retired skill root');
+    expect(result.message).toContain('archon skill install');
+  });
+
+  it('fails when skills exist but archon-cli is missing', () => {
+    mkdirSync(join(tmp, '.claude', 'skills'), { recursive: true });
+    const result = checkArchonSkill(tmp);
+    expect(result.status).toBe('fail');
+    expect(result.message).toContain('archon-cli is missing');
+  });
+
+  it('passes when archon-cli is installed and retired roots are gone', () => {
+    mkdirSync(join(tmp, '.claude', 'skills', 'archon-cli'), { recursive: true });
+    mkdirSync(join(tmp, '.agents', 'skills', 'archon-cli'), { recursive: true });
+    const result = checkArchonSkill(tmp);
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('archon-cli');
   });
 });
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -725,6 +725,64 @@ export async function checkTelegram(env: NodeJS.ProcessEnv): Promise<CheckResult
   }
 }
 
+const RETIRED_SKILL_ROOTS = ['archon', 'manage-run'] as const;
+const CURRENT_SKILL_ROOT = 'archon-cli';
+
+/**
+ * Catch the v0.10.0 skill migration that `archon skill install` performs but
+ * upgrades never run: leftover `archon` / `manage-run` roots, or a missing
+ * `archon-cli` replacement. Skip when this project has never installed skills.
+ */
+export function checkArchonSkill(cwd: string = process.cwd()): CheckResult {
+  const label = 'Archon skill';
+  const skillsRoots = [join(cwd, '.claude', 'skills'), join(cwd, '.agents', 'skills')];
+
+  const retired: string[] = [];
+  let hasCurrent = false;
+  let sawSkillsTree = false;
+
+  for (const skillsRoot of skillsRoots) {
+    if (!existsSync(skillsRoot)) {
+      continue;
+    }
+    sawSkillsTree = true;
+    for (const name of RETIRED_SKILL_ROOTS) {
+      if (existsSync(join(skillsRoot, name))) {
+        retired.push(`${skillsRoot}/${name}`);
+      }
+    }
+    if (existsSync(join(skillsRoot, CURRENT_SKILL_ROOT))) {
+      hasCurrent = true;
+    }
+  }
+
+  if (retired.length > 0) {
+    return {
+      label,
+      status: 'fail',
+      message: `retired skill root(s) still present. Run \`archon skill install .\` to replace them with ${CURRENT_SKILL_ROOT}.`,
+    };
+  }
+
+  if (sawSkillsTree && !hasCurrent) {
+    return {
+      label,
+      status: 'fail',
+      message: `${CURRENT_SKILL_ROOT} is missing. Run \`archon skill install .\` to install the current skill.`,
+    };
+  }
+
+  if (!hasCurrent) {
+    return {
+      label,
+      status: 'skip',
+      message: `not installed (run \`archon skill install .\` if you use Claude Code or Codex skills)`,
+    };
+  }
+
+  return { label, status: 'pass', message: `${CURRENT_SKILL_ROOT} installed` };
+}
+
 function renderResult(r: CheckResult): string {
   const icon = r.status === 'pass' ? '✓' : r.status === 'fail' ? '✗' : '○';
   return `${icon} ${r.label}: ${r.message}`;
@@ -755,6 +813,7 @@ export async function doctorCommand(
         checkConnectedProviders(env),
         checkWorkspaceWritable(),
         checkBundledDefaults(),
+        checkArchonSkill(),
         checkTelemetry(),
         checkSlack(env),
         checkTelegram(env),


### PR DESCRIPTION
v0.10.0 replaced the `archon` and `manage-run` skill roots with `archon-cli`, but upgrades do not run `skill install`. Doctor now fails that drift instead of printing All checks passed.

Fixes #3179


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a diagnostic check that detects outdated Archon skill directories and verifies the current `archon-cli` skill is installed.
  * The check now runs as part of the default doctor command.

* **Bug Fixes**
  * Doctor reports failures when retired skill directories remain or the current skill is missing.
  * The check is skipped when no skills have been installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->