### PR TITLE
test: skip the symlink cases on capability, not on platform

### DIFF
--- a/packages/providers/src/claude/binary-resolver.test.ts
+++ b/packages/providers/src/claude/binary-resolver.test.ts
@@ -5,9 +5,35 @@
  * with BUNDLED_IS_BINARY=true, which conflicts with other test files.
  */
 import { describe, test, expect, mock, beforeEach, afterAll, spyOn } from 'bun:test';
-import { homedir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { mkdtempSync, symlinkSync, unlinkSync } from 'node:fs';
+import { trackTempRoots } from '@archon/paths/test-utils';
 import { createMockLogger } from '../test/mocks/logger';
+
+// Windows only permits symlink creation for an elevated process or with Developer
+// Mode enabled, so the broken-symlink case below is a capability question, not a
+// platform question. Probe by attempting the real operation: a
+// `process.platform === 'win32'` guard would ALSO skip on the CI windows-latest
+// runner, which CAN create symlinks and currently covers this test.
+const canSymlink = (() => {
+  // Cleaned up with a non-recursive unlink on a single path: a module-scope probe runs
+  // before any test, so it cannot use trackTempRoots (which registers an afterEach), and
+  // a recursive rmSync is what the cleanup-drift guard exists to refuse.
+  const link = join(tmpdir(), `archon-symlink-probe-${process.pid}-${Date.now()}`);
+  try {
+    symlinkSync(join(tmpdir(), 'archon-symlink-probe-target'), link);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    try {
+      unlinkSync(link);
+    } catch {
+      // The symlink was never created — nothing to remove.
+    }
+  }
+})();
 
 const mockLogger = createMockLogger();
 
@@ -297,6 +323,8 @@ describe('resolveClaudeBinaryPath (binary mode)', () => {
 });
 
 describe('pathKind', () => {
+  const trackTempRoot = trackTempRoots();
+
   test('returns "file" for a real file', async () => {
     const { mkdtempSync, writeFileSync, rmSync } = await import('node:fs');
     const { tmpdir } = await import('node:os');
@@ -325,19 +353,13 @@ describe('pathKind', () => {
     expect(resolver.pathKind('/definitely/does/not/exist/anywhere/12345')).toBe('missing');
   });
 
-  test('returns "missing" for a broken symlink without throwing', async () => {
+  test.skipIf(!canSymlink)('returns "missing" for a broken symlink without throwing', () => {
     // statSync follows symlinks by default — broken targets raise ENOENT,
     // which must be caught and reported as 'missing' so the resolver's
     // "file does not exist" path fires instead of an uncaught exception.
-    const { mkdtempSync, symlinkSync, rmSync } = await import('node:fs');
-    const { tmpdir } = await import('node:os');
-    const dir = mkdtempSync(join(tmpdir(), 'archon-pathkind-'));
+    const dir = trackTempRoot(mkdtempSync(join(tmpdir(), 'archon-pathkind-')));
     const link = join(dir, 'broken-link');
-    try {
-      symlinkSync(join(dir, 'nonexistent-target'), link);
-      expect(resolver.pathKind(link)).toBe('missing');
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+    symlinkSync(join(dir, 'nonexistent-target'), link);
+    expect(resolver.pathKind(link)).toBe('missing');
   });
 });

--- a/packages/workflows/src/load-command-prompt.test.ts
+++ b/packages/workflows/src/load-command-prompt.test.ts
@@ -1,9 +1,33 @@
 import { describe, it, expect, mock, beforeEach, afterEach } from 'bun:test';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync, unlinkSync } from 'fs';
 import { symlink as fsSymlink } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import * as realPaths from '@archon/paths';
+
+// Windows only permits symlink creation for an elevated process or with Developer
+// Mode enabled, so the symlink case below is a capability question, not a platform
+// question. Probe by attempting the real operation: `process.platform === 'win32'`
+// would ALSO skip on the CI windows-latest runner, which CAN create symlinks and
+// currently covers this test — a platform guard would silently drop that coverage.
+const canSymlink = (() => {
+  // Cleaned up with a non-recursive unlink on a single path: a module-scope probe runs
+  // before any test, so it cannot use trackTempRoots (which registers an afterEach), and
+  // a recursive rmSync is what the cleanup-drift guard exists to refuse.
+  const link = join(tmpdir(), `archon-symlink-probe-${process.pid}-${Date.now()}`);
+  try {
+    symlinkSync(join(tmpdir(), 'archon-symlink-probe-target'), link);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    try {
+      unlinkSync(link);
+    } catch {
+      // The symlink was never created — nothing to remove.
+    }
+  }
+})();
 
 // Mock only the logger so test output stays clean. All other @archon/paths
 // exports (findMarkdownFilesRecursive, getHomeCommandsPath, etc.) use real
@@ -69,7 +93,7 @@ describe('loadCommandPrompt — home-scope resolution', () => {
     if (result.success) expect(result.content).toBe('Personal helper body');
   });
 
-  it('resolves a symlinked home command and reads target content', async () => {
+  it.skipIf(!canSymlink)('resolves a symlinked home command and reads target content', async () => {
     const sourceDir = mkdtempSync(join(tmpdir(), 'archon-command-source-'));
     try {
       writeFileSync(join(sourceDir, 'linked.md'), 'Linked body');


### PR DESCRIPTION
## Problem and outcome

Two tests create a symlink in setup, and Windows permits that only for an elevated process or with Developer Mode enabled. Neither guarded on it, so on an ordinary Windows developer machine both fail with `EPERM` before reaching the behavior they exist to check.

- **Outcome:** both tests skip explicitly where symlink creation is denied and run everywhere it is permitted, so a Windows contributor no longer reads two environmental reds as regressions.
- **Invariant:** Windows CI coverage is preserved. `windows-latest` can create symlinks, so the guard is false there and both tests still run — which a platform check would have silently ended.
- **Scope boundary:** no production code changes. The assertions, subjects, and fixtures are untouched; only the guard and the temp-tree cleanup in the case being modified change.

## Review guidance

- **Feedback requested:** whether probing by attempting the operation is the shape you want for capability guards, since the same argument applies to any future one.
- **Start here:** the module-scope `canSymlink` block at the top of either file — the two are deliberately identical.
- **Review order:** `binary-resolver.test.ts` (probe + `skipIf` + the `trackTempRoots` conversion), then `load-command-prompt.test.ts` (probe + `skipIf` only).
- **Lower-attention areas:** the `pathKind` case's move to `trackTempRoots` is mechanical; it drops a hand-rolled `try/finally` + `rmSync`.
- **Known risk or uncertainty:** the probe costs one `symlinkSync` attempt per module load. It creates and unlinks a single path in `tmpdir`, and never runs inside a test.

## Solution

Each file probes the capability by attempting a real `symlinkSync` at module scope and gates its case with `skipIf(!canSymlink)`.

The tempting alternative is `process.platform === 'win32'`, and it is wrong here: it would also skip on the `windows-latest` runner, which *can* create symlinks and is the only Windows coverage these two tests have. That trades a visible local failure for silently dropped CI coverage. The question the guard needs answered is "can this process create a symlink", so that is what it asks.

The probe runs before any test, so it cannot use `trackTempRoots` — that registers an `afterEach`. It cleans up with a non-recursive `unlinkSync` on one known path, which is also the shape `check-test-cleanup-drift` permits. While the broken-symlink case is being touched, its own temp dir moves from a hand-rolled `try/finally` + `rmSync` to `trackTempRoots`.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Both cases fail on Windows without Developer Mode; run elsewhere | Both cases skip where symlinks are denied; run everywhere they are permitted, CI included |
| **Failure behavior** | `EPERM: operation not permitted, symlink ...` from setup, reported as a test failure | No failure; the skip is explicit in the runner output |

## Validation

- `bun test packages/providers/src/claude/binary-resolver.test.ts` — before: **20 pass, 1 fail**; after: **20 pass, 1 skip, 0 fail**.
- `bun test packages/workflows/src/load-command-prompt.test.ts` — before: **8 pass, 1 fail**; after: **8 pass, 1 skip, 0 fail**.
- The denial these guards detect, reproduced directly on the same host: `EPERM: operation not permitted, symlink 'C:\Users\<user>\AppData\Local\Temp\sym-probe-target' -> '...\sym-probe-36764'`.
- `bun --filter '@archon/providers' test` — exits 0.
- `bun --filter '@archon/workflows' test` — 6 failures, identical to the 6 on pristine `dev` @ `4d48a032` on this host (`#2637`, `#2453`); unrelated to this change and unchanged by it.
- `bun run type-check`, `bun run lint` (including `check-test-cleanup-drift`), `bun run format:check` — all exit 0.
- **Not verified:** the guard was exercised only in its false state — this host cannot create symlinks, so I could not observe the tests *running* under it on Windows. On Linux and macOS the probe succeeds and the cases run, which the green `@archon/providers` run above covers only for the non-symlink cases. CI is the check for the Windows-can-symlink branch.

## Links

- Closes #3192


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability across environments with limited symlink support.
  * Symlink-dependent tests now skip automatically when the environment cannot create symlinks.
  * Added consistent temporary-file cleanup for test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->