### PR TITLE
docs: clarify that archon serve requires a compiled binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,14 @@ The coding agent handles workflow selection, branch naming, and worktree isolati
 
 ## Web UI
 
-Archon includes a web dashboard for chatting with your coding agent, running workflows, and monitoring activity. Binary installs: run `archon serve` to download and start the web UI in one step. From source: ask your coding agent to run the frontend from the Archon repo, or run `bun run dev` from the repo root yourself.
+Archon includes a web dashboard for chatting with your coding agent, running workflows, and monitoring activity.
+
+> **⚠️ `archon serve` only works with compiled binaries** (Quick Install / Homebrew).
+> If you used the [Full Setup](#full-setup-5-minutes) (clone + `bun install`), run `bun run dev` from the repo root instead.
+
+**Binary installs** (Quick Install / Homebrew): run `archon serve` to download and start the web UI in one step.
+
+**From source** (Full Setup): run `bun run dev` from the repo root, or ask your coding agent to run the frontend from the Archon repo.
 
 Register a project by clicking **+** next to "Project" in the chat sidebar - enter a GitHub URL or local path. Then start a conversation, invoke workflows, and watch progress in real time.
 


### PR DESCRIPTION
## Problem and outcome

The README's source-install setup led a user to try `archon serve` for the Web UI, although that command requires a compiled binary. The existing distinction was easy to miss.

- **Outcome:** The Web UI section explicitly separates binary installation commands from source installation commands.
- **Invariant:** The documented startup command must match the installation method.
- **Scope boundary:** README only; CLI and server behavior are unchanged.
- **Root cause:** Binary and source instructions were combined in a sentence whose qualifier was easy to overlook.

## Review guidance

- **Feedback requested:** Check that the two supported installation paths and their Web UI commands are clear.
- **Start here:** [`README.md:216`](https://github.com/coleam00/Archon/blob/55ad5ae1a2b60659a49129400ec4c3246fa693d9/README.md#L216).
- **Review order:** Read the Web UI callout, then the binary and source paragraphs against the surrounding setup instructions.
- **Lower-attention areas:** Markdown layout only; there are no generated files or code changes.
- **Known risk or uncertainty:** This clarification does not fix separate Windows runtime bugs.

## Solution

Add a visible compiled-binary warning and label the two startup paths. Binary users retain `archon serve`; users running from source are directed to `bun run dev` from the repository root.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | A source-install user could mistake `archon serve` for the Web UI startup command. | The installation-specific command is stated explicitly before the user runs it. |
| **Failure behavior** | The user encounters the compiled-binary-only error after following setup. | The README explains the prerequisite; runtime error handling is unchanged. |

## Validation

Reviewed the README diff and its surrounding setup text. This is a documentation-only change; no application tests were rerun for the description update.

- **Not verified:** No fresh binary or source installation was performed specifically for this README-only PR.

## Links

- [Maintainer template request](https://github.com/coleam00/Archon/pull/3198#issuecomment-5582117096)
