### PR TITLE
test(cli): bound startup fixture subprocesses

### DIFF
--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -91,7 +91,7 @@ describe('CLI startup import boundary', () => {
       join(repoRoot, 'packages/core/src/config/run-config-handoff.ts'),
       join(buildDir, 'handoff')
     );
-  }, 30000);
+  });
 
   afterAll(async () => {
     if (buildDir) await removeTempTree(buildDir);
@@ -1990,5 +1990,5 @@ describe('workflow test path targets', () => {
     } finally {
       await removeTempTree(repo);
     }
-  }, 30000);
+  });
 });

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1972,6 +1972,7 @@ describe('workflow test path targets', () => {
         [CLI_ENTRY, 'workflow', 'test', '../.archon/workflows/sdlc/plan', '--cwd', tools, '--json'],
         {
           encoding: 'utf8',
+          timeout: 20000,
           env: {
             ...process.env,
             ARCHON_TELEMETRY_DISABLED: '1',
@@ -1989,5 +1990,5 @@ describe('workflow test path targets', () => {
     } finally {
       await removeTempTree(repo);
     }
-  });
+  }, 30000);
 });

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -69,7 +69,7 @@ function buildImportGraph(entry: string, outdir: string): BuildMetafile {
       `--outdir=${outdir}`,
       `--metafile=${metafilePath}`,
     ],
-    { cwd: repoRoot, encoding: 'utf8' }
+    { cwd: repoRoot, encoding: 'utf8', timeout: 20000 }
   );
   if (result.status !== 0) {
     throw new Error(`Import graph build failed for ${entry}:\n${result.stdout}\n${result.stderr}`);
@@ -91,7 +91,7 @@ describe('CLI startup import boundary', () => {
       join(repoRoot, 'packages/core/src/config/run-config-handoff.ts'),
       join(buildDir, 'handoff')
     );
-  });
+  }, 30000);
 
   afterAll(async () => {
     if (buildDir) await removeTempTree(buildDir);


### PR DESCRIPTION
## Problem and outcome

The import-graph fixture and caller-relative workflow-path fixture use synchronous child processes without deadlines. A hung child can block the test process indefinitely.

- **Outcome:** Each child process has a 20-second deadline.
- **Invariant:** Existing assertions and Bun's default test/setup budgets remain unchanged.
- **Scope boundary:** Two process options in `packages/cli/src/cli.test.ts`. Telemetry shutdown and removal of avoidable fixture startup cost belong to #3225.
- **Root cause:** Both `spawnSync` calls omitted a timeout.

## Review guidance

- **Feedback requested:** Whether the two finite process deadlines adequately bound these fixtures.
- **Start here:** `packages/cli/src/cli.test.ts`, `buildImportGraph` and `workflow test path targets`.
- **Review order:** The two `spawnSync` option objects.
- **Lower-attention areas:** No generated files or assertion changes.
- **Known risk or uncertainty:** This does not fix telemetry-induced startup delays or remove compilation/subprocess work from the fixtures. #3225 tracks those changes.

## Solution

Set `timeout: 20000` on the two synchronous subprocess calls. Removed the previously proposed 30-second test/setup budgets following maintainer feedback. Preserve the existing five-second test budgets and keep the process bound independent of test scheduling.

## Validation

- Native Bun 1.4.2 on Windows, from `packages/cli`: `bun test ./src/cli.test.ts` passed 129 tests and 317 assertions after removing both enlarged budgets. The caller-relative test completed in 2.18 seconds.
- `git diff --check` passed. Changed-file lint and formatting passed through the commit hook.
- [CI on narrowed head cfa7d355](https://github.com/coleam00/Archon/actions/runs/34238390052) passed Windows, Ubuntu, workflow fixtures, types, lint, formatting, schema upgrades, Postgres parity and Docker. [Combined integration CI](https://github.com/coleam00/Archon/actions/runs/34238417160) also passed with all six reviewed PR heads and the original test budgets restored.
- **Not verified:** Telemetry shutdown latency or a fully deterministic startup-cost fix. Those are #3225's scope; this PR only bounds hung child processes.

## Links

- Related #3225, #2924 and #3221


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added 20-second execution limits to CLI subprocesses used by startup import-boundary and workflow path tests.
  * Adjusted timeout handling so these limits apply directly to the relevant test processes, helping prevent indefinite hangs while keeping test execution predictable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->