### PR TITLE
fix(workflows): a wait's completion rows have one owner on both paths

### DIFF
--- a/packages/core/src/db/workflows.ts
+++ b/packages/core/src/db/workflows.ts
@@ -38,7 +38,7 @@ import type {
   WorkflowWaitPause,
   NodeStateEventInput,
 } from '@archon/workflows/store';
-import { FAN_OUT_CANCEL_REASONS } from '@archon/workflows/store';
+import { FAN_OUT_CANCEL_REASONS, waitCompletionEvents } from '@archon/workflows/store';
 
 /** Best-effort ROLLBACK — log but swallow errors since we're already in an error path. */
 function rollback(): Promise<void> {
@@ -1547,25 +1547,10 @@ export async function clearWorkflowWaitContext(
         [id, waitContext.nodeId, cursor]
       );
       if ((result.rowCount ?? 0) === 0) return { cleared: false };
-      await insertWorkflowEvent(query, {
-        workflow_run_id: id,
-        event_type: completion.result.status === 'expired' ? 'wait_expired' : 'wait_completed',
-        step_name: completion.stepName,
-        data: completion.result,
-      });
-      const nodeEvent: NodeStateEventInput = {
-        workflow_run_id: id,
-        event_type: 'node_completed',
-        step_name: completion.stepName,
-        data: {
-          type: 'wait',
-          duration_ms: completion.result.waited_ms,
-          node_output: JSON.stringify(completion.result),
-          structured_output: completion.result,
-        },
-      };
-      await insertWorkflowEvent(query, nodeEvent);
-      return { cleared: true, nodeEvent };
+      const rows = waitCompletionEvents(id, completion);
+      await insertWorkflowEvent(query, rows.outcome);
+      await insertWorkflowEvent(query, rows.node);
+      return { cleared: true, nodeEvent: rows.node };
     });
   } catch (error) {
     const err = error as Error;

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -64,7 +64,8 @@
     [
       "src/logger.test.ts",
       "src/terminal-status-write.test.ts",
-      "src/node-event-write.test.ts"
+      "src/node-event-write.test.ts",
+      "src/wait-completion-events.test.ts"
     ],
     [
       "src/condition-evaluator.test.ts"

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -145,6 +145,7 @@ import {
 import { OutputRefError } from './output-ref';
 import type { WorkflowDeps, IWorkflowPlatform, WorkflowConfig } from './deps';
 import type { IWorkflowStore, PersistedNodeOutput } from './store';
+import { waitCompletionEvents } from './store';
 import {
   buildInstanceSnapshots,
   composeFanOutScopeSegment,
@@ -247,12 +248,7 @@ function createMockStore(): MockWorkflowStore {
     clearWorkflowWaitContext: mock<IWorkflowStore['clearWorkflowWaitContext']>(
       async (id, _waitContext, completion) => ({
         cleared: true,
-        nodeEvent: {
-          workflow_run_id: id,
-          event_type: 'node_completed',
-          step_name: completion.stepName,
-          data: { type: 'wait', duration_ms: completion.result.waited_ms },
-        },
+        nodeEvent: waitCompletionEvents(id, completion).node,
       })
     ),
     rewriteApprovalContext: mock<IWorkflowStore['rewriteApprovalContext']>(

--- a/packages/workflows/src/dag-executor.ts
+++ b/packages/workflows/src/dag-executor.ts
@@ -101,7 +101,7 @@ import type { BindingDirective } from './schemas';
 import { mapNodeTemplateSlots } from './template-walker';
 import { buildExecNodeEnvironment } from './exec-environment';
 import { planGraph, resolvedBodyNodes } from './graph-plan';
-import { FAN_OUT_CANCEL_REASONS } from './store';
+import { FAN_OUT_CANCEL_REASONS, waitCompletionEvents } from './store';
 import type { DagResumeSnapshot, FanOutCancelReason, PersistedNodeOutput } from './store';
 import { formatToolCall } from './utils/tool-formatter';
 import { createLogger, captureWorkflowCompleted } from '@archon/paths';
@@ -7312,23 +7312,9 @@ async function executeWaitNode(
     // handed it back; the transcript and emitter derive from that row, not a rebuilt one.
     await recordDerivedNodeState({ logDir }, node, outcome.nodeEvent);
   } else {
-    await deps.store.createWorkflowEvent({
-      workflow_run_id: workflowRun.id,
-      event_type: status === 'expired' ? 'wait_expired' : 'wait_completed',
-      step_name: stepName,
-      data: result,
-    });
-    await recordNodeState({ store: deps.store, logDir }, node, {
-      workflow_run_id: workflowRun.id,
-      event_type: 'node_completed',
-      step_name: stepName,
-      data: {
-        type: 'wait',
-        duration_ms: result.waited_ms,
-        node_output: output,
-        structured_output: result,
-      },
-    });
+    const rows = waitCompletionEvents(workflowRun.id, { stepName, result });
+    await deps.store.createWorkflowEvent(rows.outcome);
+    await recordNodeState({ store: deps.store, logDir }, node, rows.node);
   }
   return {
     state: 'completed',

--- a/packages/workflows/src/store.ts
+++ b/packages/workflows/src/store.ts
@@ -192,6 +192,39 @@ export type ObservabilityEventInput = WorkflowEventInput<
   Exclude<WorkflowEventType, NodeStateEventType>
 >;
 
+/**
+ * The two rows a wait's completion produces: the wait outcome for observability and
+ * the node's own completed state. A wait completes on one of two paths, in the same
+ * tick inside the executor or on resume inside the store's cursor-clearing
+ * transaction, and both paths must write the same rows for the same result. This is
+ * the only place that knows their shape.
+ */
+export function waitCompletionEvents(
+  workflowRunId: string,
+  completion: WorkflowWaitCompletion
+): { outcome: ObservabilityEventInput; node: NodeStateEventInput } {
+  const { stepName, result } = completion;
+  return {
+    outcome: {
+      workflow_run_id: workflowRunId,
+      event_type: result.status === 'expired' ? 'wait_expired' : 'wait_completed',
+      step_name: stepName,
+      data: result,
+    },
+    node: {
+      workflow_run_id: workflowRunId,
+      event_type: 'node_completed',
+      step_name: stepName,
+      data: {
+        type: 'wait',
+        duration_ms: result.waited_ms,
+        node_output: JSON.stringify(result),
+        structured_output: result,
+      },
+    },
+  };
+}
+
 export const FAN_OUT_CANCEL_REASONS = [
   'fan_out_gate',
   'fan_out_sibling',
@@ -354,10 +387,10 @@ export interface IWorkflowStore extends IRunTreeStore, IWorkflowRunNodeSessionSt
     error: string
   ): Promise<{ failed: boolean }>;
   /**
-   * Consume the exact wait cursor and persist its completion snapshot atomically. The
-   * node's `node_completed` row is written inside that transaction, so the store hands
-   * it back: the caller derives the transcript and emitter from the row that exists
-   * rather than rebuilding it (#3255).
+   * Consume the exact wait cursor and persist its completion snapshot atomically. Both
+   * rows come from `waitCompletionEvents`, and the node's `node_completed` row is
+   * handed back so the caller derives the transcript and emitter from the row that
+   * exists rather than rebuilding it (#3255).
    */
   clearWorkflowWaitContext(
     id: string,

--- a/packages/workflows/src/subrun.test.ts
+++ b/packages/workflows/src/subrun.test.ts
@@ -164,7 +164,8 @@ import { captureWorkflowSource, resolveRunSourceCapture } from './workflow-sourc
 import { discoverWorkflows } from './workflow-discovery';
 import { validateWorkflowResources } from './validator';
 import type { WorkflowDeps, IWorkflowPlatform, WorkflowConfig } from './deps';
-import type { IWorkflowStore, NodeStateEventInput } from './store';
+import type { IWorkflowStore } from './store';
+import { waitCompletionEvents } from './store';
 import type { WorkflowRun, WorkflowWaitContext } from './schemas/workflow-run';
 import type { ResolvedWorkflow } from './schemas/workflow';
 import type { WorkflowRunConfigMetadata } from './schemas/run-config';
@@ -397,25 +398,9 @@ class InMemoryStore implements IWorkflowStore {
       r.metadata = metadata;
       // Mirror the real store: both rows land in the same transaction as the cursor
       // clear, and the node row is handed back so the caller derives its sinks from it.
-      this.events.push({
-        workflow_run_id: id,
-        event_type: completion.result.status === 'expired' ? 'wait_expired' : 'wait_completed',
-        step_name: completion.stepName,
-        data: completion.result,
-      });
-      const nodeEvent: NodeStateEventInput = {
-        workflow_run_id: id,
-        event_type: 'node_completed',
-        step_name: completion.stepName,
-        data: {
-          type: 'wait',
-          duration_ms: completion.result.waited_ms,
-          node_output: JSON.stringify(completion.result),
-          structured_output: completion.result,
-        },
-      };
-      this.events.push(nodeEvent);
-      return Promise.resolve({ cleared: true, nodeEvent });
+      const rows = waitCompletionEvents(id, completion);
+      this.events.push(rows.outcome, rows.node);
+      return Promise.resolve({ cleared: true, nodeEvent: rows.node });
     }
     return Promise.resolve({ cleared: false });
   };

--- a/packages/workflows/src/wait-completion-events.test.ts
+++ b/packages/workflows/src/wait-completion-events.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'bun:test';
+import { readFile, readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { waitCompletionEvents } from './store';
+
+const satisfied = {
+  stepName: 'await-ci',
+  result: { status: 'satisfied', waited_ms: 4200 } as const,
+};
+
+describe('waitCompletionEvents', () => {
+  it('derives both rows from one result', () => {
+    const rows = waitCompletionEvents('run-1', satisfied);
+    expect(rows.outcome).toEqual({
+      workflow_run_id: 'run-1',
+      event_type: 'wait_completed',
+      step_name: 'await-ci',
+      data: satisfied.result,
+    });
+    expect(rows.node).toEqual({
+      workflow_run_id: 'run-1',
+      event_type: 'node_completed',
+      step_name: 'await-ci',
+      data: {
+        type: 'wait',
+        duration_ms: 4200,
+        node_output: JSON.stringify(satisfied.result),
+        structured_output: satisfied.result,
+      },
+    });
+  });
+
+  it('an expired event wait records wait_expired and still completes the node', () => {
+    const rows = waitCompletionEvents('run-2', {
+      stepName: 'await-signal',
+      result: { status: 'expired', waited_ms: 60000, event: 'ci.concluded' },
+    });
+    expect(rows.outcome.event_type).toBe('wait_expired');
+    expect(rows.node.event_type).toBe('node_completed');
+    expect(rows.node.data?.duration_ms).toBe(60000);
+  });
+
+  it('is the only place that spells the wait node row, in either package', async () => {
+    // The same-tick path (executor) and the resumed path (core store) both write this
+    // row. A second spelling anywhere is the hand-synced pair this owner removes.
+    const here = join(import.meta.dir);
+    const workflowSources = (await readdir(here))
+      .filter(name => name.endsWith('.ts') && !name.endsWith('.test.ts'))
+      .map(name => join(here, name));
+    const coreStore = join(here, '..', '..', 'core', 'src', 'db', 'workflows.ts');
+    const spellings: string[] = [];
+    for (const file of [...workflowSources, coreStore]) {
+      const source = await readFile(file, 'utf8');
+      if (/type: 'wait',/.test(source)) spellings.push(file);
+    }
+    expect(spellings).toEqual([join(here, 'store.ts')]);
+  });
+});

--- a/packages/workflows/src/wait-completion-events.test.ts
+++ b/packages/workflows/src/wait-completion-events.test.ts
@@ -42,16 +42,20 @@ describe('waitCompletionEvents', () => {
 
   it('is the only place that spells the wait node row, in either package', async () => {
     // The same-tick path (executor) and the resumed path (core store) both write this
-    // row. A second spelling anywhere is the hand-synced pair this owner removes.
+    // row. A second spelling anywhere is the hand-synced pair this owner removes. The
+    // row is recognised by its first two keys together: `type: 'wait'` alone also names
+    // the wait node kind elsewhere (the ignored-fields table in schemas/dag-node.ts).
     const here = join(import.meta.dir);
-    const workflowSources = (await readdir(here))
+    const workflowSources = (await readdir(here, { recursive: true }))
+      .map(String)
       .filter(name => name.endsWith('.ts') && !name.endsWith('.test.ts'))
       .map(name => join(here, name));
     const coreStore = join(here, '..', '..', 'core', 'src', 'db', 'workflows.ts');
+    const waitRow = /type:\s*'wait',\s*duration_ms\s*:/;
     const spellings: string[] = [];
     for (const file of [...workflowSources, coreStore]) {
       const source = await readFile(file, 'utf8');
-      if (/type: 'wait',/.test(source)) spellings.push(file);
+      if (waitRow.test(source)) spellings.push(file);
     }
     expect(spellings).toEqual([join(here, 'store.ts')]);
   });


### PR DESCRIPTION
## Problem and outcome

A wait node completes on two paths: in the same tick inside the executor, or on resume inside the store's cursor-clearing transaction. Each path spelled the wait outcome row and the node's `node_completed` row by hand, so the two could drift and the same logical event would leave different rows depending on which path ran. #3275 removed one such pair on the resumed path; this is the other one.

- **Outcome:** both rows come from one function, `waitCompletionEvents` in the workflows store module. Core inserts what it returns, the executor's same-tick branch records what it returns, and the test fakes use it too. A guard proves no other file in either package spells the row.
- **Invariant:** persisted `data` payloads are byte-identical to before; the store contract's return shape is unchanged; the resume wire format is untouched.
- **Scope boundary:** no other event row gains an owner here. The observability and node-state event vocabularies stay as they are (#2393, #2398).
- **Root cause:** the row shape had no owner. `WorkflowWaitCompletion` typed the store's input, but the rows derived from it were untyped records written out at each site.

## Review guidance

- **Feedback requested:** whether the owner belongs in `store.ts` beside `WorkflowWaitCompletion`, which is where both packages already import the wait types from.
- **Start here:** `packages/workflows/src/store.ts` — `waitCompletionEvents`, the only place that knows the two row shapes.
- **Review order:** `store.ts` (owner) → `packages/core/src/db/workflows.ts` (`clearWorkflowWaitContext` inserts and returns the owner's rows) → `packages/workflows/src/dag-executor.ts` (`executeWaitNode`'s same-tick branch) → the two fakes in `dag-executor.test.ts` and `subrun.test.ts` → `wait-completion-events.test.ts`.
- **Lower-attention areas:** the fakes, which now call the owner instead of restating the literal; covered by their own suites.
- **Known risk or uncertainty:** None.

## Solution

`waitCompletionEvents(workflowRunId, completion)` returns `{ outcome, node }`: the `wait_completed` or `wait_expired` observability row and the node's `node_completed` row, both built from one `WorkflowWaitCompletion`. `clearWorkflowWaitContext` inserts both inside its transaction and hands back `node`, as #3275 established. The executor's same-tick branch builds the same pair and writes them through `createWorkflowEvent` and `recordNodeState`. The guard test scans every non-test source in the workflows package plus core's store file for a second spelling of the row and expects exactly one file.

## Validation

- `bun run type-check` — clean across workspaces.
- `bun test src/wait-completion-events.test.ts` — 3 pass — proves both statuses derive the right rows and that only `store.ts` spells the row. Seen red first: with a second spelling added in a probe file the guard failed, then passed again once the probe was removed.
- `bun test src/dag-executor.test.ts` — 785 pass; `bun test src/subrun.test.ts` — 101 pass.
- `bun test src/db/workflows.test.ts` — 130 pass; `bun test src/db/workflows.resume-cas.integration.test.ts` — 54 pass, in `packages/core`.
- `bun run lint` — clean.
- **Not verified:** nothing material. Both paths and both storage engines' row shapes are covered by the suites above.

## Links

- Related #3275, #3255

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WWN4GE8VDRPBXbNPBStqf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of workflow wait completion records for both completed and expired waits.
  * Ensured wait nodes consistently retain result and duration details across execution paths.

* **Tests**
  * Added coverage for completed and expired wait outcomes, node completion records, and associated results.
  * Updated workflow execution tests to validate consistent wait completion records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->