### PR TITLE
fix(cli): `archon serve` extracts the web UI from any Windows shell

### DIFF
--- a/packages/cli/src/commands/serve.test.ts
+++ b/packages/cli/src/commands/serve.test.ts
@@ -31,7 +31,13 @@ mock.module('@archon/paths', () => ({
   BUNDLED_WEB_DIST_SHA256: '',
 }));
 
-import { serveCommand, parseChecksum, parseEmbeddedChecksum, downloadWebDist } from './serve';
+import {
+  serveCommand,
+  parseChecksum,
+  parseEmbeddedChecksum,
+  downloadWebDist,
+  resolveTarBin,
+} from './serve';
 
 describe('parseChecksum', () => {
   const validHash = 'a'.repeat(64);
@@ -179,6 +185,48 @@ function buildWebTarball(indexHtml: string): Uint8Array<ArrayBuffer> {
   );
 }
 
+describe('resolveTarBin', () => {
+  // Windows ships bsdtar at System32\tar.exe, but Git for Windows puts GNU tar
+  // on PATH ahead of it, and GNU tar cannot open a drive-letter operand: it
+  // mangles the `-C C:\Users\...` operand into a colon-escaped path and exits 2.
+  // Leaving the binary to PATH makes extraction depend on which shell launched
+  // Archon, so these cases pin the choice on every host — CI runs them off Windows.
+  const SYSTEM32_TAR = /[/\\]System32[/\\]tar\.exe$/;
+
+  it('pins the Windows system tar when it is present', () => {
+    const probed: string[] = [];
+
+    const bin = resolveTarBin('win32', path => {
+      probed.push(path);
+      return true;
+    });
+
+    expect(bin).not.toBe('tar');
+    expect(bin).toMatch(SYSTEM32_TAR);
+    // The probe must ask about the path it returns, not some other file.
+    expect(probed).toEqual([bin]);
+  });
+
+  it('falls back to PATH when Windows has no bundled tar', () => {
+    // Pre-1803 Windows ships no tar. Returning the absolute path anyway would
+    // spawn a file that does not exist, which is a worse failure than a PATH miss.
+    expect(resolveTarBin('win32', () => false)).toBe('tar');
+  });
+
+  it('leaves the binary to PATH off Windows', () => {
+    const probed: string[] = [];
+
+    const bin = resolveTarBin('linux', path => {
+      probed.push(path);
+      return true;
+    });
+
+    expect(bin).toBe('tar');
+    // No filesystem probe at all — the POSIX `tar` on PATH is the right one.
+    expect(probed).toEqual([]);
+  });
+});
+
 describe('downloadWebDist', () => {
   let tmpRoot: string;
   let tarballBytes: Uint8Array;
@@ -220,11 +268,13 @@ describe('downloadWebDist', () => {
     const targetDir = join(tmpRoot, 'target-embedded-ok');
     const spawnSpy = spyOn(Bun, 'spawn');
     let extractorStdin: unknown;
+    let extractorBin: string | undefined;
 
     try {
       await downloadWebDist('9.9.9', targetDir, tarballHash);
       // Read before restoring — mockRestore() clears the recorded calls.
       extractorStdin = (spawnSpy.mock.calls[0]?.[1] as { stdin?: unknown } | undefined)?.stdin;
+      extractorBin = (spawnSpy.mock.calls[0]?.[0] as string[] | undefined)?.[0];
     } finally {
       spawnSpy.mockRestore();
     }
@@ -240,6 +290,13 @@ describe('downloadWebDist', () => {
     // pump blocks `tar` forever — the windows hang in #2924. A BunFile is a Blob;
     // a Uint8Array is not, which is exactly the regression this catches.
     expect(extractorStdin).toBeInstanceOf(Blob);
+    // Wiring: extraction must spawn the resolved binary, not the bare name. An
+    // exported-but-uncalled resolver leaves Windows on PATH, which is the bug.
+    if (process.platform === 'win32') {
+      expect(extractorBin).toMatch(/[/\\]System32[/\\]tar\.exe$/);
+    } else {
+      expect(extractorBin).toBe('tar');
+    }
     // The staged archive is ~2 MB in production — it must not survive extraction.
     expect(existsSync(`${targetDir}.tmp.tar.gz`)).toBe(false);
   });

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1,4 +1,4 @@
-import { dirname } from 'path';
+import { dirname, join } from 'path';
 import { existsSync, mkdirSync, renameSync, rmSync } from 'fs';
 import {
   createLogger,
@@ -206,7 +206,7 @@ export async function downloadWebDist(
   // Only read after a clean `tar` exit, so the throw paths never see the seed.
   let extractionEndedAt = extractionStartedAt;
   try {
-    const proc = Bun.spawn(['tar', 'xzf', '-', '-C', tmpDir, '--strip-components=1'], {
+    const proc = Bun.spawn([resolveTarBin(), 'xzf', '-', '-C', tmpDir, '--strip-components=1'], {
       stdin: Bun.file(tarballPath),
       stderr: 'pipe',
       timeout: EXTRACTION_TIMEOUT_MS,
@@ -281,6 +281,29 @@ export async function downloadWebDist(
     'web_dist.installed'
   );
   console.log(`Extracted to ${targetDir}`);
+}
+
+/**
+ * Resolve the `tar` binary for extraction.
+ *
+ * Windows must pin it rather than leave it to PATH. Windows ships bsdtar at
+ * `System32\tar.exe`, which accepts a drive-letter operand, but Git for Windows
+ * puts GNU tar on PATH at `Git\usr\bin`, and GNU tar cannot open one — it mangles
+ * `-C C:\Users\...` and exits 2. Which one wins depends on the PATH of whichever
+ * shell launched Archon, so extraction succeeded from cmd and failed from Git Bash.
+ *
+ * `platform` and `exists` are injected so both Windows branches stay covered on a
+ * non-Windows CI runner.
+ */
+export function resolveTarBin(
+  platform: NodeJS.Platform = process.platform,
+  exists: (path: string) => boolean = existsSync
+): string {
+  if (platform !== 'win32') return 'tar';
+  const systemTar = join(process.env.SystemRoot ?? 'C:\\Windows', 'System32', 'tar.exe');
+  // Pre-1803 Windows bundles no tar; fall back to PATH rather than spawning a
+  // path we already know is absent.
+  return exists(systemTar) ? systemTar : 'tar';
 }
 
 function cleanupAndThrow(tmpDir: string, message: string): never {


### PR DESCRIPTION
## Problem and outcome

`archon serve` extracted the web UI by spawning a bare `tar`, so the binary came from PATH. Windows ships bsdtar at `System32\tar.exe`, but Git for Windows puts GNU tar at `Git\usr\bin`, and GNU tar cannot open the drive-letter operand the command passes — it mangles `-C C:\Users\...` and exits 2. Which tar won depended on the PATH of whichever shell launched Archon, so extraction succeeded from `cmd` and failed from Git Bash.

- **Outcome:** extraction resolves `tar` explicitly, so `archon serve` works from any shell on Windows.
- **Invariant:** non-Windows platforms keep using the `tar` on PATH, and a Windows install with no bundled `tar` still falls back to PATH rather than spawning a path known to be absent.
- **Scope boundary:** the extraction arguments, staging, checksum verification, and cleanup paths are untouched. No other `tar` or subprocess call site changes.
- **Root cause:** the binary name was left to PATH resolution on a platform where two incompatible `tar` implementations are routinely both installed.

## Review guidance

- **Feedback requested:** correctness of the fallback branch, and whether the injected `platform`/`exists` parameters are the shape you want for platform-conditional resolution.
- **Start here:** `packages/cli/src/commands/serve.ts:286` — `resolveTarBin` is the whole behavior change; the call site at `:209` is one substituted argument.
- **Review order:** `serve.ts` (resolver + call site), then `serve.test.ts` (three branch cases, then the wiring assertion inside the existing spawn-shape test).
- **Lower-attention areas:** none; the diff is 83 lines across two files.
- **Known risk or uncertainty:** `SystemRoot` is read once at call time with a `C:\Windows` default. An install that relocates it and unsets the variable would fall back to PATH, which is the pre-existing behavior.

## Solution

`resolveTarBin()` returns `tar` off Windows and `%SystemRoot%\System32\tar.exe` on Windows when that file exists, falling back to `tar` when it does not (pre-1803 Windows bundles none). `downloadWebDist` spawns the resolved value instead of the literal.

`platform` and `exists` are parameters with live defaults rather than module mocks. That keeps both Windows branches covered when the runner is Linux, and avoids adding a `mock.module` to a file the repository already keeps free of cross-package mock pollution.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | `archon serve` extraction depends on the launching shell's PATH on Windows | Extraction resolves the same binary from every shell |
| **Failure behavior** | `tar extraction failed (exit 2)` naming a mangled `C\:\Users\...` path | Not reached; on a Windows build with no bundled tar, resolution falls back to PATH as before |

## Validation

- `bun test packages/cli/src/commands/serve.test.ts` — 24 pass, 0 fail on Windows with Git Bash on PATH. **Before this change the same suite reports 3 failures on that host**: the new `resolveTarBin` Windows case, plus the two pre-existing `downloadWebDist` extraction cases, which fail with `tar: C\:\Users\...: Cannot open: No such file or directory`. The fix turns existing red green.
- `bun --filter '@archon/cli' test` — exits 0.
- `bun --filter '@archon/cli' type-check`, `bun run type-check` — exit 0.
- `bun run lint`, `bun run format:check` — pass, including `check-test-cleanup-drift`.
- `bun run check:bundled`, `check:bundled-skill`, `check:bundled-schema`, `check:pi-vendor-map`, `check:capability-matrix`, `check:api-types` — all pass.
- **Not verified:** `bun run test:install` — `scripts/test-install.sh` refuses MINGW/MSYS by design, and CI already skips it on Windows. The full `bun run test` was run per package rather than through the root fail-fast wrapper.

## Links

- Closes #3188


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when serving or downloading web distributions on Windows by selecting the system archive extractor when available.
  - Added a fallback to the existing PATH-based extractor when the Windows system utility is unavailable.
  - Preserved consistent archive extraction behavior across non-Windows platforms.
  - Expanded automated coverage to verify extractor selection across supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->