### PR TITLE
test(workflows): keep child accounting tests free of incidental processes

### DIFF
--- a/packages/workflows/src/subrun.test.ts
+++ b/packages/workflows/src/subrun.test.ts
@@ -3386,6 +3386,27 @@ nodes:
     expect(tracker.max).toBe(2);
   });
 
+  function makeAccountingDeps(store: IWorkflowStore): WorkflowDeps {
+    const paidProvider = makeProvider();
+    const provider = {
+      ...paidProvider,
+      sendQuery: mock(function* (prompt: string) {
+        if (prompt.includes('CHECK_SPEND')) {
+          if (prompt.includes('doomed')) throw new Error('failed after paid work');
+          // The check adds no usage to the preceding paid node's accounting.
+          yield { type: 'assistant', content: 'check passed' };
+          yield { type: 'result', sessionId: 'check' };
+          return;
+        }
+        yield* paidProvider.sendQuery();
+      }),
+    };
+    return {
+      ...makeDeps(store),
+      getAgentProvider: mock(() => provider) as unknown as WorkflowDeps['getAgentProvider'],
+    };
+  }
+
   it('rolls up child cost onto the fan-out node (Σ child costs → parent total)', async () => {
     await writeWorkflow(
       'fan-child-cost',
@@ -3404,14 +3425,10 @@ nodes:
 name: fan-cost
 description: three AI children, cost rolls up
 nodes:
-  - id: plan
-    bash: |
-      printf '%s' '["a","b","c"]'
   - id: work
     workflow: fan-child-cost
-    depends_on: [plan]
     fan_out:
-      items: "$plan.output"
+      items: '["a","b","c"]'
 `
     );
 
@@ -3430,7 +3447,7 @@ nodes:
 
     expect(result.success).toBe(true);
     const parentRun = [...store.runs.values()].find(r => r.workflow_name === 'fan-cost');
-    // 3 children × 0.01 each = 0.03 rolled up to the parent (plan is bash → 0 cost).
+    // 3 children × 0.01 each = 0.03 rolled up to the parent (the parent has no other paid nodes).
     expect((parentRun?.metadata as Record<string, unknown>).total_cost_usd).toBeCloseTo(0.03, 5);
 
     // Usage must be PERSISTED on the node_completed event, not merely computed. These
@@ -3460,8 +3477,7 @@ nodes:
     prompt: "work on $ARGUMENTS"
   - id: fail
     depends_on: [think]
-    bash: |
-      exit 1
+    prompt: "CHECK_SPEND doomed"
 `
     );
     await writeWorkflow(
@@ -3477,7 +3493,7 @@ nodes:
     );
 
     const store = new InMemoryStore();
-    const deps = makeDeps(store);
+    const deps = makeAccountingDeps(store);
     const parent = await discover('solo-parent');
     await executeWorkflow(deps, makePlatform(), 'conv-plat', cwd, parent, 'goal', 'conv-db');
 
@@ -3515,8 +3531,7 @@ nodes:
     prompt: "work on $ARGUMENTS"
   - id: check
     depends_on: [think]
-    bash: |
-      test "$ARGUMENTS" != "doomed"
+    prompt: "CHECK_SPEND $ARGUMENTS"
 `
     );
     await writeWorkflow(
@@ -3525,19 +3540,15 @@ nodes:
 name: fan-partial
 description: three children, one fails AFTER its AI node already spent tokens
 nodes:
-  - id: plan
-    bash: |
-      printf '%s' '["a","doomed","c"]'
   - id: work
     workflow: fan-child-partial
-    depends_on: [plan]
     fan_out:
-      items: "$plan.output"
+      items: '["a","doomed","c"]'
 `
     );
 
     const store = new InMemoryStore();
-    const deps = makeDeps(store);
+    const deps = makeAccountingDeps(store);
     const parent = await discover('fan-partial');
     const result = await executeWorkflow(
       deps,
@@ -3555,6 +3566,16 @@ nodes:
     expect(children).toHaveLength(3);
     const failedChild = children.find(r => r.status === 'failed');
     expect(failedChild).toBeDefined();
+    expect(children.filter(child => child.status === 'completed')).toHaveLength(2);
+    expect(children.filter(child => child.status === 'failed')).toHaveLength(1);
+    expect(
+      store.events.filter(
+        event =>
+          event.workflow_run_id === failedChild?.id &&
+          event.event_type === 'node_completed' &&
+          event.step_name === 'think'
+      )
+    ).toHaveLength(1);
 
     // The failed child's OWN row carries what it spent. This is the assertion that
     // fails on the pre-fix engine: failWorkflowRun wrote only { error }.


### PR DESCRIPTION
## Problem and outcome

Three child-accounting tests launch six Bash processes to supply constant items or fail after paid work. One exceeded the Windows test budget in run34356996353 even though its assertions concern child status and persisted usage.

The fixtures now exercise the same real workflow recursion and accounting without those incidental processes. All 23 existing assertions remain, with explicit checks for two completed children, one failed child and completion of that child's paid node.

## Review guidance

Start with `makeAccountingDeps` and the three adjacent accounting cases in `packages/workflows/src/subrun.test.ts`. Check that failure occurs after paid `think`, successful checks add no usage, and the parent still includes the failed child's spend.

The Windows operation that stalled remains unknown. This removes unnecessary test workload; it does not establish a fix for native Bash/tar latency or close the wider failure class.

## Solution

Use the existing `fan_out.items` string resolver with literal JSON arrays instead of Bash producers. For the two failure cases, a local canned-provider override delegates paid prompts to the existing provider and then either emits a zero-cost check result or throws through the real engine. Dedicated subprocess integration tests remain unchanged.

## Validation

- `bun run validate` — passed.
- Isolated `bun test src/subrun.test.ts` — 100 tests, 494 assertions passed.
- Three focused accounting cases — 26 assertions passed, including with a temporary throw at the actual Bash node entry.
- Actual cost-aggregation mutation excluding failed children — test failed with 0.02 instead of 0.03.
- Actual token-aggregation mutation excluding failed children — test failed with 14 input tokens instead of 21.
- Product files were restored after the negative controls. Native Windows regression evidence remains for CI and the wider investigation.

## Links

- Relates to #2924 and #2306.
- [Published implementation plan](https://github.com/coleam00/Archon/issues/2924#issuecomment-5602877098).
- [Observed Windows failure and attribution limits](https://github.com/coleam00/Archon/issues/2924#issuecomment-5602823627).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated workflow accounting tests to better validate cost rollups across fan-out and single-child workflows.
  - Added coverage for successful, failed, and partially completed child runs.
  - Improved verification of completion status, failure handling, and emitted workflow events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->