### PR TITLE
fix(providers): honor Claude and Copilot pins in source installs

### DIFF
--- a/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
+++ b/packages/docs-web/src/content/docs/getting-started/ai-assistants.md
@@ -74,7 +74,7 @@ If none of the three resolves in a compiled binary, Archon throws with install i
 
 The Claude Agent SDK accepts the native compiled binary, a JS `cli.js`, or the npm platform-package directory (e.g. `@anthropic-ai/claude-code-win32-x64`) — directories are auto-expanded to the contained `claude`/`claude.exe`.
 
-**Dev mode override:** when running from source (`bun run dev:server`), the SDK auto-resolves its bundled per-platform binary by default. Set `CLAUDE_BIN_PATH` if you need to override that — most commonly on glibc Linux where the SDK picks the musl variant first and fails to spawn. Config-file `claudeBinaryPath` is intentionally binary-mode-only (per-repo, not per-machine).
+**Source installs:** when running from source (`bun run dev:server`), `CLAUDE_BIN_PATH` takes precedence over `assistants.claude.claudeBinaryPath`. Both pins are validated in either build mode; an invalid pin fails instead of falling back. With neither pin set, the SDK resolves its bundled per-platform binary. Archon only probes the native-installer path in compiled builds.
 
 **Typical paths by install method:**
 
@@ -688,7 +688,7 @@ Copilot is registered as `builtIn: false` — like Pi, a bundled community provi
 
 ### Install
 
-For source installs (`bun run`), the SDK + its bundled CLI dependency come along with `bun install` — nothing extra to do.
+For source installs (`bun run`), the SDK and its bundled CLI dependency come along with `bun install`. Optional `COPILOT_BIN_PATH` and `assistants.copilot.copilotCliPath` pins override the SDK default in either build mode, with the environment variable taking precedence. An invalid pin fails instead of falling back. With neither pin set, the SDK retains its native resolution, including `COPILOT_CLI_PATH` and its bundled CLI.
 
 For compiled Archon binaries, install the Copilot CLI yourself and point Archon at it:
 
@@ -710,7 +710,7 @@ assistants:
     copilotCliPath: /absolute/path/to/copilot
 ```
 
-Or place the binary at `~/.archon/vendor/copilot/copilot` (POSIX) / `~/.archon/vendor/copilot/copilot.exe` (Windows) and the resolver picks it up automatically.
+For compiled builds, you can also place the binary at `~/.archon/vendor/copilot/copilot` (POSIX) / `~/.archon/vendor/copilot/copilot.exe` (Windows) and the resolver picks it up automatically.
 
 ### Authenticate
 

--- a/packages/docs-web/src/content/docs/getting-started/configuration.md
+++ b/packages/docs-web/src/content/docs/getting-started/configuration.md
@@ -14,7 +14,7 @@ Set these in your shell or `.env` file:
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `CLAUDE_BIN_PATH` | No (binary builds autodetect `~/.local/bin/claude`) | Absolute path to the Claude Code binary, SDK `cli.js`, or the npm platform-package directory (e.g. `@anthropic-ai/claude-code-win32-x64`, auto-expanded to `claude`/`claude.exe`). Overrides autodetection in compiled Archon binaries. Falls back to `assistants.claude.claudeBinaryPath`, then to the native-installer path. Dev mode (`bun run`) auto-resolves via `node_modules`. |
+| `CLAUDE_BIN_PATH` | No (binary builds autodetect `~/.local/bin/claude`) | Absolute path to the Claude Code binary, SDK `cli.js`, or the npm platform-package directory (auto-expanded to `claude`/`claude.exe`). Takes precedence over `assistants.claude.claudeBinaryPath` in both source and compiled builds. Invalid pins fail. Without a pin, source builds use SDK resolution and compiled builds probe the native-installer path. |
 | `CLAUDE_USE_GLOBAL_AUTH` | No | Set to `true` to use credentials from `claude /login` (default when no other Claude token is set) |
 | `CLAUDE_CODE_OAUTH_TOKEN` | No | OAuth token from `claude setup-token` (alternative to global auth) |
 | `CLAUDE_API_KEY` | No | Anthropic API key for pay-per-use (alternative to global auth) |

--- a/packages/docs-web/src/content/docs/reference/configuration.md
+++ b/packages/docs-web/src/content/docs/reference/configuration.md
@@ -71,11 +71,11 @@ assistants:
       - project       # Project-level <cwd>/.claude/ (CLAUDE.md, skills, commands, agents)
       - user          # User-level ~/.claude/ (CLAUDE.md, skills, commands, agents)
     # Optional: absolute path to the Claude Code executable.
-    # Required in compiled Archon binaries when CLAUDE_BIN_PATH is not set.
+    # Honored in both build modes, after CLAUDE_BIN_PATH.
     # Accepts the native binary (~/.local/bin/claude from the curl installer),
     # the npm-installed cli.js, or the npm platform-package directory
     # (e.g. @anthropic-ai/claude-code-win32-x64 — auto-expanded to claude/claude.exe).
-    # Source/dev mode auto-resolves.
+    # Without a pin: source builds use the SDK; compiled builds autodetect.
     # claudeBinaryPath: /absolute/path/to/claude
   codex:
     model: gpt-5.6-terra
@@ -459,7 +459,7 @@ When `CLAUDE_USE_GLOBAL_AUTH` is unset, Archon auto-detects: it uses explicit to
 | Variable | Description | Default |
 | --- | --- | --- |
 | `COPILOT_GITHUB_TOKEN` | Explicit GitHub PAT for the Copilot provider. Always wins over `useLoggedInUser` when set. | -- |
-| `COPILOT_BIN_PATH` | Absolute path to the Copilot CLI binary. Required in compiled Archon binaries when `assistants.copilot.copilotCliPath` is not set; auto-detected in dev mode. | -- |
+| `COPILOT_BIN_PATH` | Absolute path to the Copilot CLI executable. Takes precedence over `assistants.copilot.copilotCliPath` in both source and compiled builds. Invalid pins fail; unpinned source installs use SDK resolution, and compiled builds use vendor/autodetection/PATH lookup. | -- |
 
 The Copilot provider also reads `assistants.copilot.{model, modelReasoningEffort, copilotCliPath, configDir, enableConfigDiscovery, useLoggedInUser, logLevel}` from `~/.archon/config.yaml` or `.archon/config.yaml`. See the [AI Assistants guide](/getting-started/ai-assistants/) for the full setup.
 

--- a/packages/providers/src/claude/binary-resolver-dev.test.ts
+++ b/packages/providers/src/claude/binary-resolver-dev.test.ts
@@ -2,14 +2,9 @@
  * Tests for the Claude binary resolver in dev mode (BUNDLED_IS_BINARY=false).
  * Separate file because binary-mode tests mock BUNDLED_IS_BINARY=true.
  *
- * Dev mode normally lets the SDK resolve the binary from its bundled
- * platform package. CLAUDE_BIN_PATH is honored as an escape hatch for
- * environments where SDK auto-resolution picks the wrong variant — most
- * notably glibc Linux hosts, where the SDK prefers the musl binary first
- * and silently falls over with a misleading "not found" error.
- * Config-file path is intentionally NOT honored in dev mode (still binary-only).
+ * Explicit env/config pins override the SDK's bundled platform package.
  */
-import { describe, test, expect, mock, beforeEach, afterAll, spyOn } from 'bun:test';
+import { describe, test, expect, mock, beforeEach, afterEach, spyOn } from 'bun:test';
 import { join } from 'node:path';
 import { createMockLogger } from '../test/mocks/logger';
 
@@ -22,40 +17,45 @@ import * as resolver from './binary-resolver';
 import { CLAUDE_BINARY_NAME } from './binary-resolver';
 
 describe('resolveClaudeBinaryPath (dev mode)', () => {
-  const originalEnv = process.env.CLAUDE_BIN_PATH;
+  let originalEnv: string | undefined;
   let pathKindSpy: ReturnType<typeof spyOn> | undefined;
 
   beforeEach(() => {
+    originalEnv = process.env.CLAUDE_BIN_PATH;
     delete process.env.CLAUDE_BIN_PATH;
-    pathKindSpy?.mockRestore();
-    pathKindSpy = undefined;
   });
 
-  afterAll(() => {
+  afterEach(() => {
     if (originalEnv !== undefined) {
       process.env.CLAUDE_BIN_PATH = originalEnv;
     } else {
       delete process.env.CLAUDE_BIN_PATH;
     }
     pathKindSpy?.mockRestore();
+    pathKindSpy = undefined;
   });
 
   test('returns undefined when nothing is configured', async () => {
+    pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('file');
     const result = await resolver.resolveClaudeBinaryPath();
     expect(result).toBeUndefined();
+    expect(pathKindSpy).not.toHaveBeenCalled();
   });
 
-  test('returns undefined when only config path is set (config is binary-mode only)', async () => {
-    const result = await resolver.resolveClaudeBinaryPath('/some/custom/path');
-    expect(result).toBeUndefined();
+  test('honors a configured executable and reports its source', async () => {
+    expect(await resolver.resolveClaudeBinaryWithSource(process.execPath)).toEqual({
+      path: process.execPath,
+      source: 'config',
+    });
+    expect(await resolver.resolveClaudeBinaryPath(process.execPath)).toBe(process.execPath);
   });
 
   test('honors CLAUDE_BIN_PATH env var when file exists', async () => {
-    process.env.CLAUDE_BIN_PATH = '/usr/local/bin/claude';
-    pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('file');
-
-    const result = await resolver.resolveClaudeBinaryPath();
-    expect(result).toBe('/usr/local/bin/claude');
+    process.env.CLAUDE_BIN_PATH = process.execPath;
+    expect(await resolver.resolveClaudeBinaryWithSource()).toEqual({
+      path: process.execPath,
+      source: 'env',
+    });
   });
 
   test('throws when CLAUDE_BIN_PATH is set but file does not exist', async () => {
@@ -68,11 +68,51 @@ describe('resolveClaudeBinaryPath (dev mode)', () => {
   });
 
   test('env var wins over config path in dev mode', async () => {
-    process.env.CLAUDE_BIN_PATH = '/env/claude';
-    pathKindSpy = spyOn(resolver, 'pathKind').mockReturnValue('file');
+    process.env.CLAUDE_BIN_PATH = process.execPath;
 
-    const result = await resolver.resolveClaudeBinaryPath('/config/claude');
-    expect(result).toBe('/env/claude');
+    const result = await resolver.resolveClaudeBinaryWithSource('/missing/config/claude');
+    expect(result).toEqual({ path: process.execPath, source: 'env' });
+  });
+
+  test('an invalid env pin refuses a valid config executable', async () => {
+    process.env.CLAUDE_BIN_PATH = join(process.execPath, 'missing-claude');
+    await expect(resolver.resolveClaudeBinaryPath(process.execPath)).rejects.toThrow(
+      'CLAUDE_BIN_PATH'
+    );
+  });
+
+  test('an invalid config pin fails instead of using the SDK binary', async () => {
+    await expect(
+      resolver.resolveClaudeBinaryPath(join(process.execPath, 'missing-claude'))
+    ).rejects.toThrow('assistants.claude.claudeBinaryPath');
+  });
+
+  test.each(['env', 'config'] as const)(
+    'an invalid %s pin gives repair advice without probing compiled-mode candidates',
+    async source => {
+      const missing = '/missing/claude';
+      if (source === 'env') process.env.CLAUDE_BIN_PATH = missing;
+      pathKindSpy = spyOn(resolver, 'pathKind').mockImplementation((path: string) =>
+        path === missing ? 'missing' : 'file'
+      );
+      const label = source === 'env' ? 'CLAUDE_BIN_PATH' : 'assistants.claude.claudeBinaryPath';
+      await expect(
+        resolver.resolveClaudeBinaryPath(source === 'config' ? missing : undefined)
+      ).rejects.toThrow(
+        new Error(
+          `${label} is set to "${missing}" but the file does not exist.\n` +
+            'Please verify the path points to the Claude Code executable (native binary\n' +
+            'from the curl/PowerShell installer, or cli.js from an npm global install).'
+        )
+      );
+      expect(pathKindSpy).toHaveBeenCalledTimes(1);
+      expect(pathKindSpy).toHaveBeenCalledWith(missing);
+    }
+  );
+
+  test('an empty env pin allows a valid config pin', async () => {
+    process.env.CLAUDE_BIN_PATH = '';
+    expect(await resolver.resolveClaudeBinaryPath(process.execPath)).toBe(process.execPath);
   });
 
   test('falls through to undefined when CLAUDE_BIN_PATH is the empty string', async () => {
@@ -112,5 +152,29 @@ describe('resolveClaudeBinaryPath (dev mode)', () => {
     const promise = resolver.resolveClaudeBinaryPath();
     await expect(promise).rejects.toThrow('CLAUDE_BIN_PATH');
     await expect(promise).rejects.toThrow('which is a directory');
+  });
+
+  test('expands a configured directory and reports the config source', async () => {
+    const dir = '/opt/claude-code-package';
+    const expectedFile = join(dir, CLAUDE_BINARY_NAME);
+    pathKindSpy = spyOn(resolver, 'pathKind').mockImplementation((path: string) => {
+      if (path === dir) return 'directory';
+      if (path === expectedFile) return 'file';
+      return 'missing';
+    });
+    expect(await resolver.resolveClaudeBinaryWithSource(dir)).toEqual({
+      path: expectedFile,
+      source: 'config',
+    });
+  });
+
+  test('rejects a config directory without its executable', async () => {
+    const dir = '/empty/claude-package';
+    pathKindSpy = spyOn(resolver, 'pathKind').mockImplementation((path: string) =>
+      path === dir ? 'directory' : 'missing'
+    );
+    await expect(resolver.resolveClaudeBinaryPath(dir)).rejects.toThrow(
+      `assistants.claude.claudeBinaryPath is set to "${dir}", which is a directory, but it does not contain ${CLAUDE_BINARY_NAME}.`
+    );
   });
 });

--- a/packages/providers/src/claude/binary-resolver.ts
+++ b/packages/providers/src/claude/binary-resolver.ts
@@ -10,11 +10,11 @@
  * 1. `CLAUDE_BIN_PATH` environment variable (honored in both modes — escape
  *    hatch for hosts where the SDK's per-platform binary auto-resolution
  *    picks the wrong variant, e.g. glibc Linux + musl SDK package)
- * 2. `assistants.claude.claudeBinaryPath` in config (binary mode only)
+ * 2. `assistants.claude.claudeBinaryPath` in config (both modes)
  * 3. Autodetect canonical install path (binary mode only — native installer default)
  * 4. Throw with install instructions (binary mode only)
  *
- * In dev mode (BUNDLED_IS_BINARY=false), if no env var is set, returns
+ * In dev mode (BUNDLED_IS_BINARY=false), if no explicit pin is set, returns
  * undefined so the caller omits `pathToClaudeCodeExecutable` entirely and
  * the SDK resolves via its normal node_modules lookup.
  */
@@ -140,7 +140,7 @@ export interface ClaudeBinaryResolution {
  * legacy `cli.js` is still accepted for operators pinned to npm-installed
  * SDKs that ship a JS entry point).
  *
- * In dev mode: honors `CLAUDE_BIN_PATH` if set; otherwise returns undefined
+ * In dev mode: honors explicit env/config pins; otherwise returns undefined
  * (let SDK resolve from its bundled per-platform native binary in
  * `@anthropic-ai/claude-agent-sdk-<platform>`).
  * In binary mode: resolves from env/config/autodetect, or throws with
@@ -159,7 +159,8 @@ export async function resolveClaudeBinaryPath(
  * binary was found (env / config / autodetect) instead of asserting that only
  * `CLAUDE_BIN_PATH` counts (#2263). Returns undefined when the SDK should
  * resolve the binary itself; throws with install instructions in binary mode
- * when the whole chain comes up empty.
+ * when the whole chain comes up empty. An invalid explicit env or config pin
+ * throws in either mode.
  */
 export async function resolveClaudeBinaryWithSource(
   configClaudeBinaryPath?: string
@@ -178,8 +179,6 @@ export async function resolveClaudeBinaryWithSource(
     return { path: resolvedEnv, source: 'env' };
   }
 
-  if (!BUNDLED_IS_BINARY) return undefined;
-
   // 2. Config file override
   if (configClaudeBinaryPath) {
     const resolvedConfig = validateAndExpand(
@@ -188,11 +187,13 @@ export async function resolveClaudeBinaryWithSource(
         sourceLabel: 'assistants.claude.claudeBinaryPath',
         removableSetting: 'claudeBinaryPath',
       },
-      findAutodetectedBinary
+      BUNDLED_IS_BINARY ? findAutodetectedBinary : undefined
     );
     getLog().info({ binaryPath: resolvedConfig, source: 'config' }, 'claude.binary_resolved');
     return { path: resolvedConfig, source: 'config' };
   }
+
+  if (!BUNDLED_IS_BINARY) return undefined;
 
   // 3. Autodetect — the Anthropic native installer
   // (`curl -fsSL https://claude.ai/install.sh | bash` on macOS/Linux,

--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -19,9 +19,9 @@
  *   Claude CLI itself ignores it; it neither gates nor filters env here.
  *
  * Binary resolution:
- * - In compiled binaries, `pathToClaudeCodeExecutable` is resolved from
+ * - In both build modes, `pathToClaudeCodeExecutable` honors
  *   `CLAUDE_BIN_PATH` env or `assistants.claude.claudeBinaryPath` config;
- *   see ./binary-resolver.ts. In dev mode the resolver returns undefined
+ *   see ./binary-resolver.ts. In unpinned dev mode the resolver returns undefined
  *   and the SDK picks its bundled per-platform native binary (Mach-O/ELF/PE
  *   from `@anthropic-ai/claude-agent-sdk-<platform>` optional dep). Pre-0.2.x
  *   SDKs shipped `cli.js` in the package and dev mode resolved that JS file;
@@ -801,8 +801,8 @@ function buildBaseClaudeOptions(
 
   return {
     cwd,
-    // In compiled binaries, the resolver supplies an absolute executable path;
-    // in dev mode it returns undefined and the SDK resolves from node_modules.
+    // Explicit pins resolve in both build modes. Unpinned source installs leave
+    // resolution to the SDK; compiled builds use the autodetected executable.
     // Both are skipped for container runs (spawn hook bypasses disk resolution).
     ...(cliPath !== undefined && containerExecContext === undefined
       ? { pathToClaudeCodeExecutable: cliPath }
@@ -1429,9 +1429,8 @@ export class ClaudeProvider implements IAgentProvider {
     let lastError: Error | undefined;
     const assistantDefaults = parseClaudeConfig(requestOptions?.assistantConfig ?? {});
 
-    // Resolve Claude CLI path once before the retry loop. In binary mode this
-    // throws immediately if neither env nor config supplies a valid path, so
-    // the user gets a clean error rather than N retries of "Module not found".
+    // Resolve Claude CLI path once before the retry loop so an invalid explicit
+    // pin, or an unresolved compiled-mode binary, fails without retries.
     // SKIP entirely for container runs: the SDK bypasses disk resolution when
     // `spawnClaudeCodeProcess` is set (buildBaseClaudeOptions omits
     // pathToClaudeCodeExecutable), and Claude is baked into the runner image — a

--- a/packages/providers/src/community/copilot/binary-resolver-dev.test.ts
+++ b/packages/providers/src/community/copilot/binary-resolver-dev.test.ts
@@ -2,7 +2,8 @@
  * Tests for the Copilot binary resolver in dev mode (BUNDLED_IS_BINARY=false).
  * Separate file because binary-mode tests mock BUNDLED_IS_BINARY=true.
  */
-import { describe, test, expect, mock } from 'bun:test';
+import { afterEach, beforeEach, describe, test, expect, mock, spyOn } from 'bun:test';
+import { dirname, join } from 'node:path';
 import { createMockLogger } from '../../test/mocks/logger';
 
 mock.module('@archon/paths', () => ({
@@ -11,16 +12,87 @@ mock.module('@archon/paths', () => ({
   getArchonHome: mock(() => '/tmp/test-archon-home'),
 }));
 
-import { resolveCopilotBinaryPath } from './binary-resolver';
+import * as resolver from './binary-resolver';
+const { resolveCopilotBinaryPath } = resolver;
 
 describe('resolveCopilotBinaryPath (dev mode)', () => {
-  test('returns undefined when BUNDLED_IS_BINARY is false', async () => {
+  let savedPin: string | undefined;
+  beforeEach(() => {
+    savedPin = process.env.COPILOT_BIN_PATH;
+    delete process.env.COPILOT_BIN_PATH;
+  });
+  afterEach(() => {
+    if (savedPin === undefined) delete process.env.COPILOT_BIN_PATH;
+    else process.env.COPILOT_BIN_PATH = savedPin;
+  });
+
+  test('leaves unpinned resolution to the SDK without probing compiled-mode candidates', async () => {
+    const fileSpy = spyOn(resolver, 'isExecutableFile').mockReturnValue(true);
+    const pathSpy = spyOn(resolver, 'resolveFromPath').mockReturnValue('/path/copilot');
+    try {
+      expect(await resolveCopilotBinaryPath()).toBeUndefined();
+      expect(fileSpy).not.toHaveBeenCalled();
+      expect(pathSpy).not.toHaveBeenCalled();
+    } finally {
+      fileSpy.mockRestore();
+      pathSpy.mockRestore();
+    }
+  });
+
+  test('honors a valid env executable', async () => {
+    process.env.COPILOT_BIN_PATH = process.execPath;
+    expect(await resolveCopilotBinaryPath()).toBe(process.execPath);
+  });
+
+  test('honors a valid config executable', async () => {
+    expect(await resolveCopilotBinaryPath(process.execPath)).toBe(process.execPath);
+  });
+
+  test('env pin takes precedence over config', async () => {
+    process.env.COPILOT_BIN_PATH = process.execPath;
+    expect(await resolveCopilotBinaryPath('/missing/config/copilot')).toBe(process.execPath);
+  });
+
+  test('an invalid env pin refuses a valid config executable with repair advice', async () => {
+    const missing = join(process.execPath, 'missing-copilot');
+    process.env.COPILOT_BIN_PATH = missing;
+    await expect(resolveCopilotBinaryPath(process.execPath)).rejects.toThrow(
+      new Error(
+        `COPILOT_BIN_PATH is set to "${missing}" but it is not an executable file.\n` +
+          'Please verify the path points to the Copilot CLI executable (chmod +x if needed).'
+      )
+    );
+  });
+
+  test('an invalid config pin fails with repair advice instead of using the SDK', async () => {
+    const missing = join(process.execPath, 'missing-copilot');
+    await expect(resolveCopilotBinaryPath(missing)).rejects.toThrow(
+      new Error(
+        `assistants.copilot.copilotCliPath is set to "${missing}" but it is not an executable file.\n` +
+          'Please verify the path in .archon/config.yaml points to the Copilot CLI executable (chmod +x if needed).'
+      )
+    );
+  });
+
+  test('rejects a directory supplied as an env pin', async () => {
+    process.env.COPILOT_BIN_PATH = dirname(process.execPath);
+    await expect(resolveCopilotBinaryPath()).rejects.toThrow('is not an executable file');
+  });
+
+  test('rejects a directory supplied as a config pin', async () => {
+    await expect(resolveCopilotBinaryPath(dirname(process.execPath))).rejects.toThrow(
+      'is not an executable file'
+    );
+  });
+
+  test('an empty env pin keeps the SDK default', async () => {
+    process.env.COPILOT_BIN_PATH = '';
     const result = await resolveCopilotBinaryPath();
     expect(result).toBeUndefined();
   });
 
-  test('returns undefined even with config path set', async () => {
-    const result = await resolveCopilotBinaryPath('/some/custom/path');
-    expect(result).toBeUndefined();
+  test('an empty env pin allows a valid config pin', async () => {
+    process.env.COPILOT_BIN_PATH = '';
+    expect(await resolveCopilotBinaryPath(process.execPath)).toBe(process.execPath);
   });
 });

--- a/packages/providers/src/community/copilot/binary-resolver.ts
+++ b/packages/providers/src/community/copilot/binary-resolver.ts
@@ -5,7 +5,7 @@
  * dep, and by default the SDK resolves the binary from its own bundled copy
  * via `import.meta.url`. In compiled archon binaries that path is frozen to
  * the build host's filesystem, so we resolve explicitly and pass the result
- * via `new CopilotClient({ cliPath })`.
+ * via `new CopilotClient({ connection: { kind: 'stdio', path } })`.
  *
  * Resolution order:
  *  1. `COPILOT_BIN_PATH` environment variable
@@ -15,7 +15,8 @@
  *  5. PATH lookup via `which` / `where`
  *  6. Throw with install instructions
  *
- * Mirrors `codex/binary-resolver.ts` and `claude/binary-resolver.ts`.
+ * Source installs honor explicit env/config pins, then defer to the SDK's
+ * bundled CLI when no pin is configured. Tiers 3-6 apply only to compiled builds.
  */
 import {
   accessSync as _accessSync,
@@ -96,14 +97,13 @@ function getVendorBinaryName(): string | undefined {
 /**
  * Resolve the path to the Copilot CLI binary.
  *
- * In dev mode: returns undefined (SDK resolves via its bundled CLI).
+ * In dev mode: honors explicit pins, otherwise lets the SDK use its bundled CLI.
  * In binary mode: env / config / vendor / autodetect, else throw.
+ * An invalid explicit env or config pin throws in either mode.
  */
 export async function resolveCopilotBinaryPath(
   configCliPath?: string
 ): Promise<string | undefined> {
-  if (!BUNDLED_IS_BINARY) return undefined;
-
   // 1. Environment variable override
   const envPath = process.env.COPILOT_BIN_PATH;
   if (envPath) {
@@ -128,6 +128,8 @@ export async function resolveCopilotBinaryPath(
     getLog().info({ source: 'config' }, 'copilot.binary_resolved');
     return configCliPath;
   }
+
+  if (!BUNDLED_IS_BINARY) return undefined;
 
   // 3. Vendor directory (user-placed)
   const binaryName = getVendorBinaryName();

--- a/packages/providers/src/types.ts
+++ b/packages/providers/src/types.ts
@@ -19,9 +19,9 @@ export interface ClaudeProviderDefaults {
    *  @default ['project', 'user']
    */
   settingSources?: ('project' | 'user')[];
-  /** Absolute path to the Claude Code SDK's `cli.js`. Required in compiled
-   *  Archon builds when `CLAUDE_BIN_PATH` is not set; optional in dev mode
-   *  (SDK resolves from node_modules). */
+  /** Path to the Claude Code executable or its platform-package directory.
+   *  Honored in source and compiled builds, after `CLAUDE_BIN_PATH`.
+   *  Unpinned source installs use SDK resolution; compiled builds autodetect. */
   claudeBinaryPath?: string;
 }
 
@@ -50,9 +50,9 @@ export interface CopilotProviderDefaults {
    */
   modelReasoningEffort?: EffortRung;
   /**
-   * Absolute path to the Copilot CLI binary. Required in compiled Archon
-   * builds when `COPILOT_BIN_PATH` env var is not set. Dev-mode builds let
-   * the SDK resolve from `$PATH`.
+   * Absolute path to the Copilot CLI executable. Honored in source and compiled
+   * builds, after `COPILOT_BIN_PATH`. Unpinned source installs use SDK resolution;
+   * compiled builds search the vendor directory, canonical installs, and PATH.
    */
   copilotCliPath?: string;
   /**


### PR DESCRIPTION
Withdrawal: simplifying the factory to shared Archon workflows. Sibling-provider executable pin support is outside the workflow-only factory change. Branch retained for reference; this is not a factory prerequisite.

## Problem and outcome

Source installations silently ignored Claude's configured executable and Copilot's environment/config executable pins. Both providers now honor explicit pins before deferring to their SDKs. Invalid pins fail with repair guidance instead of selecting another binary.

## Review guidance

This is the focused provider parity follow-up requested in R2 on #3200. It is stacked on that PR's corrected head. Review the two resolver changes first, then their source-mode tests. Unpinned source behavior and compiled resolution remain unchanged.

## Solution

- Resolve Claude's config pin and Copilot's environment/config pins before the source-mode fallback.
- Preserve environment precedence, existing validation and provider-specific diagnostics. Source-mode errors do not advertise compiled-only autodetection.
- Update provider/config documentation to describe the actual SDK launch contract and pin behavior.

## Validation

- All 25 source-mode cases passed. Running these tests against the original resolvers produced 6 Claude and 8 Copilot failures, confirming regression coverage.
- All provider package test invocations completed: 922 passed, 1 failed, 1 skipped. The unchanged broken-symlink test fails with Windows EPERM, also reproduced against the base implementation.
- 77 doctor tests, generated checks, workspace type checks, lint, formatting and installer checks passed. The aggregate local suite is not fully green: the inherited symlink and container mount-prefix failures remain, and the parallel runner stops remaining suites after failure.
- No live provider execution or global configuration changes were needed for this resolver change.
