### PR TITLE
fix(cli): archon serve works from a source checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ The coding agent handles workflow selection, branch naming, and worktree isolati
 
 ## Web UI
 
-Archon includes a web dashboard for chatting with your coding agent, running workflows, and monitoring activity. Binary installs: run `archon serve` to download and start the web UI in one step. From source: ask your coding agent to run the frontend from the Archon repo, or run `bun run dev` from the repo root yourself.
+Archon includes a web dashboard for chatting with your coding agent, running workflows, and monitoring activity. Run `archon serve` to start it, whichever way you installed. A binary downloads the matching web UI on first run. A source checkout serves the copy you build: run `bun run build:web` once from the repo root, then `archon serve`.
 
 Register a project by clicking **+** next to "Project" in the chat sidebar - enter a GitHub URL or local path. Then start a conversation, invoke workflows, and watch progress in real time.
 

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -395,7 +395,7 @@ Commands:
   isolation cleanup [days]   Remove stale environments (default: 7 days)
   isolation cleanup --merged Remove environments with branches merged into main
   complete <branch> [...]    Complete branch lifecycle (remove worktree + branches)
-  serve                      Start the web UI server (downloads web UI on first run)
+  serve                      Start the web UI server (binary installs download it on first run)
   skill install [path]       Install archon-cli into .claude/skills and .agents/skills
   doctor [--full]            Verify your Archon setup (Claude/Codex binaries, gh auth, DB, adapters; --full also probes the OpenCode runtime SDK)
   auth github                Connect your GitHub identity via device flow (multi-user installs)

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -338,7 +338,7 @@ const commandHelp: HelpEntry[] = [
   {
     command: 'serve',
     spec: 'serve',
-    description: 'Start the web UI server (downloads web UI on first run)',
+    description: 'Start the web UI server (binary installs download it on first run)',
   },
   {
     command: 'skill',

--- a/packages/cli/src/commands/serve.test.ts
+++ b/packages/cli/src/commands/serve.test.ts
@@ -9,12 +9,14 @@ import {
   afterEach,
   spyOn,
 } from 'bun:test';
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
 // Mock @archon/paths BEFORE importing the module under test.
-// This sets BUNDLED_IS_BINARY = false (dev mode) so serveCommand rejects.
+// BUNDLED_IS_BINARY = false puts serveCommand on its source-checkout path, and
+// getSourceWebDistDir is redirected at a temp tree so a test can decide whether
+// `bun run build:web` has been run without depending on this checkout's state.
 const mockLogger = {
   fatal: mock(() => undefined),
   error: mock(() => undefined),
@@ -23,14 +25,27 @@ const mockLogger = {
   debug: mock(() => undefined),
   trace: mock(() => undefined),
 };
+let sourceWebDistDir = '/tmp/test-archon/unset-source-web-dist';
 mock.module('@archon/paths', () => ({
   createLogger: mock(() => mockLogger),
   getWebDistDir: mock((version: string) => `/tmp/test-archon/web-dist/${version}`),
+  getSourceWebDistDir: mock(() => sourceWebDistDir),
   BUNDLED_IS_BINARY: false,
   BUNDLED_VERSION: 'dev',
   BUNDLED_WEB_DIST_SHA256: '',
 }));
 
+// serveCommand reaches the real server through a dynamic import. Stub it so the
+// source-mode tests can read back which dist it was handed without opening a
+// listening socket.
+const startServerCalls: Array<{ webDistPath: string; port?: number }> = [];
+mock.module('@archon/server', () => ({
+  startServer: mock(async (opts: { webDistPath: string; port?: number }) => {
+    startServerCalls.push(opts);
+  }),
+}));
+
+import { trackTempRoots } from '@archon/paths/test-utils';
 import { serveCommand, parseChecksum, parseEmbeddedChecksum, downloadWebDist } from './serve';
 
 describe('parseChecksum', () => {
@@ -319,6 +334,119 @@ describe('buildWebTarball structural conformance', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// serveCommand blocks in the foreground until SIGINT/SIGTERM. Raising a real
+// signal here would also reach the test runner, so the tests call the listeners
+// the command registered and drop them — what the signal itself would do — and
+// only ever touch listeners that were not already there.
+// ---------------------------------------------------------------------------
+
+const SHUTDOWN_SIGNALS = ['SIGINT', 'SIGTERM'] as const;
+type ShutdownListener = () => void;
+
+function shutdownListeners(): Map<string, Set<ShutdownListener>> {
+  return new Map(
+    SHUTDOWN_SIGNALS.map(signal => [
+      signal,
+      new Set(process.listeners(signal) as unknown as ShutdownListener[]),
+    ])
+  );
+}
+
+/** Listeners registered since `before` — the ones serveCommand is parked on. */
+function newShutdownListeners(
+  before: Map<string, Set<ShutdownListener>>
+): Array<[(typeof SHUTDOWN_SIGNALS)[number], ShutdownListener]> {
+  const added: Array<[(typeof SHUTDOWN_SIGNALS)[number], ShutdownListener]> = [];
+  for (const signal of SHUTDOWN_SIGNALS) {
+    for (const listener of process.listeners(signal) as unknown as ShutdownListener[]) {
+      if (!before.get(signal)?.has(listener)) added.push([signal, listener]);
+    }
+  }
+  return added;
+}
+
+/** Resolve once the command has started the server and parked on a signal. */
+async function waitForForegroundWait(before: Map<string, Set<ShutdownListener>>): Promise<void> {
+  for (let attempt = 0; attempt < 200; attempt++) {
+    if (newShutdownListeners(before).length > 0) return;
+    await new Promise(resolve => setTimeout(resolve, 5));
+  }
+  throw new Error('serveCommand never reached its foreground wait');
+}
+
+function interruptForegroundWait(before: Map<string, Set<ShutdownListener>>): void {
+  for (const [signal, listener] of newShutdownListeners(before)) {
+    process.removeListener(signal, listener);
+    listener();
+  }
+}
+
+describe('serveCommand in a source checkout', () => {
+  const trackTempRoot = trackTempRoots();
+  let consoleErrorSpy: ReturnType<typeof spyOn>;
+  let fetchSpy: ReturnType<typeof spyOn>;
+  let builtDist: string;
+
+  beforeEach(() => {
+    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
+    // Any fetch at all would mean the source path tried to download a release.
+    fetchSpy = spyOn(globalThis, 'fetch');
+    fetchSpy.mockImplementation(async () => {
+      throw new Error('serveCommand must not download in a source checkout');
+    });
+    startServerCalls.length = 0;
+    builtDist = trackTempRoot(mkdtempSync(join(tmpdir(), 'serve-source-dist-')));
+    writeFileSync(join(builtDist, 'index.html'), '<html>built</html>');
+    sourceWebDistDir = builtDist;
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
+
+  it('serves the locally built dist on the requested port', async () => {
+    const before = shutdownListeners();
+    const pending = serveCommand({ port: 4321 });
+
+    await waitForForegroundWait(before);
+    expect(startServerCalls).toEqual([{ webDistPath: builtDist, port: 4321 }]);
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    interruptForegroundWait(before);
+    expect(await pending).toBe(0);
+  });
+
+  it('refuses with a build instruction when the dist has not been built', async () => {
+    sourceWebDistDir = join(builtDist, 'not-built-yet');
+
+    const exitCode = await serveCommand({});
+
+    expect(exitCode).toBe(1);
+    expect(startServerCalls).toEqual([]);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    const errors = consoleErrorSpy.mock.calls.flat().join('\n');
+    expect(errors).toContain(sourceWebDistDir);
+    expect(errors).toContain('bun run build:web');
+    // The old refusal sent source installs to `bun run dev`, which is a different
+    // thing (every package's dev server, HMR, a held terminal) and is why #3218
+    // was reported. It must not come back.
+    expect(errors).not.toContain('bun run dev');
+  });
+
+  it('refuses --download-only because a source checkout downloads nothing', async () => {
+    const exitCode = await serveCommand({ downloadOnly: true });
+
+    expect(exitCode).toBe(1);
+    expect(startServerCalls).toEqual([]);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(consoleErrorSpy.mock.calls.flat().join('\n')).toContain(
+      '--download-only is for binary installs'
+    );
+  });
+});
+
 describe('serveCommand', () => {
   let consoleErrorSpy: ReturnType<typeof spyOn>;
 
@@ -328,19 +456,6 @@ describe('serveCommand', () => {
 
   afterEach(() => {
     consoleErrorSpy.mockRestore();
-  });
-
-  it('should reject in dev mode (non-binary)', async () => {
-    const exitCode = await serveCommand({});
-    expect(exitCode).toBe(1);
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      'Error: `archon serve` is for compiled binaries only.'
-    );
-  });
-
-  it('should reject with downloadOnly in dev mode', async () => {
-    const exitCode = await serveCommand({ downloadOnly: true });
-    expect(exitCode).toBe(1);
   });
 
   it('should reject invalid port (NaN)', async () => {

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, renameSync, rmSync } from 'fs';
 import {
   createLogger,
   getWebDistDir,
+  getSourceWebDistDir,
   BUNDLED_IS_BINARY,
   BUNDLED_VERSION,
   BUNDLED_WEB_DIST_SHA256,
@@ -50,10 +51,29 @@ export async function serveCommand(opts: ServeOptions): Promise<number> {
     return 1;
   }
 
+  // A source checkout builds the web UI locally instead of downloading it: there
+  // is no release tagged `dev` to fetch from, and the tree already holds the
+  // dist that `bun run build:web` produces.
   if (!BUNDLED_IS_BINARY) {
-    console.error('Error: `archon serve` is for compiled binaries only.');
-    console.error('For development, use: bun run dev');
-    return 1;
+    const webDistDir = getSourceWebDistDir();
+
+    if (opts.downloadOnly) {
+      console.error(
+        'Error: --download-only is for binary installs. A source checkout has nothing to download.'
+      );
+      console.error('Build the web UI instead: bun run build:web');
+      return 1;
+    }
+
+    if (!existsSync(webDistDir)) {
+      log.error({ webDistDir }, 'web_dist.source_build_missing');
+      console.error(`Error: Web UI is not built at ${webDistDir}.`);
+      console.error('Build it first: bun run build:web');
+      return 1;
+    }
+
+    log.info({ webDistDir }, 'web_dist.source_build_found');
+    return startServerUntilSignal(webDistDir, opts.port);
   }
 
   const version = BUNDLED_VERSION;
@@ -78,16 +98,24 @@ export async function serveCommand(opts: ServeOptions): Promise<number> {
     return 0;
   }
 
+  return startServerUntilSignal(webDistDir, opts.port);
+}
+
+/** Run the server in the foreground until the operator interrupts it. */
+async function startServerUntilSignal(
+  webDistDir: string,
+  port: number | undefined
+): Promise<number> {
   // Import server and start (dynamic import keeps CLI startup fast for other commands)
   try {
     const { startServer } = await import('@archon/server');
     await startServer({
       webDistPath: webDistDir,
-      port: opts.port,
+      port,
     });
   } catch (err) {
     const error = toError(err);
-    log.error({ err: error, version, webDistDir, port: opts.port }, 'server.start_failed');
+    log.error({ err: error, webDistDir, port }, 'server.start_failed');
     console.error(`Error: Server failed to start: ${error.message}`);
     return 1;
   }

--- a/packages/docs-web/src/content/docs/reference/cli.md
+++ b/packages/docs-web/src/content/docs/reference/cli.md
@@ -922,18 +922,20 @@ before removing it. Accepts multiple branch names in one call.
 
 ### `serve`
 
-Start the web UI server. On first run, downloads a pre-built web UI tarball from the matching GitHub release, verifies the SHA-256 checksum, and extracts it. Subsequent runs use the cached copy.
+Start the web UI server in the foreground. The same command works from a binary install and from a source checkout. Only the source of the web UI differs.
 
-**Binary installs only** — in development, use `bun run dev` instead.
+**Binary installs** download a pre-built web UI tarball from the matching GitHub release on first run, verify its SHA-256 checksum, and extract it. Later runs use the cached copy.
+
+**Source checkouts** serve the web UI you build yourself, at `packages/web/dist`. Run `bun run build:web` from the repo root before your first `archon serve`, and again after frontend changes. Nothing is downloaded, so `--download-only` is refused, and a missing build stops the command with the build command to run instead of serving an empty page.
 
 ```bash
-# Start web UI server (downloads on first run)
+# Start web UI server (binary installs download it on first run)
 archon serve
 
 # Override the default port
 archon serve --port 4000
 
-# Download the web UI without starting the server
+# Download the web UI without starting the server (binary installs only)
 archon serve --download-only
 ```
 
@@ -942,9 +944,9 @@ archon serve --download-only
 | Flag | Effect |
 |------|--------|
 | `--port <port>` | Override server port (default: 3090, range: 1–65535) |
-| `--download-only` | Download and cache the web UI, then exit without starting the server |
+| `--download-only` | Download and cache the web UI, then exit without starting the server. Binary installs only |
 
-The cached web UI is stored at `~/.archon/web-dist/<version>/`. Each version is cached independently, so upgrading the binary automatically downloads the matching web UI.
+The downloaded web UI is cached at `~/.archon/web-dist/<version>/`. Each version is cached independently, so upgrading the binary automatically downloads the matching web UI.
 
 ### `skill install [path]`
 

--- a/packages/paths/src/archon-paths.test.ts
+++ b/packages/paths/src/archon-paths.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { homedir, tmpdir } from 'os';
-import { join, sep } from 'path';
+import { dirname, join, sep } from 'path';
 import { existsSync, readFileSync } from 'fs';
 import { mkdir, rm, writeFile, lstat, readlink, symlink as fsSymlink } from 'fs/promises';
 import { removeTempTree } from './test-utils';
@@ -28,6 +28,7 @@ import {
   expandTilde,
   canonicalizeProjectPath,
   getAppArchonBasePath,
+  getSourceWebDistDir,
   getDefaultCommandsPath,
   getDefaultWorkflowsPath,
   logArchonPaths,
@@ -480,6 +481,19 @@ describe('archon-paths', () => {
       // The path should end with .archon and the directory should exist
       expect(path).toMatch(/\.archon$/);
       expect(existsSync(path)).toBe(true);
+    });
+  });
+
+  describe('getSourceWebDistDir', () => {
+    test('points at the web package build output in this checkout', () => {
+      const path = getSourceWebDistDir();
+      expect(path.endsWith(join('packages', 'web', 'dist'))).toBe(true);
+      // Anchored on the package that owns the build rather than on a second copy
+      // of the same path arithmetic: `bun run build:web` writes this directory,
+      // and `archon serve` refuses to start without it.
+      const webPackageJson = join(dirname(path), 'package.json');
+      expect(existsSync(webPackageJson)).toBe(true);
+      expect(JSON.parse(readFileSync(webPackageJson, 'utf8')).name).toBe('@archon/web');
     });
   });
 

--- a/packages/paths/src/archon-paths.ts
+++ b/packages/paths/src/archon-paths.ts
@@ -463,6 +463,17 @@ async function findMarkdownFilesRecursiveImpl(
 }
 
 /**
+ * Root of the checkout this build runs from.
+ *
+ * This file is at packages/paths/src/archon-paths.ts, so the repo root is three
+ * levels up from `import.meta.dir` (src → paths → packages → root). In Docker
+ * that is /app.
+ */
+function getSourceRepoRoot(): string {
+  return dirname(dirname(dirname(import.meta.dir)));
+}
+
+/**
  * Get the path to the app's base directory
  * This is where default commands/workflows are stored for copying to new repos
  *
@@ -470,11 +481,19 @@ async function findMarkdownFilesRecursiveImpl(
  * Locally: {repo_root}/.archon
  */
 export function getAppArchonBasePath(): string {
-  // This file is at packages/paths/src/archon-paths.ts
-  // Go up from src → paths → packages → repo root
-  // import.meta.dir = packages/paths/src
-  const repoRoot = dirname(dirname(dirname(import.meta.dir)));
-  return join(repoRoot, '.archon');
+  return join(getSourceRepoRoot(), '.archon');
+}
+
+/**
+ * Where a source checkout keeps its built web UI: the output of
+ * `bun run build:web`. Owns that location for every consumer, so the CLI's
+ * pre-flight check and the server's default cannot drift apart.
+ *
+ * A compiled binary has no checkout to build in and caches a downloaded copy
+ * under `getWebDistDir(version)` instead.
+ */
+export function getSourceWebDistDir(): string {
+  return join(getSourceRepoRoot(), 'packages', 'web', 'dist');
 }
 
 /**

--- a/packages/paths/src/index.ts
+++ b/packages/paths/src/index.ts
@@ -58,6 +58,7 @@ export {
   findMarkdownFilesRecursive,
   findCommandFiles,
   getWebDistDir,
+  getSourceWebDistDir,
 } from './archon-paths';
 export type { ProjectStorageKey, ProjectStoragePaths } from './archon-paths';
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -120,6 +120,7 @@ import {
   shutdownTelemetry,
   captureArchonStarted,
   captureArchonActive,
+  getSourceWebDistDir,
 } from '@archon/paths';
 import { selectGitHubAuthMode, parseGitCredentialPath } from './github-auth-bootstrap';
 import { isDiscordMentionRequired } from './discord-mention';
@@ -855,13 +856,12 @@ export async function startServer(opts: ServerOptions = {}): Promise<void> {
   });
 
   // Serve web UI static files in production
-  // Uses import.meta.dir for absolute path (CWD varies with bun --filter)
   if (process.env.NODE_ENV === 'production' || !process.env.WEB_UI_DEV) {
     const { serveStatic } = await import('hono/bun');
-    const pathModule = await import('path');
-    const webDistPath =
-      opts.webDistPath ??
-      pathModule.join(pathModule.dirname(pathModule.dirname(import.meta.dir)), 'web', 'dist');
+    // Without an explicit path this is a source checkout or the Docker image,
+    // where the web UI is whatever `bun run build:web` produced. The resolved
+    // path is absolute because CWD varies with `bun --filter`.
+    const webDistPath = opts.webDistPath ?? getSourceWebDistDir();
 
     if (!existsSync(webDistPath)) {
       getLog().warn({ webDistPath }, 'web_dist_not_found');


### PR DESCRIPTION
## Problem and outcome

`archon serve` refused to run outside a compiled binary and told the user to run `bun run dev` instead. The README's Full Setup path is a source install, so anyone who followed the recommended setup and then ran the documented command to get the Web UI hit a dead end. The pointer it gave is not an equivalent: `bun run dev` starts every package's dev server with HMR and holds a terminal open. A community user reported this, their coding agent tried `bun run dev:server`, hit its own tool timeout, and concluded the Web UI does not work from source.

- **Outcome:** `archon serve` starts the Web UI from a source checkout the same way it does from a binary. Same foreground server, same port handling, same output. With no built dist it exits non-zero naming `bun run build:web`.
- **Invariant:** `serve` serves a built dist. It never starts a dev server, and a source checkout never downloads a release tarball.
- **Scope boundary:** The binary path is untouched. Download on first run, embedded-checksum verification, extraction, and the `~/.archon/web-dist/<version>/` cache all behave exactly as before. No HMR or dev-mode machinery was added.
- **Root cause:** The `BUNDLED_IS_BINARY` gate guarded nothing. Everything past it needs only a directory of built web assets to hand to `startServer`, and a source checkout already has one at `packages/web/dist` after `bun run build:web`.

## Review guidance

- **Feedback requested:** Correctness of the source-mode branch, and whether moving the dist-path resolution into `@archon/paths` is the right ownership call.
- **Start here:** `packages/cli/src/commands/serve.ts:57` — the source-checkout branch that replaces the refusal.
- **Review order:** `packages/cli/src/commands/serve.ts`, then `packages/paths/src/archon-paths.ts` for the new resolver, then `packages/server/src/index.ts` where the duplicate path arithmetic goes away, then the tests.
- **Lower-attention areas:** The README, the CLI reference, and the one-line help string with its snapshot in `packages/cli/src/cli.test.ts`.
- **Known risk or uncertainty:** None. The server's default dist path is now computed in `@archon/paths` rather than inline; both derivations resolve to the same `packages/web/dist`, in a checkout and in the Docker image at `/app`.

## Solution

In a source checkout `serve` resolves `packages/web/dist`, checks it exists, and starts the server on it. Nothing is fetched, because there is no release tagged `dev` to fetch from. A missing build stops the command with the exact command to run rather than starting a server that would return an empty page, and `--download-only` is refused outright because a source checkout has nothing to download.

The path itself moved to `@archon/paths` as `getSourceWebDistDir()`. The server was already computing the same `packages/web/dist` inline as its default, so this is now one owner for the location instead of two copies of the same path arithmetic that had to agree. The server keeps its existing behavior: an explicit `webDistPath` still wins, and the default is only reached from a source checkout or the Docker image.

The server-start-and-block tail of `serveCommand` became a small helper so both installs reach it identically instead of the source branch duplicating it.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Source install: exit 1, "`archon serve` is for compiled binaries only. For development, use: bun run dev". Binary install: serves the downloaded dist. | Both installs: `archon serve` serves a built web dist in the foreground on the default or `--port` port. |
| **Failure behavior** | No failure path for a source install; the command never got that far. | No built dist: exit 1 naming the directory and `bun run build:web`. `--download-only` in a source checkout: exit 1 saying there is nothing to download. |

## Architecture

### Changed seams

| Boundary or contract | Change | Evidence |
|---|---|---|
| `@archon/paths → @archon/cli`, `@archon/server` | New `getSourceWebDistDir()` owns the built-web-UI location for both consumers. The server's inline duplicate of that path arithmetic is deleted. | `packages/paths/src/archon-paths.ts:495`, `packages/server/src/index.ts:864`, `packages/paths/src/archon-paths.test.ts:487` |

## Validation

- `bun run validate` — pass — proves type-check, lint, format, and every package suite are green on this branch.
- `bun test src/commands/serve.test.ts` in `packages/cli` — 22 pass — proves source-mode path selection with the dist present and missing, and the `--download-only` refusal, all without spawning a server.
- Guards seen red: dropping the built-dist check and serving the binary cache directory instead each turned the two new source-mode tests red; deleting the `--download-only` refusal turned its test red. Restoring the implementation returned all 22 to green.
- Runtime evidence in a source checkout, before `bun run build:web`:

```
$ archon serve
Error: Web UI is not built at /…/packages/web/dist.
Build it first: bun run build:web
$ echo $?
1
$ archon serve --download-only
Error: --download-only is for binary installs. A source checkout has nothing to download.
Build the web UI instead: bun run build:web
$ echo $?
1
```

- After `bun run build:web`, `archon serve --port 3399` served the real build: `GET /` returned 200 with the built `index.html`, `GET /assets/index-BKE0brhn.js` returned 200 and 1,584,531 bytes, and `GET /health` returned `{"status":"ok"}`. SIGTERM shut it down and the command exited 0.
- **Not verified:** The binary install path was not re-exercised end to end, because it needs a released tarball and an embedded checksum that only a build produces. Its code is unchanged apart from the extracted server-start helper, and its existing download, checksum, and extraction tests still pass.

## Links

- Closes #3218
- Supersedes #3198


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `archon serve` now works from source checkouts, serving the locally built web dashboard.
  * Binary installations continue downloading the web dashboard on first run.
  * Clear guidance is provided when the source dashboard build is missing.

* **Documentation**
  * Updated CLI help, reference documentation, and README instructions to explain behavior for binary installations and source checkouts.
  * Clarified that `--download-only` is available only for binary installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->