### PR TITLE
chore(ci): validate now runs every pull-request gate a contributor can run

### DIFF
--- a/.claude/commands/validate.md
+++ b/.claude/commands/validate.md
@@ -105,9 +105,10 @@ bun --filter @archon/workflows test
 bun run validate
 ```
 
-Equivalent to: `bun run type-check && bun run lint --max-warnings 0 && bun run format:check && bun run test`
+`scripts/validate.ts` lists what this runs; the levels above are a subset of it.
 
-This is the exact command CI runs. If this passes locally, CI will pass.
+This is the command CI runs. If it passes locally, CI will pass — except for the
+PostgreSQL and Docker jobs, which CONTRIBUTING.md lists with how to run each one.
 
 ---
 

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -44,5 +44,6 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      # The command lives in scripts/validate.ts so `bun run validate` builds the docs too.
       - name: Build docs
-        run: bun run build:docs
+        run: bun run validate --only docs-build

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      # The command lives in scripts/validate.ts so `bun run validate` builds the docs too.
+      # A declared exclusion from `bun run validate` (scripts/validate-ci-parity.test.ts):
+      # the gate must run on a Bun-only checkout, and this build needs the Node setup above.
       - name: Build docs
-        run: bun run validate --only docs-build
+        run: bun run build:docs

--- a/.github/workflows/marketplace-lint.yml
+++ b/.github/workflows/marketplace-lint.yml
@@ -23,5 +23,7 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      # The command lives in scripts/validate.ts so `bun run validate` lints the
+      # marketplace too.
       - name: Run marketplace lint
-        run: bun packages/docs-web/scripts/lint-marketplace.ts
+        run: bun run validate --only marketplace-lint

--- a/.github/workflows/marketplace-lint.yml
+++ b/.github/workflows/marketplace-lint.yml
@@ -23,7 +23,10 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      # The command lives in scripts/validate.ts so `bun run validate` lints the
-      # marketplace too.
+      # Deliberately outside `bun run validate`: this makes 9 unauthenticated github.com
+      # API calls per run against a 60/hour per-IP quota, so putting it in the gate every
+      # contributor runs turns that gate red with HTTP 403s that say nothing about the
+      # change. scripts/validate-ci-parity.test.ts records the exclusion; CONTRIBUTING.md
+      # tells contributors touching marketplace.ts to run this command themselves.
       - name: Run marketplace lint
-        run: bun run validate --only marketplace-lint
+        run: bun packages/docs-web/scripts/lint-marketplace.ts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,8 +59,11 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      # A dedicated job so fixture breakage reports in ~2 minutes instead of behind the
+      # full matrix. The command itself lives in scripts/validate.ts, which is also what
+      # `bun run validate` runs locally.
       - name: Run workflow fixtures
-        run: bun run cli workflow test --json
+        run: bun run validate --only workflow-fixtures
 
   test:
     needs: changes
@@ -76,6 +79,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+
+      # `validate` builds the docs site, and Astro's CLI runs under Node rather than
+      # Bun — keep this matched to docs-build.yml and deploy-docs.yml.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -95,44 +104,6 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Check CLI import boundaries
-        run: bun run check:cli-import-boundary
-
-      - name: Check bundled defaults
-        run: bun run check:bundled
-
-      - name: Check bundled skill
-        run: bun run check:bundled-skill
-
-      - name: Check bundled schema
-        run: bun run check:bundled-schema
-
-      - name: Check Pi vendor map
-        run: bun run check:pi-vendor-map
-
-      - name: Check provider capability matrix
-        run: bun run check:capability-matrix
-
-      - name: Check generated API types
-        run: bun run check:api-types
-
-      - name: Type check
-        run: bun run type-check
-
-      - name: Lint
-        run: bun run lint --max-warnings 0
-
-      - name: Check formatting
-        run: bun run format:check
-
-      - name: Run installer tests
-        # POSIX-shell installer only. scripts/install.sh refuses MINGW/MSYS by design
-        # (Windows users are directed to WSL2), and test-install.sh runs the real
-        # installer with only curl mocked — so on windows-latest `uname -s` reports
-        # MINGW64_NT, the installer exits, and `set -euo pipefail` fails the job.
-        if: runner.os != 'Windows'
-        run: bun run test:install
-
       # No Windows Defender exclusion step here on purpose. It was the named
       # remaining suspect behind the downloadWebDist stalls (#2924), so one was
       # added and run on windows-latest — and its own readback disproved the
@@ -140,8 +111,15 @@ jobs:
       # drive root, recursively, so nothing under either was being scanned to
       # begin with. `Add-MpPreference` also cost 5s per run to change nothing.
       # Evidence: https://github.com/coleam00/Archon/pull/2943
-      - name: Run tests
-        run: bun run test
+
+      # This job used to restate every command in `bun run validate`, which meant the
+      # documented pre-pull-request command and the gate it was supposed to reproduce
+      # could disagree — and did. scripts/validate.ts now owns the list, this step runs
+      # it, and scripts/validate-ci-parity.test.ts fails if a check reappears here as its
+      # own step. Add a check there, not here. The installer test skips itself on Windows
+      # (scripts/install.sh refuses MINGW/MSYS by design) and says so in the log.
+      - name: Validate
+        run: bun run validate
 
   schema-upgrade:
     needs: changes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,12 +80,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # `validate` builds the docs site, and Astro's CLI runs under Node rather than
-      # Bun — keep this matched to docs-build.yml and deploy-docs.yml.
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,8 +168,8 @@ what you changed — a thin brief is cheaper to correct before a run than after 
 - Bun's module mocks pollute the process cache. Use the package test scripts that preserve isolation; do not run `bun test` from the repository root.
 - Always run lint through `bun run lint` or `bun run lint:fix`; the wrapper isolates packages to keep typed lint within its memory budget.
 - Run the narrow checks that prove the changed behavior while iterating.
-- Run `bun run validate` before opening a pull request. CI may contain additional environment-dependent checks; inspect changed-path workflows and run applicable checks when practical.
-- Schema changes also require the PostgreSQL upgrade check documented in the contributor docs and CI.
+- Run `bun run validate` before opening a pull request. It runs every pull-request gate except the jobs needing a live PostgreSQL or a Docker daemon: `scripts/validate.ts` owns the check list and the workflows call that script rather than restating it.
+- Those excluded jobs are listed in [`CONTRIBUTING.md`](CONTRIBUTING.md) with the command to run each one yourself. Schema changes require the PostgreSQL upgrade check from that list.
 - For visual or runtime behavior, add direct evidence when static tests cannot prove the outcome.
 - Destructive verification, including DDL, migrations, and data writes, runs only against a scratch database you create and drop. A configured live DSN is read-only at most; when only a live resource exists, stop and surface it to the operator.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,7 @@ what you changed — a thin brief is cheaper to correct before a run than after 
 - Bun's module mocks pollute the process cache. Use the package test scripts that preserve isolation; do not run `bun test` from the repository root.
 - Always run lint through `bun run lint` or `bun run lint:fix`; the wrapper isolates packages to keep typed lint within its memory budget.
 - Run the narrow checks that prove the changed behavior while iterating.
-- Run `bun run validate` before opening a pull request. It runs every pull-request gate except the jobs needing a live PostgreSQL or a Docker daemon: `scripts/validate.ts` owns the check list and the workflows call that script rather than restating it.
+- Run `bun run validate` before opening a pull request. It runs every pull-request gate except the ones needing something a contributor may not have — a live PostgreSQL, a Docker daemon, GitHub API quota — because `scripts/validate.ts` owns the check list and the workflows call that script rather than restating it.
 - Those excluded jobs are listed in [`CONTRIBUTING.md`](CONTRIBUTING.md) with the command to run each one yourself. Schema changes require the PostgreSQL upgrade check from that list.
 - For visual or runtime behavior, add direct evidence when static tests cannot prove the outcome.
 - Destructive verification, including DDL, migrations, and data writes, runs only against a scratch database you create and drop. A configured live DSN is read-only at most; when only a live resource exists, stop and surface it to the operator.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,7 @@ what you changed — a thin brief is cheaper to correct before a run than after 
 - Bun's module mocks pollute the process cache. Use the package test scripts that preserve isolation; do not run `bun test` from the repository root.
 - Always run lint through `bun run lint` or `bun run lint:fix`; the wrapper isolates packages to keep typed lint within its memory budget.
 - Run the narrow checks that prove the changed behavior while iterating.
-- Run `bun run validate` before opening a pull request. It runs every pull-request gate except the ones needing something a contributor may not have — a live PostgreSQL, a Docker daemon, GitHub API quota — because `scripts/validate.ts` owns the check list and the workflows call that script rather than restating it.
+- Run `bun run validate` before opening a pull request. It runs every pull-request gate except the ones needing something a contributor may not have — a live PostgreSQL, a Docker daemon, an unshallowed checkout, Node for the docs site, GitHub API quota — because `scripts/validate.ts` owns the check list and the workflows call that script rather than restating it.
 - Those excluded jobs are listed in [`CONTRIBUTING.md`](CONTRIBUTING.md) with the command to run each one yourself. Schema changes require the PostgreSQL upgrade check from that list.
 - For visual or runtime behavior, add direct evidence when static tests cannot prove the outcome.
 - Destructive verification, including DDL, migrations, and data writes, runs only against a scratch database you create and drop. A configured live DSN is read-only at most; when only a live resource exists, stop and surface it to the operator.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,32 +14,49 @@ Thank you for your interest in contributing to Archon!
 
 ### Code Quality
 
-Before submitting a PR, ensure:
+`bun run validate` is the gate. Run it before opening a pull request: it runs every
+check that gates a pull request except the three service-dependent jobs listed below,
+so a green run means CI's `test`, `workflow-fixtures`, `docs-build` and
+`marketplace-lint` jobs will pass. It takes a couple of minutes and prints what each
+check cost, so you can see where the time goes.
 
 ```bash
-bun run check:bundled  # Bundled defaults are up to date
-bun run type-check     # TypeScript types
-bun run lint           # ESLint
-bun run format         # Prettier
-bun run test           # All tests (per-package isolation)
-
-# Or run the full validation suite:
-bun run validate
+bun run validate                            # the whole gate
+bun run validate --only workflow-fixtures   # one check, while iterating
 ```
 
-**Schema changes**: `bun run validate` does not cover `migrations/000_combined.sql`
-upgrades — that check needs a live PostgreSQL, so CI runs it as its own job. If you
-touched the schema, run it yourself against any PostgreSQL:
+`scripts/validate.ts` owns the list of checks, and the CI jobs call that script instead
+of restating its commands, so the two cannot describe different work.
 
-```bash
-bun run check:schema-upgrades   # PGHOST/PGUSER/… or DATABASE_URL
-```
+While you work, run the narrow check instead — `bun run type-check`, `bun run lint`,
+`bun run test <path>`, `bun run check:bundled` — and keep the full gate for the end.
+
+**Important:** Use `bun run test` (not `bun test` from the repo root) to avoid mock pollution across packages.
+
+**Network:** the marketplace lint resolves each marketplace entry at its pinned SHA
+against github.com, so `bun run validate` needs network access.
+
+#### What `bun run validate` deliberately leaves out
+
+Three PR-gating jobs need a service or daemon a contributor may not have, so they stay
+in CI only. If you touched what they cover, run them yourself.
+
+| CI job | Needs | Run it yourself |
+| --- | --- | --- |
+| `schema-upgrade` | a live PostgreSQL; the SQLite half also reads every release tag | `bun run check:schema-upgrades` (`PGHOST`/`PGUSER`/… or `DATABASE_URL`) and `bun run check:sqlite-vintages` |
+| `postgres-parity` | a live PostgreSQL | `ARCHON_TEST_PG_URL=postgres://… bun test packages/core/src/db/isolation-environments.live-run.postgres.integration.test.ts` |
+| `docker-build` | a Docker daemon, and ~14GB of free disk for the image | `docker build .` |
+
+**Schema changes**: run `bun run check:schema-upgrades` yourself if you touched
+`migrations/000_combined.sql`. A statement that applies cleanly to a fresh install can
+abort the whole apply on an upgrade, and nothing before that job catches it.
+
+`scripts/validate-ci-parity.test.ts` holds the same exclusions as a machine-checked list,
+so a fourth PR-gating command cannot appear without a deliberate decision to leave it out.
 
 **SDLC workflows**: We do not accept pull requests that change
 `.archon/workflows/sdlc/`. Open an issue instead and describe the problem or
 change you want the maintainers to consider.
-
-**Important:** Use `bun run test` (not `bun test` from the repo root) to avoid mock pollution across packages.
 
 ### Commit messages
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,10 +15,10 @@ Thank you for your interest in contributing to Archon!
 ### Code Quality
 
 `bun run validate` is the gate. Run it before opening a pull request: it runs every
-check that gates a pull request except the three service-dependent jobs listed below,
-so a green run means CI's `test`, `workflow-fixtures`, `docs-build` and
-`marketplace-lint` jobs will pass. It takes a couple of minutes and prints what each
-check cost, so you can see where the time goes.
+check that gates a pull request except the four listed below, so a green run means CI's
+`test`, `workflow-fixtures` and `docs-build` jobs will pass. It needs no network and no
+services, takes a couple of minutes, and prints what each check cost so you can see
+where the time goes.
 
 ```bash
 bun run validate                            # the whole gate
@@ -33,26 +33,24 @@ While you work, run the narrow check instead — `bun run type-check`, `bun run 
 
 **Important:** Use `bun run test` (not `bun test` from the repo root) to avoid mock pollution across packages.
 
-**Network:** the marketplace lint resolves each marketplace entry at its pinned SHA
-against github.com, so `bun run validate` needs network access.
-
 #### What `bun run validate` deliberately leaves out
 
-Three PR-gating jobs need a service or daemon a contributor may not have, so they stay
-in CI only. If you touched what they cover, run them yourself.
+These PR-gating jobs need something a contributor may not have, so they stay in CI only.
+If you touched what they cover, run them yourself.
 
 | CI job | Needs | Run it yourself |
 | --- | --- | --- |
 | `schema-upgrade` | a live PostgreSQL; the SQLite half also reads every release tag | `bun run check:schema-upgrades` (`PGHOST`/`PGUSER`/… or `DATABASE_URL`) and `bun run check:sqlite-vintages` |
 | `postgres-parity` | a live PostgreSQL | `ARCHON_TEST_PG_URL=postgres://… bun test packages/core/src/db/isolation-environments.live-run.postgres.integration.test.ts` |
 | `docker-build` | a Docker daemon, and ~14GB of free disk for the image | `docker build .` |
+| `marketplace-lint` | 9 unauthenticated github.com API calls against a 60/hour per-IP quota, which six `validate` runs an hour would exhaust | `bun packages/docs-web/scripts/lint-marketplace.ts` — run it when you change `packages/docs-web/src/data/marketplace.ts` |
 
 **Schema changes**: run `bun run check:schema-upgrades` yourself if you touched
 `migrations/000_combined.sql`. A statement that applies cleanly to a fresh install can
 abort the whole apply on an upgrade, and nothing before that job catches it.
 
 `scripts/validate-ci-parity.test.ts` holds the same exclusions as a machine-checked list,
-so a fourth PR-gating command cannot appear without a deliberate decision to leave it out.
+so another PR-gating command cannot appear without a deliberate decision to leave it out.
 
 **SDLC workflows**: We do not accept pull requests that change
 `.archon/workflows/sdlc/`. Open an issue instead and describe the problem or

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Thank you for your interest in contributing to Archon!
 
 `bun run validate` is the gate. Run it before opening a pull request: it runs every
 check that gates a pull request except the four listed below, so a green run means CI's
-`test`, `workflow-fixtures` and `docs-build` jobs will pass. It needs no network and no
+`test` and `workflow-fixtures` jobs will pass. It needs no network and no
 services, takes a couple of minutes, and prints what each check cost so you can see
 where the time goes.
 
@@ -43,10 +43,11 @@ If you touched what they cover, run them yourself.
 | `schema-upgrade` | a live PostgreSQL; the SQLite half also reads every release tag | `bun run check:schema-upgrades` (`PGHOST`/`PGUSER`/… or `DATABASE_URL`) and `bun run check:sqlite-vintages` |
 | `postgres-parity` | a live PostgreSQL | `ARCHON_TEST_PG_URL=postgres://… bun test packages/core/src/db/isolation-environments.live-run.postgres.integration.test.ts` |
 | `docker-build` | a Docker daemon, and ~14GB of free disk for the image | `docker build .` |
-| `marketplace-lint` | 9 unauthenticated github.com API calls against a 60/hour per-IP quota, which six `validate` runs an hour would exhaust | `bun packages/docs-web/scripts/lint-marketplace.ts` — run it when you change `packages/docs-web/src/data/marketplace.ts` |
+| `docs-build` | Node (Astro's CLI does not run under Bun); path-filtered to `packages/docs-web/` | `bun run build:docs` — run it when you change the docs site |
+| `marketplace-lint` | 9 unauthenticated github.com API calls against a 60/hour per-IP quota, which seven `validate` runs an hour would exhaust | `bun packages/docs-web/scripts/lint-marketplace.ts` — run it when you change `packages/docs-web/src/data/marketplace.ts` |
 
-**Schema changes**: run `bun run check:schema-upgrades` yourself if you touched
-`migrations/000_combined.sql`. A statement that applies cleanly to a fresh install can
+**Schema changes**: run `bun run check:schema-upgrades` and `bun run check:sqlite-vintages`
+yourself if you touched `migrations/000_combined.sql`. A statement that applies cleanly to a fresh install can
 abort the whole apply on an upgrade, and nothing before that job catches it.
 
 `scripts/validate-ci-parity.test.ts` holds the same exclusions as a machine-checked list,

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "build:web": "bun --filter @archon/web build",
     "dev:docs": "bun --filter @archon/docs-web dev",
     "build:docs": "bun --filter @archon/docs-web build",
-    "validate": "bun run check:cli-import-boundary && bun run check:bundled && bun run check:bundled-skill && bun run check:bundled-schema && bun run check:pi-vendor-map && bun run check:capability-matrix && bun run check:api-types && bun run type-check && bun run lint --max-warnings 0 && bun run format:check && bun run test:install && bun run test",
+    "validate": "bun run scripts/validate.ts",
     "prepare": "husky",
     "setup-auth": "bun --filter @archon/server setup-auth",
     "check:cli-import-boundary": "bun run scripts/check-cli-import-boundary.ts"

--- a/packages/workflows/src/fixture-runner.test.ts
+++ b/packages/workflows/src/fixture-runner.test.ts
@@ -599,6 +599,39 @@ describe('runFixtures', () => {
     expect(report.passed).toBe(1);
   });
 
+  it('matches a multi-line fragment against a command file checked out with CRLF', async () => {
+    // A command file is read as raw text, so `* text=auto` hands a Windows clone CRLF inside
+    // it — while a fixture spells its expectation with `\n` escapes that stay LF everywhere.
+    // Three archon-ship fixtures failed on windows-latest alone until this comparison
+    // normalized. (Workflow YAML is immune: the YAML parser normalizes its own line breaks.)
+    const { cwd } = writeTempProject({
+      workflowYaml:
+        'name: test-wf\ndescription: test\ninputs:\n  target:\n    default: ""\nnodes:\n' +
+        '  - id: node-a\n    command: bind-test\n    with:\n      target: "$INPUTS.target"\n',
+      body: [
+        'fixture:',
+        '  inputs:',
+        '    target: "issue #3031"',
+        '  resolved-text-contains:',
+        '    node-a: "target:\\n\\nissue #3031\\n\\nThe operator request"',
+        'node-a: "stub"',
+      ].join('\n'),
+    });
+    mkdirSync(join(cwd, '.archon', 'commands'), { recursive: true });
+    writeFileSync(
+      join(cwd, '.archon', 'commands', 'bind-test.md'),
+      'target:\r\n\r\n$INPUTS.target\r\n\r\nThe operator request\r\n'
+    );
+
+    const report = await runFixtures({
+      workflows: [workflowsOnDisk(cwd, ['test-wf'])[0]],
+      cwd,
+    });
+
+    expect(report.results[0].failureReason).toBeUndefined();
+    expect(report.passed).toBe(1);
+  });
+
   it('reports a malformed fixture as a failure, not a crash', async () => {
     const { cwd } = writeTempProject({ body: ['fixture:', '  expect: bogus'].join('\n') });
     const report = await runFixtures({

--- a/packages/workflows/src/fixture-runner.ts
+++ b/packages/workflows/src/fixture-runner.ts
@@ -53,6 +53,9 @@ import {
   type WorkflowSourceRoots,
 } from './workflow-source';
 
+/** Compares text the checkout may have converted to CRLF against a fixture's LF expectation. */
+const withLfEndings = (text: string): string => text.replaceAll('\r\n', '\n');
+
 /** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
 let cachedLog: ReturnType<typeof createLogger> | undefined;
 function getLog(): ReturnType<typeof createLogger> {
@@ -649,7 +652,20 @@ async function checkFixture(
           failureReason = `expected resolved text for node '${nodeId}', but it was not reached`;
           break;
         }
-        if (!traceEntries.some(entry => entry.resolvedText?.includes(expectedText) === true)) {
+        // Line endings belong to the checkout, not to the workflow. A command file is read as
+        // raw text, so `* text=auto` gives a Windows clone CRLF inside it, while a fixture
+        // spells its expectation with `\n` escapes that stay LF everywhere. This declaration is
+        // about interpolated content, so it compares on LF alone rather than passing on Linux
+        // and failing on Windows for the same workflow. (Workflow YAML is immune: the parser
+        // normalizes line breaks in its own scalars.)
+        const expected = withLfEndings(expectedText);
+        if (
+          !traceEntries.some(
+            entry =>
+              entry.resolvedText !== undefined &&
+              withLfEndings(entry.resolvedText).includes(expected)
+          )
+        ) {
           failureReason = `expected node '${nodeId}' resolved text to contain ${JSON.stringify(expectedText)}`;
           break;
         }

--- a/scripts/should-run-test-suite.test.ts
+++ b/scripts/should-run-test-suite.test.ts
@@ -167,7 +167,9 @@ describe('test-suite change decision', () => {
     expect(fixtureJob).toContain('bun-version: ${{ env.BUN_VERSION }}');
     expect(fixtureJob).toContain('uses: astral-sh/setup-uv@v4');
     expect(fixtureJob).toContain('run: bun install --frozen-lockfile');
-    expect(fixtureJob).toContain('run: bun run cli workflow test --json');
+    // The fixture command itself lives in scripts/validate.ts so `bun run validate` runs it
+    // too; scripts/validate-ci-parity.test.ts proves this id still names a real check.
+    expect(fixtureJob).toContain('run: bun run validate --only workflow-fixtures');
   });
 });
 

--- a/scripts/validate-ci-parity.test.ts
+++ b/scripts/validate-ci-parity.test.ts
@@ -60,13 +60,17 @@ interface WorkflowCommand {
 
 /** Workflows that gate a pull request. `pull_request_target` is deliberately not one. */
 function pullRequestWorkflows(): { name: string; content: string }[] {
-  return readdirSync(WORKFLOW_DIR)
-    .filter(name => name.endsWith('.yml'))
-    .map(name => ({
-      name,
-      content: readFileSync(resolve(WORKFLOW_DIR, name), 'utf8').replace(/\r\n/g, '\n'),
-    }))
-    .filter(({ content }) => /^ {2}pull_request:\s*$/m.test(content));
+  return (
+    readdirSync(WORKFLOW_DIR)
+      .filter(name => name.endsWith('.yml'))
+      .map(name => ({
+        name,
+        content: readFileSync(resolve(WORKFLOW_DIR, name), 'utf8').replace(/\r\n/g, '\n'),
+      }))
+      // Matches the block form these workflows use and an inline `pull_request: {…}` alike, so a
+      // future workflow cannot slip past this test by writing its trigger in flow style.
+      .filter(({ content }) => /^ {2}pull_request(?![_A-Za-z])/m.test(content))
+  );
 }
 
 /** Every `run:` step body, inline or block scalar. */

--- a/scripts/validate-ci-parity.test.ts
+++ b/scripts/validate-ci-parity.test.ts
@@ -52,10 +52,16 @@ const NOT_IN_VALIDATE: readonly { command: string; reason: string }[] = [
     reason: 'Exercises the Postgres dialect against a live PostgreSQL service.',
   },
   {
+    command: 'bun run build:docs',
+    reason:
+      "Astro's CLI runs under Node, not Bun, so a checkout with only Bun cannot build the docs " +
+      'site; docs-build.yml runs it with a Node setup, path-filtered to the docs site.',
+  },
+  {
     command: 'bun packages/docs-web/scripts/lint-marketplace.ts',
     reason:
       'Spends 9 unauthenticated github.com API calls per run against a 60/hour per-IP quota, so ' +
-      'six validate runs an hour turn the gate red with HTTP 403s that say nothing about the change.',
+      'seven validate runs an hour turn the gate red with HTTP 403s that say nothing about the change.',
   },
 ];
 
@@ -68,14 +74,15 @@ interface WorkflowCommand {
 function pullRequestWorkflows(): { name: string; content: string }[] {
   return (
     readdirSync(WORKFLOW_DIR)
-      .filter(name => name.endsWith('.yml'))
+      .filter(name => name.endsWith('.yml') || name.endsWith('.yaml'))
       .map(name => ({
         name,
         content: readFileSync(resolve(WORKFLOW_DIR, name), 'utf8').replace(/\r\n/g, '\n'),
       }))
-      // Matches the block form these workflows use and an inline `pull_request: {…}` alike, so a
-      // future workflow cannot slip past this test by writing its trigger in flow style.
-      .filter(({ content }) => /^ {2}pull_request(?![_A-Za-z])/m.test(content))
+      // Matches the key at any indentation and inside a flow list (`on: [push, pull_request]`),
+      // so a future workflow cannot slip past this test by writing its trigger another way. A
+      // comment line starts with `#`, so prose mentioning the trigger does not match.
+      .filter(({ content }) => /(?:^\s*|[[,]\s*)pull_request(?![_A-Za-z])/m.test(content))
   );
 }
 
@@ -111,14 +118,15 @@ function runSteps(workflow: string): string[] {
 
 /**
  * Bun invocations inside one step body. `bun` is matched as a command word so command
- * substitution (`x=$(bun …)`) counts, and shell comment lines are dropped so the prose in
- * these workflows cannot register as a command.
+ * substitution (`x=$(bun …)`) counts, a command ends at a shell separator so `a && bun b`
+ * and `bun a && bun b` each yield their own entry, and shell comment lines are dropped so
+ * the prose in these workflows cannot register as a command.
  */
 function bunCommands(step: string): string[] {
   return step
     .split('\n')
     .filter(line => !line.trimStart().startsWith('#'))
-    .flatMap(line => [...line.matchAll(/(?:^|[\s;&|($])bun\s+(?:[^\n]*)/g)])
+    .flatMap(line => [...line.matchAll(/(?:^|[\s;&|($])bun\s+[^;&|)\n]*/g)])
     .map(match => match[0].replace(/^[\s;&|($]+/, '').trim());
 }
 

--- a/scripts/validate-ci-parity.test.ts
+++ b/scripts/validate-ci-parity.test.ts
@@ -1,0 +1,186 @@
+/**
+ * `bun run validate` is the documented pre-pull-request command, so a green run has to mean
+ * the pull-request gates will pass. It stops meaning that the moment a workflow runs a check
+ * of its own — which is how the workflow fixtures, the docs build and the marketplace lint
+ * ended up gating pull requests while `validate` knew nothing about them (#3290).
+ *
+ * So: every Bun command a `pull_request`-triggered workflow runs is either `bun run validate`,
+ * dependency install, or an entry in `NOT_IN_VALIDATE` with the reason it cannot join. Adding a
+ * gate without deciding which of the three it is fails here.
+ *
+ * Two limits worth knowing. Non-Bun steps are out of scope, so the Docker image build is
+ * excluded by prose (CONTRIBUTING.md) rather than by this test. And `pull_request_target`
+ * workflows are excluded because they run maintainer automation against a fork's head rather
+ * than checks a contributor can reproduce.
+ *
+ * Text scanning, not YAML parsing: the repository has no YAML dependency at the root, and
+ * `scripts/bun-version-consistency.test.ts` and `scripts/publish-triggers.test.ts` already read
+ * these files the same way.
+ */
+import { describe, expect, test } from 'bun:test';
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { VALIDATE_CHECKS } from './validate';
+
+const WORKFLOW_DIR = resolve(import.meta.dir, '../.github/workflows');
+
+/** Not a repository check, so it needs no justification. */
+const DEPENDENCY_INSTALL = 'bun install';
+
+/**
+ * PR-gating Bun commands that deliberately stay out of `validate`, each with the environment
+ * it needs that a contributor may not have. Adding an entry is the decision to leave a gate
+ * unreproducible locally; CONTRIBUTING.md carries the same list in prose for contributors.
+ */
+const NOT_IN_VALIDATE: readonly { command: string; reason: string }[] = [
+  {
+    command: 'bun scripts/should-run-test-suite.ts',
+    reason: 'Decides whether the suite runs at all. CI plumbing, not a repository check.',
+  },
+  {
+    command: 'bun run check:schema-upgrades',
+    reason: 'Applies every released schema to a live PostgreSQL service.',
+  },
+  {
+    command: 'bun run check:sqlite-vintages',
+    reason:
+      'Reads every release tag with `git show`, so it needs the unshallowed checkout its job takes.',
+  },
+  {
+    command:
+      'bun test packages/core/src/db/isolation-environments.live-run.postgres.integration.test.ts',
+    reason: 'Exercises the Postgres dialect against a live PostgreSQL service.',
+  },
+];
+
+interface WorkflowCommand {
+  workflow: string;
+  command: string;
+}
+
+/** Workflows that gate a pull request. `pull_request_target` is deliberately not one. */
+function pullRequestWorkflows(): { name: string; content: string }[] {
+  return readdirSync(WORKFLOW_DIR)
+    .filter(name => name.endsWith('.yml'))
+    .map(name => ({
+      name,
+      content: readFileSync(resolve(WORKFLOW_DIR, name), 'utf8').replace(/\r\n/g, '\n'),
+    }))
+    .filter(({ content }) => /^ {2}pull_request:\s*$/m.test(content));
+}
+
+/** Every `run:` step body, inline or block scalar. */
+function runSteps(workflow: string): string[] {
+  const lines = workflow.split('\n');
+  const steps: string[] = [];
+
+  for (let index = 0; index < lines.length; index++) {
+    const match = /^(\s*)(- )?run:\s*(.*)$/.exec(lines[index]);
+    if (match === null) continue;
+
+    const keyIndent = match[1].length + (match[2] === undefined ? 0 : 2);
+    const inline = match[3].trim();
+    if (!/^[|>][+-]?\d*$/.test(inline)) {
+      steps.push(inline.replace(/^(['"])(.*)\1$/, '$2'));
+      continue;
+    }
+
+    const body: string[] = [];
+    while (index + 1 < lines.length) {
+      const next = lines[index + 1];
+      const indent = next.length - next.trimStart().length;
+      if (next.trim() !== '' && indent <= keyIndent) break;
+      body.push(next);
+      index++;
+    }
+    steps.push(body.join('\n'));
+  }
+
+  return steps;
+}
+
+/**
+ * Bun invocations inside one step body. `bun` is matched as a command word so command
+ * substitution (`x=$(bun …)`) counts, and shell comment lines are dropped so the prose in
+ * these workflows cannot register as a command.
+ */
+function bunCommands(step: string): string[] {
+  return step
+    .split('\n')
+    .filter(line => !line.trimStart().startsWith('#'))
+    .flatMap(line => [...line.matchAll(/(?:^|[\s;&|($])bun\s+(?:[^\n]*)/g)])
+    .map(match => match[0].replace(/^[\s;&|($]+/, '').trim());
+}
+
+function workflowBunCommands(): WorkflowCommand[] {
+  return pullRequestWorkflows().flatMap(({ name, content }) =>
+    runSteps(content)
+      .flatMap(bunCommands)
+      .map(command => ({ workflow: name, command }))
+  );
+}
+
+/** Check ids one `bun run validate …` invocation gates. No `--only` gates everything. */
+function gatedIds(command: string): string[] {
+  const only = [...command.matchAll(/--only[= ]([^\s)"']+)/g)].flatMap(match =>
+    match[1].split(',').filter(id => id.length > 0)
+  );
+  return only.length > 0 ? only : VALIDATE_CHECKS.map(check => check.id);
+}
+
+describe('validate covers the pull-request gates', () => {
+  test('every Bun command in a PR-gating workflow runs through validate or is declared', () => {
+    const undeclared = workflowBunCommands()
+      .filter(
+        ({ command }) =>
+          !command.startsWith('bun run validate') &&
+          !command.startsWith(DEPENDENCY_INSTALL) &&
+          !NOT_IN_VALIDATE.some(entry => command.startsWith(entry.command))
+      )
+      .map(({ workflow, command }) => `${workflow}: ${command}`);
+
+    expect(
+      undeclared,
+      [
+        'A pull-request gate runs a command `bun run validate` does not.',
+        'Add the check to VALIDATE_CHECKS in scripts/validate.ts and call it from the workflow',
+        'as `bun run validate --only <id>`, or add it to NOT_IN_VALIDATE here with the reason',
+        'a contributor cannot run it — and say so in CONTRIBUTING.md.',
+      ].join('\n')
+    ).toEqual([]);
+  });
+
+  test('every --only id names a check that exists', () => {
+    const known = new Set(VALIDATE_CHECKS.map(check => check.id));
+    const unknown = workflowBunCommands()
+      .filter(({ command }) => command.startsWith('bun run validate'))
+      .flatMap(({ workflow, command }) =>
+        [...command.matchAll(/--only[= ]([^\s)"']+)/g)]
+          .flatMap(match => match[1].split(','))
+          .filter(id => id.length > 0 && !known.has(id))
+          .map(id => `${workflow}: --only ${id}`)
+      );
+
+    expect(unknown).toEqual([]);
+  });
+
+  test('every check validate runs is gated by CI', () => {
+    const gated = new Set(
+      workflowBunCommands()
+        .filter(({ command }) => command.startsWith('bun run validate'))
+        .flatMap(({ command }) => gatedIds(command))
+    );
+
+    const ungated = VALIDATE_CHECKS.map(check => check.id).filter(id => !gated.has(id));
+    expect(ungated).toEqual([]);
+  });
+
+  test('every declared exclusion is still a command CI runs', () => {
+    const commands = workflowBunCommands().map(({ command }) => command);
+    const stale = NOT_IN_VALIDATE.filter(
+      entry => !commands.some(command => command.startsWith(entry.command))
+    ).map(entry => entry.command);
+
+    expect(stale).toEqual([]);
+  });
+});

--- a/scripts/validate-ci-parity.test.ts
+++ b/scripts/validate-ci-parity.test.ts
@@ -51,6 +51,12 @@ const NOT_IN_VALIDATE: readonly { command: string; reason: string }[] = [
       'bun test packages/core/src/db/isolation-environments.live-run.postgres.integration.test.ts',
     reason: 'Exercises the Postgres dialect against a live PostgreSQL service.',
   },
+  {
+    command: 'bun packages/docs-web/scripts/lint-marketplace.ts',
+    reason:
+      'Spends 9 unauthenticated github.com API calls per run against a 60/hour per-IP quota, so ' +
+      'six validate runs an hour turn the gate red with HTTP 403s that say nothing about the change.',
+  },
 ];
 
 interface WorkflowCommand {

--- a/scripts/validate.test.ts
+++ b/scripts/validate.test.ts
@@ -1,0 +1,44 @@
+/**
+ * CI selects checks by id (`bun run validate --only docs-build`), so a mistyped or removed id
+ * must fail loudly. Selecting nothing and exiting 0 would leave a job that reports green while
+ * running no check at all.
+ */
+import { describe, expect, test } from 'bun:test';
+import { VALIDATE_CHECKS, parseOnly, selectChecks } from './validate';
+
+describe('validate check selection', () => {
+  test('no selection runs every check in declaration order', () => {
+    expect(selectChecks([]).map(check => check.id)).toEqual(VALIDATE_CHECKS.map(check => check.id));
+  });
+
+  test('a selection runs in declaration order, not argument order', () => {
+    expect(selectChecks(['tests', 'lint']).map(check => check.id)).toEqual(['lint', 'tests']);
+  });
+
+  test('an unknown id fails instead of selecting nothing', () => {
+    expect(() => selectChecks(['docs_build'])).toThrow(/Unknown check id: docs_build/);
+  });
+
+  test('check ids are unique', () => {
+    const ids = VALIDATE_CHECKS.map(check => check.id);
+    expect(ids).toEqual([...new Set(ids)]);
+  });
+});
+
+describe('validate argument parsing', () => {
+  test('--only accepts repetition and comma-separated ids', () => {
+    expect(parseOnly(['--only', 'lint,format', '--only=tests'])).toEqual([
+      'lint',
+      'format',
+      'tests',
+    ]);
+  });
+
+  test('a stray argument fails instead of being forwarded to a check', () => {
+    expect(() => parseOnly(['--fix'])).toThrow(/unsupported argument: --fix/);
+  });
+
+  test('--only without a value fails', () => {
+    expect(() => parseOnly(['--only'])).toThrow(/--only needs a check id/);
+  });
+});

--- a/scripts/validate.test.ts
+++ b/scripts/validate.test.ts
@@ -1,5 +1,5 @@
 /**
- * CI selects checks by id (`bun run validate --only docs-build`), so a mistyped or removed id
+ * CI selects checks by id (`bun run validate --only workflow-fixtures`), so a mistyped or removed id
  * must fail loudly. Selecting nothing and exiting 0 would leave a job that reports green while
  * running no check at all.
  */

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -76,11 +76,6 @@ export const VALIDATE_CHECKS: readonly ValidateCheck[] = [
     command: ['bun', 'run', 'format:check'],
   },
   {
-    id: 'marketplace-lint',
-    label: 'Marketplace entries resolve at their pinned SHAs (reaches github.com)',
-    command: ['bun', 'packages/docs-web/scripts/lint-marketplace.ts'],
-  },
-  {
     id: 'workflow-fixtures',
     label: 'Every workflow fixture reaches its expected outcome under dry-run',
     command: ['bun', 'run', 'cli', 'workflow', 'test'],

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -10,7 +10,7 @@
  *
  * Checks run in declaration order and the run stops at the first failure, so the list is ordered
  * roughly cheapest first: a type error surfaces in seconds rather than after the test suite. The
- * two exceptions are the last two entries, and their comment says why they sit there.
+ * one exception is the last entry, and its comment says why it sits there.
  */
 import { resolve } from 'node:path';
 
@@ -89,23 +89,21 @@ export const VALIDATE_CHECKS: readonly ValidateCheck[] = [
     label: 'Test suite, per-package isolation preserved',
     command: ['bun', 'run', 'test'],
   },
-  // The two heavy filesystem checks run LAST, after the suite, and that ordering is
-  // load-bearing on Windows. Running them first put 48 workflow captures (a tree created and
-  // deleted each) and an Astro build immediately before a suite whose own slowest tests copy
-  // trees in %TEMP% and spawn `bun`/`git`: the suite stayed the same speed overall (median
-  // 0.87x of the same run on dev, 2612 tests compared) but its tail blew Bun's 5s per-test
-  // budget — one timeout in each of two runs, on tests that cost 350ms on dev, against zero
-  // timeouts in six dev runs. Put them back in front only with Windows evidence that the tail
-  // holds.
+  // The fixture check runs LAST, after the suite, and that ordering is load-bearing on
+  // Windows. Running it first put 48 workflow captures (a tree created and deleted each)
+  // immediately before a suite whose own slowest tests copy trees in %TEMP% and spawn
+  // `bun`/`git`: the suite stayed the same speed overall (median 0.87x of the same run on
+  // dev, 2612 tests compared) but its tail blew Bun's 5s per-test budget — one timeout in
+  // each of two runs, on tests that cost 350ms on dev, against zero timeouts in six dev runs.
+  // Put it back in front only with Windows evidence that the tail holds.
+  //
+  // The docs build is not here on purpose: Astro's CLI runs under Node, and this gate must
+  // run on a checkout that has only Bun. It stays a declared exclusion with its own CI job,
+  // path-filtered to the docs site — see NOT_IN_VALIDATE in validate-ci-parity.test.ts.
   {
     id: 'workflow-fixtures',
     label: 'Every workflow fixture reaches its expected outcome under dry-run',
     command: ['bun', 'run', 'cli', 'workflow', 'test'],
-  },
-  {
-    id: 'docs-build',
-    label: 'The docs site builds',
-    command: ['bun', 'run', 'build:docs'],
   },
 ];
 

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -9,7 +9,8 @@
  * left out of here, each with its reason.
  *
  * Checks run in declaration order and the run stops at the first failure, so the list is ordered
- * roughly cheapest first: a type error surfaces in seconds rather than after the test suite.
+ * roughly cheapest first: a type error surfaces in seconds rather than after the test suite. The
+ * two exceptions are the last two entries, and their comment says why they sit there.
  */
 import { resolve } from 'node:path';
 
@@ -76,16 +77,6 @@ export const VALIDATE_CHECKS: readonly ValidateCheck[] = [
     command: ['bun', 'run', 'format:check'],
   },
   {
-    id: 'workflow-fixtures',
-    label: 'Every workflow fixture reaches its expected outcome under dry-run',
-    command: ['bun', 'run', 'cli', 'workflow', 'test'],
-  },
-  {
-    id: 'docs-build',
-    label: 'The docs site builds',
-    command: ['bun', 'run', 'build:docs'],
-  },
-  {
     id: 'installer',
     label: 'Install script, against a mocked download',
     command: ['bun', 'run', 'test:install'],
@@ -97,6 +88,24 @@ export const VALIDATE_CHECKS: readonly ValidateCheck[] = [
     id: 'tests',
     label: 'Test suite, per-package isolation preserved',
     command: ['bun', 'run', 'test'],
+  },
+  // The two heavy filesystem checks run LAST, after the suite, and that ordering is
+  // load-bearing on Windows. Running them first put 48 workflow captures (a tree created and
+  // deleted each) and an Astro build immediately before a suite whose own slowest tests copy
+  // trees in %TEMP% and spawn `bun`/`git`: the suite stayed the same speed overall (median
+  // 0.87x of the same run on dev, 2612 tests compared) but its tail blew Bun's 5s per-test
+  // budget — one timeout in each of two runs, on tests that cost 350ms on dev, against zero
+  // timeouts in six dev runs. Put them back in front only with Windows evidence that the tail
+  // holds.
+  {
+    id: 'workflow-fixtures',
+    label: 'Every workflow fixture reaches its expected outcome under dry-run',
+    command: ['bun', 'run', 'cli', 'workflow', 'test'],
+  },
+  {
+    id: 'docs-build',
+    label: 'The docs site builds',
+    command: ['bun', 'run', 'build:docs'],
   },
 ];
 

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -1,0 +1,212 @@
+/**
+ * The repository's pre-pull-request gate.
+ *
+ * `VALIDATE_CHECKS` is the single declaration of what that gate runs. `bun run validate` runs
+ * every check; a CI job that gates one of them selects it by id with `--only`. Nothing in
+ * `.github/workflows/` restates a command, so the gate a contributor runs and the gate a pull
+ * request must pass cannot describe different work — `scripts/validate-ci-parity.test.ts` is the
+ * mechanism that keeps that true, and it also holds the list of PR-gating commands deliberately
+ * left out of here, each with its reason.
+ *
+ * Checks run in declaration order and the run stops at the first failure, so the list is ordered
+ * roughly cheapest first: a type error surfaces in seconds rather than after the test suite.
+ */
+import { resolve } from 'node:path';
+
+export interface ValidateCheck {
+  /** Stable identifier. CI selects checks by it, so treat it as a contract. */
+  id: string;
+  /** What the check proves. Printed as the step header. */
+  label: string;
+  /** Argv, run from the repository root. */
+  command: readonly string[];
+  /** Why the check cannot run on Windows. Printed when it is skipped there. */
+  skipOnWindows?: string;
+}
+
+export const VALIDATE_CHECKS: readonly ValidateCheck[] = [
+  {
+    id: 'cli-import-boundary',
+    label: 'CLI import boundaries',
+    command: ['bun', 'run', 'check:cli-import-boundary'],
+  },
+  {
+    id: 'bundled-defaults',
+    label: 'Bundled workflow and command defaults are regenerated',
+    command: ['bun', 'run', 'check:bundled'],
+  },
+  {
+    id: 'bundled-skill',
+    label: 'Bundled CLI skill is regenerated',
+    command: ['bun', 'run', 'check:bundled-skill'],
+  },
+  {
+    id: 'bundled-schema',
+    label: 'Bundled workflow schema is regenerated',
+    command: ['bun', 'run', 'check:bundled-schema'],
+  },
+  {
+    id: 'pi-vendor-map',
+    label: 'Pi vendor map is regenerated',
+    command: ['bun', 'run', 'check:pi-vendor-map'],
+  },
+  {
+    id: 'capability-matrix',
+    label: 'Provider capability matrix is regenerated',
+    command: ['bun', 'run', 'check:capability-matrix'],
+  },
+  {
+    id: 'api-types',
+    label: 'Generated API types match the schemas',
+    command: ['bun', 'run', 'check:api-types'],
+  },
+  {
+    id: 'type-check',
+    label: 'TypeScript across every package and script project',
+    command: ['bun', 'run', 'type-check'],
+  },
+  {
+    id: 'lint',
+    label: 'ESLint, warnings included',
+    command: ['bun', 'run', 'lint', '--max-warnings', '0'],
+  },
+  {
+    id: 'format',
+    label: 'Prettier formatting',
+    command: ['bun', 'run', 'format:check'],
+  },
+  {
+    id: 'marketplace-lint',
+    label: 'Marketplace entries resolve at their pinned SHAs (reaches github.com)',
+    command: ['bun', 'packages/docs-web/scripts/lint-marketplace.ts'],
+  },
+  {
+    id: 'workflow-fixtures',
+    label: 'Every workflow fixture reaches its expected outcome under dry-run',
+    command: ['bun', 'run', 'cli', 'workflow', 'test'],
+  },
+  {
+    id: 'docs-build',
+    label: 'The docs site builds',
+    command: ['bun', 'run', 'build:docs'],
+  },
+  {
+    id: 'installer',
+    label: 'Install script, against a mocked download',
+    command: ['bun', 'run', 'test:install'],
+    // scripts/install.sh refuses MINGW/MSYS by design (Windows users are directed to WSL2),
+    // so the installer test cannot pass in a Windows shell — in CI or on a contributor's machine.
+    skipOnWindows: 'scripts/install.sh is POSIX-only and refuses to run under MINGW/MSYS',
+  },
+  {
+    id: 'tests',
+    label: 'Test suite, per-package isolation preserved',
+    command: ['bun', 'run', 'test'],
+  },
+];
+
+const REPO_ROOT = resolve(import.meta.dir, '..');
+
+/** Ids in declaration order, so `--only` cannot reorder the run. */
+export function selectChecks(only: readonly string[]): ValidateCheck[] {
+  if (only.length === 0) return [...VALIDATE_CHECKS];
+  const requested = new Set(only);
+  const unknown = only.filter(id => !VALIDATE_CHECKS.some(check => check.id === id));
+  if (unknown.length > 0) {
+    throw new Error(
+      [
+        `Unknown check id: ${unknown.join(', ')}`,
+        `Known ids: ${VALIDATE_CHECKS.map(check => check.id).join(', ')}`,
+      ].join('\n')
+    );
+  }
+  return VALIDATE_CHECKS.filter(check => requested.has(check.id));
+}
+
+/**
+ * `--only <id>[,<id>]` selects checks and may repeat. Any other argument is rejected rather
+ * than ignored, because a CI job passing one would otherwise report green on a run that
+ * checked something other than what the job's author asked for.
+ */
+export function parseOnly(argv: readonly string[]): string[] {
+  const only: string[] = [];
+  for (let index = 0; index < argv.length; index++) {
+    const argument = argv[index];
+    const inlineValue = argument.startsWith('--only=') ? argument.slice('--only='.length) : null;
+    const value = inlineValue ?? (argument === '--only' ? argv[++index] : undefined);
+    if (value === undefined || value.length === 0) {
+      const problem = argument === '--only' ? '--only needs a check id' : 'unsupported argument';
+      throw new Error(`${problem}: ${argument}\nUsage: bun run validate [--only <id>[,<id>...]]`);
+    }
+    only.push(...value.split(',').filter(id => id.length > 0));
+  }
+  return only;
+}
+
+function formatDuration(milliseconds: number): string {
+  const seconds = milliseconds / 1000;
+  if (seconds < 60) return `${seconds.toFixed(1)}s`;
+  return `${String(Math.floor(seconds / 60))}m ${(seconds % 60).toFixed(0)}s`;
+}
+
+interface CheckResult {
+  check: ValidateCheck;
+  milliseconds: number;
+  skipped: boolean;
+}
+
+async function main(): Promise<number> {
+  const checks = selectChecks(parseOnly(Bun.argv.slice(2)));
+  const onWindows = process.platform === 'win32';
+  const results: CheckResult[] = [];
+  const startedAt = Date.now();
+
+  for (const check of checks) {
+    if (onWindows && check.skipOnWindows !== undefined) {
+      console.log(`\n=== SKIP ${check.id} — ${check.skipOnWindows} ===\n`);
+      results.push({ check, milliseconds: 0, skipped: true });
+      continue;
+    }
+
+    console.log(`\n=== ${check.id} — ${check.label} ===`);
+    console.log(`$ ${check.command.join(' ')}\n`);
+    const checkStartedAt = Date.now();
+    const child = Bun.spawn([...check.command], {
+      cwd: REPO_ROOT,
+      stdin: 'inherit',
+      stdout: 'inherit',
+      stderr: 'inherit',
+    });
+    const exitCode = await child.exited;
+    const milliseconds = Date.now() - checkStartedAt;
+
+    if (exitCode !== 0) {
+      console.error(
+        [
+          '',
+          `validate failed: ${check.id} exited ${String(exitCode)} after ${formatDuration(milliseconds)}.`,
+          `Re-run just this check with: bun run validate --only ${check.id}`,
+        ].join('\n')
+      );
+      return exitCode;
+    }
+    results.push({ check, milliseconds, skipped: false });
+  }
+
+  const total = Date.now() - startedAt;
+  console.log(`\n=== validate passed in ${formatDuration(total)} ===`);
+  for (const result of results) {
+    const detail = result.skipped ? 'skipped' : formatDuration(result.milliseconds);
+    console.log(`  ${result.check.id.padEnd(22)} ${detail}`);
+  }
+  return 0;
+}
+
+if (import.meta.main) {
+  try {
+    process.exit(await main());
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Problem and outcome

`bun run validate` is what `AGENTS.md` and `CONTRIBUTING.md` tell you to run before opening a pull request, but it reproduced exactly one of the four PR-gating CI jobs. A change to dry-run or the docs site passed `validate` clean and only failed after a push — the case in #3290 was a `simulateLoopGroup` change that broke four `archon-deliver` fixtures, reproducible locally in about twenty seconds by a command that was not in the list. CI also restated `validate`'s twelve commands as twelve steps of its own, so the two could describe different work without anything failing.

- **Outcome:** `bun run validate` runs the workflow fixtures alongside its existing checks, and CI's `test` job runs `bun run validate` instead of its own copy of the list. A broken fixture now fails `validate` locally.
- **Invariant:** one declaration of what the gate runs. `scripts/validate.ts` owns it; every PR-gating workflow either calls that script or is listed as a deliberate exclusion with its reason.
- **Scope boundary:** the two PostgreSQL jobs and the Docker image build stay out — they need a service or daemon a contributor may not have. The marketplace lint and the docs build join them, against the issue's plan, each for a measured reason (below). Those exclusions are now written down instead of implied.

## Review guidance

- **Feedback requested:** two judgement calls, both evidenced below and both cheap to reverse — excluding the marketplace lint, and running the two filesystem-heavy checks after the test suite rather than before it.
- **Start here:** `scripts/validate.ts` — the ordered check list, and the only place a command is written.
- **Review order:** `scripts/validate.ts`, then `scripts/validate-ci-parity.test.ts` (the drift mechanism and the exclusion list), then `.github/workflows/test.yml`, then `CONTRIBUTING.md`, then the `fixture-runner.ts` fix.
- **Known risk or uncertainty:** the Windows leg is red, on a test-timeout tail that predates this change and that this change makes reproducible. Everything else passes on both legs. Read "What the Windows leg found" before merging — this is not ready without a decision there.

## Solution

`scripts/validate.ts` holds one ordered array of checks, each with a stable id, the argv to run, and — for the installer test — the reason it cannot run on Windows. `bun run validate` runs all of them and stops at the first failure; `bun run validate --only <id>` runs a subset. CI selects by id rather than restating a command:

| job | before | after |
| --- | --- | --- |
| `test` | twelve named steps | `bun run validate` |
| `workflow-fixtures` | `bun run cli workflow test --json` | `bun run validate --only workflow-fixtures` |
| `docs-build` | `bun run build:docs` | unchanged — a declared exclusion |
| `marketplace-lint` | `bun packages/docs-web/scripts/lint-marketplace.ts` | unchanged — a declared exclusion |

The three jobs keep their triggers and path filters. `docs-build` and `marketplace-lint` still run on documentation-only pull requests, where `should-run-test-suite.ts` skips the `test` job; `workflow-fixtures` keeps its fast dedicated signal. What changed is only where the fixtures command is written down.

`scripts/validate-ci-parity.test.ts` is what makes drift fail: every Bun command in a `pull_request`-triggered workflow must be `bun run validate`, a dependency install, or an entry in `NOT_IN_VALIDATE` carrying what it needs that a contributor may not have. `CONTRIBUTING.md` carries the same five jobs in prose with the command to run each one yourself. Adding a gate without deciding which side it belongs to fails the test.

The installer test's `if: runner.os != 'Windows'` moved into the check list as `skipOnWindows`, with the same reason (`scripts/install.sh` refuses MINGW/MSYS by design), so one command works on both matrix legs and the skip is visible in the log.

### Why the docs build is excluded

It was in for two rounds. Astro's CLI runs under Node, not Bun, so putting the build in `validate` made Node a requirement of the gate every agent and contributor runs, and CI's `test` job had to grow a Node setup step to match. The pack's implement and validate prompts invoke the documented aggregate command several times per run, so every delivery paid an Astro build that says nothing about the change unless it touched `packages/docs-web`. `docs-build.yml` already runs the same build, path-filtered to the docs site, with the Node it needs. It is now a declared exclusion with that reason, and the Node setup is gone from `test.yml`.

### Why the marketplace lint is excluded

The issue included it because it "needs nothing a contributor does not already have". That turned out to be false, and the cost lands on the gate everyone runs. The lint verifies nine `/tree/` entries through the unauthenticated github.com API, which allows 60 requests per hour per IP. After a morning of `validate` runs on one machine:

```
$ curl -s https://api.github.com/rate_limit   →   {limit: 60, remaining: 0, used: 60}

  ✗ [archon-comprehensive-mr-review] Directory not found at pinned SHA: … (HTTP 403)
  … 9 errors
Marketplace lint FAILED — 9 error(s) found.
validate failed: marketplace-lint exited 1 after 0.4s.
```

Six `validate` runs in an hour is enough — and this repository routinely has several agent worktrees running it on one machine. A gate that goes red for someone else's quota is a gate people stop trusting. It is now a declared exclusion beside the PostgreSQL and Docker jobs, and `validate` needs no network again.

### Why the two new checks run last

They ran ahead of the suite until the Windows leg objected; see "What the Windows leg found". The
ordering did **not** turn out to be the cause, and it is kept only because it costs nothing. Every
check still runs on both legs. The cost is that a broken fixture reports after the test suite rather
than before it, about a minute later; `bun run validate --only workflow-fixtures` remains the
twenty-second loop for anyone iterating on fixtures.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | `bun run validate` ran twelve checks; the fixtures ran only in CI | `bun run validate` runs thirteen checks and prints what each one cost |
| **Failure behavior** | A broken fixture passed locally and failed after a push | `validate failed: workflow-fixtures exited 1 after 18.5s. Re-run just this check with: bun run validate --only workflow-fixtures` |

## Validation

### Runtime — what the gate now costs

Measured on an Apple M3 Pro (11 cores, 18 GB, macOS 26.6.2), warm checkout, each pair run back to back so both halves share the same machine load. "Before" is the twelve pre-change checks selected with `--only`, which is the same twelve commands in the same order.

| | Before | After | Delta |
| --- | --- | --- | --- |
| Quiet machine | **1m 55s** | **2m 24s** | +29s |
| Machine under load | **2m 19s** | **2m 57s** | +38s |

Per-check cost, from the two runs: **workflow fixtures 18.4s / 26.6s**, docs build 9.6s / 12.7s (now excluded), marketplace lint 0.4s (now excluded).

A third pair on 11 September on an M3 Pro carrying four Archon runs (load average ~5): dev `validate` 1m 48s, this branch with both additions 2m 17s, of which fixtures 17.2s and docs build 8.7s. With only the fixtures kept, the gate grows by about 17 seconds, or 15%, on a two-minute baseline. That is well inside what someone will sit through, so **no `validate:quick` split** — a split gate people run the fast half of is how this gap comes back. The runner prints the per-check table on every run, so the next person deciding whether to keep the gate can see where the time goes without re-deriving it.

### Acceptance 1 — the additions run

```
=== validate passed in 2m 57s ===
  cli-import-boundary    0.6s      format                15.0s
  bundled-defaults       0.1s      installer              4.0s
  bundled-skill          0.0s      tests                 58.3s
  bundled-schema         0.0s      workflow-fixtures     26.6s
  pi-vendor-map          0.0s
  capability-matrix      0.1s
  api-types              0.7s
  type-check            46.9s
  lint                  11.7s
```

### Acceptance 2 — a broken fixture fails `validate` locally, observed rather than asserted

`.archon/workflows/sdlc/deliver/fixtures/clean.stubs.yaml` was changed to `expect: paused` and the full gate run:

```
✘ sdlc/deliver/fixtures/clean.stubs.yaml → archon-deliver
    expected paused, dry-run reported completed
47 passed, 1 failed

validate failed: workflow-fixtures exited 1 after 18.5s.
Re-run just this check with: bun run validate --only workflow-fixtures
```

Exit code 1. The fixture was restored; it is unchanged in this diff.

### Acceptance 3 — the exclusions are explicit

`CONTRIBUTING.md` names `schema-upgrade`, `postgres-parity`, `docker-build` and `marketplace-lint`, what each needs, and how to run it; `AGENTS.md` points at that list; `NOT_IN_VALIDATE` in the parity test carries the same four with their reasons.

### Acceptance 4 — drift fails something

Each assertion was watched red before being trusted:

| Probe | Test that failed |
| --- | --- |
| `bun run type-check` re-added as a step in the `test` job | every Bun command in a PR-gating workflow runs through validate or is declared |
| `--only docs_build` typo in `docs-build.yml` | every `--only` id names a check that exists |
| `test` job narrowed to `bun run validate --only lint` | every check validate runs is gated by CI (listed the ungated ids) |
| `bun run check:schema-upgrades` removed from CI | every declared exclusion is still a command CI runs |

### What the Windows leg found

Running these checks on Windows for the first time produced two findings: one bug, fixed here, and
one open problem that is bigger than this pull request.

**A real bug in the fixture runner, fixed here.** Three `archon-ship` fixtures failed their
`resolved-text-contains` declaration on Windows and nowhere else. A command markdown file is read as
raw text, so `* text=auto` gives a Windows checkout CRLF inside it, while a fixture spells its
expectation with `\n` escapes that stay LF. `fixture-runner.ts` now compares with line endings
normalized, and `fixture-runner.test.ts` reproduces the failure on any platform — with the fix
reverted it fails with exactly the message CI produced. Workflow YAML was never affected: the YAML
parser normalizes its own line breaks, which is why the test drives the command-file path. Fixtures
now report `48 passed, 0 failed` on Windows, twice.

**One test per run then times out, and this is still open.** Three Windows runs, three different
victims, each on Bun's default 5000ms budget and each a test that spawns processes and copies trees
in `%TEMP%`:

| run | test | on dev's Windows leg | here |
| --- | --- | --- | --- |
| 1 | `captureWorkflowSource > replaces a stale capture…` | 351.9ms | **9625.6ms** |
| 2 | `generate-bundled-defaults > exits 1 and leaves the bundle untouched…` | ≤1842.9ms | **7995.7ms** |
| 3 | `downloadWebDist > leaves nothing behind when tar exits non-zero` | 1680.6ms | **5823.8ms** |

The suite is not broadly slower — that is the striking part. Matching tests by name against dev's
Windows leg, the median ratio is **0.85–0.87** and the totals are lower: these runs are *faster*
overall. Only the tail moves, by 3× to 27×, and whichever default-budget test has the least headroom
that run is the one that dies. Control: **six recent dev Windows legs, zero 5000ms timeouts; this
branch, one in each of three runs.**

**My hypothesis was that the new checks caused it, and run 3 disproved that.** The theory was that 48
workflow captures and an Astro build immediately before the suite left Windows IO busy. So the two
checks were moved after the suite — and run 3 still timed out, 15.8 seconds into a test step that had
executed neither of them. Whatever is happening is not IO left behind by the fixtures or the docs
build. What still differs from dev's job is smaller: it runs the checks as one `Validate` step
rather than twelve. The Node setup this job had grown is gone with the docs build; the Windows
run after that change is the experiment.

### A finding that outlives this PR

The Windows leg has less slack than it looks. Both tests that timed out run on Bun's **default 5000ms** budget and cost **352ms** and **≤1.8s** on dev — so a 3× to 14× headroom, which one bad run ate. (The 8–16 tests per Windows run that already exceed four seconds are a different population: they pass because they declare their own longer budgets. The exposure is in the fast default-budget tests, not the slow declared-budget ones.) Method, if anyone wants to re-derive it: pull the Windows job log with `gh api repos/coleam00/Archon/actions/jobs/<id>/logs`, extract `(pass|fail) <name> [<ms>]` per test, and join two runs by test name.

Any pull request that adds IO to the `test` job can tip one of those over, and it will look like a flake in someone else's test. #3290 did not create this; running more in that job is what made it visible. It is worth its own issue rather than a line in this one.

**Windows, after the docs build left.** The first run at `0375d2c28`, with the Node setup gone and
the checks otherwise unchanged, passed on both legs: `test (windows-latest)` green in 11m 34s with
zero 5000 ms timeouts in the job log, `validate` itself reporting `passed in 9m 26s` there. One run
is a sample, not a proof, and the headroom finding above still stands on its own; it is recorded on
#3294. Every other job passes on both legs: ubuntu, the fixtures job, the docs build (its own job,
as before), both PostgreSQL jobs, and the Docker build.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Rollout / rollback | No job was renamed or removed, so required-check names are unchanged | `.github/workflows/test.yml` diff |
| Observability | `validate` prints a per-check duration summary, so a slow check is visible rather than inferred | Runtime section |
| Documentation / communication | `CONTRIBUTING.md` rewritten around the one command and its exclusions; `AGENTS.md` and `.claude/commands/validate.md` updated — the latter listed four commands as "equivalent to" `validate`, which had been false for some time | diff |

## Links

- Closes #3290
- Related #2283
