### PR TITLE
perf(workflows): measure where a child-spawn source capture spends its time

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "check:sqlite-vintages": "bun run scripts/generate-sqlite-vintages.ts --check",
     "check:schema-upgrades": "bun run scripts/check-schema-upgrades.ts",
     "lens-yield": "bun run scripts/lens-yield.ts",
+    "bench:capture": "bun run scripts/capture-cost.ts",
     "test:install": "bash scripts/test-install.sh",
     "test": "bun --filter '*' --parallel test && bun test ./scripts/ && bun test ./.archon/scripts/",
     "test:watch": "bun --filter @archon/server test:watch",

--- a/packages/workflows/src/workflow-source.test.ts
+++ b/packages/workflows/src/workflow-source.test.ts
@@ -34,6 +34,8 @@ mock.module('@archon/paths', () => ({
 import {
   captureWorkflowSource,
   capturedSourceRoots,
+  createCaptureProfiler,
+  CAPTURE_PHASES,
   assertWorkflowSourceIntegrity,
   loadWorkflowSource,
   recordSelectedWorkflow,
@@ -455,6 +457,61 @@ describe('the bundled scope is hoisted out of the per-capture path', () => {
 
     const capture = await loadWorkflowSource(captureRoot, digest);
     expect(capture.manifest.digest).toBe(digest);
+  });
+});
+
+describe('measuring where a capture spends its time', () => {
+  /**
+   * The phase hook exists to find out what a capture costs on Windows (#3282), and that
+   * answer is only worth anything if the capture being measured is the one an unmeasured
+   * run takes. So: two captures of the same source, one profiled and one not, agree on
+   * every byte — and the phases account for exactly the files the manifest recorded, or
+   * the numbers describe some other work than the capture.
+   *
+   * The mocked bundled root is this file's shared empty tree, so the file written into it
+   * here is removed again before the test returns.
+   */
+  test('profiling changes nothing, and the phase counts reconcile with the manifest', async () => {
+    const { source, runArtifacts, root } = await createSandbox();
+    const bundledFile = join(bundledDefaultsRoot, 'defaults', 'profiled-capture.yaml');
+    // Both captures are compared to each other, so the global scope has to be a tree this
+    // test owns rather than whatever `~/.archon` holds while the suite runs.
+    const previousHome = process.env.ARCHON_HOME;
+    process.env.ARCHON_HOME = join(root, 'home');
+    await writeFile(bundledFile, 'name: profiled-capture\n');
+
+    try {
+      const plain = await captureWorkflowSource({
+        sourceRoot: source,
+        captureRoot: captureRootIn(runArtifacts, 'plain'),
+      });
+      const { profiler, totals } = createCaptureProfiler();
+      const profiled = await captureWorkflowSource({
+        sourceRoot: source,
+        captureRoot: captureRootIn(runArtifacts, 'profiled'),
+        profiler,
+      });
+
+      expect(profiled.manifest.digest).toBe(plain.manifest.digest);
+      expect(profiled.manifest.file_count).toBe(plain.manifest.file_count);
+      expect(profiled.manifest.byte_count).toBe(plain.manifest.byte_count);
+
+      // Every captured file is written by exactly one of the two write phases, which is
+      // what makes "writes are the cost" a claim the numbers can support or refute.
+      expect(totals.copy.files + totals.bundled_write.files).toBe(profiled.manifest.file_count);
+      expect(totals.copy.bytes + totals.bundled_write.bytes).toBe(profiled.manifest.byte_count);
+      // The bundled half is the one the digest does not read back, so it has to be present
+      // and it has to be excluded — a zero here would make the identity above vacuous.
+      expect(totals.bundled_write.files).toBeGreaterThan(0);
+      expect(totals.digest.files).toBe(totals.copy.files);
+      for (const phase of CAPTURE_PHASES) {
+        expect(totals[phase].ms).toBeGreaterThanOrEqual(0);
+      }
+    } finally {
+      await rm(bundledFile, { force: true });
+      if (previousHome === undefined) delete process.env.ARCHON_HOME;
+      else process.env.ARCHON_HOME = previousHome;
+    }
   });
 });
 

--- a/packages/workflows/src/workflow-source.test.ts
+++ b/packages/workflows/src/workflow-source.test.ts
@@ -478,9 +478,11 @@ describe('measuring where a capture spends its time', () => {
     // test owns rather than whatever `~/.archon` holds while the suite runs.
     const previousHome = process.env.ARCHON_HOME;
     process.env.ARCHON_HOME = join(root, 'home');
-    await writeFile(bundledFile, 'name: profiled-capture\n');
 
+    // Inside the try: a rejection between here and the cleanup would otherwise leave
+    // ARCHON_HOME pointed at this test's sandbox for every test that follows.
     try {
+      await writeFile(bundledFile, 'name: profiled-capture\n');
       const plain = await captureWorkflowSource({
         sourceRoot: source,
         captureRoot: captureRootIn(runArtifacts, 'plain'),
@@ -504,6 +506,7 @@ describe('measuring where a capture spends its time', () => {
       // and it has to be excluded — a zero here would make the identity above vacuous.
       expect(totals.bundled_write.files).toBeGreaterThan(0);
       expect(totals.digest.files).toBe(totals.copy.files);
+      expect(totals.digest.bytes).toBe(totals.copy.bytes);
       // Every declared phase is actually wired to a range of the capture. A phase that is
       // named but never timed reports 0.00 forever, which reads as "free" rather than as
       // "unmeasured" — the one way this instrument can lie to whoever runs it.

--- a/packages/workflows/src/workflow-source.test.ts
+++ b/packages/workflows/src/workflow-source.test.ts
@@ -504,8 +504,11 @@ describe('measuring where a capture spends its time', () => {
       // and it has to be excluded — a zero here would make the identity above vacuous.
       expect(totals.bundled_write.files).toBeGreaterThan(0);
       expect(totals.digest.files).toBe(totals.copy.files);
+      // Every declared phase is actually wired to a range of the capture. A phase that is
+      // named but never timed reports 0.00 forever, which reads as "free" rather than as
+      // "unmeasured" — the one way this instrument can lie to whoever runs it.
       for (const phase of CAPTURE_PHASES) {
-        expect(totals[phase].ms).toBeGreaterThanOrEqual(0);
+        expect(totals[phase].ms).toBeGreaterThan(0);
       }
     } finally {
       await rm(bundledFile, { force: true });

--- a/packages/workflows/src/workflow-source.ts
+++ b/packages/workflows/src/workflow-source.ts
@@ -695,6 +695,101 @@ async function writeManifest(captureRoot: string, manifest: WorkflowSourceManife
 }
 
 /**
+ * The contiguous blocks one capture spends its time in.
+ *
+ * Named here rather than in the measuring script because the names have to keep meaning
+ * the same thing as the code moves: a phase is a range of {@link captureWorkflowSource},
+ * and a reader comparing one platform's numbers with another's is comparing these ranges.
+ */
+export const CAPTURE_PHASES = [
+  /** Probe which mutable source directories exist and are worth capturing. */
+  'scan',
+  /** Clear and create the `.partial` staging root. */
+  'stage',
+  /** Walk each mutable source tree, listing its directories and files. */
+  'walk',
+  /** Recreate those directories in staging and copy every listed file into them. */
+  'copy',
+  /** Resolve this build's bundled bytes: revalidate the cached scope, or read it. */
+  'bundled_read',
+  /** Write those bytes into staging, one file at a time. */
+  'bundled_write',
+  /** Read back and hash every non-bundled captured file, then fold the capture digest. */
+  'digest',
+  /** Write `manifest.json`. */
+  'manifest',
+  /** Remove any prior capture at the destination and rename staging into place. */
+  'publish',
+] as const;
+
+export type CapturePhase = (typeof CAPTURE_PHASES)[number];
+
+/** What one phase spent, and what it spent it on. */
+export interface CapturePhaseTotals {
+  ms: number;
+  /** Directories walked or created. */
+  dirs: number;
+  /** Files walked, copied, written, or hashed. */
+  files: number;
+  /** Bytes those files carry. */
+  bytes: number;
+}
+
+/**
+ * Measurement hook for one capture.
+ *
+ * Production callers pass nothing and get {@link NO_PROFILER}, which adds one function
+ * call per phase — nine per capture — and no clock reads, allocations, or syscalls. The
+ * only caller that passes a real one is `scripts/capture-cost.ts`, so a normal run never
+ * pays for a measurement nobody asked for.
+ */
+export interface CaptureProfiler {
+  time<T>(phase: CapturePhase, work: () => Promise<T>): Promise<T>;
+  count(phase: CapturePhase, counts: Partial<Omit<CapturePhaseTotals, 'ms'>>): void;
+}
+
+/** The profiler an unmeasured capture runs against. */
+const NO_PROFILER: CaptureProfiler = {
+  time: (_phase, work) => work(),
+  count: () => undefined,
+};
+
+/**
+ * A profiler and the totals it accumulates.
+ *
+ * `totals` is live: it is the same object the returned profiler writes into, so a caller
+ * reads it after the capture resolves rather than being handed a snapshot mid-flight.
+ */
+export function createCaptureProfiler(): {
+  profiler: CaptureProfiler;
+  totals: Record<CapturePhase, CapturePhaseTotals>;
+} {
+  const totals = Object.fromEntries(
+    CAPTURE_PHASES.map(phase => [phase, { ms: 0, dirs: 0, files: 0, bytes: 0 }])
+  ) as Record<CapturePhase, CapturePhaseTotals>;
+
+  return {
+    totals,
+    profiler: {
+      time: async <T>(phase: CapturePhase, work: () => Promise<T>): Promise<T> => {
+        const started = performance.now();
+        try {
+          return await work();
+        } finally {
+          totals[phase].ms += performance.now() - started;
+        }
+      },
+      count: (phase, counts): void => {
+        const total = totals[phase];
+        total.dirs += counts.dirs ?? 0;
+        total.files += counts.files ?? 0;
+        total.bytes += counts.bytes ?? 0;
+      },
+    },
+  };
+}
+
+/**
  * Freeze `sourceRoot`'s executable source, plus every other statically reachable scope,
  * into `captureRoot`.
  *
@@ -710,12 +805,18 @@ export async function captureWorkflowSource(opts: {
   captureRoot: string;
   commandFolder?: string;
   sourceConfig?: WorkflowSourceConfig;
+  /**
+   * Measure where this capture spends its time. Off unless a caller asks — see
+   * {@link CaptureProfiler}. Passing one changes nothing the capture produces.
+   */
+  profiler?: CaptureProfiler;
 }): Promise<WorkflowSourceCapture> {
   const {
     sourceRoot,
     captureRoot,
     commandFolder,
     sourceConfig = DEFAULT_WORKFLOW_SOURCE_CONFIG,
+    profiler = NO_PROFILER,
   } = opts;
 
   // (relative destination, absolute origin) pairs, one per MUTABLE directory worth copying.
@@ -723,32 +824,41 @@ export async function captureWorkflowSource(opts: {
   // {@link BundledScope} and written from there.
   const jobs: { dest: string; from: string; scope: 'project' | 'global' }[] = [];
 
-  for (const dir of projectSourceDirs(commandFolder)) {
-    const from = join(sourceRoot, dir);
-    if (await isDirectory(from))
-      jobs.push({ dest: join(PROJECT_SCOPE_DIR, dir), from, scope: 'project' });
-  }
-  for (const [name, from] of [
-    ['workflows', archonPaths.getHomeWorkflowsPath()],
-    ['commands', archonPaths.getHomeCommandsPath()],
-    ['scripts', archonPaths.getHomeScriptsPath()],
-  ] as const) {
-    if (await isDirectory(from))
-      jobs.push({ dest: join(GLOBAL_SCOPE_DIR, name), from, scope: 'global' });
-  }
+  await profiler.time('scan', async () => {
+    for (const dir of projectSourceDirs(commandFolder)) {
+      const from = join(sourceRoot, dir);
+      if (await isDirectory(from))
+        jobs.push({ dest: join(PROJECT_SCOPE_DIR, dir), from, scope: 'project' });
+    }
+    for (const [name, from] of [
+      ['workflows', archonPaths.getHomeWorkflowsPath()],
+      ['commands', archonPaths.getHomeCommandsPath()],
+      ['scripts', archonPaths.getHomeScriptsPath()],
+    ] as const) {
+      if (await isDirectory(from))
+        jobs.push({ dest: join(GLOBAL_SCOPE_DIR, name), from, scope: 'global' });
+    }
+  });
 
   const staging = `${captureRoot}.partial`;
-  await rm(staging, { recursive: true, force: true });
+  await profiler.time('stage', () => rm(staging, { recursive: true, force: true }));
 
   let fileCount = 0;
   let byteCount = 0;
   const scopesCaptured = new Set<'project' | 'global' | 'bundled'>(jobs.map(j => j.scope));
   try {
-    await mkdir(staging, { recursive: true });
+    await profiler.time('stage', () => mkdir(staging, { recursive: true }));
     for (const job of jobs) {
       const target = join(staging, job.dest);
-      await mkdir(dirname(target), { recursive: true });
-      const copied = await copyListing(await listTree(job.from), target);
+      await profiler.time('copy', () => mkdir(dirname(target), { recursive: true }));
+      const listing = await profiler.time('walk', () => listTree(job.from));
+      profiler.count('walk', { dirs: listing.dirs.length, files: listing.files.length });
+      const copied = await profiler.time('copy', () => copyListing(listing, target));
+      profiler.count('copy', {
+        dirs: listing.dirs.length,
+        files: copied.files,
+        bytes: copied.bytes,
+      });
       fileCount += copied.files;
       byteCount += copied.bytes;
     }
@@ -756,9 +866,14 @@ export async function captureWorkflowSource(opts: {
     // The run's own bundled bytes, written from what this process already holds. They have
     // to be present, not referenced: that is what lets a run that statically included a
     // bundled workflow prove on resume that it did not change under an Archon upgrade.
-    const bundled = await resolveBundledScope();
+    const bundled = await profiler.time('bundled_read', () => resolveBundledScope());
     if (bundled) {
-      await writeBundledScope(bundled, staging);
+      await profiler.time('bundled_write', () => writeBundledScope(bundled, staging));
+      profiler.count('bundled_write', {
+        dirs: bundled.dirs.length,
+        files: bundled.files.length,
+        bytes: bundled.byteCount,
+      });
       fileCount += bundled.files.length;
       byteCount += bundled.byteCount;
       scopesCaptured.add('bundled');
@@ -766,10 +881,11 @@ export async function captureWorkflowSource(opts: {
 
     // The bundled files were written from bytes whose hashes are already known, so reading
     // them back would restate what the scope already carries. Everything else is read.
-    const digest = foldDigest([
-      ...(await digestEntries(staging, bundled ? BUNDLED_SCOPE_DIR : undefined)),
-      ...(bundled?.files ?? []),
-    ]);
+    const digest = await profiler.time('digest', async () => {
+      const read = await digestEntries(staging, bundled ? BUNDLED_SCOPE_DIR : undefined);
+      profiler.count('digest', { files: read.length });
+      return foldDigest([...read, ...(bundled?.files ?? [])]);
+    });
     const manifest: WorkflowSourceManifest = {
       version: 1,
       engine_version: BUNDLED_VERSION,
@@ -781,13 +897,15 @@ export async function captureWorkflowSource(opts: {
       scopes: [...scopesCaptured],
       source_config: sourceConfig,
     };
-    await writeManifest(staging, manifest);
+    await profiler.time('manifest', () => writeManifest(staging, manifest));
 
     // Replace rather than merge: a stale capture at this path would silently mix two
     // vintages of source, which is the failure this module exists to prevent.
-    await rm(captureRoot, { recursive: true, force: true });
-    await mkdir(dirname(captureRoot), { recursive: true });
-    await rename(staging, captureRoot);
+    await profiler.time('publish', async () => {
+      await rm(captureRoot, { recursive: true, force: true });
+      await mkdir(dirname(captureRoot), { recursive: true });
+      await rename(staging, captureRoot);
+    });
 
     if (byteCount > CAPTURE_WARN_BYTES) {
       getLog().warn(

--- a/packages/workflows/src/workflow-source.ts
+++ b/packages/workflows/src/workflow-source.ts
@@ -657,9 +657,17 @@ function foldDigest(entries: readonly DigestEntry[]): string {
  * `skipScope` names a top-level scope directory whose per-file digests the caller already
  * holds — the bundled scope, written from bytes this process is still holding. Everything
  * else is read here, which is what makes the digest a statement about bytes, not paths.
+ *
+ * `bytes` is what was actually read, not what the caller expected to be there. It is the
+ * only phase whose byte volume no other counter already holds, and a phase reporting zero
+ * bytes while reading a megabyte is the way a measurement lies to whoever reads it.
  */
-async function digestEntries(root: string, skipScope?: string): Promise<DigestEntry[]> {
+async function digestEntries(
+  root: string,
+  skipScope?: string
+): Promise<{ entries: DigestEntry[]; bytes: number }> {
   const entries: DigestEntry[] = [];
+  let bytes = 0;
 
   const walk = async (dir: string, rel: string): Promise<void> => {
     let dirEntries;
@@ -676,18 +684,19 @@ async function digestEntries(root: string, skipScope?: string): Promise<DigestEn
       } else if (entry.isFile()) {
         if (relPath === MANIFEST_FILE) continue;
         const content = await readFile(join(dir, entry.name));
+        bytes += content.byteLength;
         entries.push({ relPath, hash: createHash('sha256').update(content).digest('hex') });
       }
     }
   };
   await walk(root, '');
 
-  return entries;
+  return { entries, bytes };
 }
 
 /** Content digest over every captured file. */
 async function digestTree(root: string): Promise<string> {
-  return foldDigest(await digestEntries(root));
+  return foldDigest((await digestEntries(root)).entries);
 }
 
 async function writeManifest(captureRoot: string, manifest: WorkflowSourceManifest): Promise<void> {
@@ -883,8 +892,8 @@ export async function captureWorkflowSource(opts: {
     // them back would restate what the scope already carries. Everything else is read.
     const digest = await profiler.time('digest', async () => {
       const read = await digestEntries(staging, bundled ? BUNDLED_SCOPE_DIR : undefined);
-      profiler.count('digest', { files: read.length });
-      return foldDigest([...read, ...(bundled?.files ?? [])]);
+      profiler.count('digest', { files: read.entries.length, bytes: read.bytes });
+      return foldDigest([...read.entries, ...(bundled?.files ?? [])]);
     });
     const manifest: WorkflowSourceManifest = {
       version: 1,

--- a/scripts/capture-cost.ts
+++ b/scripts/capture-cost.ts
@@ -162,23 +162,41 @@ async function runLoadWorker(dir: string): Promise<never> {
 }
 
 interface LoadHandle {
-  stop: () => void;
+  /**
+   * Kill every worker and wait for it to be gone.
+   *
+   * Awaited rather than fire-and-forget because the scratch tree is removed next, and a
+   * worker still writing inside it makes that removal fail — on Windows, the platform this
+   * tool exists for, with a lock error rather than a clean one.
+   */
+  stop: () => Promise<void>;
 }
 
 async function startLoad(count: number, dir: string): Promise<LoadHandle> {
   const children = Array.from({ length: count }, (_unused, i) =>
     Bun.spawn([process.execPath, import.meta.path, '--load-worker', join(dir, `w${String(i)}`)], {
       stdout: 'ignore',
-      stderr: 'ignore',
+      // Inherited, not dropped: a worker that dies says why, and the next block turns its
+      // silence into a failure rather than into a quietly lighter measurement.
+      stderr: 'inherit',
     })
   );
+  const stop = async (): Promise<void> => {
+    for (const child of children) child.kill();
+    await Promise.all(children.map(child => child.exited));
+  };
+
   // Let the workers reach steady state before anything is timed against them.
   await Bun.sleep(500);
-  return {
-    stop: (): void => {
-      for (const child of children) child.kill();
-    },
-  };
+  const exited = children.filter(child => child.exitCode !== null).length;
+  if (exited > 0) {
+    await stop();
+    throw new Error(
+      `${String(exited)} of ${String(count)} load workers exited during startup. The loaded ` +
+        'pass would report contention it never ran under, so it is not run at all.'
+    );
+  }
+  return { stop };
 }
 
 // ---------------------------------------------------------------------------
@@ -435,7 +453,7 @@ async function main(): Promise<number> {
           await runPass(`under load (${String(options.load)} workers)`, scratch, options)
         );
       } finally {
-        load.stop();
+        await load.stop();
       }
     }
     for (const pass of passes) printPass(pass);

--- a/scripts/capture-cost.ts
+++ b/scripts/capture-cost.ts
@@ -1,0 +1,451 @@
+/**
+ * Where a child-spawn source capture spends its time, and which write primitive it pays for.
+ *
+ * Every `workflow:` child freezes its own source (#2924), and the write half of that freeze
+ * is untouched: `captureWorkflowSource` copies every mutable source file and writes every
+ * bundled file into each capture. On Windows, file creation is what Defender interposes on,
+ * so writes are the suspected cost — but every number the project holds was measured on
+ * macOS, which does not exhibit the problem. Hard-linking, the obvious way to stop paying
+ * per-file write cost, measured 3x WORSE than copying on APFS; a hard link is a directory
+ * entry with no new content, which is plausibly the one thing Defender does not scan. The
+ * lever that looks worst here may be the best one there.
+ *
+ * So this harness measures rather than fixes. It answers four questions:
+ *
+ *   1. What fraction of a capture is copying versus digesting versus everything else?
+ *      Measured on the REAL `captureWorkflowSource`, through the phase hook it now accepts.
+ *   2. Does per-file cost scale with file COUNT or with total BYTES? Interposition predicts
+ *      count; ordinary I/O predicts bytes. Measured by holding total bytes fixed and moving
+ *      the file count.
+ *   3. Does a hard link avoid the per-file cost a copy pays? Measured as `copyFile` versus
+ *      `link` versus `writeFile` over one identical tree.
+ *   4. How much does a neighbouring workload change all of the above? Measured by repeating
+ *      everything with N background workers churning files.
+ *
+ * Questions 2-4 cannot run on the real capture: they need trees this harness controls. Those
+ * sections are explicitly synthetic and say so in their output. Section 1 is not — it calls
+ * `captureWorkflowSource` with the options `prepareWorkflowSource` builds for a child spawn
+ * (`packages/workflows/src/executor.ts`), against this checkout.
+ *
+ * Usage:
+ *
+ *   bun run bench:capture                  # everything, idle then under load
+ *   bun run bench:capture -- --help        # options
+ *
+ * `ARCHON_HOME` is pinned to a scratch directory for the duration, so the global source
+ * scope is empty and two machines measure the same tree. Nothing is written outside the OS
+ * temp directory, and the repository is only ever read.
+ */
+import { mkdir, mkdtemp, writeFile, copyFile, link, readFile, readdir, rm } from 'node:fs/promises';
+import { cpus, tmpdir, totalmem } from 'node:os';
+import { join, resolve } from 'node:path';
+import { setLogLevel } from '@archon/paths';
+import { loadConfig } from '../packages/core/src/config/config-loader';
+import {
+  captureWorkflowSource,
+  createCaptureProfiler,
+  workflowSourceConfigFrom,
+  CAPTURE_PHASES,
+  type CapturePhase,
+  type CapturePhaseTotals,
+} from '../packages/workflows/src/workflow-source';
+
+const REPO_ROOT = resolve(import.meta.dir, '..');
+
+/** Attempts before a scratch tree that will not come free is reported rather than retried. */
+const CLEANUP_ATTEMPTS = 10;
+const CLEANUP_DELAY_MS = 50;
+
+interface Options {
+  /** Captures and repetitions per measurement. */
+  runs: number;
+  /** Background worker processes for the loaded pass. Zero skips that pass. */
+  load: number;
+  /** Files in the synthetic tree the write-primitive sections use. */
+  files: number;
+  /** Bytes per file in that tree. */
+  bytes: number;
+  json: boolean;
+}
+
+const DEFAULTS: Options = { runs: 7, load: 4, files: 200, bytes: 8192, json: false };
+
+const USAGE = `Measure what a child-spawn source capture costs, and which write primitive it pays for.
+
+  bun run bench:capture [-- options]
+
+Options:
+  --runs N     captures and repetitions per measurement (default ${DEFAULTS.runs})
+  --load N     background worker processes for the loaded pass, 0 to skip (default ${DEFAULTS.load})
+  --files N    files in the synthetic write-primitive tree (default ${DEFAULTS.files})
+  --bytes N    bytes per file in that tree (default ${DEFAULTS.bytes})
+  --json       also print the whole result as one JSON object
+  --help       this text
+
+Report the full output. On Windows, run it with real-time protection on — that is the
+condition under measurement — and say in the report whether the repository sits on an
+excluded path.`;
+
+function parseOptions(argv: readonly string[]): Options | 'help' {
+  const options = { ...DEFAULTS };
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    if (flag === '--help' || flag === '-h') return 'help';
+    if (flag === '--json') {
+      options.json = true;
+      continue;
+    }
+    const key = flag.startsWith('--') ? flag.slice(2) : '';
+    if (key !== 'runs' && key !== 'load' && key !== 'files' && key !== 'bytes') {
+      throw new Error(`Unknown option ${flag}. Run with --help.`);
+    }
+    const raw = argv[++i];
+    const value = Number(raw);
+    if (!Number.isInteger(value) || value < 0) {
+      throw new Error(`${flag} needs a non-negative integer, got ${raw}.`);
+    }
+    if (value === 0 && key !== 'load') throw new Error(`${flag} must be at least 1.`);
+    options[key] = value;
+  }
+  return options;
+}
+
+/** Remove a scratch tree, retrying while the OS still holds a handle inside it. */
+async function removeScratchTree(path: string): Promise<void> {
+  // Written out rather than delegated to `rm`'s own `maxRetries`, which Bun accepts and
+  // ignores, and duplicated from `@archon/paths/test-utils` rather than imported because
+  // that module pulls in `bun:test`. See its comment for the measurement.
+  for (let attempt = 1; ; attempt++) {
+    try {
+      await rm(path, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if (attempt >= CLEANUP_ATTEMPTS) {
+        console.warn(`scratch cleanup failed for ${path}: ${String(error)}`);
+        return;
+      }
+      await Bun.sleep(CLEANUP_DELAY_MS);
+    }
+  }
+}
+
+function median(values: readonly number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle];
+}
+
+const ms = (value: number): string => value.toFixed(2);
+
+// ---------------------------------------------------------------------------
+// Background load
+// ---------------------------------------------------------------------------
+
+/**
+ * One background worker: churn small files forever, in its own directory.
+ *
+ * File churn rather than pure CPU because contention on macOS moved an identical capture
+ * from 33.6 ms to 395.2 ms with byte-identical operation counts, and the suspected Windows
+ * cost is in the filesystem path too. Workers run as separate processes because the load
+ * that produces the flake class is `bun --filter --parallel`, which is processes (#2306).
+ */
+async function runLoadWorker(dir: string): Promise<never> {
+  await mkdir(dir, { recursive: true });
+  const payload = Buffer.alloc(16 * 1024, 7);
+  for (let round = 0; ; round++) {
+    const roundDir = join(dir, `r${String(round % 4)}`);
+    await mkdir(roundDir, { recursive: true });
+    for (let i = 0; i < 32; i++) await writeFile(join(roundDir, `f${String(i)}`), payload);
+    for (const entry of await readdir(roundDir)) await readFile(join(roundDir, entry));
+    await rm(roundDir, { recursive: true, force: true });
+  }
+}
+
+interface LoadHandle {
+  stop: () => void;
+}
+
+async function startLoad(count: number, dir: string): Promise<LoadHandle> {
+  const children = Array.from({ length: count }, (_unused, i) =>
+    Bun.spawn([process.execPath, import.meta.path, '--load-worker', join(dir, `w${String(i)}`)], {
+      stdout: 'ignore',
+      stderr: 'ignore',
+    })
+  );
+  // Let the workers reach steady state before anything is timed against them.
+  await Bun.sleep(500);
+  return {
+    stop: (): void => {
+      for (const child of children) child.kill();
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Section 1: the real capture
+// ---------------------------------------------------------------------------
+
+interface CaptureSample {
+  totalMs: number;
+  phases: Record<CapturePhase, CapturePhaseTotals>;
+}
+
+interface CaptureResult {
+  /** The first capture in the process, which reads the bundled trees rather than revalidating. */
+  cold: CaptureSample;
+  /** Every capture after it — the shape a run's second and later children pay. */
+  warm: CaptureSample[];
+  fileCount: number;
+  byteCount: number;
+  digest: string;
+  scopes: string[];
+}
+
+async function measureCapture(scratch: string, options: Options): Promise<CaptureResult> {
+  const config = workflowSourceConfigFrom(await loadConfig(REPO_ROOT));
+
+  const samples: CaptureSample[] = [];
+  let fileCount = 0;
+  let byteCount = 0;
+  let digest = '';
+  let scopes: string[] = [];
+
+  for (let run = 0; run <= options.runs; run++) {
+    const captureRoot = join(scratch, 'captures', `run-${String(run)}`);
+    const { profiler, totals } = createCaptureProfiler();
+    const started = performance.now();
+    const capture = await captureWorkflowSource({
+      sourceRoot: REPO_ROOT,
+      captureRoot,
+      commandFolder: config.command_folder,
+      sourceConfig: config,
+      profiler,
+    });
+    samples.push({ totalMs: performance.now() - started, phases: totals });
+    ({ file_count: fileCount, byte_count: byteCount, digest } = capture.manifest);
+    scopes = capture.manifest.scopes;
+    await removeScratchTree(captureRoot);
+  }
+
+  return { cold: samples[0], warm: samples.slice(1), fileCount, byteCount, digest, scopes };
+}
+
+function printCapture(result: CaptureResult): void {
+  const warmTotal = median(result.warm.map(s => s.totalMs));
+  console.log(
+    `capture of ${REPO_ROOT}\n` +
+      `  scopes ${result.scopes.join('+')}, ${String(result.fileCount)} files, ` +
+      `${String(result.byteCount)} bytes, digest ${result.digest.slice(0, 12)}\n` +
+      `  first capture (reads the bundled trees) ${ms(result.cold.totalMs)} ms\n` +
+      `  median of ${String(result.warm.length)} later captures ${ms(warmTotal)} ms`
+  );
+  console.log(
+    `  ${'phase'.padEnd(14)}${'median ms'.padStart(10)}${'%'.padStart(7)}` +
+      `${'cold ms'.padStart(10)}${'dirs'.padStart(7)}${'files'.padStart(7)}${'bytes'.padStart(11)}`
+  );
+  for (const phase of CAPTURE_PHASES) {
+    const warm = median(result.warm.map(s => s.phases[phase].ms));
+    const counts = result.warm[result.warm.length - 1].phases[phase];
+    console.log(
+      `  ${phase.padEnd(14)}${ms(warm).padStart(10)}` +
+        ((warm / warmTotal) * 100).toFixed(1).padStart(7) +
+        ms(result.cold.phases[phase].ms).padStart(10) +
+        `${String(counts.dirs).padStart(7)}${String(counts.files).padStart(7)}` +
+        String(counts.bytes).padStart(11)
+    );
+  }
+  // Whatever the phases do not cover: loop bookkeeping, building the manifest, the call
+  // itself. Printed so "everything else" is a measured number rather than a subtraction
+  // the reader has to do and cannot check.
+  const unphased = (sample: CaptureSample): number =>
+    sample.totalMs - CAPTURE_PHASES.reduce((sum, phase) => sum + sample.phases[phase].ms, 0);
+  const warmUnphased = median(result.warm.map(unphased));
+  console.log(
+    `  ${'(unphased)'.padEnd(14)}${ms(warmUnphased).padStart(10)}` +
+      ((warmUnphased / warmTotal) * 100).toFixed(1).padStart(7) +
+      ms(unphased(result.cold)).padStart(10)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sections 2 and 3: write primitives, and what their cost scales with
+// ---------------------------------------------------------------------------
+
+const WRITE_MODES = ['copyFile', 'link', 'writeFile'] as const;
+type WriteMode = (typeof WRITE_MODES)[number];
+
+interface WriteSample {
+  files: number;
+  bytes: number;
+  /** Median ms for one full pass over the tree, per mode. */
+  perMode: Record<WriteMode, number>;
+}
+
+/** A flat tree of `files` identical files, plus the buffer `writeFile` writes from. */
+async function makeTree(
+  root: string,
+  files: number,
+  bytes: number
+): Promise<{ paths: string[]; payload: Buffer }> {
+  await mkdir(root, { recursive: true });
+  const payload = Buffer.alloc(bytes, 42);
+  const paths: string[] = [];
+  for (let i = 0; i < files; i++) {
+    const path = join(root, `f${String(i)}.txt`);
+    await writeFile(path, payload);
+    paths.push(path);
+  }
+  return { paths, payload };
+}
+
+async function measureWriteModes(
+  scratch: string,
+  files: number,
+  bytes: number,
+  runs: number
+): Promise<WriteSample> {
+  const source = join(scratch, `src-${String(files)}x${String(bytes)}`);
+  const { paths, payload } = await makeTree(source, files, bytes);
+  const perMode = {} as Record<WriteMode, number>;
+
+  for (const mode of WRITE_MODES) {
+    const timings: number[] = [];
+    for (let run = 0; run < runs; run++) {
+      const dest = join(scratch, `dest-${mode}-${String(files)}-${String(run)}`);
+      await mkdir(dest, { recursive: true });
+      const started = performance.now();
+      for (let i = 0; i < paths.length; i++) {
+        const target = join(dest, `f${String(i)}.txt`);
+        if (mode === 'copyFile') await copyFile(paths[i], target);
+        else if (mode === 'link') await link(paths[i], target);
+        else await writeFile(target, payload);
+      }
+      timings.push(performance.now() - started);
+      await removeScratchTree(dest);
+    }
+    perMode[mode] = median(timings);
+  }
+
+  await removeScratchTree(source);
+  return { files, bytes, perMode };
+}
+
+/** File counts to sweep at a fixed total size, centred on the configured tree. */
+function scalingPoints(files: number, bytes: number): { files: number; bytes: number }[] {
+  const total = files * bytes;
+  return [4, 2, 1, 0.5, 0.25]
+    .map(factor => Math.round(files * factor))
+    .filter(count => count >= 1 && total % count === 0)
+    .map(count => ({ files: count, bytes: total / count }));
+}
+
+function printWriteModes(samples: readonly WriteSample[]): void {
+  const total = samples[0].files * samples[0].bytes;
+  console.log(
+    `write primitives, synthetic flat tree, ${String(total)} bytes total in every row\n` +
+      '  a per-file cost shows as ms rising with the file count; a per-byte cost stays flat'
+  );
+  console.log(
+    `  ${'files'.padStart(7)}${'bytes/file'.padStart(12)}` +
+      WRITE_MODES.map(m => `${m} ms`.padStart(16)).join('') +
+      'us/file copy'.padStart(14)
+  );
+  for (const sample of samples) {
+    console.log(
+      `  ${String(sample.files).padStart(7)}${String(sample.bytes).padStart(12)}` +
+        WRITE_MODES.map(m => ms(sample.perMode[m]).padStart(16)).join('') +
+        ((sample.perMode.copyFile / sample.files) * 1000).toFixed(1).padStart(14)
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Passes
+// ---------------------------------------------------------------------------
+
+interface Pass {
+  label: string;
+  capture: CaptureResult;
+  writes: WriteSample[];
+}
+
+async function runPass(label: string, scratch: string, options: Options): Promise<Pass> {
+  const capture = await measureCapture(scratch, options);
+  const writes: WriteSample[] = [];
+  for (const point of scalingPoints(options.files, options.bytes)) {
+    writes.push(await measureWriteModes(scratch, point.files, point.bytes, options.runs));
+  }
+  return { label, capture, writes };
+}
+
+function printPass(pass: Pass): void {
+  console.log(`\n=== ${pass.label} ===\n`);
+  printCapture(pass.capture);
+  console.log('');
+  printWriteModes(pass.writes);
+}
+
+async function main(): Promise<number> {
+  const argv = process.argv.slice(2);
+  if (argv[0] === '--load-worker') {
+    const dir = argv[1];
+    if (dir === undefined) throw new Error('--load-worker needs a directory.');
+    await runLoadWorker(dir);
+  }
+
+  let options: Options | 'help';
+  try {
+    options = parseOptions(argv);
+  } catch (error) {
+    console.error((error as Error).message);
+    return 1;
+  }
+  if (options === 'help') {
+    console.log(USAGE);
+    return 0;
+  }
+
+  const scratch = await mkdtemp(join(tmpdir(), 'archon-capture-cost-'));
+  // Pin the global source scope to an empty directory so the capture under measurement is
+  // this checkout's project and bundled scopes, and nothing a particular machine happens to
+  // keep in its real Archon home.
+  process.env.ARCHON_HOME = join(scratch, 'home');
+  // Keep the report readable while leaving real warnings — an oversized capture is one —
+  // visible. Set here rather than through LOG_LEVEL because the root logger is built when
+  // this file's imports are evaluated, long before main runs; an explicit LOG_LEVEL wins.
+  if (process.env.LOG_LEVEL === undefined) setLogLevel('warn');
+
+  console.log(
+    'archon capture cost\n' +
+      `  ${process.platform}/${process.arch}, ${String(cpus().length)} cpus, ` +
+      `${String(Math.round(totalmem() / 2 ** 30))} GiB, bun ${Bun.version}\n` +
+      `  repo ${REPO_ROOT}\n` +
+      `  scratch ${scratch} (ARCHON_HOME pinned there; global scope empty)\n` +
+      `  runs ${String(options.runs)}, load workers ${String(options.load)}`
+  );
+
+  const passes: Pass[] = [];
+  try {
+    passes.push(await runPass('idle', scratch, options));
+    if (options.load > 0) {
+      const loadDir = join(scratch, 'load');
+      const load = await startLoad(options.load, loadDir);
+      try {
+        passes.push(
+          await runPass(`under load (${String(options.load)} workers)`, scratch, options)
+        );
+      } finally {
+        load.stop();
+      }
+    }
+    for (const pass of passes) printPass(pass);
+    if (options.json) {
+      console.log(`\n${JSON.stringify({ platform: process.platform, options, passes }, null, 2)}`);
+    }
+  } finally {
+    await removeScratchTree(scratch);
+  }
+  return 0;
+}
+
+process.exit(await main());


### PR DESCRIPTION
## Problem and outcome

Every `workflow:` child freezes its own source, and `captureWorkflowSource` writes the whole bundled scope into each capture — 200 files on this checkout, plus 227 copied project files, growing with every workflow added. #3277 removed the *read* half (836 → 591 filesystem ops per spawn); the write half is untouched, and writes are what Windows charges for because Defender interposes on file creation. We cannot pick a fix, because every number we hold came from macOS, which does not exhibit the bug: hard-linking, the obvious lever, measured **3x worse** than copying on APFS, yet a hard link is a directory entry with no new content and is plausibly the one thing Defender does not scan.

- **Outcome:** `bun run bench:capture` prints per-phase timings and operation counts for a real child-spawn capture, then compares `copyFile` / `link` / `writeFile` at fixed total bytes and a moving file count, idle and under a controllable background load. It runs the same way on macOS, Linux and Windows.
- **Invariant:** measurement only. A capture produces the same files, the same digest and the same manifest whether or not it is being measured, and an unmeasured capture pays nine function calls and no clock reads.
- **Scope boundary:** no write-side fix. Hard-linking is measured, not shipped. The bundled bytes stay present in every capture — `workflow-source.ts` records why: it is what lets a paused run resume across an upgrade.

## Review guidance

- **Feedback requested:** whether the phase boundaries are the right cut, and whether the instrumentation is small enough to live in the capture path.
- **Start here:** `packages/workflows/src/workflow-source.ts` — `CAPTURE_PHASES` and `CaptureProfiler`, then the wiring inside `captureWorkflowSource`.
- **Review order:** `workflow-source.ts` (the hook), `scripts/capture-cost.ts` (the harness), `workflow-source.test.ts` (the equivalence and accounting guard).
- **Lower-attention areas:** the `package.json` script entry.
- **Known risk or uncertainty:** sections 2–4 of the harness are synthetic by necessity — file count, file size and background load all have to be controlled, so they cannot run on the real capture. They say so in their own output. Section 1 is the real `captureWorkflowSource`, called with the options `prepareWorkflowSource` builds for a child spawn; only that option construction is mirrored, and the harness header names the site it mirrors.

## Solution

`captureWorkflowSource` takes an optional `profiler`. Absent — every production caller — it resolves to a module-level no-op, so an unmeasured capture pays nine extra function calls and nothing else: no clock reads, no allocations, no syscalls. There is no env var and no global state to leave switched on.

The phases are named in the engine rather than in the script, because a phase is a range of `captureWorkflowSource` and two platforms' numbers are only comparable if the ranges mean the same thing. Counts come from values the phases already produce (a listing's length, a scope's file count), so nothing is instrumented per file.

The harness runs three measurements per pass and both passes back to back:

1. **The real capture**, N times. The first is reported separately because it reads the bundled trees while later ones only revalidate them — that is the difference between a run's first child and its later ones.
2. **Write primitives at a fixed total size.** `copyFile` vs `link` vs `writeFile` over one tree, swept across file counts at constant total bytes. Cost rising with the row is per-file; cost staying flat is per-byte.
3. **The same, under load.** N worker processes churning files, because the load that produces this flake class is `bun --filter --parallel`, which is processes.

`ARCHON_HOME` is pinned to a scratch directory for the duration, so the global source scope is empty and two machines measure the same tree. Nothing is written outside the OS temp directory and the repository is only read.

### macOS baseline (Apple M-series, 11 cpus, Bun 1.4.2, `bun run bench:capture`)

Capture of this checkout: 427 files, 2,552,180 bytes, `project+bundled`.

| phase | idle ms | % | under load ms | dirs | files | bytes |
|---|---|---|---|---|---|---|
| scan | 0.18 | 0.2 | 0.42 | 0 | 0 | 0 |
| stage | 0.10 | 0.1 | 0.43 | 0 | 0 | 0 |
| walk | 6.91 | 9.3 | 18.43 | 47 | 227 | 0 |
| **copy** | **32.38** | **43.6** | **75.38** | 47 | 227 | 1,304,677 |
| bundled_read | 4.72 | 6.4 | 16.72 | 0 | 0 | 0 |
| **bundled_write** | **20.85** | **28.1** | **56.53** | 42 | 200 | 1,247,503 |
| digest | 8.94 | 12.1 | 32.45 | 0 | 227 | 1,304,677 |
| manifest | 0.12 | 0.2 | 0.17 | 0 | 0 | 0 |
| publish | 0.15 | 0.2 | 0.38 | 0 | 0 | 0 |
| (unphased) | 0.08 | 0.1 | 0.09 | | | |
| **total** | **74.19** | | **215.17** | | | |

First capture in the process (reads the bundled trees rather than revalidating): 104.05 ms idle. The digest phase reads back exactly the bytes the copy phase wrote, which is the identity the added test pins.

Write primitives, 1,638,400 bytes total in every row:

| files | bytes/file | copyFile ms | link ms | writeFile ms | µs/file (copy) |
|---|---|---|---|---|---|
| 800 | 2,048 | 103.50 | 248.84 | 69.20 | 129.4 |
| 400 | 4,096 | 55.20 | 130.21 | 39.73 | 138.0 |
| 200 | 8,192 | 31.90 | 61.53 | 25.88 | 159.5 |
| 100 | 16,384 | 13.90 | 31.27 | 10.18 | 139.0 |
| 50 | 32,768 | 6.63 | 16.18 | 4.67 | 132.6 |

### Linux spot check, and why it matters here

Run in `oven/bun:1.4.2` (arm64) against this checkout, `--runs 3 --load 2`. The repository is bind-mounted through the macOS VM, so `walk` and `bundled_read` are inflated and the absolute numbers are not comparable with the table above — what is comparable is the ordering of the write primitives, all of which happen inside the container's own filesystem:

| files | bytes/file | copyFile ms | link ms | writeFile ms |
|---|---|---|---|---|
| 800 | 2,048 | 45.53 | **36.75** | 38.81 |
| 400 | 4,096 | 22.21 | **19.19** | 21.38 |
| 200 | 8,192 | 11.72 | **9.48** | 10.38 |
| 100 | 16,384 | 5.94 | **4.58** | 5.41 |
| 50 | 32,768 | 3.15 | **2.25** | 2.82 |

On Linux `link` is the *cheapest* of the three at every size; on macOS it is the most expensive by ~2x. That is the inversion this issue was worried about, already visible between two platforms we can both reach — which is the strongest available argument that the macOS link result cannot be generalized to Windows, and that the harness can detect the difference when it is there.

What macOS says, for Windows to be compared against: writing is **71.7%** of a capture (copy 43.6 + bundled_write 28.1) and the phases account for 99.9% of its wall clock; cost tracks file **count**, not bytes — 16x the files at the same total size costs ~16x the time, and µs/file is roughly flat; `link` is consistently **~2.4x worse** than `copyFile`, which is the result Windows would have to invert; and 4 background workers cost **2.9x** on an otherwise identical capture (74.19 → 215.17 ms, byte-identical counts).

## Validation

- `bun run validate` — passed — the full gate on this branch.
- `cd packages/workflows && bun run test` — passed (all groups, 0 fail) — includes the new equivalence and accounting test.
- `bun run bench:capture` — output above — proves the harness runs end to end on macOS and that the phases account for 99.9% of capture wall clock.
- Both guards were **seen red**. Reporting `copied.files - 1` from the copy phase fails the accounting identity `totals.copy.files + totals.bundled_write.files === manifest.file_count`; adding a phase to `CAPTURE_PHASES` without wiring it fails `totals[phase].ms > 0`. Each was 1 fail / 39 pass, and each was restored before commit.
- `git status` is clean after a full harness run — nothing is written into the repository.
- Linux run — output above — proves the harness runs unchanged on a second platform. The harness uses only `node:fs/promises`, `node:os` and `Bun.spawn`, with no platform branch.
- **Not verified:** the Windows numbers, which is the point of #3282 and is the work this hands over. The Linux run was in a container with the repository bind-mounted, so its `walk` and `bundled_read` figures describe the mount rather than the filesystem; only its write-primitive ordering is used above.

## Links

- Related #3282
- Related #2924
- Related #3277

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqEroYXiJbgGesqZqyUgZ6
