### PR TITLE
feat(forge): add recoverable work-item operations

### DIFF
--- a/packages/cli/src/commands/forge.ts
+++ b/packages/cli/src/commands/forge.ts
@@ -60,7 +60,7 @@ export async function forgeCommand(
     if (values.help) {
       await writeJsonLine({
         usage:
-          'archon forge resolve --json | checks --ref <PrRef JSON> --json | pr view/create/edit-body/ready/merge-pinned | work-item view | comment upsert --request <JSON or -> | --request-file <file or -> --json',
+          'archon forge resolve --json | checks --ref <PrRef JSON> --json | pr view/create/edit-body/ready/merge-pinned | work-item view/search/create/labels | comment upsert --request <JSON or -> | --request-file <file or -> --json',
         config:
           'Optional --config <file> containing {"hosts":{...}}; defaults to ~/.archon/forge.json',
       });

--- a/packages/docs-web/src/content/docs/reference/forge.md
+++ b/packages/docs-web/src/content/docs/reference/forge.md
@@ -146,6 +146,60 @@ Self-hosted credentials remain the configured plugin's responsibility.
 These are implementation choices for this slice, not approval of all broader
 credential, invocation-gate or plugin-distribution designs discussed in #3040.
 
+## Work-item operations
+
+`archon forge work-item view|search|create|labels --request - --json` uses the
+same schema, credential, exec-plugin and audit path as PR operations. Requests
+carry a qualified `repo: {host, path}` or `ref: {repo, number}`. GitHub supports
+github.com issues, including closed issues, and refuses PRs as work items.
+GitHub records contain `ref`, `url`, `title`, `body`, `state` and `labels` (names).
+Existing protocol-1 plugins may omit labels on view; the new operations require them.
+
+- **Search:** `{repo, marker?, max_pages?}` enumerates repository issues in
+  ascending creation order, all states, 100 entries per page. `max_pages` is
+  1 through 100, default 100. Without a marker it returns the title and body of
+  each issue for the caller's semantic comparison. With a marker it returns only
+  exact first-line matches. It uses the repository list endpoint, avoiding the
+  search index's lag and result ceiling. PRs count toward pagination but are
+  excluded from returned items. The result is `{repo, items, pages, completeness}`;
+  `completeness` is `complete` or `truncated`. A full final page is conservatively
+  truncated. Transport or malformed-response failures return errors, never an
+  empty successful search. Truncated results cannot establish marker absence or
+  uniqueness. Pagination is an observation, not a snapshot of concurrent edits.
+- **Create:** `{repo, marker, title, body, max_pages?}` requires a stable
+  caller-generated marker using the same syntax as comment upsert, for example
+  `<!-- archon-discovery:0123456789abcdef -->` (discovery supplies its full SHA-256 digest). Supply the same marker on every
+  retry. The owner prepends it as the first line; `body` must not repeat it.
+  Before writing, every bounded page is checked. Incomplete enumeration or
+  multiple matches refuses. A single match returns its verified existing
+  identity and preserves title, body, labels and state, even when the requested
+  content differs. No match creates an issue and reads back its qualified
+  identity, marker, title and body. An uncertain write returns `verify_failed`
+  with a leave-behind warning; retry the same marker to recover. GitHub marker
+  creation is **not atomic uniqueness** against simultaneous creators. Serialize
+  creators sharing a marker; this operation does not promise exactly once.
+- **Labels:** `{ref, add: string[], remove: string[], create?: [{name, color,
+  description}]}` adds and removes only named labels. Add/remove overlap and
+  duplicates are refused case-insensitively. Optional definitions create missing
+  repository labels and verify them, preserving existing definitions. The owner
+  uses additive POST and per-label DELETE, never whole-set replacement, so an
+  unrelated concurrent addition survives. Read-back verifies additions,
+  removals, and preservation of previously observed unrelated labels. Partial
+  writes return an uncertain-write refusal; repeating the delta reconciles it.
+  Opposing simultaneous changes to the same labels require caller coordination.
+
+For discovery, search exact markers and compare unfiltered summaries before
+choosing an action. Reuse `work-item view` for current evidence and
+`comment upsert` with `target: {kind: "workitem", ref}` to publish an explicitly
+chosen update. Work-item title/body editing is not currently supported. Create
+never doubles as an update operation. The workflow owns disclosure judgments,
+human gates and automatic-publication policy; these operations add none of them.
+The existing credential and local-artifact disclosure check still applies.
+
+Triage uses labels with only its five owned pack labels in the delta and missing
+label definitions. Other proposed labels are reported as skipped. Discovery
+retains its proposal-only workflow until governed publication is implemented.
+
 ## Plugins
 
 A plugin responds to `<executable> metadata` and `<executable> op <op-id>`.
@@ -158,7 +212,8 @@ release version. Unknown metadata fields and additive capability strings are
 allowed. Undeclared capabilities return `unsupported_op` before execution.
 
 The implemented capabilities include `resolve`, `checks.state`, `pr.merge-pinned`,
-`pr.view`, `pr.create`, `pr.edit-body`, `pr.ready`, `workitem.view` and
+`pr.view`, `pr.create`, `pr.edit-body`, `pr.ready`, `workitem.view`,
+`workitem.search`, `workitem.create`, `workitem.labels` and
 `comment.upsert`. Resolve is the
 protocol root operation; subsequent forge intents use namespaced identifiers.
 Plugins receive a qualified repository for resolve and a qualified PR for checks.

--- a/packages/forge/src/dispatch/dispatcher.ts
+++ b/packages/forge/src/dispatch/dispatcher.ts
@@ -325,7 +325,7 @@ export class ForgeDispatcher {
     return this.audited(
       parsed.success ? parsed.data.op : 'invalid',
       repo && parsed.success
-        ? `${repo.host}/${repo.path}${parsed.data.op === 'pr.create' ? '' : parsed.data.op === 'comment.upsert' ? `#${String(parsed.data.target.ref.number)}:${parsed.data.target.kind}` : `#${String(parsed.data.ref.number)}`}`
+        ? `${repo.host}/${repo.path}${'repo' in parsed.data ? '' : parsed.data.op === 'comment.upsert' ? `#${String(parsed.data.target.ref.number)}:${parsed.data.target.kind}` : `#${String(parsed.data.ref.number)}`}`
         : 'invalid-ref',
       async () => {
         if (!parsed.success || !repo)
@@ -370,11 +370,19 @@ export class ForgeDispatcher {
         plugin: id,
       };
     const publicRequest = publicRequestSchema.safeParse(request);
-    if (publicRequest.success && 'body' in publicRequest.data) {
-      const content = [
-        publicRequest.data.body,
-        ...('title' in publicRequest.data ? [publicRequest.data.title] : []),
-      ].join('\n');
+    if (publicRequest.success) {
+      const request = publicRequest.data;
+      const content = (
+        request.op === 'workitem.labels'
+          ? [...request.add, ...request.create.flatMap(label => [label.name, label.description])]
+          : 'body' in request
+            ? [
+                request.body,
+                ...('title' in request ? [request.title] : []),
+                ...('marker' in request ? [request.marker] : []),
+              ]
+            : []
+      ).join('\n');
       const artifacts = this.opts.env.ARTIFACTS_DIR?.replaceAll('\\', '/');
       if (
         (token && content.includes(token)) ||

--- a/packages/forge/src/github/public.test.ts
+++ b/packages/forge/src/github/public.test.ts
@@ -81,6 +81,7 @@ function fixture() {
           number: 42,
           html_url: 'https://github.com/owner/repo/issues/42',
           title: 'Issue',
+          labels: [],
           body: null,
           state: 'open',
           ...(state.wrongIssueKind ? { pull_request: {} } : {}),

--- a/packages/forge/src/github/public.ts
+++ b/packages/forge/src/github/public.ts
@@ -8,7 +8,8 @@ import {
   type RepoRef,
   type ForgeOpError,
   type expectedPrSchema,
-  type workItemRecordSchema,
+  type labeledWorkItemRecordSchema,
+  type workItemSearchResultSchema,
 } from '../schemas';
 import type { RawOpOutcome } from '../dispatch/plugin-handle';
 import type { GitHubPluginOptions } from './plugin';
@@ -34,6 +35,7 @@ const issue = z.object({
   body: z.string().nullable(),
   state: z.enum(['open', 'closed']),
   pull_request: z.unknown().optional(),
+  labels: z.array(z.object({ name: z.string() })),
 });
 const comment = z.object({
   id: z.number().int().positive(),
@@ -128,7 +130,7 @@ export async function publicOperation(
               evidence: `GitHub ${method} failed (HTTP ${String(response.status)})`,
             }
       );
-    const result = schema.safeParse(await response.json());
+    const result = schema.safeParse(response.status === 204 ? null : await response.json());
     if (!result.success)
       throw new Refusal({
         kind: 'invalid_response',
@@ -160,8 +162,10 @@ export async function publicOperation(
   async function readPr(number: number): Promise<PrRecord> {
     return record(await api(`${base}/pulls/${String(number)}`, pull), number);
   }
-  async function readIssue(number: number): Promise<z.infer<typeof workItemRecordSchema>> {
-    const value = await api(`${base}/issues/${String(number)}`, issue);
+  function issueRecord(
+    value: z.infer<typeof issue>,
+    number = value.number
+  ): z.infer<typeof labeledWorkItemRecordSchema> {
     if (
       value.number !== number ||
       value.pull_request !== undefined ||
@@ -175,7 +179,42 @@ export async function publicOperation(
       title: value.title,
       body: value.body ?? '',
       state: value.state,
+      labels: value.labels.map(label => label.name),
     };
+  }
+  async function readIssue(number: number): Promise<z.infer<typeof labeledWorkItemRecordSchema>> {
+    return issueRecord(await api(`${base}/issues/${String(number)}`, issue), number);
+  }
+  async function searchItems(
+    maxPages: number,
+    marker?: string
+  ): Promise<z.infer<typeof workItemSearchResultSchema>> {
+    const items: z.infer<typeof labeledWorkItemRecordSchema>[] = [];
+    const seen = new Set<number>();
+    for (let page = 1; page <= maxPages; page++) {
+      // Listing avoids the search index's lag and 1,000-result ceiling. Ascending creation
+      // order keeps newly created items from shifting earlier pages during recovery.
+      const values = await api(
+        `${base}/issues?state=all&sort=created&direction=asc&per_page=100&page=${String(page)}`,
+        z.array(issue).max(100)
+      );
+      for (const value of values) {
+        const kind = value.pull_request === undefined ? 'issues' : 'pull';
+        if (
+          value.html_url.toLowerCase() !==
+          `https://${repo.host}/${repo.path}/${kind}/${String(value.number)}`.toLowerCase()
+        )
+          refuse('work items from requested repository', 'listing target mismatch');
+        if (seen.has(value.number))
+          refuse('distinct paginated identities', 'listing repeated an item');
+        seen.add(value.number);
+        if (value.pull_request !== undefined) continue;
+        const item = issueRecord(value);
+        if (marker === undefined || item.body.split(/\r?\n/, 1)[0] === marker) items.push(item);
+      }
+      if (values.length < 100) return { repo, items, completeness: 'complete', pages: page };
+    }
+    return { repo, items, completeness: 'truncated', pages: maxPages };
   }
   async function pages<T>(path: string, schema: z.ZodType<T>): Promise<T[]> {
     const results: T[] = [];
@@ -196,6 +235,90 @@ export async function publicOperation(
     if (request.op === 'pr.view') return { kind: 'ok', value: await readPr(request.ref.number) };
     if (request.op === 'workitem.view')
       return { kind: 'ok', value: await readIssue(request.ref.number) };
+    if (request.op === 'workitem.search')
+      return { kind: 'ok', value: await searchItems(request.max_pages, request.marker) };
+    if (request.op === 'workitem.create') {
+      const matches = await searchItems(request.max_pages, request.marker);
+      if (matches.completeness !== 'complete')
+        refuse(
+          'complete marker enumeration',
+          'pagination bound reached; marker uniqueness unknown'
+        );
+      if (matches.items.length > 1)
+        refuse('one canonical marker work item', 'duplicate markers; operator must reconcile');
+      const previous = matches.items[0];
+      const body = `${request.marker}\n${request.body}`;
+      const written =
+        previous ??
+        issueRecord(
+          await api(`${base}/issues`, issue, 'POST', {
+            title: request.title,
+            body,
+          })
+        );
+      const observed = await readIssue(written.ref.number);
+      if (
+        observed.body.split(/\r?\n/, 1)[0] !== request.marker ||
+        (!previous && (observed.body !== body || observed.title !== request.title))
+      )
+        refuse(
+          'requested work item with exact marker and created content',
+          'work item read-back mismatch'
+        );
+      // A reused item belongs to its public history. Create never rewrites it.
+      return { kind: 'ok', value: observed };
+    }
+    if (request.op === 'workitem.labels') {
+      const before = await readIssue(request.ref.number);
+      const names = (labels: string[]): Set<string> =>
+        new Set(labels.map(label => label.toLowerCase()));
+      const current = names(before.labels);
+      const adding = names(request.add);
+      const removing = names(request.remove);
+      if (request.create.length) {
+        const label = z.object({
+          name: z.string(),
+          color: z.string(),
+          description: z.string().nullable(),
+        });
+        const existing = names((await pages(`${base}/labels`, label)).map(value => value.name));
+        for (const definition of request.create) {
+          if (existing.has(definition.name.toLowerCase())) continue;
+          const written = await api(`${base}/labels`, label, 'POST', definition);
+          const observed = await api(
+            `${base}/labels/${encodeURIComponent(definition.name)}`,
+            label
+          );
+          if (
+            written.name !== definition.name ||
+            observed.name !== definition.name ||
+            observed.color.toLowerCase() !== definition.color.toLowerCase() ||
+            observed.description !== definition.description
+          )
+            refuse('requested label definition', 'label definition read-back mismatch');
+        }
+      }
+      const path = `${base}/issues/${String(request.ref.number)}/labels`;
+      const additions = request.add.filter(name => !current.has(name.toLowerCase()));
+      if (additions.length)
+        await api(path, z.array(z.object({ name: z.string() })), 'POST', { labels: additions });
+      for (const name of request.remove) {
+        if (current.has(name.toLowerCase()))
+          await api(`${path}/${encodeURIComponent(name)}`, z.unknown(), 'DELETE');
+      }
+      const observed = await readIssue(request.ref.number);
+      const actual = names(observed.labels);
+      if (
+        [...adding].some(name => !actual.has(name)) ||
+        [...removing].some(name => actual.has(name)) ||
+        [...current].some(name => !removing.has(name) && !actual.has(name))
+      )
+        refuse(
+          'added labels present, removed labels absent and unrelated labels preserved',
+          'label read-back mismatch'
+        );
+      return { kind: 'ok', value: observed };
+    }
     if (request.op === 'pr.create') {
       if (request.head_repo.host !== repo.host || request.head_repo.path.split('/').length !== 2)
         refuse('GitHub head repository', 'unsupported head host or path');

--- a/packages/forge/src/github/workitem.test.ts
+++ b/packages/forge/src/github/workitem.test.ts
@@ -1,0 +1,330 @@
+import { afterEach, beforeEach, expect, test } from 'bun:test';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { trackTempRoots } from '@archon/paths/test-utils';
+import { ForgeDispatcher } from '../dispatch/dispatcher';
+import { publicRequestSchema, type ForgeOpAuditEvent } from '../schemas';
+import { workItemFixture } from '../test/workitem-fixture';
+
+const track = trackTempRoots();
+let f: ReturnType<typeof workItemFixture>;
+let root: string;
+let audits: ForgeOpAuditEvent[];
+let dispatcher: ForgeDispatcher;
+const marker = `<!-- archon-discovery:${'a'.repeat(64)} -->`;
+const content = 'Unicode café é 🦊 東京 `literal` $(data)';
+beforeEach(async () => {
+  f = workItemFixture();
+  root = track(await mkdtemp(join(tmpdir(), 'forge work items ')));
+  await writeFile(join(root, 'forge.json'), JSON.stringify({ hosts: {} }));
+  audits = [];
+  dispatcher = new ForgeDispatcher(
+    [
+      {
+        source: 'fixture:github',
+        command: process.execPath,
+        args: [join(import.meta.dir, '../dispatch/fixtures/github-plugin.ts'), f.server.url.origin],
+      },
+    ],
+    {
+      cwd: root,
+      env: { GH_TOKEN: 'fixture-secret', ARTIFACTS_DIR: root },
+      discoverHome: async () => [],
+      discoverPath: async () => [],
+      audit: event => {
+        audits.push(event);
+      },
+    }
+  );
+});
+afterEach(async () => {
+  await f.server.stop(true);
+});
+function dispatch(request: unknown) {
+  return dispatcher.publicOperation(publicRequestSchema.parse(request));
+}
+function create(overrides = {}) {
+  return dispatch({
+    op: 'workitem.create',
+    repo: f.repo,
+    marker,
+    title: content,
+    body: content,
+    ...overrides,
+  });
+}
+function fillPages() {
+  f.items.splice(0, f.items.length, ...Array.from({ length: 201 }, (_, i) => f.makeItem(i + 1)));
+  f.items[200].body = `${marker}\nOriginal public body`;
+  f.items[200].state = 'closed';
+}
+test('exact marker recovery scans beyond page one including closed items and preserves content', async () => {
+  fillPages();
+  f.items[0].body = `Mention\n${marker}`;
+  const result = await create();
+  expect(result).toMatchObject({
+    kind: 'ok',
+    value: {
+      ref: { number: 201 },
+      title: 'Work item',
+      body: `${marker}\nOriginal public body`,
+      state: 'closed',
+    },
+  });
+  expect(f.calls.some(call => call.path.endsWith('page=3'))).toBe(true);
+  expect(f.calls.every(call => call.method === 'GET')).toBe(true);
+});
+test('bounded search reports incomplete enumeration and creation refuses even an early match', async () => {
+  fillPages();
+  expect(
+    await dispatch({ op: 'workitem.search', repo: f.repo, marker, max_pages: 1 })
+  ).toMatchObject({
+    kind: 'ok',
+    value: { items: [], pages: 1, completeness: 'truncated' },
+  });
+  f.items[0].body = marker;
+  expect(await create({ max_pages: 1 })).toMatchObject({
+    kind: 'error',
+    error: {
+      kind: 'verify_failed',
+      observed: 'pagination bound reached; marker uniqueness unknown',
+    },
+  });
+  expect(f.calls.every(call => call.method === 'GET')).toBe(true);
+});
+test('unfiltered search returns qualified content for semantic judgment, excluding PRs', async () => {
+  f.items[0].body = content;
+  f.items.push({
+    ...f.makeItem(43),
+    html_url: 'https://github.com/owner/repo/pull/43',
+    ...{ pull_request: {} },
+  });
+  expect(await dispatch({ op: 'workitem.search', repo: f.repo })).toMatchObject({
+    kind: 'ok',
+    value: {
+      repo: f.repo,
+      completeness: 'complete',
+      items: [{ ref: { repo: f.repo, number: 42 }, body: content }],
+    },
+  });
+});
+test('multiple markers across pages refuse creation', async () => {
+  fillPages();
+  f.items[0].body = marker;
+  expect(await create()).toMatchObject({
+    kind: 'error',
+    error: { kind: 'verify_failed', observed: 'duplicate markers; operator must reconcile' },
+  });
+  expect(f.calls.every(call => call.method === 'GET')).toBe(true);
+});
+test('accepted create with lost response retries the same marker without rewriting public content', async () => {
+  f.state.mode = 'write_then_fail';
+  expect(await create()).toMatchObject({
+    kind: 'error',
+    error: {
+      kind: 'verify_failed',
+      leave_behind: expect.stringContaining('Write may have been accepted'),
+    },
+  });
+  f.state.mode = '';
+  expect(await create({ title: 'Changed', body: 'Changed' })).toMatchObject({
+    kind: 'ok',
+    value: { ref: { repo: f.repo, number: 43 }, title: content, body: `${marker}\n${content}` },
+  });
+  expect(f.calls.filter(call => call.method === 'POST')).toHaveLength(1);
+  expect(JSON.stringify(audits)).not.toContain(content);
+  expect(JSON.stringify(audits)).not.toContain('fixture-secret');
+  expect(audits.map(event => event.target)).toEqual([
+    'github.com/owner/repo',
+    'github.com/owner/repo',
+  ]);
+});
+test.each(['missing_marker', 'wrong_create', 'wrong_after', 'read_failure'])(
+  'create read-back refuses %s as an uncertain write',
+  async mode => {
+    f.state.mode = mode;
+    expect(await create()).toMatchObject({
+      kind: 'error',
+      error: { kind: 'verify_failed', leave_behind: expect.any(String) },
+    });
+  }
+);
+test('wrong repository and duplicate pagination identities refuse before creation', async () => {
+  f.items[0].html_url = 'https://github.com/wrong/repo/issues/42';
+  expect(await create()).toMatchObject({ kind: 'error', error: { kind: 'verify_failed' } });
+  fillPages();
+  f.items[100] = f.items[0];
+  expect(await create()).toMatchObject({
+    kind: 'error',
+    error: { kind: 'verify_failed', observed: 'listing repeated an item' },
+  });
+  expect(f.calls.every(call => call.method === 'GET')).toBe(true);
+});
+test('schema rejects missing, malformed and repeated caller markers and invalid identities', () => {
+  for (const request of [
+    { marker: undefined },
+    { marker: '' },
+    { marker: 'some prose' },
+    { marker: `${marker}\n` },
+    { body: marker },
+    { repo: { host: 'github.com', path: 'owner/../repo' } },
+    { max_pages: 101 },
+  ])
+    expect(
+      publicRequestSchema.safeParse({
+        op: 'workitem.create',
+        repo: f.repo,
+        marker,
+        title: 'Title',
+        body: '',
+        ...request,
+      }).success
+    ).toBe(false);
+  for (const number of [0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1])
+    expect(
+      publicRequestSchema.safeParse({ op: 'workitem.view', ref: { repo: f.repo, number } }).success
+    ).toBe(false);
+});
+test('label delta preserves concurrent unrelated labels and encodes Unicode, slash and comma data', async () => {
+  f.state.mode = 'concurrent_unrelated';
+  f.items[0].labels.push({ name: 'area:old/cli,api' });
+  const request = {
+    op: 'workitem.labels',
+    ref: { repo: f.repo, number: 42 },
+    add: ['東京/cli,api'],
+    remove: ['area:old/cli,api'],
+  };
+  expect(await dispatch(request)).toMatchObject({
+    kind: 'ok',
+    value: {
+      labels: expect.arrayContaining([
+        '東京/cli,api',
+        'area:concurrent/cli,api',
+        'unrelated-label',
+      ]),
+    },
+  });
+  expect(f.calls.find(call => call.method === 'DELETE')?.path).toEndWith('area%3Aold%2Fcli%2Capi');
+  const writes = f.calls.filter(call => call.method !== 'GET').length;
+  expect(await dispatch(request)).toMatchObject({ kind: 'ok' });
+  expect(f.calls.filter(call => call.method !== 'GET')).toHaveLength(writes);
+});
+test('overlapping label deltas refuse case-insensitively', () => {
+  expect(
+    publicRequestSchema.safeParse({
+      op: 'workitem.labels',
+      ref: { repo: f.repo, number: 42 },
+      add: ['Ready'],
+      remove: ['ready'],
+    }).success
+  ).toBe(false);
+});
+test('content disclosure guard rejects credentials and artifacts before transport', async () => {
+  for (const body of ['fixture-secret', root])
+    expect(await create({ body })).toMatchObject({
+      kind: 'error',
+      error: { kind: 'invalid_request' },
+    });
+  expect(f.calls).toHaveLength(0);
+});
+test('label content and marker disclosure checks run before any write', async () => {
+  expect(await create({ marker: '<!-- fixture-secret -->' })).toMatchObject({
+    kind: 'error',
+    error: { kind: 'invalid_request' },
+  });
+  for (const request of [
+    { add: ['fixture-secret'], create: [] },
+    { add: [], create: [{ name: 'safe', color: '123456', description: root }] },
+  ])
+    expect(
+      await dispatch({
+        op: 'workitem.labels',
+        ref: { repo: f.repo, number: 42 },
+        remove: [],
+        ...request,
+      })
+    ).toMatchObject({ kind: 'error', error: { kind: 'invalid_request' } });
+  expect(f.calls).toHaveLength(0);
+});
+test('native credential resolution reaches the real plugin and response redaction without changing host context', async () => {
+  const env = { GH_CONFIG_DIR: join(root, 'native-config') };
+  const subject = new ForgeDispatcher(
+    [
+      {
+        source: 'fixture:github',
+        command: process.execPath,
+        args: [join(import.meta.dir, '../dispatch/fixtures/github-plugin.ts'), f.server.url.origin],
+      },
+    ],
+    {
+      cwd: root,
+      env,
+      discoverHome: async () => [],
+      discoverPath: async () => [],
+      resolveCredential: async host => {
+        expect(host).toBe('github.com');
+        return 'fixture-secret';
+      },
+    }
+  );
+  f.items[0].body = 'reflected fixture-secret';
+  const result = await subject.publicOperation({
+    op: 'workitem.view',
+    ref: { repo: f.repo, number: 42 },
+  });
+  expect(result).toMatchObject({ kind: 'ok', value: { body: 'reflected [REDACTED]' } });
+  expect(env).toEqual({ GH_CONFIG_DIR: join(root, 'native-config') });
+});
+test('CLI stdin uses real owner/plugin, Unicode and separate redacted audit', async () => {
+  const cli = join(import.meta.dir, '../../../cli/src/commands/fixtures/forge-public-cli.ts');
+  const run = async (op: string, request: unknown) => {
+    const child = Bun.spawn(
+      [
+        process.execPath,
+        cli,
+        f.server.url.origin,
+        'forge',
+        'work-item',
+        op,
+        '--request',
+        '-',
+        '--json',
+      ],
+      {
+        cwd: root,
+        env: { ...process.env, ARCHON_HOME: root, GH_TOKEN: 'fixture-secret', GITHUB_TOKEN: '' },
+        stdin: new Blob([JSON.stringify(request)]),
+        stdout: 'pipe',
+        stderr: 'pipe',
+      }
+    );
+    const [code, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ]);
+    return { code, stdout, stderr };
+  };
+  const created = await run('create', { repo: f.repo, marker, title: content, body: content });
+  expect(created.code, created.stdout).toBe(0);
+  expect(JSON.parse(created.stdout)).toMatchObject({ body: `${marker}\n${content}` });
+  const searched = await run('search', { repo: f.repo, marker });
+  expect(searched.code, searched.stdout).toBe(0);
+  expect(JSON.parse(searched.stdout)).toMatchObject({
+    completeness: 'complete',
+    items: [JSON.parse(created.stdout)],
+  });
+  const invalid = await run('create', {
+    repo: { host: 'github.com', path: 'owner/repo/extra' },
+    marker,
+    title: content,
+    body: content,
+  });
+  expect(invalid.code).toBe(1);
+  expect(created.stderr).toContain('"op":"workitem.create"');
+  expect(created.stderr).not.toContain(content);
+  expect(created.stdout + created.stderr + invalid.stdout + invalid.stderr).not.toContain(
+    'fixture-secret'
+  );
+});

--- a/packages/forge/src/schemas.ts
+++ b/packages/forge/src/schemas.ts
@@ -38,6 +38,25 @@ export const workItemRecordSchema = z.object({
   title: z.string(),
   body: z.string(),
   state: z.enum(['open', 'closed']),
+  // Protocol-1 plugins may predate label operations. Their existing view remains valid.
+  labels: z.array(z.string()).optional(),
+});
+export const labeledWorkItemRecordSchema = workItemRecordSchema.required({ labels: true });
+export const markerSchema = z.string().regex(/^<!-- [a-z0-9-]+(?::[a-z0-9-]+)? -->$/);
+const maxPagesSchema = z.number().int().min(1).max(100).default(100);
+const labelNameSchema = z.string().min(1).max(50);
+const labelNamesSchema = z
+  .array(labelNameSchema)
+  .max(100)
+  .refine(
+    values => new Set(values.map(value => value.toLowerCase())).size === values.length,
+    'Duplicate label names'
+  );
+export const workItemSearchResultSchema = z.object({
+  repo: repoRefSchema,
+  items: z.array(labeledWorkItemRecordSchema),
+  completeness: z.enum(['complete', 'truncated']),
+  pages: z.number().int().min(1).max(100),
 });
 export const commentTargetSchema = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('pr'), ref: prRefSchema, expected: expectedPrSchema }),
@@ -68,9 +87,57 @@ export const publicRequestSchema = z.discriminatedUnion('op', [
   z.object({ op: z.literal('pr.ready'), ref: prRefSchema, expected: expectedPrSchema }),
   z.object({ op: z.literal('workitem.view'), ref: workItemRefSchema }),
   z.object({
+    op: z.literal('workitem.search'),
+    repo: repoRefSchema,
+    marker: markerSchema.optional(),
+    max_pages: maxPagesSchema,
+  }),
+  z
+    .object({
+      op: z.literal('workitem.create'),
+      repo: repoRefSchema,
+      marker: markerSchema,
+      title: z.string().min(1),
+      body: z.string(),
+      max_pages: maxPagesSchema,
+    })
+    .refine(
+      value => !value.body.split(/\r?\n/).includes(value.marker),
+      'Body must not repeat the caller marker'
+    ),
+  z
+    .object({
+      op: z.literal('workitem.labels'),
+      ref: workItemRefSchema,
+      add: labelNamesSchema,
+      remove: labelNamesSchema,
+      create: z
+        .array(
+          z.object({
+            name: labelNameSchema,
+            color: z.string().regex(/^[a-fA-F0-9]{6}$/),
+            description: z.string().max(100),
+          })
+        )
+        .max(100)
+        .default([]),
+    })
+    .refine(
+      value =>
+        !value.add.some(name =>
+          value.remove.some(removed => removed.toLowerCase() === name.toLowerCase())
+        ),
+      'Cannot add and remove the same label'
+    )
+    .refine(
+      value =>
+        new Set(value.create.map(label => label.name.toLowerCase())).size === value.create.length,
+      'Duplicate label definitions'
+    ),
+  z.object({
     op: z.literal('comment.upsert'),
     target: commentTargetSchema,
-    marker: z.string().regex(/^<!-- [a-z0-9-]+ -->$/),
+    marker: markerSchema,
     body: z.string(),
   }),
 ]);
@@ -81,11 +148,14 @@ export const publicResultSchemas = {
   'pr.edit-body': prRecordSchema,
   'pr.ready': prRecordSchema,
   'workitem.view': workItemRecordSchema,
+  'workitem.search': workItemSearchResultSchema,
+  'workitem.create': labeledWorkItemRecordSchema,
+  'workitem.labels': labeledWorkItemRecordSchema,
   'comment.upsert': commentRecordSchema,
-};
+} satisfies Record<PublicRequest['op'], z.ZodType>;
 export type PublicResult = z.infer<(typeof publicResultSchemas)[keyof typeof publicResultSchemas]>;
 export function publicRequestRepo(request: PublicRequest): RepoRef {
-  return request.op === 'pr.create'
+  return 'repo' in request
     ? request.repo
     : request.op === 'comment.upsert'
       ? request.target.ref.repo

--- a/packages/forge/src/test/workitem-fixture.ts
+++ b/packages/forge/src/test/workitem-fixture.ts
@@ -1,0 +1,103 @@
+/** Fake GitHub transport shared by owner and pack integration tests. */
+export function workItemFixture(path = 'owner/repo') {
+  const repo = { host: 'github.com', path };
+  const makeItem = (number: number, body = '') => ({
+    number,
+    html_url: `https://github.com/${path}/issues/${String(number)}`,
+    title: 'Work item',
+    body,
+    state: 'open',
+    labels: [] as { name: string }[],
+  });
+  const items = [makeItem(42)];
+  items[0].labels = [{ name: 'unrelated-label' }, { name: 'archon-blocked' }];
+  const definitions: { name: string; color: string; description: string }[] = [];
+  const calls: { method: string; path: string; body: unknown }[] = [];
+  const state = { mode: '', written: false };
+  const server = Bun.serve({
+    hostname: '127.0.0.1',
+    port: 0,
+    async fetch(request) {
+      const url = new URL(request.url);
+      const endpoint = decodeURIComponent(url.pathname);
+      const method = request.method;
+      const payload: unknown = method === 'POST' ? await request.json() : undefined;
+      calls.push({ method, path: url.pathname + url.search, body: payload });
+      if (request.headers.get('Authorization') !== 'Bearer fixture-secret')
+        return new Response('', { status: 401 });
+      const base = `/repos/${path}`;
+      if (!endpoint.startsWith(base + '/')) return new Response('', { status: 404 });
+      const fail = () =>
+        new Response('fixture-secret reflected transport failure', { status: 502 });
+      const page = <T>(values: T[]) => {
+        const n = Number(url.searchParams.get('page') ?? 1);
+        return values.slice((n - 1) * 100, n * 100);
+      };
+      if (endpoint === `${base}/issues`) {
+        if (method === 'POST') {
+          const body = payload as { title: string; body: string };
+          const item = makeItem(Math.max(0, ...items.map(value => value.number)) + 1, body.body);
+          item.title = body.title;
+          if (state.mode === 'missing_marker') item.body = 'lost marker';
+          items.push(item);
+          state.written = true;
+          if (state.mode === 'write_then_fail') return fail();
+          if (state.mode === 'wrong_create')
+            return Response.json({ ...item, html_url: 'https://github.com/wrong/repo/issues/43' });
+          return Response.json(item);
+        }
+        return Response.json(page(items));
+      }
+      const issue = items.find(item => endpoint === `${base}/issues/${String(item.number)}`);
+      if (issue) {
+        if (state.mode === 'read_failure' && state.written) return fail();
+        return Response.json({
+          ...issue,
+          ...(state.mode === 'wrong_before' || (state.mode === 'wrong_after' && state.written)
+            ? { html_url: 'https://github.com/wrong/repo/issues/42' }
+            : {}),
+          ...(state.mode === 'is_pr' ? { pull_request: {} } : {}),
+          ...(state.mode === 'malformed_labels' ? { labels: [{}] } : {}),
+        });
+      }
+      if (endpoint === `${base}/labels`) {
+        if (method === 'GET') return Response.json(page(definitions));
+        if (state.mode === 'partial_create' && definitions.length) return fail();
+        const definition = payload as (typeof definitions)[number];
+        definitions.push(definition);
+        return Response.json(definition);
+      }
+      if (endpoint.startsWith(`${base}/labels/`)) {
+        const definition = definitions.find(value => endpoint === `${base}/labels/${value.name}`);
+        return definition ? Response.json(definition) : new Response('', { status: 404 });
+      }
+      const target = items.find(item =>
+        endpoint.startsWith(`${base}/issues/${String(item.number)}/labels`)
+      );
+      if (!target) return new Response('', { status: 404 });
+      if (!state.written && state.mode === 'concurrent_unrelated')
+        target.labels.push({ name: 'area:concurrent/cli,api' });
+      if (!state.written && state.mode === 'concurrent_pack')
+        target.labels.push({ name: 'archon-close' });
+      if (method === 'POST' && state.mode !== 'noop_write') {
+        for (const name of (payload as { labels: string[] }).labels)
+          if (!target.labels.some(label => label.name === name)) target.labels.push({ name });
+      }
+      if (method === 'DELETE') {
+        if (state.mode === 'partial_remove') return fail();
+        if (!['noop_write', 'retain_stale'].includes(state.mode))
+          target.labels = target.labels.filter(
+            label => endpoint !== `${base}/issues/${String(target.number)}/labels/${label.name}`
+          );
+      }
+      if (state.mode === 'drop_unrelated')
+        target.labels = target.labels.filter(label => label.name !== 'unrelated-label');
+      state.written = true;
+      if (state.mode === 'write_then_fail') return fail();
+      return method === 'DELETE'
+        ? new Response(null, { status: 204 })
+        : Response.json(target.labels);
+    },
+  });
+  return { repo, items, definitions, calls, state, server, makeItem };
+}

--- a/packages/forge/wire-schema.json
+++ b/packages/forge/wire-schema.json
@@ -758,6 +758,199 @@
         "properties": {
           "op": {
             "type": "string",
+            "const": "workitem.search"
+          },
+          "repo": {
+            "type": "object",
+            "properties": {
+              "host": {
+                "type": "string",
+                "pattern": "^[a-z0-9]+(?:[.-][a-z0-9]+)*$"
+              },
+              "path": {
+                "type": "string",
+                "pattern": "^[\\p{L}\\p{N}_.-]+(?:\\/[\\p{L}\\p{N}_.-]+)+$"
+              }
+            },
+            "required": [
+              "host",
+              "path"
+            ],
+            "additionalProperties": false
+          },
+          "marker": {
+            "type": "string",
+            "pattern": "^<!-- [a-z0-9-]+(?::[a-z0-9-]+)? -->$"
+          },
+          "max_pages": {
+            "default": 100,
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          }
+        },
+        "required": [
+          "op",
+          "repo",
+          "max_pages"
+        ],
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "properties": {
+          "op": {
+            "type": "string",
+            "const": "workitem.create"
+          },
+          "repo": {
+            "type": "object",
+            "properties": {
+              "host": {
+                "type": "string",
+                "pattern": "^[a-z0-9]+(?:[.-][a-z0-9]+)*$"
+              },
+              "path": {
+                "type": "string",
+                "pattern": "^[\\p{L}\\p{N}_.-]+(?:\\/[\\p{L}\\p{N}_.-]+)+$"
+              }
+            },
+            "required": [
+              "host",
+              "path"
+            ],
+            "additionalProperties": false
+          },
+          "marker": {
+            "type": "string",
+            "pattern": "^<!-- [a-z0-9-]+(?::[a-z0-9-]+)? -->$"
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "body": {
+            "type": "string"
+          },
+          "max_pages": {
+            "default": 100,
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          }
+        },
+        "required": [
+          "op",
+          "repo",
+          "marker",
+          "title",
+          "body",
+          "max_pages"
+        ],
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "properties": {
+          "op": {
+            "type": "string",
+            "const": "workitem.labels"
+          },
+          "ref": {
+            "type": "object",
+            "properties": {
+              "repo": {
+                "type": "object",
+                "properties": {
+                  "host": {
+                    "type": "string",
+                    "pattern": "^[a-z0-9]+(?:[.-][a-z0-9]+)*$"
+                  },
+                  "path": {
+                    "type": "string",
+                    "pattern": "^[\\p{L}\\p{N}_.-]+(?:\\/[\\p{L}\\p{N}_.-]+)+$"
+                  }
+                },
+                "required": [
+                  "host",
+                  "path"
+                ],
+                "additionalProperties": false
+              },
+              "number": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              }
+            },
+            "required": [
+              "repo",
+              "number"
+            ],
+            "additionalProperties": false
+          },
+          "add": {
+            "maxItems": 100,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 50
+            }
+          },
+          "remove": {
+            "maxItems": 100,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 50
+            }
+          },
+          "create": {
+            "default": [],
+            "maxItems": 100,
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 50
+                },
+                "color": {
+                  "type": "string",
+                  "pattern": "^[a-fA-F0-9]{6}$"
+                },
+                "description": {
+                  "type": "string",
+                  "maxLength": 100
+                }
+              },
+              "required": [
+                "name",
+                "color",
+                "description"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "op",
+          "ref",
+          "add",
+          "remove",
+          "create"
+        ],
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "properties": {
+          "op": {
+            "type": "string",
             "const": "comment.upsert"
           },
           "target": {
@@ -903,7 +1096,7 @@
           },
           "marker": {
             "type": "string",
-            "pattern": "^<!-- [a-z0-9-]+ -->$"
+            "pattern": "^<!-- [a-z0-9-]+(?::[a-z0-9-]+)? -->$"
           },
           "body": {
             "type": "string"
@@ -1384,6 +1577,12 @@
           "open",
           "closed"
         ]
+      },
+      "labels": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
       }
     },
     "required": [
@@ -1392,6 +1591,264 @@
       "title",
       "body",
       "state"
+    ],
+    "additionalProperties": false
+  },
+  "workitem.search": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "repo": {
+        "type": "object",
+        "properties": {
+          "host": {
+            "type": "string",
+            "pattern": "^[a-z0-9]+(?:[.-][a-z0-9]+)*$"
+          },
+          "path": {
+            "type": "string",
+            "pattern": "^[\\p{L}\\p{N}_.-]+(?:\\/[\\p{L}\\p{N}_.-]+)+$"
+          }
+        },
+        "required": [
+          "host",
+          "path"
+        ],
+        "additionalProperties": false
+      },
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "ref": {
+              "type": "object",
+              "properties": {
+                "repo": {
+                  "type": "object",
+                  "properties": {
+                    "host": {
+                      "type": "string",
+                      "pattern": "^[a-z0-9]+(?:[.-][a-z0-9]+)*$"
+                    },
+                    "path": {
+                      "type": "string",
+                      "pattern": "^[\\p{L}\\p{N}_.-]+(?:\\/[\\p{L}\\p{N}_.-]+)+$"
+                    }
+                  },
+                  "required": [
+                    "host",
+                    "path"
+                  ],
+                  "additionalProperties": false
+                },
+                "number": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                }
+              },
+              "required": [
+                "repo",
+                "number"
+              ],
+              "additionalProperties": false
+            },
+            "url": {
+              "type": "string",
+              "format": "uri"
+            },
+            "title": {
+              "type": "string"
+            },
+            "body": {
+              "type": "string"
+            },
+            "state": {
+              "type": "string",
+              "enum": [
+                "open",
+                "closed"
+              ]
+            },
+            "labels": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "required": [
+            "ref",
+            "url",
+            "title",
+            "body",
+            "state",
+            "labels"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "completeness": {
+        "type": "string",
+        "enum": [
+          "complete",
+          "truncated"
+        ]
+      },
+      "pages": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 100
+      }
+    },
+    "required": [
+      "repo",
+      "items",
+      "completeness",
+      "pages"
+    ],
+    "additionalProperties": false
+  },
+  "workitem.create": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "ref": {
+        "type": "object",
+        "properties": {
+          "repo": {
+            "type": "object",
+            "properties": {
+              "host": {
+                "type": "string",
+                "pattern": "^[a-z0-9]+(?:[.-][a-z0-9]+)*$"
+              },
+              "path": {
+                "type": "string",
+                "pattern": "^[\\p{L}\\p{N}_.-]+(?:\\/[\\p{L}\\p{N}_.-]+)+$"
+              }
+            },
+            "required": [
+              "host",
+              "path"
+            ],
+            "additionalProperties": false
+          },
+          "number": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991
+          }
+        },
+        "required": [
+          "repo",
+          "number"
+        ],
+        "additionalProperties": false
+      },
+      "url": {
+        "type": "string",
+        "format": "uri"
+      },
+      "title": {
+        "type": "string"
+      },
+      "body": {
+        "type": "string"
+      },
+      "state": {
+        "type": "string",
+        "enum": [
+          "open",
+          "closed"
+        ]
+      },
+      "labels": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "required": [
+      "ref",
+      "url",
+      "title",
+      "body",
+      "state",
+      "labels"
+    ],
+    "additionalProperties": false
+  },
+  "workitem.labels": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "ref": {
+        "type": "object",
+        "properties": {
+          "repo": {
+            "type": "object",
+            "properties": {
+              "host": {
+                "type": "string",
+                "pattern": "^[a-z0-9]+(?:[.-][a-z0-9]+)*$"
+              },
+              "path": {
+                "type": "string",
+                "pattern": "^[\\p{L}\\p{N}_.-]+(?:\\/[\\p{L}\\p{N}_.-]+)+$"
+              }
+            },
+            "required": [
+              "host",
+              "path"
+            ],
+            "additionalProperties": false
+          },
+          "number": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991
+          }
+        },
+        "required": [
+          "repo",
+          "number"
+        ],
+        "additionalProperties": false
+      },
+      "url": {
+        "type": "string",
+        "format": "uri"
+      },
+      "title": {
+        "type": "string"
+      },
+      "body": {
+        "type": "string"
+      },
+      "state": {
+        "type": "string",
+        "enum": [
+          "open",
+          "closed"
+        ]
+      },
+      "labels": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "required": [
+      "ref",
+      "url",
+      "title",
+      "body",
+      "state",
+      "labels"
     ],
     "additionalProperties": false
   },


### PR DESCRIPTION
Withdrawal: simplifying the factory to shared Archon workflows. Discovery publication uses gh within its workflow command node. Branch retained for reference; this is not a factory prerequisite.

## Problem and outcome

Shared workflows need recoverable work-item operations without invoking GitHub writes from agents. This adds qualified search, marker-based creation and owned-label updates to the forge boundary.

## Review guidance

Draft. The temporary `integration/sdlc-public-forge-base` contains the dependency stack so this diff contains only work-item operations. Align with the final #3232/#3238 heads and retarget after prerequisite integration before merging.

## Solution

Search paginates open and closed items with explicit truncation. Creation reuses an exact marker after uncertain responses and refuses ambiguous duplicates. Label updates preserve unrelated labels and verify results. Existing comment upsert remains the update owner.

## Validation

121 forge cases passed on the follow-up source containing the same forge implementation, at unchanged deadlines. Focused owner/CLI tests use real scripts and controlled HTTP transport. Earlier component tests needed a larger local test-runner deadline and are not presented as default-budget evidence. Static and generated checks passed; inherited Windows failures prevent a fully green root suite.

Marker uniqueness is not an atomic GitHub guarantee. Final dependency alignment and live governed publication remain pending.
