### PR TITLE
fix(setup): recommend a classic token; fine-grained cannot read check runs

### DIFF
--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -1338,13 +1338,15 @@ async function collectGitHubConfig(): Promise<GitHubConfig> {
   note(
     'GitHub Personal Access Token Setup\n\n' +
       '1. Go to github.com/settings/tokens\n' +
-      '2. Click "Generate new token" -> "Fine-grained token"\n' +
-      '3. Set expiration and select your target repository\n' +
-      '4. Under Permissions, enable:\n' +
-      '   - Issues: Read and write\n' +
-      '   - Pull requests: Read and write\n' +
-      '   - Contents: Read\n' +
-      '5. Generate and copy the token',
+      '2. Click "Generate new token" -> "Generate new token (classic)"\n' +
+      '3. Set an expiration and select these scopes:\n' +
+      '   - repo (clone and push, issues, pull requests, and CI check state)\n' +
+      '   - workflow (only if runs may change .github/workflows/ files)\n' +
+      '4. Generate and copy the token\n\n' +
+      'A fine-grained token cannot read GitHub Actions check runs: GitHub exposes\n' +
+      'no Checks permission to them, so a workflow that waits on CI stops there.\n' +
+      'The repo scope is broad, so prefer GitHub App mode when you want access\n' +
+      'granted per repository (docs: adapters/github-app-setup).',
     'GitHub Setup'
   );
 

--- a/packages/docs-web/src/content/docs/getting-started/overview.md
+++ b/packages/docs-web/src/content/docs/getting-started/overview.md
@@ -90,8 +90,10 @@ You need two things: a GitHub token (for cloning repos) and Claude authenticatio
 
 1. Go to [github.com/settings/tokens](https://github.com/settings/tokens)
 2. Click **"Generate new token (classic)"**
-3. Select scope: **`repo`**
+3. Select scope: **`repo`**, plus **`workflow`** if your runs may change files under `.github/workflows/`
 4. Copy the token (starts with `ghp_...`)
+
+> **Why classic and not fine-grained?** GitHub exposes no Checks permission to fine-grained tokens, so they cannot read GitHub Actions check runs and a workflow that waits on CI fails at that gate. The `repo` scope is broad in exchange; [GitHub App mode](/adapters/github-app-setup/) grants access per repository and reads checks, if you would rather not hand over a repo-wide token.
 
 ### Claude Authentication
 


### PR DESCRIPTION
## Problem and outcome

`archon setup` tells the operator to build a fine-grained personal access token with Issues:
Read and write, Pull requests: Read and write, and Contents: Read. A token built to that recipe
cannot complete a run. Contents: Read cannot push the branch a run works on, and no fine-grained
token can read GitHub Actions check runs at all, so `archon-deliver`'s `await-checks` gate dies on
`gh pr checks` with `GraphQL: Resource not accessible by personal access token
(node.statusCheckRollup...)`, after the implementation, review, validation and PR are already
done and paid for.

- **Outcome:** The wizard prints a token recipe that completes a run, and names the one capability
  no personal access token recipe can supply, at setup time rather than an hour into a run.
- **Invariant:** The token recipe the setup wizard prints is sufficient for the workflows Archon
  ships.
- **Scope boundary:** No code path changes. Only the wizard's `note()` text and the
  getting-started token section.
- **Root cause:** `Checks` is not one of the 30 repository permissions GitHub offers fine-grained
  tokens. The Checks API is reachable only by GitHub Apps and by classic tokens with `repo`.
  GitHub lists this among the published fine-grained PAT limitations, and GitHub staff have stated
  it directly: "it isn't possible to assign Checks permissions to a Fine-grained PAT, only GitHub
  Apps can access this API."

## Review guidance

- **Feedback requested:** Whether steering solo installs to a classic `repo` token is the right
  default given how coarse that scope is, versus pushing harder toward App mode.
- **Start here:** `packages/cli/src/commands/setup.ts:1338`, the recipe an operator actually
  follows.
- **Review order:** `setup.ts`, then `overview.md`. The docs already said classic + `repo` while
  the wizard said fine-grained; both now carry the same reasoning so they cannot silently drift
  apart again.
- **Lower-attention areas:** None. Two prose edits.
- **Known risk or uncertainty:** `repo` is broad, all-or-nothing across every repository the
  owner can reach. The note names App mode as the per-repository alternative but does not route a
  solo user through App setup.

## Solution

Replace the fine-grained recipe with a classic token carrying `repo`, plus `workflow` only when
runs may change files under `.github/workflows/`. Both surfaces keep one sentence explaining why
fine-grained is not merely under-specified but structurally unable to read check runs, and both
point at GitHub App mode, which Archon already supports, for operators who want per-repository
access and the CI gate.

The alternative, keeping fine-grained and adding `Contents: Read and write`, `Commit statuses:
Read-only` and `Actions: Read-only`, was tried and rejected: it fixes push and the commit-status
half of `statusCheckRollup`, but every check run stays unreadable, so a repository whose CI is
GitHub Actions still fails the gate. That is not a recipe worth printing.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Wizard prints a fine-grained recipe: Issues, Pull requests, Contents: Read | Wizard prints a classic recipe: `repo`, plus `workflow` when workflow files change |
| **Failure behavior** | A run implements, reviews, validates and opens the PR, then fails at `await-checks` with `Resource not accessible by personal access token` | The limitation is stated at setup time, with App mode named as the alternative that reads checks |

## Validation

- `bun x tsc --noEmit` (packages/cli): clean.
- `bun run lint`: clean.
- `bun x prettier --check` on both changed files: clean.
- `bun test src/commands/setup.test.ts src/commands/doctor.test.ts`: 143 pass, 1 skip, 0 fail.
- `bun run check:bundled`, `check:bundled-skill`, `check:bundled-schema`, `check:pi-vendor-map`,
  `check:capability-matrix`: all OK.
- `bun run build` (packages/docs-web): 85 pages built; the new `/adapters/github-app-setup/` link
  resolves in `dist`.
- Behavioral evidence, against a private repository whose CI is GitHub Actions:
  a fine-grained token with Contents, Pull requests, Issues, Commit statuses and Actions granted
  returns `Resource not accessible by personal access token` on both
  `GET /repos/{owner}/{repo}/commits/{ref}/check-runs` and `gh pr checks`; a token carrying `repo`
  returns all five check buckets from `gh pr checks` and a valid payload from the same REST
  endpoint.
- **Not verified:** the `repo`-scoped token used above was an OAuth token minted by `gh auth
  login`, not a literal `ghp_` classic token. GitHub documents both under the same requirement for
  this endpoint ("OAuth app tokens and personal access tokens (classic) need the `repo` scope to
  use this endpoint on a private repository"), so they share the code path, but a `ghp_` token was
  not probed directly.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Security / permissions / data | `repo` is coarser than a fine-grained token scoped to one repository. Accepted because the shipped workflows cannot function without check-run reads; the note names App mode as the narrower alternative. | `packages/cli/src/commands/setup.ts:1349`, `packages/docs-web/src/content/docs/adapters/github-app-setup.md` |
| Documentation / communication | The wizard and the getting-started guide disagreed on token class. Both updated in this PR. | `packages/docs-web/src/content/docs/getting-started/overview.md:93` |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated GitHub token setup guidance to recommend classic personal access tokens with the `repo` scope.
  - Clarified when the `workflow` scope is needed for changes involving GitHub Actions workflows.
  - Added an explanation that fine-grained tokens cannot read Actions check runs, which may cause workflows waiting on CI to fail.
  - Documented GitHub App mode as an alternative for narrower repository access while retaining check-run visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->