### PR TITLE
fix(forge): expose exact-base required-check evidence

### DIFF
--- a/packages/docs-web/src/content/docs/reference/forge.md
+++ b/packages/docs-web/src/content/docs/reference/forge.md
@@ -35,8 +35,29 @@ count totals and aggregation precedence, which JSON Schema does not express.
 
 Aggregation is red, gated, unknown, pending, then green, in that order. Deliver
 reports gated and unknown as non-green and retains its registration grace for an
-empty set. The optional required-check subset is reserved in the contract but is
-not queried by this initial GitHub implementation; consumers use the full set.
+empty set.
+
+GitHub also returns `base_ref` and, when policy is known, a `required` summary.
+It queries the exact base ref's legacy `branchProtectionRule` through GraphQL and
+paginates [active branch rules](https://docs.github.com/en/rest/repos/rules#get-rules-for-a-branch),
+including inherited organization rules. GitHub resolves branch matching and legacy
+precedence. Required app/context pairs are deduplicated across both sources;
+missing required checks are pending. App-bound requirements cannot be satisfied
+by another app or by a status whose originating app cannot be verified.
+
+`required.state: none` with zero counts means both policy sources established no
+required status checks. An absent `required` means policy is unknown, with
+`required_policy_error` explaining the failed read without exposing response bodies.
+Permissions errors, GraphQL partial errors, malformed responses and unsupported
+required workflow, deployment, code-scanning or unrecognized rules remain unknown. HTTP 404 never means no
+policy. A PR head or base-branch change during enumeration refuses the observation.
+The result is a current observation, not an atomic lock on remote policy.
+
+The supervised merge queue requires the same pinned head and target base, known
+required policy, and green external CI. Absence of CI is accepted only when zero
+required checks are known and `.archon/merge-queue-policy.json` at the queue's
+original pinned base contains exactly `{"external_ci":"none"}`. A candidate's file,
+an agent verdict, and a caller-supplied policy cannot authorize that exception.
 
 ## Pinned merge
 

--- a/packages/forge/src/github/checks.ts
+++ b/packages/forge/src/github/checks.ts
@@ -1,3 +1,4 @@
+import { requiredChecks } from './required-checks';
 import { z } from 'zod';
 import {
   CHECKS,
@@ -5,6 +6,7 @@ import {
   aggregateChecks,
   emptyCounts,
   shaSchema,
+  branchSchema,
   type ChecksStateRequest,
   type ChecksVerdict,
   type ForgeOpError,
@@ -14,7 +16,10 @@ import type { RawOpOutcome } from '../dispatch/plugin-handle';
 import { GITHUB_HOST, metadata } from './metadata';
 import type { GitHubPluginOptions } from './plugin';
 // Validate the REST fields we consume. Open strings preserve unknown upstream states.
-const pullSchema = z.object({ head: z.object({ sha: shaSchema }) });
+const pullSchema = z.object({
+  head: z.object({ sha: shaSchema }),
+  base: z.object({ ref: branchSchema }),
+});
 const runSchema = z.object({
   id: z.number().int(),
   name: z.string(),
@@ -97,15 +102,18 @@ export async function checks(
     };
   const timeout = AbortSignal.timeout(30_000);
   const boundedSignal = signal ? AbortSignal.any([signal, timeout]) : timeout;
-  async function api<T>(path: string, schema: z.ZodType<T>): Promise<T> {
+  async function api<T>(path: string, schema: z.ZodType<T>, body?: unknown): Promise<T> {
     const response = await (options.fetchImpl ?? fetch)(
       `${options.apiBase ?? 'https://api.github.com'}${path}`,
       {
         signal: boundedSignal,
+        method: body === undefined ? 'GET' : 'POST',
+        body: body === undefined ? undefined : JSON.stringify(body),
         redirect: 'error',
         headers: {
           Authorization: `Bearer ${token}`,
           Accept: 'application/vnd.github+json',
+          'Content-Type': 'application/json',
           'X-GitHub-Api-Version': '2022-11-28',
           'User-Agent': 'archon-forge-github',
         },
@@ -130,7 +138,20 @@ export async function checks(
   try {
     const base = `/repos/${request.ref.repo.path.split('/').map(encodeURIComponent).join('/')}`;
     const prPath = `${base}/pulls/${String(request.ref.number)}`;
-    const headSha = (await api(prPath, pullSchema)).head.sha;
+    const pull = await api(prPath, pullSchema);
+    const headSha = pull.head.sha;
+    let policy: Awaited<ReturnType<typeof requiredChecks>> | undefined;
+    let policyError: string | undefined;
+    try {
+      policy = await requiredChecks(api, request.ref.repo.path, pull.base.ref);
+    } catch (error) {
+      // Keep observed CI useful when policy access is unavailable. Absence of the
+      // required summary means unknown, never an empty set or permission bypass.
+      policyError =
+        error instanceof ApiError
+          ? `Required-check policy unavailable: ${error.error.kind}${error.error.kind === 'forge_error' && error.error.status !== undefined ? ` (HTTP ${String(error.error.status)})` : ''}`
+          : 'Required-check policy could not be established from GitHub responses';
+    }
     const runs: z.infer<typeof runSchema>[] = [];
     const statuses: z.infer<typeof statusSchema>[] = [];
     // Fixed-origin page numbers, never follow a server-supplied URL with credentials.
@@ -170,9 +191,16 @@ export async function checks(
         kind: 'invalid_response',
         detail: 'Check run belongs to a different SHA',
       });
-    const observed = (await api(prPath, pullSchema)).head.sha;
+    const observedPull = await api(prPath, pullSchema);
+    const observed = observedPull.head.sha;
     if (observed !== headSha)
       throw new ApiError({ kind: 'verify_failed', expected: headSha, observed });
+    if (observedPull.base.ref !== pull.base.ref)
+      throw new ApiError({
+        kind: 'verify_failed',
+        expected: pull.base.ref,
+        observed: observedPull.base.ref,
+      });
     // A push suite and a PR suite may have the same job name. Both are current.
     const latestRuns = new Map<string, z.infer<typeof runSchema>>();
     for (const run of runs) {
@@ -201,6 +229,38 @@ export async function checks(
       counts.total++;
       counts[unit.state]++;
     }
+    let required: ChecksVerdict['required'];
+    if (policy !== undefined) {
+      const requiredCounts = emptyCounts();
+      for (const check of policy) {
+        const matchingRuns = [...latestRuns.values()].filter(
+          run => run.name === check.context && (check.appId === null || run.app?.id === check.appId)
+        );
+        const states = [
+          ...matchingRuns.map(runState),
+          // REST commit statuses do not identify their originating app. They can
+          // satisfy unbound contexts only. Once an app-bound run is present, a
+          // same-name status must also pass, as GitHub requires both channels.
+          ...[...latestStatuses.values()]
+            .filter(
+              status =>
+                (check.appId === null || matchingRuns.length > 0) &&
+                status.context === check.context
+            )
+            .map(status => statusState(status.state)),
+        ];
+        const matching = emptyCounts();
+        for (const state of states) {
+          matching.total++;
+          matching[state]++;
+        }
+        const state = states.length ? aggregateChecks(matching) : CHECKS.pending;
+        if (state === CHECKS.none) throw new Error('Required check has no state');
+        requiredCounts.total++;
+        requiredCounts[state]++;
+      }
+      required = { state: aggregateChecks(requiredCounts), counts: requiredCounts };
+    }
     return {
       kind: 'ok',
       value: {
@@ -208,6 +268,8 @@ export async function checks(
         counts,
         units: units.slice(0, CHECKS_VERDICT_UNITS_CAP),
         head_sha: headSha,
+        base_ref: pull.base.ref,
+        ...(required === undefined ? { required_policy_error: policyError } : { required }),
       } satisfies ChecksVerdict,
     };
   } catch (error) {

--- a/packages/forge/src/github/fixtures/required-checks.ts
+++ b/packages/forge/src/github/fixtures/required-checks.ts
@@ -1,0 +1,134 @@
+import { expect } from 'bun:test';
+import { join } from 'node:path';
+import { z } from 'zod';
+import { ForgeDispatcher } from '../../dispatch/dispatcher';
+import { checksVerdictSchema, type ChecksVerdict } from '../../schemas';
+import { createGitHubPlugin } from '../plugin';
+
+const sha = 'a'.repeat(40);
+const ref = { repo: { host: 'github.com', path: 'owner/repo' }, number: 42 };
+export const baseRef = 'release/queue';
+export const run = {
+  id: 1,
+  name: 'build',
+  head_sha: sha,
+  status: 'completed',
+  conclusion: 'success',
+  check_suite: { id: 1 },
+  app: { id: 7 },
+};
+export const legacy = {
+  requiresStatusChecks: true,
+  requiredStatusCheckContexts: ['build'],
+  requiredStatusChecks: [{ context: 'build', app: { databaseId: 7 } }],
+};
+export const rule = {
+  type: 'required_status_checks',
+  ruleset_source_type: 'Organization',
+  parameters: { required_status_checks: [{ context: 'build', integration_id: 7 }] },
+};
+interface Fixture {
+  subprocess?: boolean;
+  protection?: unknown;
+  rules?: readonly unknown[];
+  runs?: readonly unknown[];
+  statuses?: readonly unknown[];
+  policyHttp?: number;
+  rulesHttp?: number;
+  graphqlErrors?: boolean;
+  movedBase?: boolean;
+  wrongLegacyBase?: boolean;
+}
+export async function produce(options: Fixture = {}): Promise<{
+  result: Awaited<ReturnType<ForgeDispatcher['checksState']>>;
+  paths: string[];
+}> {
+  let pulls = 0;
+  const paths: string[] = [];
+  const server = Bun.serve({
+    port: 0,
+    hostname: '127.0.0.1',
+    fetch: async request => {
+      const url = new URL(request.url);
+      paths.push(url.pathname + url.search);
+      expect(request.headers.get('authorization')).toBe('Bearer fixture-secret');
+      if (url.pathname === '/graphql') {
+        const body = z
+          .object({
+            query: z.string(),
+            variables: z.object({ owner: z.string(), name: z.string(), ref: z.string() }),
+          })
+          .parse(await request.json());
+        expect(body.query).toContain('branchProtectionRule');
+        expect(body.variables).toEqual({
+          owner: 'owner',
+          name: 'repo',
+          ref: `refs/heads/${baseRef}`,
+        });
+        if (options.policyHttp)
+          return new Response('fixture-secret inaccessible', { status: options.policyHttp });
+        return Response.json({
+          ...(options.graphqlErrors ? { errors: [{ message: 'fixture-secret forbidden' }] } : {}),
+          data: {
+            repository: {
+              ref: {
+                name: options.wrongLegacyBase ? 'main' : baseRef,
+                branchProtectionRule: options.protection ?? null,
+              },
+            },
+          },
+        });
+      }
+      if (url.pathname.endsWith('/pulls/42')) {
+        pulls++;
+        return Response.json({
+          head: { sha },
+          base: { ref: options.movedBase && pulls > 1 ? 'other' : baseRef },
+        });
+      }
+      if (url.pathname.endsWith('/check-runs')) {
+        const runs = options.runs ?? [run];
+        return Response.json({ total_count: runs.length, check_runs: runs });
+      }
+      if (url.pathname.endsWith('/statuses')) return Response.json(options.statuses ?? []);
+      if (url.pathname === '/repos/owner/repo/rules/branches/release%2Fqueue') {
+        if (options.rulesHttp)
+          return new Response('fixture-secret inaccessible', { status: options.rulesHttp });
+        const page = Number(url.searchParams.get('page'));
+        return Response.json((options.rules ?? []).slice((page - 1) * 100, page * 100));
+      }
+      return new Response('unexpected route', { status: 500 });
+    },
+  });
+  try {
+    const dispatcher = new ForgeDispatcher(
+      [
+        options.subprocess
+          ? {
+              source: 'fixture:github',
+              command: process.execPath,
+              args: [
+                join(import.meta.dir, '../../dispatch/fixtures/github-plugin.ts'),
+                server.url.origin,
+              ],
+            }
+          : createGitHubPlugin({ apiBase: server.url.origin }),
+      ],
+      {
+        cwd: process.cwd(),
+        env: { GH_TOKEN: 'fixture-secret' },
+        discoverHome: async (): Promise<[]> => [],
+        discoverPath: async (): Promise<[]> => [],
+      }
+    );
+    return { result: await dispatcher.checksState(ref), paths };
+  } finally {
+    server.stop(true);
+  }
+}
+export async function verdict(options: Fixture = {}): Promise<ChecksVerdict> {
+  const { result } = await produce(options);
+  expect(result.kind).toBe('ok');
+  if (result.kind !== 'ok') throw new Error(JSON.stringify(result));
+  return checksVerdictSchema.parse(result.value);
+}

--- a/packages/forge/src/github/plugin.test.ts
+++ b/packages/forge/src/github/plugin.test.ts
@@ -51,7 +51,10 @@ async function verdict(
       if (options.http) return new Response('fixture evidence', { status: options.http });
       if (url.pathname.endsWith('/pulls/42')) {
         pulls++;
-        return Response.json({ head: { sha: options.moved && pulls > 1 ? 'b'.repeat(40) : sha } });
+        return Response.json({
+          head: { sha: options.moved && pulls > 1 ? 'b'.repeat(40) : sha },
+          base: { ref: 'dev' },
+        });
       }
       const page = Number(url.searchParams.get('page'));
       if (url.pathname.endsWith(`/commits/${sha}/check-runs`))

--- a/packages/forge/src/github/public.test.ts
+++ b/packages/forge/src/github/public.test.ts
@@ -71,6 +71,15 @@ function fixture() {
         if (request.method === 'PATCH' && !state.mismatch) pr.body = String(body.body);
         if (state.moved) pr.head.sha = 'c'.repeat(40);
         result = pr;
+      } else if (
+        url.pathname === '/graphql' &&
+        String(body.query).startsWith('query RequiredChecks(')
+      ) {
+        result = {
+          data: { repository: { ref: { name: pr.base.ref, branchProtectionRule: null } } },
+        };
+      } else if (url.pathname.startsWith('/repos/owner/repo/rules/branches/')) {
+        result = [];
       } else if (url.pathname === '/graphql') {
         expect(body.query).toContain('markPullRequestReadyForReview');
         expect(body.variables).toEqual({ id: 'PR_node' });

--- a/packages/forge/src/github/required-checks.test.ts
+++ b/packages/forge/src/github/required-checks.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'bun:test';
+import { baseRef, run, legacy, rule, produce, verdict } from './fixtures/required-checks';
+
+describe('required GitHub checks from exact-base policy and actual checks', () => {
+  it('produces required evidence through the executable plugin protocol', async () => {
+    expect(await verdict({ rules: [rule], subprocess: true })).toMatchObject({
+      required: { state: 'green', counts: { total: 1 } },
+      base_ref: baseRef,
+    });
+  });
+  it('distinguishes known absence from no CI', async () => {
+    expect(await verdict({ runs: [] })).toMatchObject({
+      state: 'none',
+      base_ref: baseRef,
+      required: { state: 'none', counts: { total: 0 } },
+    });
+  });
+  it('unions legacy and inherited rules, deduplicating exact app/context requirements', async () => {
+    expect(
+      await verdict({
+        protection: legacy,
+        rules: [
+          rule,
+          {
+            ...rule,
+            parameters: {
+              required_status_checks: [{ context: 'external' }],
+            },
+          },
+        ],
+        statuses: [{ id: 2, context: 'external', state: 'failure' }],
+      })
+    ).toMatchObject({
+      required: { state: 'red', counts: { total: 2, green: 1, red: 1 } },
+    });
+  });
+  it('counts a missing required context as pending despite unrelated green CI', async () => {
+    expect(
+      await verdict({
+        rules: [{ ...rule, parameters: { required_status_checks: [{ context: 'missing' }] } }],
+      })
+    ).toMatchObject({
+      state: 'green',
+      required: { state: 'pending', counts: { total: 1, pending: 1 } },
+    });
+  });
+  it('cannot satisfy an app-bound requirement with another app or a commit status', async () => {
+    expect(
+      await verdict({
+        protection: legacy,
+        runs: [{ ...run, app: { id: 8 } }],
+        statuses: [{ id: 1, context: 'build', state: 'success' }],
+      })
+    ).toMatchObject({ required: { state: 'pending' } });
+  });
+  it('requires a same-name commit status to pass alongside the bound check run', async () => {
+    expect(
+      await verdict({
+        protection: legacy,
+        statuses: [{ id: 1, context: 'build', state: 'failure' }],
+      })
+    ).toMatchObject({ required: { state: 'red' } });
+  });
+  it('accepts an unbound legacy context from commit statuses', async () => {
+    expect(
+      await verdict({
+        runs: [],
+        protection: { ...legacy, requiredStatusChecks: [{ context: 'build', app: null }] },
+        statuses: [{ id: 1, context: 'build', state: 'success' }],
+      })
+    ).toMatchObject({ required: { state: 'green' } });
+  });
+  it('retains failed same-name suites and stale conclusions', async () => {
+    expect(
+      await verdict({
+        rules: [rule],
+        runs: [run, { ...run, id: 2, check_suite: { id: 2 }, conclusion: 'stale' }],
+      })
+    ).toMatchObject({ required: { state: 'red', counts: { total: 1, red: 1 } } });
+  });
+  it('uses the latest rerun inside each suite', async () => {
+    expect(
+      await verdict({
+        rules: [rule],
+        runs: [
+          { ...run, conclusion: 'failure' },
+          { ...run, id: 2 },
+        ],
+      })
+    ).toMatchObject({ required: { state: 'green' } });
+  });
+  it('paginates inherited rules without applying local branch globs', async () => {
+    const { result, paths } = await produce({
+      rules: [...Array.from({ length: 100 }, () => ({ type: 'deletion' })), rule],
+    });
+    expect(result).toMatchObject({
+      kind: 'ok',
+      value: { required: { state: 'green', counts: { total: 1 } } },
+    });
+    expect(paths).toContain('/repos/owner/repo/rules/branches/release%2Fqueue?per_page=100&page=2');
+  });
+  for (const [label, fixture] of Object.entries({
+    'legacy 403': { policyHttp: 403 },
+    'legacy 404': { policyHttp: 404 },
+    'rules 403': { rulesHttp: 403 },
+    'rules 404': { rulesHttp: 404 },
+    'GraphQL partial data': { graphqlErrors: true },
+    'malformed legacy': { protection: {} },
+    'missing legacy identities': { protection: { ...legacy, requiredStatusChecks: [] } },
+    'malformed rules': { rules: [{ type: 'required_status_checks' }] },
+    'wrong legacy branch': { wrongLegacyBase: true },
+    'required workflow policy': { rules: [{ type: 'workflows' }] },
+    'unrecognized policy': { rules: [{ type: 'future_ci_rule' }], runs: [] },
+    'required deployments': { rules: [{ type: 'required_deployments' }] },
+  }))
+    it(`holds unknown policy for ${label}`, async () => {
+      const value = await verdict(fixture);
+      expect(value.required).toBeUndefined();
+      expect(value.required_policy_error).toBeDefined();
+      expect(JSON.stringify(value)).not.toContain('fixture-secret');
+    });
+  it('refuses base retargeting during enumeration', async () => {
+    expect((await produce({ movedBase: true })).result).toMatchObject({
+      kind: 'error',
+      error: { kind: 'verify_failed' },
+    });
+  });
+});

--- a/packages/forge/src/github/required-checks.ts
+++ b/packages/forge/src/github/required-checks.ts
@@ -1,0 +1,121 @@
+import { z } from 'zod';
+
+const legacyCheckSchema = z.object({
+  context: z.string().min(1),
+  app: z.object({ databaseId: z.number().int().positive() }).nullable(),
+});
+const legacySchema = z.object({
+  errors: z.array(z.unknown()).max(0).optional(),
+  data: z.object({
+    repository: z.object({
+      ref: z.object({
+        name: z.string(),
+        branchProtectionRule: z
+          .object({
+            requiresStatusChecks: z.boolean(),
+            requiredStatusCheckContexts: z.array(z.string()),
+            requiredStatusChecks: z.array(legacyCheckSchema),
+          })
+          .nullable(),
+      }),
+    }),
+  }),
+});
+const ruleSchema = z.object({ type: z.string(), parameters: z.unknown().optional() });
+const statusParametersSchema = z.object({
+  required_status_checks: z.array(
+    z.object({
+      context: z.string().min(1),
+      integration_id: z.number().int().positive().nullable().optional(),
+    })
+  ),
+});
+
+export interface RequiredCheck {
+  context: string;
+  appId: number | null;
+}
+
+// Query the exact ref so GitHub, rather than a local glob implementation, resolves
+// legacy precedence. A successful null rule is absence; HTTP/GraphQL errors are not.
+const legacyQuery = `query RequiredChecks($owner: String!, $name: String!, $ref: String!) {
+  repository(owner: $owner, name: $name) {
+    ref(qualifiedName: $ref) {
+      name
+      branchProtectionRule {
+        requiresStatusChecks requiredStatusCheckContexts
+        requiredStatusChecks { context app { databaseId } }
+      }
+    }
+  }
+}`;
+
+export async function requiredChecks(
+  api: <T>(path: string, schema: z.ZodType<T>, body?: unknown) => Promise<T>,
+  repo: string,
+  baseRef: string
+): Promise<RequiredCheck[]> {
+  const [owner, name] = repo.split('/');
+  const legacy = await api('/graphql', legacySchema, {
+    query: legacyQuery,
+    variables: { owner, name, ref: `refs/heads/${baseRef}` },
+  });
+  const ref = legacy.data.repository.ref;
+  if (ref.name !== baseRef) throw new Error('Legacy policy returned a different branch');
+  const result: RequiredCheck[] = [];
+  const protection = ref.branchProtectionRule;
+  if (protection?.requiresStatusChecks) {
+    const names = new Set(protection.requiredStatusChecks.map(check => check.context));
+    if (protection.requiredStatusCheckContexts.some(context => !names.has(context)))
+      throw new Error('Legacy policy omitted required check identities');
+    result.push(
+      ...protection.requiredStatusChecks.map(check => ({
+        context: check.context,
+        appId: check.app?.databaseId ?? null,
+      }))
+    );
+  }
+  // This endpoint includes active inherited rules and excludes evaluate/disabled
+  // rulesets. Never substitute the repository-only ruleset listing or a 404 for [].
+  const path = `/repos/${repo.split('/').map(encodeURIComponent).join('/')}/rules/branches/${encodeURIComponent(baseRef)}`;
+  for (let page = 1; ; page++) {
+    if (page > 100) throw new Error('Required-check policy enumeration exceeded its page limit');
+    const rules = await api(`${path}?per_page=100&page=${String(page)}`, z.array(ruleSchema));
+    for (const rule of rules) {
+      if (rule.type === 'required_status_checks') {
+        const parameters = statusParametersSchema.parse(rule.parameters);
+        result.push(
+          ...parameters.required_status_checks.map(check => ({
+            context: check.context,
+            appId: check.integration_id ?? null,
+          }))
+        );
+      } else {
+        // Only known rules unrelated to CI can be excluded. New rule types and
+        // required workflows/deployments/scanning need evidence we do not model.
+        switch (rule.type) {
+          case 'creation':
+          case 'update':
+          case 'deletion':
+          case 'required_linear_history':
+          case 'required_signatures':
+          case 'pull_request':
+          case 'commit_message_pattern':
+          case 'commit_author_email_pattern':
+          case 'committer_email_pattern':
+          case 'branch_name_pattern':
+          case 'tag_name_pattern':
+          case 'file_path_restriction':
+          case 'max_file_path_length':
+          case 'file_extension_restriction':
+          case 'max_file_size':
+            break;
+          default:
+            throw new Error('Required-check policy contains an unsupported rule');
+        }
+      }
+    }
+    if (rules.length < 100) break;
+  }
+  return [...new Map(result.map(check => [JSON.stringify(check), check])).values()];
+}

--- a/packages/forge/src/schemas.ts
+++ b/packages/forge/src/schemas.ts
@@ -139,6 +139,8 @@ export const checksVerdictSchema = summarySchema
     units: z.array(checkUnitSummarySchema).max(CHECKS_VERDICT_UNITS_CAP),
     required: summarySchema.refine(consistentSummary, 'counts and state disagree').optional(),
     head_sha: shaSchema,
+    base_ref: branchSchema.optional(),
+    required_policy_error: z.string().min(1).optional(),
   })
   .refine(consistentSummary, 'counts and state disagree')
   .refine(value => {

--- a/packages/forge/wire-schema.json
+++ b/packages/forge/wire-schema.json
@@ -1947,6 +1947,14 @@
       "head_sha": {
         "type": "string",
         "pattern": "^[a-f0-9]{40}$"
+      },
+      "base_ref": {
+        "type": "string",
+        "minLength": 1
+      },
+      "required_policy_error": {
+        "type": "string",
+        "minLength": 1
       }
     },
     "required": [


### PR DESCRIPTION
Withdrawal: simplifying the factory to shared Archon workflows. The merge workflow checks CI using gh; this forge extension is unnecessary. Branch retained for reference; this is not a factory prerequisite.

## Problem and outcome

Observed green checks do not establish that every required check has run. This adds required-check evidence for the exact PR base, combining GitHub's selected legacy protection rule with active inherited rulesets.

## Review guidance

Draft, based on the temporary integrated queue prerequisite branch. Align with the final forge heads before merge. A live private-repository entitlement case is unresolved: rules access returns 403 even when the branch reports unprotected. It currently remains unknown and holds the queue.

## Solution

Resolve legacy precedence through the exact ref, paginate active branch rules, preserve app-bound check identities, and distinguish known absence from inaccessible policy. Missing required checks remain pending. Unsupported policy types retain uncertainty.

## Validation

138 forge cases passed in the combined source, including required-policy fixtures and public-operation consumers. Tests cover legacy/ruleset requirements, app identity, unknown policy and stale PR identity. Broader integration still has a compiled acceptance failure and inherited Windows suite failures. No successful live merge is claimed.

The final integration at `0941538c` also completed compiled acceptance successfully after correcting native credential-helper isolation in the test. The earlier compiled failure is resolved in that integration, not an unresolved production failure. The live private-repository policy entitlement case remains pending.
