### PR TITLE
chore: upgrade Bun to 1.4.2 across development and runtime images

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  BUN_VERSION: '1.4.0'
+  BUN_VERSION: '1.4.2'
 
 permissions:
   contents: read

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -18,7 +18,7 @@ on:
       - '.github/workflows/docs-build.yml'
 
 env:
-  BUN_VERSION: '1.4.0'
+  BUN_VERSION: '1.4.2'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -19,7 +19,7 @@ on:
         default: false
 
 env:
-  BUN_VERSION: '1.4.0'
+  BUN_VERSION: '1.4.2'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/marketplace-auto-review.yml
+++ b/.github/workflows/marketplace-auto-review.yml
@@ -7,7 +7,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 env:
-  BUN_VERSION: '1.4.0'
+  BUN_VERSION: '1.4.2'
 
 jobs:
   auto-review:

--- a/.github/workflows/marketplace-lint.yml
+++ b/.github/workflows/marketplace-lint.yml
@@ -7,7 +7,7 @@ on:
       - 'packages/docs-web/src/data/marketplace.ts'
 
 env:
-  BUN_VERSION: '1.4.0'
+  BUN_VERSION: '1.4.2'
 
 jobs:
   lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
         type: string
 
 env:
-  BUN_VERSION: '1.4.0'
+  BUN_VERSION: '1.4.2'
 
 concurrency:
   group: release-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
     branches: [main, dev]
 
 env:
-  BUN_VERSION: '1.4.0'
+  BUN_VERSION: '1.4.2'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Multi-stage build: deps → web build → production image
 # =============================================================================
 
-ARG BUN_VERSION=1.4.0
+ARG BUN_VERSION=1.4.2
 
 # ---------------------------------------------------------------------------
 # Stage 1: Install dependencies
@@ -53,7 +53,7 @@ RUN bun run build:web && \
 # ---------------------------------------------------------------------------
 # Stage 3: Production image
 # ---------------------------------------------------------------------------
-ARG BUN_VERSION=1.4.0
+ARG BUN_VERSION=1.4.2
 FROM oven/bun:${BUN_VERSION}-slim AS production
 
 # OCI Labels for GHCR

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "typescript-eslint": "^8.48.0"
   },
   "engines": {
-    "bun": "1.4.0"
+    "bun": "1.4.2"
   },
   "overrides": {
     "test-exclude": "^7.0.1",

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -56,33 +56,41 @@ function repositoryInput(path: string): string | undefined {
   return packagesIndex === -1 ? undefined : normalized.slice(packagesIndex);
 }
 
+function buildImportGraph(entry: string, outdir: string): BuildMetafile {
+  const metafilePath = join(outdir, 'metafile.json');
+  const result = spawnSync(
+    process.execPath,
+    [
+      'build',
+      entry,
+      '--target=bun',
+      '--format=esm',
+      '--splitting',
+      `--outdir=${outdir}`,
+      `--metafile=${metafilePath}`,
+    ],
+    { cwd: repoRoot, encoding: 'utf8' }
+  );
+  if (result.status !== 0) {
+    throw new Error(`Import graph build failed for ${entry}:\n${result.stdout}\n${result.stderr}`);
+  }
+  return JSON.parse(readFileSync(metafilePath, 'utf8')) as BuildMetafile;
+}
+
 describe('CLI startup import boundary', () => {
   let buildDir: string;
   let metafile: BuildMetafile;
+  let handoffMetafile: BuildMetafile;
 
-  beforeAll(async () => {
+  beforeAll(() => {
     buildDir = mkdtempSync(join(tmpdir(), 'archon-cli-import-graph-'));
-    const metafilePath = join(buildDir, 'metafile.json');
-    const result = spawnSync(
-      process.execPath,
-      [
-        'build',
-        CLI_ENTRY,
-        '--target=bun',
-        '--format=esm',
-        '--splitting',
-        `--outdir=${buildDir}`,
-        `--metafile=${metafilePath}`,
-      ],
-      {
-        cwd: repoRoot,
-        encoding: 'utf8',
-      }
+    metafile = buildImportGraph(CLI_ENTRY, join(buildDir, 'cli'));
+    // Shared chunks can include unrelated CLI inputs as Bun's splitting changes.
+    // An isolated entrypoint measures the decoder's own dependency boundary.
+    handoffMetafile = buildImportGraph(
+      join(repoRoot, 'packages/core/src/config/run-config-handoff.ts'),
+      join(buildDir, 'handoff')
     );
-    if (result.status !== 0) {
-      throw new Error(`CLI graph build failed:\n${result.stdout}\n${result.stderr}`);
-    }
-    metafile = JSON.parse(readFileSync(metafilePath, 'utf8')) as BuildMetafile;
   });
 
   afterAll(async () => {
@@ -110,16 +118,10 @@ describe('CLI startup import boundary', () => {
   });
 
   it('keeps detached handoff decoding on its audited schema, crypto, and path leaves', () => {
-    const decoderChunk = Object.entries(metafile.outputs).find(([, output]) =>
-      Object.keys(output.inputs).some(input =>
-        input.replaceAll('\\', '/').endsWith('packages/core/src/config/run-config-handoff.ts')
-      )
-    )?.[0];
-    expect(decoderChunk).toBeDefined();
-
-    const internalInputs = staticallyReachableInputs(metafile, decoderChunk ?? '')
+    const internalInputs = Object.keys(handoffMetafile.inputs)
       .map(repositoryInput)
-      .filter((input): input is string => input !== undefined);
+      .filter((input): input is string => input !== undefined)
+      .sort();
     expect(internalInputs).toEqual([
       'packages/core/src/config/run-config-handoff.ts',
       'packages/core/src/utils/token-crypto.ts',

--- a/packages/isolation/docker/runner.Dockerfile
+++ b/packages/isolation/docker/runner.Dockerfile
@@ -24,7 +24,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Pinned tool versions (bump deliberately; keep in sync with the version the
 # maintainer validated). CLAUDE_VERSION 'stable' / 'latest' / 'X.Y.Z' accepted.
 ARG CLAUDE_VERSION=2.1.211
-ARG BUN_VERSION=1.3.14
+ARG BUN_VERSION=1.4.2
 ARG UV_VERSION=0.11.29
 
 # Runtime deps: git/bash/rsync for workflow work, ca-certificates+curl for the

--- a/scripts/bun-version-consistency.test.ts
+++ b/scripts/bun-version-consistency.test.ts
@@ -5,7 +5,7 @@ import { resolve } from 'node:path';
 /**
  * Every declaration of the Bun runtime version in the repository must agree.
  * This includes every workflow file's BUN_VERSION env var, package.json
- * engines.bun, and the Dockerfile base image. A hand-synced pair between any
+ * engines.bun, and both Dockerfiles. A hand-synced pair between any
  * of these is a present defect — this test is the mechanism that catches drift.
  */
 describe('Bun version consistency', () => {
@@ -24,7 +24,7 @@ describe('Bun version consistency', () => {
     const declarations: { file: string; version: string }[] = [];
     for (const file of yamlFiles) {
       const content = readFileSync(resolve(workflowDir, file), 'utf8');
-      // Match both quoted and unquoted env values: BUN_VERSION: '1.4.0' and BUN_VERSION: 1.4.0
+      // Accept both quoted and unquoted env values.
       const match = content.match(/^\s*BUN_VERSION:\s*['"]?([^'"\s]+)['"]?\s*$/m);
       if (!match) continue;
       declarations.push({ file, version: match[1] });
@@ -41,25 +41,25 @@ describe('Bun version consistency', () => {
     expect(mismatches).toEqual([]);
   });
 
-  test('Dockerfile base image version agrees with package.json engines.bun', () => {
-    const dockerfile = readFileSync(resolve(root, 'Dockerfile'), 'utf8');
+  test.each(['Dockerfile', 'packages/isolation/docker/runner.Dockerfile'])(
+    '%s Bun version agrees with package.json engines.bun',
+    file => {
+      const dockerfile = readFileSync(resolve(root, file), 'utf8');
 
-    // Extract the ARG BUN_VERSION default value and the FROM references
-    const argMatch = dockerfile.match(/^ARG BUN_VERSION=(\S+)/m);
-    expect(argMatch).not.toBeNull();
-    const argVersion = argMatch![1];
+      // Extract the ARG BUN_VERSION default value and the FROM references
+      const argMatches = [...dockerfile.matchAll(/^ARG BUN_VERSION=(\S+)/gm)];
+      expect(argMatches.length).toBeGreaterThan(0);
+      for (const match of argMatches) expect(match[1]).toBe(expected);
 
-    // Every FROM oven/bun:... must use the ARG, not a literal version
-    const fromLines = [...dockerfile.matchAll(/^FROM oven\/bun:(\S+)/gm)];
-    expect(fromLines.length).toBeGreaterThan(0);
+      // Every FROM oven/bun:... must use the ARG, not a literal version
+      const fromLines = [...dockerfile.matchAll(/^FROM oven\/bun:(\S+)/gm)];
 
-    for (const match of fromLines) {
-      const imageTag = match[1];
-      // The image tag must either reference the ARG or match the expected version
-      if (imageTag === '${BUN_VERSION}-slim') continue;
-      expect(imageTag).toBe(`${expected}-slim`);
+      for (const match of fromLines) {
+        const imageTag = match[1];
+        // The image tag must either reference the ARG or match the expected version
+        if (imageTag === '${BUN_VERSION}-slim') continue;
+        expect(imageTag).toBe(`${expected}-slim`);
+      }
     }
-
-    expect(argVersion).toBe(expected);
-  });
+  );
 });

--- a/scripts/should-run-test-suite.test.ts
+++ b/scripts/should-run-test-suite.test.ts
@@ -150,16 +150,14 @@ describe('test-suite change decision', () => {
     ).replaceAll('\r\n', '\n');
     const pullRequestTrigger = workflow.slice(
       workflow.indexOf('  pull_request:'),
-      workflow.indexOf('\n\nconcurrency:')
+      workflow.indexOf('\n\nenv:')
     );
     const fixtureJob = workflow.slice(
       workflow.indexOf('  workflow-fixtures:'),
       workflow.indexOf('  test:')
     );
 
-    expect(pullRequestTrigger).toBe(
-      "  pull_request:\n    branches: [main, dev]\n\nenv:\n  BUN_VERSION: '1.4.0'"
-    );
+    expect(pullRequestTrigger).toBe('  pull_request:\n    branches: [main, dev]');
     expect(fixtureJob).toContain("if: github.event_name == 'pull_request'");
     expect(fixtureJob).toContain('runs-on: ubuntu-latest');
     expect(fixtureJob).not.toContain('needs:');


### PR DESCRIPTION
## Problem and outcome

The repository and CI used Bun 1.4.0 while the isolation runner still used 1.3.14. Upgrading locally to 1.4.2 also exposed a CLI test that depended on Bun's shared-chunk layout.

This updates every Bun runtime pin to 1.4.2, including both Dockerfiles. The CLI dependency guard now measures the decoder's own imports, so bundler chunk placement cannot create a false failure.

## Review guidance

- **Start here:** `packages/cli/src/cli.test.ts` — the handoff decoder is built as an isolated entrypoint; its expected nine-module dependency list is unchanged.
- **Review order:** dependency guard, version-consistency checks, runtime pins.
- **Known risk or uncertainty:** Docker images were not built locally because the Docker daemon is unavailable.

## Solution

Bun 1.4.2 places shared exports in a chunk that links back to the CLI entrypoint. Walking those output links counted 17 unrelated CLI modules as decoder dependencies. Independent diagnosis found the same nine decoder dependencies and unchanged CLI startup closure under both Bun versions.

The test retains the CLI startup graph check and separately audits the decoder's build inputs. Version-consistency tests now cover the runner Dockerfile and every Bun ARG declaration. The workflow-trigger test no longer duplicates a runtime version unrelated to the trigger it checks.

## Validation

- `bun run validate` — passed on Bun 1.4.2.
- `bun run build:docs` — passed.
- CLI dependency guards — passed; independent mutation adding the broad paths entrypoint expands the decoder audit and is rejected by the unchanged expected module list.
- Version and CI-trigger tests — 37 passed. Restoring the runner's 1.3.14 pin in a scratch copy makes the version guard fail.
- Docker image builds — not run locally; Docker daemon unavailable.

## Links

- Follows #3173, already merged into dev.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Bun runtime used across documentation, testing, release, marketplace, and deployment workflows.
  * Updated container environments to use Bun 1.4.2 for more consistent builds and executions.
  * Standardized the required Bun version across project tooling and runtime environments.

* **Tests**
  * Improved validation to ensure all supported container and workflow environments use the expected Bun version.
  * Updated workflow checks to more accurately validate pull request trigger configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->