### PR TITLE
fix: preserve Windows fixture and extraction failure evidence

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -223,10 +223,24 @@ export async function downloadWebDist(
       'web_dist.extract_spawned'
     );
     // Drain stderr while waiting rather than after: a pipe nobody reads is the
-    // same deadlock in the other direction once `tar` fills its buffer.
+    // same deadlock in the other direction once `tar` fills its buffer. Record
+    // each completion separately: the combined wait has exceeded five seconds
+    // on Windows without revealing whether the child or its pipe was delayed.
     const [exitCode, stderrText] = await Promise.all([
-      proc.exited,
-      new Response(proc.stderr).text(),
+      proc.exited.then(exitCode => {
+        log.info(
+          { tarPid: proc.pid, exitCode, durationMs: Math.round(performance.now() - spawnedAt) },
+          'web_dist.extract_process_exited'
+        );
+        return exitCode;
+      }),
+      new Response(proc.stderr).text().then(stderr => {
+        log.info(
+          { tarPid: proc.pid, durationMs: Math.round(performance.now() - spawnedAt) },
+          'web_dist.extract_stderr_drained'
+        );
+        return stderr;
+      }),
     ]);
     extractionEndedAt = performance.now();
     log.info(

--- a/packages/cli/src/commands/workflow-terminal-event.integration.spec.ts
+++ b/packages/cli/src/commands/workflow-terminal-event.integration.spec.ts
@@ -80,6 +80,9 @@ function readRunById(
   if (!existsSync(databasePath)) return undefined;
   const database = new Database(databasePath, { readonly: true });
   try {
+    // The last writer's WAL cleanup can briefly lock a new reader. Wait for that
+    // lock, not for the acknowledged row to appear.
+    database.run('PRAGMA busy_timeout = 5000');
     return (
       database
         .query<

--- a/packages/cli/src/utils/safe-console.test.ts
+++ b/packages/cli/src/utils/safe-console.test.ts
@@ -108,32 +108,32 @@ function listThroughVerySlowPipe(target: string): number | null {
   ).status;
 }
 
-beforeAll(() => {
-  scratch = mkdtempSync(join(tmpdir(), 'archon-pipe-test-'));
-  archonHome = join(scratch, 'home');
-  repoDir = join(scratch, 'repo');
-  mkdirSync(archonHome, { recursive: true });
-  const workflowsDir = join(repoDir, '.archon', 'workflows');
-  mkdirSync(workflowsDir, { recursive: true });
-  spawnSync('git', ['init', '-q', '.'], { cwd: repoDir });
-
-  const padding = 'x'.repeat(DESCRIPTION_CHARS);
-  for (let i = 0; i < WORKFLOW_COUNT; i++) {
-    const name = `probe-${String(i).padStart(3, '0')}`;
-    writeFileSync(
-      join(workflowsDir, `${name}.yaml`),
-      `name: ${name}\ndescription: ${padding}${i}\nnodes:\n  - id: only\n    prompt: hello\n`
-    );
-  }
-});
-
-afterAll(() => {
-  if (scratch) rmSync(scratch, { recursive: true, force: true });
-});
-
 const describePosix = process.platform === 'win32' ? describe.skip : describe;
 
 describePosix('CLI human-readable console.log over a real pipe (#2400)', () => {
+  beforeAll(() => {
+    scratch = mkdtempSync(join(tmpdir(), 'archon-pipe-test-'));
+    archonHome = join(scratch, 'home');
+    repoDir = join(scratch, 'repo');
+    mkdirSync(archonHome, { recursive: true });
+    const workflowsDir = join(repoDir, '.archon', 'workflows');
+    mkdirSync(workflowsDir, { recursive: true });
+    spawnSync('git', ['init', '-q', '.'], { cwd: repoDir });
+
+    const padding = 'x'.repeat(DESCRIPTION_CHARS);
+    for (let i = 0; i < WORKFLOW_COUNT; i++) {
+      const name = `probe-${String(i).padStart(3, '0')}`;
+      writeFileSync(
+        join(workflowsDir, `${name}.yaml`),
+        `name: ${name}\ndescription: ${padding}${i}\nnodes:\n  - id: only\n    prompt: hello\n`
+      );
+    }
+  });
+
+  afterAll(() => {
+    if (scratch) rmSync(scratch, { recursive: true, force: true });
+  });
+
   it('delivers the whole document, byte-identical to a file redirect, against a slow consumer', () => {
     const referencePath = join(scratch, 'reference.txt');
     expect(listToFile(referencePath)).toBe(0);

--- a/packages/core/src/orchestrator/orchestrator.test.ts
+++ b/packages/core/src/orchestrator/orchestrator.test.ts
@@ -1814,8 +1814,11 @@ describe('orchestrator-agent handleMessage', () => {
       // under /var → /private/var), so the stored default_cwd is canonical.
       const canonicalPath = await mockCanonicalizeProjectPath(projectPath);
       try {
-        await Bun.spawn(['git', 'init', '-b', 'develop'], { cwd: projectPath }).exited;
-        await Bun.spawn(['git', 'commit', '--allow-empty', '-m', 'init'], {
+        const initExit = await Bun.spawn(['git', 'init', '-b', 'develop'], {
+          cwd: projectPath,
+        }).exited;
+        expect(initExit, 'git init failed during registration fixture setup').toBe(0);
+        const commitExit = await Bun.spawn(['git', 'commit', '--allow-empty', '-m', 'init'], {
           cwd: projectPath,
           env: {
             ...process.env,
@@ -1825,6 +1828,7 @@ describe('orchestrator-agent handleMessage', () => {
             GIT_COMMITTER_EMAIL: 'archon-test@example.com',
           },
         }).exited;
+        expect(commitExit, 'git commit failed during registration fixture setup').toBe(0);
         mockExistsSync.mockReturnValue(true);
         mockListCodebases.mockResolvedValue([]);
         mockCreateCodebase.mockResolvedValue({

--- a/packages/workflows/src/defaults/generate-bundled-defaults.test.ts
+++ b/packages/workflows/src/defaults/generate-bundled-defaults.test.ts
@@ -17,21 +17,14 @@
  * tracked-set check) whose failure messages land on stderr
  * nondeterministically if raced in parallel, so merging them would force
  * weaker assertions. All original assertions from the six-case suite are
- * preserved verbatim (30 expect() calls).
+ * preserved verbatim.
  */
 import { describe, it, expect, afterAll } from 'bun:test';
-import {
-  cpSync,
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
+import { removeTempTree } from '@archon/paths/test-utils';
 
 const SCRIPT = resolve(import.meta.dir, '../../../../scripts/generate-bundled-defaults.ts');
 const OUTPUT_REL = 'packages/workflows/src/defaults/bundled-defaults.generated.ts';
@@ -81,9 +74,9 @@ function getTemplateRepo(): string {
   return templateRepo;
 }
 
-afterAll(() => {
+afterAll(async () => {
   if (templateRepo !== null) {
-    rmSync(templateRepo, { recursive: true, force: true });
+    await removeTempTree(templateRepo);
     templateRepo = null;
   }
 });
@@ -107,7 +100,7 @@ function runScript(repoRoot: string): { exitCode: number; stderr: string } {
 }
 
 describe('generate-bundled-defaults: untracked-file guard (#1578)', () => {
-  it('exits 0 for tracked defaults, staged-but-uncommitted defaults, and embedded packaged workflows (single amortized run)', () => {
+  it('exits 0 for tracked defaults, staged-but-uncommitted defaults, and embedded packaged workflows (single amortized run)', async () => {
     // One scenario covers what used to be three separate generator runs:
     //   - all tracked legacy defaults (positive path)
     //   - staged-but-uncommitted default (staged is not untracked)
@@ -166,11 +159,11 @@ describe('generate-bundled-defaults: untracked-file guard (#1578)', () => {
       expect(packagedOutput).toContain('__archon_pack__bundled:author-pack:release-flow::announce');
       expect(packagedOutput).toContain('BUNDLED_SCRIPTS');
     } finally {
-      rmSync(repoRoot, { recursive: true, force: true });
+      await removeTempTree(repoRoot);
     }
   });
 
-  it('exits 1 and leaves the bundle untouched for an untracked workflow default', () => {
+  it('exits 1 and leaves the bundle untouched for an untracked workflow default', async () => {
     const repoRoot = createRepo();
     try {
       writeFileSync(
@@ -185,11 +178,11 @@ describe('generate-bundled-defaults: untracked-file guard (#1578)', () => {
       expect(stderr).toContain('.archon/workflows/');
       expect(readFileSync(join(repoRoot, OUTPUT_REL), 'utf-8')).toBe(SENTINEL);
     } finally {
-      rmSync(repoRoot, { recursive: true, force: true });
+      await removeTempTree(repoRoot);
     }
   });
 
-  it('exits 1 and leaves the bundle untouched for an untracked command default', () => {
+  it('exits 1 and leaves the bundle untouched for an untracked command default', async () => {
     const repoRoot = createRepo();
     try {
       writeFileSync(join(repoRoot, '.archon/commands/defaults/untracked-draft.md'), '# Draft\n');
@@ -201,11 +194,11 @@ describe('generate-bundled-defaults: untracked-file guard (#1578)', () => {
       expect(stderr).toContain('.archon/commands/ (project-scope)');
       expect(readFileSync(join(repoRoot, OUTPUT_REL), 'utf-8')).toBe(SENTINEL);
     } finally {
-      rmSync(repoRoot, { recursive: true, force: true });
+      await removeTempTree(repoRoot);
     }
   });
 
-  it('embeds a tracked defaults/legacy/ workflow into the flat bundle (#2781)', () => {
+  it('embeds a tracked defaults/legacy/ workflow into the flat bundle (#2781)', async () => {
     const repoRoot = createRepo();
     try {
       const legacyDir = join(repoRoot, '.archon/workflows/defaults/legacy');
@@ -224,11 +217,11 @@ describe('generate-bundled-defaults: untracked-file guard (#1578)', () => {
       const output = readFileSync(join(repoRoot, OUTPUT_REL), 'utf-8');
       expect(output).toContain('"tracked-legacy-workflow"');
     } finally {
-      rmSync(repoRoot, { recursive: true, force: true });
+      await removeTempTree(repoRoot);
     }
   });
 
-  it('rejects an untracked file inside a packaged workflow', () => {
+  it('rejects an untracked file inside a packaged workflow', async () => {
     const repoRoot = createRepo();
     try {
       const packageDir = join(repoRoot, '.archon/workflows/author-pack/release-flow');
@@ -244,7 +237,7 @@ describe('generate-bundled-defaults: untracked-file guard (#1578)', () => {
       expect(stderr).toContain('.archon/workflows/author-pack/release-flow/release.yaml');
       expect(readFileSync(join(repoRoot, OUTPUT_REL), 'utf-8')).toBe(SENTINEL);
     } finally {
-      rmSync(repoRoot, { recursive: true, force: true });
+      await removeTempTree(repoRoot);
     }
   });
 });

--- a/packages/workflows/src/fixture-runner.test.ts
+++ b/packages/workflows/src/fixture-runner.test.ts
@@ -1324,7 +1324,8 @@ describe('runFixtures exec-code isolation (#2851)', () => {
       workflows: [workflowsOnDisk(cwd, ['script-wf'])[0]],
       cwd,
     });
-    expect(report.results[0].outcome).toBe('completed');
+    const result = report.results[0];
+    expect(result?.outcome, result?.failureReason).toBe('completed');
   });
 
   it('captures the command folder the source config names (#2851)', async () => {

--- a/packages/workflows/src/workflow-source-binary.test.ts
+++ b/packages/workflows/src/workflow-source-binary.test.ts
@@ -15,10 +15,11 @@
  * Own file, own `bun test` invocation: `mock.module` is process-global and irreversible,
  * and pretending to be a binary would poison every other suite in the process.
  */
-import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
-import { mkdtemp, mkdir, rm, readFile } from 'fs/promises';
+import { describe, test, expect, beforeAll, afterAll, mock } from 'bun:test';
+import { cp, mkdtemp, mkdir, readFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { removeTempTree } from '@archon/paths/test-utils';
 
 const actual = await import('./defaults/bundled-defaults');
 mock.module('./defaults/bundled-defaults', () => ({ ...actual, isBinaryBuild: () => true }));
@@ -29,43 +30,38 @@ const { loadCommandPrompt } = await import('./executor-shared');
 const { discoverScriptsForCwd } = await import('./script-discovery');
 
 let root: string;
-let source: string;
 let target: string;
+let capture: Awaited<ReturnType<typeof captureWorkflowSource>>;
 
 const deps = {
   loadConfig: () => Promise.resolve({} as unknown as Awaited<ReturnType<() => Promise<never>>>),
 };
 
-beforeEach(async () => {
+beforeAll(async () => {
   root = await mkdtemp(join(tmpdir(), 'archon-binary-source-'));
-  source = join(root, 'authoring');
+  const source = join(root, 'authoring');
   target = join(root, 'target');
   await mkdir(join(source, '.archon', 'workflows'), { recursive: true });
   await mkdir(target, { recursive: true });
+  // The readers share one immutable real bundle; the tamper case copies it below.
+  capture = await captureWorkflowSource({
+    sourceRoot: source,
+    captureRoot: join(root, 'capture'),
+  });
 });
 
-afterEach(async () => {
-  await rm(root, { recursive: true, force: true });
+afterAll(async () => {
+  await removeTempTree(root);
 });
 
 describe('a binary freezes its embedded bundled source', () => {
   test('the capture claims the bundled scope, which a binary never could before', async () => {
-    const capture = await captureWorkflowSource({
-      sourceRoot: source,
-      captureRoot: join(root, 'capture'),
-    });
-
     // Without materialization this is absent in a binary, and absence is what forced the
     // resume-blocking engine-version check that used to live here.
     expect(capture.manifest.scopes).toContain('bundled');
   });
 
   test('a bundled command exists as a file and resolves from the capture', async () => {
-    const capture = await captureWorkflowSource({
-      sourceRoot: source,
-      captureRoot: join(root, 'capture'),
-    });
-
     const onDisk = await readFile(
       join(capture.anchor.root, 'bundled', 'commands', 'defaults', 'archon-assist.md'),
       'utf-8'
@@ -85,11 +81,6 @@ describe('a binary freezes its embedded bundled source', () => {
   });
 
   test('bundled workflows are written where discovery expects them', async () => {
-    const capture = await captureWorkflowSource({
-      sourceRoot: source,
-      captureRoot: join(root, 'capture'),
-    });
-
     const roots = capturedSourceRoots(capture.anchor);
     const yaml = await readFile(
       join(roots.bundledWorkflows, 'defaults', 'archon-assist.yaml'),
@@ -99,36 +90,25 @@ describe('a binary freezes its embedded bundled source', () => {
   });
 
   test('script discovery reads the capture rather than re-materializing constants', async () => {
-    const capture = await captureWorkflowSource({
-      sourceRoot: source,
-      captureRoot: join(root, 'capture'),
-    });
-
-    // No bundled scripts ship today, so the assertion is about WHERE it looked: a captured
-    // run must not fall back to the embedded-constant path.
+    // A captured run must read scripts from its frozen roots.
     const roots = capturedSourceRoots(capture.anchor);
     expect(roots.kind).toBe('captured');
     await expect(discoverScriptsForCwd(target, roots)).resolves.toBeInstanceOf(Map);
   });
 
   test('the digest covers the bundled bytes, so an upgrade cannot change them unnoticed', async () => {
-    const capture = await captureWorkflowSource({
-      sourceRoot: source,
-      captureRoot: join(root, 'capture'),
-    });
-
     // Verifies end to end — this is what replaced refusing the resume outright.
     const loaded = await loadWorkflowSource(capture.anchor.root, capture.manifest.digest);
     expect(loaded.manifest.digest).toBe(capture.manifest.digest);
 
-    // And a bundled byte changing IS caught, rather than being invisible.
+    // Mutate a copy so this test cannot alter what the other readers observe.
+    const tamperedRoot = join(root, 'tampered-capture');
+    await cp(capture.anchor.root, tamperedRoot, { recursive: true });
     const { writeFile } = await import('fs/promises');
     await writeFile(
-      join(capture.anchor.root, 'bundled', 'commands', 'defaults', 'archon-assist.md'),
+      join(tamperedRoot, 'bundled', 'commands', 'defaults', 'archon-assist.md'),
       'swapped by a different Archon build'
     );
-    await expect(
-      loadWorkflowSource(capture.anchor.root, capture.manifest.digest)
-    ).rejects.toThrow();
+    await expect(loadWorkflowSource(tamperedRoot, capture.manifest.digest)).rejects.toThrow();
   });
 });

--- a/scripts/check-test-cleanup-drift.ts
+++ b/scripts/check-test-cleanup-drift.ts
@@ -372,7 +372,6 @@ export const LEGACY_RECURSIVE_CLEANUP: ReadonlyMap<string, number> = buildLedger
   ['packages/server/src/routes/api.workflows.test.ts', 29],
   ['packages/workflows/src/artifacts-index.test.ts', 1],
   ['packages/workflows/src/dag-executor.test.ts', 54],
-  ['packages/workflows/src/defaults/generate-bundled-defaults.test.ts', 6],
   ['packages/workflows/src/dry-run.test.ts', 1],
   ['packages/workflows/src/executor-preamble.test.ts', 1],
   ['packages/workflows/src/executor.test.ts', 3],

--- a/scripts/check-test-cleanup-drift.ts
+++ b/scripts/check-test-cleanup-drift.ts
@@ -383,7 +383,6 @@ export const LEGACY_RECURSIVE_CLEANUP: ReadonlyMap<string, number> = buildLedger
   ['packages/workflows/src/subrun.test.ts', 8],
   ['packages/workflows/src/validator.test.ts', 5],
   ['packages/workflows/src/workflow-discovery-command-scan.test.ts', 1],
-  ['packages/workflows/src/workflow-source-binary.test.ts', 1],
   ['packages/workflows/src/workflow-source.test.ts', 1],
 ]);
 


### PR DESCRIPTION
## Problem and outcome

Windows CI failures on unrelated PRs exposed fixture and diagnostic defects: failed Git fixture setup could look like broken branch detection, an acknowledgement query could fail during WAL cleanup, Windows unit tests built a large fixture used only by POSIX pipe tests, the generator guard could pass then fail while removing its fixture, and binary-source cases repeatedly rebuilt the same immutable bundle. A fixture-runner assertion also hid its existing failure reason, and extraction logs combined child exit with stderr drain despite a measured 5–6 second wait.

- **Outcome:** Setup failures are reported at setup, acknowledgement reads tolerate the reproduced cleanup lock, Windows avoids unused pipe-fixture work, generator fixtures retry transient removal locks, and binary cases share one immutable capture.
- **Invariant:** The acknowledged row must already exist. Real Git branch detection, POSIX pipe/backpressure assertions, Windows unit coverage, and existing deadlines remain intact.
- **Scope boundary:** These are D1, D2, the proved D4 cleanup failure, and the unused-fixture cost in D9. It also removes proved redundant binary materialization, exposes D3 failure diagnostics, and separates D5 extraction completion events. Remaining latency families in #2924/#2306 are still under investigation.
- **Root cause:** Unchecked Git exit statuses; a readonly SQLite handle with zero busy timeout racing last-writer WAL cleanup; fixture hooks registered outside their existing POSIX-only group; direct generator fixture removal after a real subprocess.

## Review guidance

- **Feedback requested:** Check that the SQLite change waits for a lock without polling for row creation, and that hook scoping preserves all pipe assertions.
- **Start here:** `packages/cli/src/commands/workflow-terminal-event.integration.spec.ts` — direct acknowledgement query.
- **Review order:** Acknowledgement reader, registration setup, POSIX fixture hooks, generator cleanup.
- **Known risk or uncertainty:** This does not establish the cause of the other intermittent Windows latency failures. The SQLite scratch reproduction widens the actual cleanup window with a 20 MB WAL; it does not assert that production databases have that size.

## Solution

Check the two real Git setup exit statuses before calling registration. Give the acknowledgement reader the same 5000 ms SQLite busy timeout used by production, keeping a single direct query and preserving thrown errors. Scope the large pipe fixture's setup and cleanup to its existing POSIX test group. Use the existing `removeTempTree` helper at all six generator cleanup sites and remove the obsolete allowance from the cleanup checker. Materialize the binary capture once for readonly cases and copy it for the tamper case; suite cleanup uses the same owning helper. Include the existing failure reason in the fixture-runner outcome assertion. Log tar process exit and stderr completion separately within the existing concurrent wait, retaining original results and rejections. These events fix attribution; they do not claim to cure extraction latency.

## Validation

- `bun run validate` — passed locally and independently at final head `386338ea3`.
- [Current-head CI](https://github.com/coleam00/Archon/actions/runs/34223253306) — all checks green, including Windows, Ubuntu, Docker smoke/cleanup, aggregate Test Suite and CodeRabbit. [Independent review](https://github.com/coleam00/Archon/pull/3214#issuecomment-5584432779) — zero code/seam/simplification findings.
- Real registration case — passed. Deliberately invalid commit — fails immediately at the setup assertion with exit 129, before registration runs.
- Actual acknowledgement helper against a separate writer's WAL cleanup — before: 100 consecutive reads during one close event failed with `SQLITE_BUSY`; after: 100 reads during a separate close event returned the current durable row. Ordinary WAL writes alone did not reproduce the error.
- Missing row still returns `undefined`; a persistently held lock still throws `SQLITE_BUSY` after the configured wait.
- Real terminal-event and POSIX slow-reader tests — 11 passed, 48 assertions.
- Temporary win32-platform trace — same four Windows unit tests and eight assertions pass; fixture Git/temp-file operations drop to zero. Actual current-head Windows CI also passed.
- Generator cleanup: Windows [job102036306390](https://github.com/coleam00/Archon/actions/runs/34218623846/job/102036306390) failed with `EBUSY` after assertions at455ms. Injecting two transient removal failures per fixture fails the old cleanup; the replacement passes all five cases and33 assertions. Ordinary focused run also passes.
- Binary-source: five materializations become one plus one isolated tamper copy. All five tests/eight assertions pass; suppressing the tamper write fails the integrity assertion. Windows trace showed a 6678 ms cleanup overlapping the next setup; the preceding body delay remains unattributed.
- D3 diagnostic assertion: an injected actual git-worktree failure now prints its command/error instead of only an undefined outcome. Normal case passes.
- Ordinary Windows CI at `9048668b1` failed in D5: tar spawn took 37/4 ms, then combined child-exit/stderr waits took 5172/6237 ms. The new ordinary phase events now separate those two completions. A subsequent scratch run measured native Windows tar exit154/11/18ms and stderr137/9/14ms; the long wait did not recur.
- Durable extraction events: all21 serve tests/37 assertions pass, including actual extraction content and nonzero-exit cleanup. No stderr content is logged; deadlines, concurrent drain and rejection behavior are unchanged.
- **Not verified:** Remaining D3–D8 latency attribution, including the generator five-second timeout, which this distinct455ms cleanup failure does not explain. Separate diagnostic runs retain traces; the first exposed a diagnostic preload quoting error, which was corrected.

## Links

- Related #2924 and #2306.
- [Published implementation plan](https://github.com/coleam00/Archon/issues/2924#issuecomment-5584166256).
- [Finite findings ledger](https://github.com/coleam00/Archon/issues/2924#issuecomment-5584098985).
- [Corrected Windows diagnostic run](https://github.com/coleam00/Archon/actions/runs/34219652948).
