### PR TITLE
fix(workflows): follow symlinks when deciding whether a scope root is a directory

### DIFF
--- a/packages/workflows/src/workflow-source.test.ts
+++ b/packages/workflows/src/workflow-source.test.ts
@@ -306,6 +306,37 @@ describe('captureWorkflowSource', () => {
     );
   });
 
+  test('captures a scope whose root is a symlinked directory', async () => {
+    // The global-workflows guide tells people to symlink a scope root out of a dotfiles
+    // repo (`ln -sf ~/dotfiles/archon/workflows ~/.archon/workflows`). An `lstat` guard
+    // reports such a root as "not a directory" and drops the whole scope from the
+    // capture — silently, since a missing scope is a legitimate state. `copyTree` already
+    // dereferences symlinks, so the entry guard has to as well.
+    const { root, runArtifacts } = await createSandbox();
+    const sourceRoot = join(root, 'linked-source');
+    const realCommands = join(root, 'dotfiles', 'commands');
+    await mkdir(realCommands, { recursive: true });
+    await mkdir(join(sourceRoot, '.archon'), { recursive: true });
+    await writeFile(join(realCommands, 'review.md'), 'review the diff');
+    await symlink(realCommands, join(sourceRoot, '.archon', 'commands'), 'dir');
+
+    const capture = await captureWorkflowSource({
+      sourceRoot,
+      captureRoot: captureRootIn(runArtifacts),
+    });
+
+    expect(capture.manifest.scopes).toContain('project');
+    expect(await countScopeFiles(capture.anchor.root, 'project')).toBe(1);
+    // Dereferenced into an ordinary file, so the capture owns its bytes and stays
+    // readable after the link's target moves.
+    expect(
+      await readFile(
+        join(capture.anchor.root, 'project', '.archon', 'commands', 'review.md'),
+        'utf-8'
+      )
+    ).toBe('review the diff');
+  });
+
   test('leaves no usable capture behind when it cannot finish', async () => {
     const { source, runArtifacts } = await createSandbox();
     await writeFile(join(source, '.archon', 'commands', 'review.md'), 'x');

--- a/packages/workflows/src/workflow-source.ts
+++ b/packages/workflows/src/workflow-source.ts
@@ -45,7 +45,6 @@ import {
   rm,
   rename,
   stat,
-  lstat,
   realpath,
   readFile,
   writeFile,
@@ -293,10 +292,17 @@ function dedupeNestedDirs(dirs: readonly string[]): string[] {
   );
 }
 
-/** True when `path` exists and is a directory. */
+/**
+ * True when `path` exists and is a directory.
+ *
+ * `stat`, not `lstat`: a scope root is routinely a symlink — the dotfiles layout the
+ * global-workflows guide recommends makes `~/.archon/workflows` one — and dropping it
+ * here would silently omit that whole scope from the capture. This matches `copyTree`
+ * below, which dereferences symlinks on purpose.
+ */
 async function isDirectory(path: string): Promise<boolean> {
   try {
-    return (await lstat(path)).isDirectory();
+    return (await stat(path)).isDirectory();
   } catch {
     return false;
   }


### PR DESCRIPTION
Fixes #3184.

## The bug

`captureWorkflowSource` skips a scope whose root is not a directory, and `isDirectory` asks `lstat`, which does not follow symlinks.

The [global-workflows guide](https://archon.diy/guides/global-workflows/) tells people to symlink a scope root out of a dotfiles repo:

```bash
ln -sf ~/dotfiles/archon/workflows ~/.archon/workflows
```

With that layout the home scope reports "not a directory", is never captured, and every home-scoped workflow disappears the moment you try to run one:

```
Discovery: root=<repo> workflows=32 bundled=32 global=0 project=0
Error: Workflow '<name>' not found.
```

`archon workflow list` still lists them, because listing takes no capture — which is what makes the failure hard to place. Observed on `8a5c9055` with eight home workflows, all un-runnable, while `list` reported `home_workflows_loaded count=8` in the same shell.

The same guard governs the project scope (`workflow-source.ts:510-514`), so a symlinked `.archon/workflows` inside a repo is dropped identically. Only the scope **root** is affected — a real directory holding symlinked *files* captures fine, because `copyTree` uses `stat`.

## Why this is an inconsistency rather than a policy

Forty lines below the guard, `copyTree` already dereferences symlinks on purpose:

> `// Symlinks are DEREFERENCED into ordinary files. Preserving the link would keep a live`
> `// reference to a path outside the capture … stat (not lstat) resolves the target`

So the module's stated intent is to follow links; only the entry guard did not.

## The change

One line, plus the comment explaining why the choice matters here. `stat` was already imported; `lstat` becomes unused and is dropped. A dangling link still throws into the existing `catch` and returns `false`, unchanged.

## Test

The added test symlinks a project scope root, then asserts the scope is captured and its bytes dereferenced into the capture.

It is a real regression test, not a passing assertion: reverting the one-line change fails it with

```
Expected to contain: "project"
Received: [ "global", "bundled" ]
```

— the scope silently absent, which is exactly the shape of the bug.

`bun test packages/workflows/src/workflow-source.test.ts` → **38 pass, 0 fail** on this branch.

## Two things I did not assume

- Whether a scope root that exists but is not a directory should log a `warn`. Today the scope is dropped with no signal at all, which is why this went unnoticed between #2660 and the first attempted run. Happy to add one if you want it.
- `getHomeCommandsPath()` and `getHomeScriptsPath()` go through the same guard and are fixed by the same line, but the test covers the project scope only, since asserting on the home scope would read the developer's real `~/.archon`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workflow captures for scopes whose root directory is a symbolic link.
  * Symlinked workflow directories are now recognized correctly, included in manifests, and copied with their files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->