### PR TITLE
fix(skills,providers): drop the last references to the env-leak gate #1135 removed

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -674,7 +674,7 @@ This will:
 - Verify the binary reports the correct version and `Build: binary`
 - Verify bundled workflows load
 - Verify the SDK spawn path works (a minimal assist workflow)
-- Verify the env-leak gate is active (if shipped in this release)
+- Verify the env-leak guard strips sensitive keys from a leaky .env (Test 4)
 - Uninstall cleanly
 - Produce a PASS/FAIL report
 

--- a/.claude/skills/test-release/SKILL.md
+++ b/.claude/skills/test-release/SKILL.md
@@ -301,7 +301,7 @@ Quickly verify the resolver fails loud when nothing is configured:
 
 If you *do* have `claudeBinaryPath` set globally, skip this test or temporarily rename `~/.archon/config.yaml`.
 
-### Test 4 — Env-leak gate refuses a leaky .env (optional, for releases including #1036/#1038/#983)
+### Test 4 — Env-leak guard strips sensitive keys from .env
 
 Create a second throwaway repo with a fake sensitive key:
 
@@ -475,7 +475,7 @@ Dev binary:   /Users/rasmus/.bun/bin/archon → ../install/.../cli.ts (unchanged
   [PASS]  Test 1  version reports 0.3.1, Build: binary, commit abc1234
   [PASS]  Test 2  workflow list returned 21 bundled workflows
   [PASS]  Test 3  workflow run assist produced output
-  [PASS]  Test 4  env-leak gate refused leaky .env with context-aware error
+  [PASS]  Test 4  env-leak guard stripped exactly the planted key
   [PASS]  Test 5  isolation list executed without errors
   [PASS]  Cleanup brew uninstall + untap clean, dev binary unchanged
 

--- a/.claude/skills/test-release/SKILL.md
+++ b/.claude/skills/test-release/SKILL.md
@@ -506,7 +506,7 @@ Dev binary:   /Users/rasmus/.bun/bin/archon (unchanged)
       Found 0 workflow(s):
 
   [SKIP]  Test 3  SDK test skipped because Test 2 failed
-  [SKIP]  Test 4  env-leak gate test skipped because Test 2 failed
+  [SKIP]  Test 4  env-leak guard test skipped because Test 2 failed
   [PASS]  Test 5  isolation list executed without errors
   [PASS]  Cleanup VPS binary removed
 

--- a/packages/providers/src/claude/provider.ts
+++ b/packages/providers/src/claude/provider.ts
@@ -1416,10 +1416,10 @@ export class ClaudeProvider implements IAgentProvider {
    * Send a query to Claude and stream responses.
    * Orchestrates option building, nodeConfig translation, streaming, and retry.
    */
-  // TODO(#1135): Pre-spawn env-leak gate was removed during provider extraction.
-  // Caller-side enforcement (orchestrator, dag-executor) is tracked in #1135.
-  // Providers must NOT implement security gates — the platform guarantees safety
-  // before a provider runs.
+  // No security gate lives here on purpose. Env hygiene for a target repo is
+  // structural (the platform strips what must not reach a subprocess before a
+  // provider runs), so a provider that scanned or refused would be a second,
+  // divergent copy of that policy.
   async *sendQuery(
     prompt: string,
     cwd: string,


### PR DESCRIPTION
## Problem and outcome

Issue #2375 flagged that Test 4 of the `test-release` skill asserted an env-leak **refusal** gate that #1135 deliberately removed and replaced with a strip-and-proceed guard. The test body was already corrected in #2437, but two prose spots in `.claude/skills/test-release/SKILL.md` still told testers that a leaky `.env` gets refused, contradicting what the released binary actually does.

- **Outcome:** No repo text still describes the removed refusal gate as current behavior. Test 4's heading, its example PASS and SKIP report lines, the release skill's step that invokes it, and a provider comment that promised gate work "tracked in #1135" now all describe what the binary does.
- **Invariant:** Test 4 must not describe refusal as current behavior; the strip-line assertion from #2437 stays exactly as-is.
- **Scope boundary:** The test body (already correct since #2437) and the intentional history note are untouched.

## Review guidance

- **Feedback requested:** The replacement wording, which mirrors the strip line the test already asserts.
- **Start here:** `.claude/skills/test-release/SKILL.md:304` — the Test 4 heading.
- **Review order:** Heading (line 304), the example PASS and SKIP reports (lines 478 and 509), the release skill step (`.claude/skills/release/SKILL.md:677`), then the comment above `sendQuery` in `packages/providers/src/claude/provider.ts`.
- **Known risk or uncertainty:** None. Prose and comment only; the text is verified against the strip message format emitted by `stripCwdEnv` in `packages/paths/src/strip-cwd-env.ts`.

## Solution

The env-leak guard (introduced in #1135, commit `a8ac3f0`) prints `[archon] stripped N keys from <repo> (.env)...` and proceeds; it does not refuse. Test 4's body has asserted that strip line since #2437, but the heading and the example PASS report in the same file still described the removed refusal gate. This PR rewrites those strings to describe the behavior the test actually asserts, and drops the obsolete `#1036/#1038/#983` references from the heading — those were the old gate's issues, and the transition itself is already recorded in the body's history note.

The run's review pass found two more members of the same set: the example SKIP line in the same file, and the release skill's step list, which told the operator to "verify the env-leak gate is active". Both now say "guard". A third stale pointer sat in code: a `TODO(#1135)` above `ClaudeProvider.sendQuery` promised caller-side enforcement "tracked in #1135", but that issue closed by removing the gate everywhere. The comment now states only the invariant that still holds (a provider carries no security gate) and drops the dead pointer.

## Behavior change

| | Before | After |
|---|---|---|
| **Test 4 heading** | `Env-leak gate refuses a leaky .env (optional, for releases including #1036/#1038/#983)` | `Env-leak guard strips sensitive keys from .env` |
| **Example PASS report** | `[PASS]  Test 4  env-leak gate refused leaky .env with context-aware error` | `[PASS]  Test 4  env-leak guard stripped exactly the planted key` |
| **Example SKIP report** | `[SKIP]  Test 4  env-leak gate test skipped because Test 2 failed` | `[SKIP]  Test 4  env-leak guard test skipped because Test 2 failed` |
| **Release skill step 12** | `Verify the env-leak gate is active (if shipped in this release)` | `Verify the env-leak guard strips sensitive keys from a leaky .env (Test 4)` |
| **`provider.ts` comment** | `TODO(#1135)` promising tracked enforcement work | the invariant only; no issue pointer |

## Validation

Prose and a code comment; no behavior changes. `grep -rn 'env-leak gate' .claude/skills/` returns nothing on the head. CI (type-check, lint, tests, fixtures) is green on every head, which covers the comment edit in `provider.ts`.

## Links

- Closes #2375


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated release-testing guidance to reflect current environment-variable protection behavior.
  - Clarified that sensitive keys are stripped from configuration files before workflows proceed.
  - Updated validation criteria, verification checklists, and example reports to match the stripping behavior.
  - Standardized terminology for environment-leak protection across testing and release documentation.
  - Removed references to the previous behavior where workflows were blocked by sensitive keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->