### PR TITLE
test(cli): retain owner failures and avoid duplicate skill installs

### DIFF
--- a/packages/cli/src/commands/setup.test.ts
+++ b/packages/cli/src/commands/setup.test.ts
@@ -21,7 +21,6 @@ import {
   writeInstallDefaults,
 } from './setup';
 import * as setupModule from './setup';
-import { copyArchonSkill } from './skill';
 import { parse as parseDotenv } from 'dotenv';
 
 // Test directory for file operations
@@ -395,81 +394,6 @@ CODEX_ACCOUNT_ID=account1
       expect(content).toContain('OPENROUTER_API_KEY=or-key');
       expect(content).toContain('DEFAULT_AI_ASSISTANT=claude');
       expect(content).toContain('# Pi Authentication');
-    });
-  });
-
-  describe('copyArchonSkill', () => {
-    it('should create skill files in target directory', async () => {
-      const target = join(TEST_DIR, 'skill-target');
-      mkdirSync(target, { recursive: true });
-
-      await copyArchonSkill(target);
-
-      expect(existsSync(join(target, '.claude', 'skills', 'archon-cli', 'SKILL.md'))).toBe(true);
-      expect(
-        existsSync(join(target, '.claude', 'skills', 'archon-cli', 'manage-run', 'manage-runs.md'))
-      ).toBe(true);
-      expect(
-        existsSync(
-          join(
-            target,
-            '.claude',
-            'skills',
-            'archon-cli',
-            'authoring-workflows',
-            'node-reference.md'
-          )
-        )
-      ).toBe(true);
-      // Codex path is also populated
-      expect(existsSync(join(target, '.agents', 'skills', 'archon-cli', 'SKILL.md'))).toBe(true);
-    });
-
-    it('should write non-empty content to skill files', async () => {
-      const target = join(TEST_DIR, 'skill-target-content');
-      mkdirSync(target, { recursive: true });
-
-      await copyArchonSkill(target);
-
-      const content = readFileSync(
-        join(target, '.claude', 'skills', 'archon-cli', 'SKILL.md'),
-        'utf-8'
-      );
-      expect(content.length).toBeGreaterThan(0);
-      expect(content).toContain('archon');
-      // Codex SKILL.md mirrors the Claude one
-      const codexContent = readFileSync(
-        join(target, '.agents', 'skills', 'archon-cli', 'SKILL.md'),
-        'utf-8'
-      );
-      expect(codexContent).toBe(content);
-    });
-
-    it('should overwrite existing skill files', async () => {
-      const target = join(TEST_DIR, 'skill-target-overwrite');
-      const skillDir = join(target, '.claude', 'skills', 'archon-cli');
-      const codexSkillDir = join(target, '.agents', 'skills', 'archon-cli');
-      mkdirSync(skillDir, { recursive: true });
-      mkdirSync(codexSkillDir, { recursive: true });
-      writeFileSync(join(skillDir, 'SKILL.md'), 'old content');
-      writeFileSync(join(codexSkillDir, 'SKILL.md'), 'old codex content');
-
-      await copyArchonSkill(target);
-
-      const content = readFileSync(join(skillDir, 'SKILL.md'), 'utf-8');
-      expect(content).not.toBe('old content');
-      const codexContent = readFileSync(join(codexSkillDir, 'SKILL.md'), 'utf-8');
-      expect(codexContent).not.toBe('old codex content');
-    });
-
-    it('should create skill files even when target directory does not exist', async () => {
-      const target = join(TEST_DIR, 'non-existent-parent', 'skill-target-new');
-      // Do NOT pre-create target — copyArchonSkill must handle it
-
-      await copyArchonSkill(target);
-
-      expect(existsSync(join(target, '.claude', 'skills', 'archon-cli', 'SKILL.md'))).toBe(true);
-      expect(existsSync(join(target, '.agents', 'skills', 'archon-cli', 'SKILL.md'))).toBe(true);
     });
   });
 

--- a/packages/cli/src/commands/skill.test.ts
+++ b/packages/cli/src/commands/skill.test.ts
@@ -2,9 +2,10 @@
  * Tests for skill install command
  */
 import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { removeTempTree } from '@archon/paths/test-utils';
 import { BUNDLED_SKILL_FILES } from '../bundled-skill';
 import { copyArchonSkill, skillInstallCommand } from './skill';
 
@@ -15,64 +16,48 @@ describe('copyArchonSkill', () => {
     tempDir = mkdtempSync(join(tmpdir(), 'archon-skill-test-'));
   });
 
-  afterEach(() => {
-    rmSync(tempDir, { recursive: true, force: true });
+  afterEach(async () => {
+    await removeTempTree(tempDir);
   });
 
-  it('writes every bundled skill file under .claude/skills/archon-cli/', async () => {
-    await copyArchonSkill(tempDir);
+  it('creates missing parents and writes exact bundled content in both destinations', async () => {
+    const target = join(tempDir, 'missing-parent', 'project');
+    expect(existsSync(target)).toBe(false);
+    await copyArchonSkill(target);
 
-    const skillRoot = join(tempDir, '.claude', 'skills', 'archon-cli');
-    for (const [relativePath, content] of Object.entries(BUNDLED_SKILL_FILES)) {
-      const dest = join(skillRoot, relativePath);
-      expect(existsSync(dest)).toBe(true);
-      expect(readFileSync(dest, 'utf-8')).toBe(content);
+    for (const root of ['.claude', '.agents']) {
+      const skillRoot = join(target, root, 'skills', 'archon-cli');
+      for (const [relativePath, content] of Object.entries(BUNDLED_SKILL_FILES)) {
+        expect(readFileSync(join(skillRoot, relativePath), 'utf-8')).toBe(content);
+      }
     }
   });
 
-  it('writes every bundled skill file under .agents/skills/archon-cli/ (Codex path)', async () => {
-    await copyArchonSkill(tempDir);
-
-    const skillRoot = join(tempDir, '.agents', 'skills', 'archon-cli');
-    for (const [relativePath, content] of Object.entries(BUNDLED_SKILL_FILES)) {
-      const dest = join(skillRoot, relativePath);
-      expect(existsSync(dest)).toBe(true);
-      expect(readFileSync(dest, 'utf-8')).toBe(content);
-    }
+  it('bundles active cancel guidance without the obsolete abandon mapping', () => {
+    const content = BUNDLED_SKILL_FILES['manage-run/manage-runs.md'];
+    expect(content).toContain('archon workflow cancel <run-id>');
+    expect(content).toContain('archon workflow abandon <run-id>');
+    expect(content).toContain('archon workflow respond <run-id>');
+    expect(content).not.toContain('there is no `archon workflow cancel` CLI subcommand');
+    expect(content).not.toContain('There is no separate `cancel` verb');
+    expect(content).not.toContain('cancel via reject');
+    expect(content).not.toContain('Reject (cancels the workflow)');
   });
 
-  it('installs active cancel guidance without the obsolete abandon mapping', async () => {
-    await copyArchonSkill(tempDir);
-
-    const guidance = [
-      join(tempDir, '.claude', 'skills', 'archon-cli', 'manage-run', 'manage-runs.md'),
-      join(tempDir, '.agents', 'skills', 'archon-cli', 'manage-run', 'manage-runs.md'),
-    ].map(path => readFileSync(path, 'utf-8'));
-
-    for (const content of guidance) {
-      expect(content).toContain('archon workflow cancel <run-id>');
-      expect(content).toContain('archon workflow abandon <run-id>');
-      expect(content).toContain('archon workflow respond <run-id>');
-      expect(content).not.toContain('there is no `archon workflow cancel` CLI subcommand');
-      expect(content).not.toContain('There is no separate `cancel` verb');
-      expect(content).not.toContain('cancel via reject');
-      expect(content).not.toContain('Reject (cancels the workflow)');
+  it('overwrites pre-existing skill files with bundled content in both destinations', async () => {
+    for (const root of ['.claude', '.agents']) {
+      const skillRoot = join(tempDir, root, 'skills', 'archon-cli');
+      mkdirSync(skillRoot, { recursive: true });
+      writeFileSync(join(skillRoot, 'SKILL.md'), 'STALE');
     }
-    expect(guidance[0]).toContain('archon workflow abandon <run-id>');
-    expect(guidance[0]).toContain('archon workflow respond <run-id>');
-  });
-
-  it('overwrites pre-existing skill files with bundled content', async () => {
-    const skillRoot = join(tempDir, '.claude', 'skills', 'archon-cli');
-    const skillMdPath = join(skillRoot, 'SKILL.md');
-
-    // Pre-seed with stale content; copyArchonSkill must overwrite it.
-    await copyArchonSkill(tempDir);
-    writeFileSync(skillMdPath, 'STALE');
-    expect(readFileSync(skillMdPath, 'utf-8')).toBe('STALE');
 
     await copyArchonSkill(tempDir);
-    expect(readFileSync(skillMdPath, 'utf-8')).toBe(BUNDLED_SKILL_FILES['SKILL.md']);
+
+    for (const root of ['.claude', '.agents']) {
+      expect(readFileSync(join(tempDir, root, 'skills', 'archon-cli', 'SKILL.md'), 'utf-8')).toBe(
+        BUNDLED_SKILL_FILES['SKILL.md']
+      );
+    }
   });
 
   it('removes obsolete skills from both supported skill roots during upgrades', async () => {
@@ -107,8 +92,8 @@ describe('skillInstallCommand', () => {
     errSpy = spyOn(console, 'error').mockImplementation(() => {});
   });
 
-  afterEach(() => {
-    rmSync(tempDir, { recursive: true, force: true });
+  afterEach(async () => {
+    await removeTempTree(tempDir);
     logSpy.mockRestore();
     errSpy.mockRestore();
   });

--- a/packages/cli/src/commands/workflow-wait.integration.spec.ts
+++ b/packages/cli/src/commands/workflow-wait.integration.spec.ts
@@ -7,7 +7,7 @@
  * process against a real SQLite database, so a wake that only works in-process
  * would fail here.
  */
-import { afterEach, describe, expect, test } from 'bun:test';
+import { afterEach, describe, expect, spyOn, test } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -18,11 +18,13 @@ import { requestDetachedRunStop } from '../utils/detached-run-control';
 
 const cleanupPaths: string[] = [];
 const activeRunIds = new Set<string>();
+const foregroundOwners = new Set<ForegroundOwner>();
 
 // One explicit hook, not `trackTempRoots()`: a still-running owner has to be stopped
 // before its tree can go, and two hooks would leave registration order as the only
 // thing keeping that correct.
 afterEach(async () => {
+  await stopForegroundOwners();
   for (const runId of activeRunIds) {
     try {
       const target = await requestDetachedRunStop(runId);
@@ -83,6 +85,55 @@ async function runCli(
     new Response(child.stderr).text(),
   ]);
   return { exitCode, stdout, stderr };
+}
+
+interface ForegroundOwner {
+  child: Bun.Subprocess<'ignore', 'pipe', 'pipe'>;
+  settled: Promise<number>;
+  output: { stdout: string; stderr: string };
+}
+
+function startForegroundOwner(fixture: Fixture, args: string[]): ForegroundOwner {
+  const child = Bun.spawn([process.execPath, ...args], {
+    cwd: fixture.projectRoot,
+    env: { ...process.env, ARCHON_HOME: fixture.archonHome },
+    stdin: 'ignore',
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const output = { stdout: '', stderr: '' };
+  const drain = async (
+    stream: ReadableStream<Uint8Array>,
+    key: keyof typeof output
+  ): Promise<void> => {
+    const decoder = new TextDecoder();
+    for await (const chunk of stream) output[key] += decoder.decode(chunk, { stream: true });
+    output[key] += decoder.decode();
+  };
+  const settled = Promise.all([
+    child.exited,
+    drain(child.stdout, 'stdout'),
+    drain(child.stderr, 'stderr'),
+  ]).then(([exitCode]) => exitCode);
+  // Teardown still observes stream failures when discovery fails before awaiting exit.
+  settled.catch(() => undefined);
+  const owner = { child, settled, output };
+  foregroundOwners.add(owner);
+  return owner;
+}
+
+async function stopForegroundOwners(): Promise<void> {
+  for (const owner of foregroundOwners) {
+    if (owner.child.exitCode === null && owner.child.signalCode === null)
+      owner.child.kill('SIGKILL');
+    await owner.child.exited;
+    await owner.settled;
+    foregroundOwners.delete(owner);
+  }
+}
+
+function ownerDiagnostics(owner: ForegroundOwner): string {
+  return `owner pid ${String(owner.child.pid)}, exit ${String(owner.child.exitCode)}, signal ${String(owner.child.signalCode)}\nstdout:\n${owner.output.stdout}\nstderr:\n${owner.output.stderr}`;
 }
 
 /**
@@ -300,22 +351,93 @@ function readRunStatus(archonHome: string, runId: string): string | undefined {
 async function waitFor<T>(
   what: string,
   read: () => T | undefined | Promise<T | undefined>,
-  timeoutMs = 30_000
+  timeoutMs = 30_000,
+  owner?: ForegroundOwner
 ): Promise<T> {
   const deadline = Date.now() + timeoutMs;
   let lastError: unknown;
   while (Date.now() < deadline) {
+    // Observe exit before the read, so a row committed just before exit gets a final read.
+    const ownerExited = owner && (owner.child.exitCode !== null || owner.child.signalCode !== null);
     try {
       const value = await read();
+      lastError = undefined;
       if (value !== undefined) return value;
     } catch (error) {
       lastError = error;
     }
-    await Bun.sleep(50);
+    if (owner) {
+      if (ownerExited) {
+        await owner.settled;
+        throw new Error(`Owner exited before ${what}: ${ownerDiagnostics(owner)}`, {
+          cause: lastError,
+        });
+      }
+      await Promise.race([Bun.sleep(50), owner.settled]);
+    } else {
+      await Bun.sleep(50);
+    }
   }
   const detail = lastError instanceof Error ? `: ${lastError.message}` : '';
-  throw new Error(`Timed out waiting for ${what}${detail}`);
+  throw new Error(
+    `Timed out waiting for ${what}${detail}${owner ? `\n${ownerDiagnostics(owner)}` : ''}`
+  );
 }
+
+describe('foreground run discovery', () => {
+  test('reports owner exit and both streams before the row-discovery deadline', async () => {
+    const fixture = makeFixture('archon-wait-startup-failure-', {});
+    const owner = startForegroundOwner(fixture, [
+      '-e',
+      'console.log("startup stdout"); console.error("controlled startup failure"); process.exit(23)',
+    ]);
+    const error = await waitFor('the failed run row', () => undefined, 30_000, owner).catch(
+      (error: unknown) => error
+    );
+    expect(String(error)).toMatch(
+      /Owner exited before the failed run row:.*exit 23[\s\S]*startup stdout[\s\S]*controlled startup failure/
+    );
+  });
+
+  test('successful empty reads replace an obsolete database error', async () => {
+    let reads = 0;
+    const now = spyOn(Date, 'now')
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(1)
+      .mockReturnValue(2);
+    try {
+      const error = await waitFor(
+        'an absent row',
+        () => {
+          if (reads++ === 0) throw new Error('obsolete schema error');
+          return undefined;
+        },
+        2
+      ).catch((error: unknown) => error);
+      expect(error).toEqual(new Error('Timed out waiting for an absent row'));
+      expect(reads).toBe(2);
+    } finally {
+      now.mockRestore();
+    }
+  });
+
+  test('failed discovery cleanup reaps the foreground child before fixture removal', async () => {
+    const fixture = makeFixture('archon-wait-startup-stall-', {});
+    const owner = startForegroundOwner(fixture, ['-e', 'setInterval(() => {}, 1000)']);
+    try {
+      const error = await waitFor('an absent row', () => undefined, 0, owner).catch(
+        (error: unknown) => error
+      );
+      expect(String(error)).toContain('Timed out waiting for an absent row');
+    } finally {
+      await stopForegroundOwners();
+    }
+    expect(owner.child.exitCode !== null || owner.child.signalCode !== null).toBe(true);
+    expect(foregroundOwners.size).toBe(0);
+    expect(existsSync(fixture.projectRoot)).toBe(true);
+  });
+});
 
 describe('archon workflow wait against a detached run', () => {
   test.each([
@@ -365,28 +487,22 @@ describe('archon workflow wait against a detached run', () => {
   test('wakes with awaiting_response on a gate, then with cancelled when it is rejected', async () => {
     const fixture = makeFixture('archon-wait-gate-', { 'wait-gated': GATED });
     // Owned by another process; it exits on its own once the run parks on the gate.
-    const owner = Bun.spawn(
-      [
-        process.execPath,
-        CLI_PATH,
-        'workflow',
-        'run',
-        'wait-gated',
-        'run-attention wait integration',
-        '--folder',
-      ],
-      {
-        cwd: fixture.projectRoot,
-        env: { ...process.env, ARCHON_HOME: fixture.archonHome },
-        stdout: 'pipe',
-        stderr: 'pipe',
-      }
-    );
+    const owner = startForegroundOwner(fixture, [
+      CLI_PATH,
+      'workflow',
+      'run',
+      'wait-gated',
+      'run-attention wait integration',
+      '--folder',
+    ]);
 
     // Discovering the id is test setup, not the contract under test — the launcher
     // above has no `--detach --json` ack to carry one.
-    const runId = await waitFor('the gated run row', () =>
-      readRunId(fixture.archonHome, 'wait-gated')
+    const runId = await waitFor(
+      'the gated run row',
+      () => readRunId(fixture.archonHome, 'wait-gated'),
+      30_000,
+      owner
     );
     activeRunIds.add(runId);
 
@@ -404,7 +520,8 @@ describe('archon workflow wait against a detached run', () => {
         message: 'Approve the plan?',
       },
     });
-    await owner.exited;
+    const ownerExit = await owner.settled;
+    if (ownerExit !== 0) throw new Error(`Gated owner failed: ${ownerDiagnostics(owner)}`);
 
     // Resolving the gate is the ordinary next step, and it is what makes the wake
     // actionable. Rejecting to termination also exercises the transition that writes

--- a/scripts/check-test-cleanup-drift.ts
+++ b/scripts/check-test-cleanup-drift.ts
@@ -339,7 +339,6 @@ export const LEGACY_RECURSIVE_CLEANUP: ReadonlyMap<string, number> = buildLedger
   ['packages/cli/src/commands/doctor.test.ts', 2],
   ['packages/cli/src/commands/serve.test.ts', 1],
   ['packages/cli/src/commands/setup.test.ts', 4],
-  ['packages/cli/src/commands/skill.test.ts', 2],
   ['packages/cli/src/commands/telemetry.test.ts', 2],
   ['packages/cli/src/commands/validate.test.ts', 1],
   ['packages/cli/src/commands/workflow.test.ts', 5],


### PR DESCRIPTION
## Problem and outcome

The gated workflow-wait test discarded the foreground child's output and exit, could report an old database error after successful reads, and lost process cleanup ownership when run discovery failed. Setup tests also repeated full skill installations already covered by the owning helper tests.

- **Outcome:** Failed discovery reports the child's exit and output, teardown reaps it before removing fixtures, and skill coverage requires four full installations instead of eleven.
- **Invariant:** Preserve real CLI/database/separate-waiter gate behavior, exact bundled content and overwrite in both destinations, missing-parent creation, and existing process deadlines.
- **Scope boundary:** These are two proven test defects. The wider Windows application-latency families remain unresolved; neither tracking issue closes.
- **Root cause:** Cleanup registration depended on finding the run row, readiness never observed the child, and `lastError` outlived the failed read. Skill helper assertions were duplicated across setup and skill tests.

## Review guidance

- **Feedback requested:** Foreground ownership before run discovery, exit/output diagnostics, and preservation of skill-install coverage.
- **Start here:** `packages/cli/src/commands/workflow-wait.integration.spec.ts` — child registration, stream capture, readiness, and cleanup share one local owner.
- **Review order:** Foreground helpers and their negative tests, the real gate case, then skill consolidation and setup deletion.
- **Lower-attention areas:** The cleanup ledger drops the skill test's obsolete direct-removal entry.
- **Known risk or uncertainty:** Local passing behavior does not explain intermittent Windows application stalls. Windows CI remains the platform verification gate.

## Solution

Register the foreground child at spawn, collect both streams immediately, and use its existing exit promise during readiness. A final database read can still find a row committed before exit. Successful reads clear obsolete database errors. Teardown kills and reaps the exact foreground child before fixture cleanup.

Keep direct skill-helper coverage in `skill.test.ts`: one installation verifies every file in both destinations and missing-parent creation; stale files are seeded directly before overwrite testing. Guidance assertions read the bundle whose exact installed contents are already checked. Obsolete-root removal and standalone install command behavior remain covered. Seven removed installations eliminate 126 bundled-file writes, or 1,088,234 bytes on this bundle, excluding fixture writes and cleanup.

## Validation

- `bun test src/commands/setup.test.ts src/commands/skill.test.ts` from `packages/cli` — 67 passed.
- `bun test src/commands/workflow-wait.integration.spec.ts` from `packages/cli` — 10 passed, including real gate/reject and separate-process waiting.
- Controlled before-fix probe reproduced stale schema reporting and loss of a real child's exit23/stderr. Removing the stale-error correction makes its new exact-error assertion fail.
- `bun run validate` — passed.
- **Not verified:** The underlying Windows application stall has not been attributed or fixed by these test corrections.

## Links

- Related #2924 and #2306.
- [Published implementation plan](https://github.com/coleam00/Archon/issues/2924#issuecomment-5599302888).
- Debug evidence: [#2924](https://github.com/coleam00/Archon/issues/2924#issuecomment-5599208695), [#2306](https://github.com/coleam00/Archon/issues/2306#issuecomment-5599214366).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved validation of skill installation across supported project roots, including overwrite behavior and cancellation guidance.
  - Added coverage for foreground workflow execution, including early process termination, stale error recovery, and reliable teardown.
  - Improved temporary resource cleanup during test runs.
  - Removed redundant legacy test coverage and cleanup tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->