### PR TITLE
fix(pi): emit StringEnum tool params so manage_run works on Vertex

### DIFF
--- a/packages/providers/src/community/pi/native-tools.test.ts
+++ b/packages/providers/src/community/pi/native-tools.test.ts
@@ -49,4 +49,13 @@ describe('buildPiNativeToolDefinitions (Pi JSON-Schema → TypeBox)', () => {
       ])
     ).toThrow(/non-empty strings/);
   });
+
+  test('enum fields produce StringEnum shape (Google/Vertex compatible)', () => {
+    const defs = buildPiNativeToolDefinitions([
+      spec({ type: 'object', properties: { action: { type: 'string', enum: ['list', 'get'] } }, required: ['action'] }),
+    ]);
+    const params = (defs[0] as unknown as { parameters: Record<string, unknown> }).parameters;
+    const props = params.properties as Record<string, Record<string, unknown>>;
+    expect(props.action).toMatchObject({ type: 'string', enum: ['list', 'get'] });
+  });
 });

--- a/packages/providers/src/community/pi/native-tools.test.ts
+++ b/packages/providers/src/community/pi/native-tools.test.ts
@@ -52,7 +52,11 @@ describe('buildPiNativeToolDefinitions (Pi JSON-Schema → TypeBox)', () => {
 
   test('enum fields produce StringEnum shape (Google/Vertex compatible)', () => {
     const defs = buildPiNativeToolDefinitions([
-      spec({ type: 'object', properties: { action: { type: 'string', enum: ['list', 'get'] } }, required: ['action'] }),
+      spec({
+        type: 'object',
+        properties: { action: { type: 'string', enum: ['list', 'get'] } },
+        required: ['action'],
+      }),
     ]);
     const params = (defs[0] as unknown as { parameters: Record<string, unknown> }).parameters;
     const props = params.properties as Record<string, Record<string, unknown>>;

--- a/packages/providers/src/community/pi/native-tools.ts
+++ b/packages/providers/src/community/pi/native-tools.ts
@@ -1,7 +1,8 @@
-import { Type, type TObject, type TSchema } from '@sinclair/typebox';
-import { StringEnum } from '@earendil-works/pi-ai';
+import { Type, StringEnum, type TSchema } from '@earendil-works/pi-ai';
 import { defineTool, type ToolDefinition } from '@earendil-works/pi-coding-agent';
 import type { NativeTool } from '../../types';
+
+type TObject = ReturnType<typeof Type.Object>;
 
 function isString(v: unknown): v is string {
   return typeof v === 'string';
@@ -34,7 +35,7 @@ function jsonSchemaToTypeBox(schema: Record<string, unknown>): TObject {
       if (values.length === 0) {
         throw new Error(`native tool schema: enum for '${key}' must be non-empty strings`);
       }
-      field = StringEnum(values as [string, ...string[]]) as unknown as TSchema;
+      field = StringEnum(values as [string, ...string[]]);
     } else if (prop.type === 'string') {
       field = Type.String();
     } else if (prop.type === 'boolean') {

--- a/packages/providers/src/community/pi/native-tools.ts
+++ b/packages/providers/src/community/pi/native-tools.ts
@@ -1,4 +1,5 @@
 import { Type, type TObject, type TSchema } from '@sinclair/typebox';
+import { StringEnum } from '@earendil-works/pi-ai';
 import { defineTool, type ToolDefinition } from '@earendil-works/pi-coding-agent';
 import type { NativeTool } from '../../types';
 
@@ -33,7 +34,7 @@ function jsonSchemaToTypeBox(schema: Record<string, unknown>): TObject {
       if (values.length === 0) {
         throw new Error(`native tool schema: enum for '${key}' must be non-empty strings`);
       }
-      field = Type.Union(values.map(v => Type.Literal(v)));
+      field = StringEnum(values as [string, ...string[]]) as unknown as TSchema;
     } else if (prop.type === 'string') {
       field = Type.String();
     } else if (prop.type === 'boolean') {


### PR DESCRIPTION
## Problem and outcome

Pi native tools built every enum parameter as `Type.Union(Type.Literal(...))`. Pi's own SDK documentation says that shape does not work on Google/Vertex backends, and `manage_run`'s `action` enum (11 values) flows through this converter into every Pi session, so that tool's schema is incompatible with Vertex today.

- **Outcome:** Enum fields in Pi native tool schemas are now emitted through `StringEnum` as `{ type: 'string', enum: [...] }` — the shape Pi's SDK prescribes for Google/Vertex compatibility.
- **Root cause:** `jsonSchemaToTypeBox` in `packages/providers/src/community/pi/native-tools.ts` constructed every string enum as a `Type.Union` of `Type.Literal`s instead of using the `StringEnum` helper from `@earendil-works/pi-ai`.
- **Invariant:** The JSON-Schema input contract is unchanged; only the emitted TypeBox shape changes.
- **Scope boundary:** No other converter sites were changed. `jsonSchemaToTypeBox` is the only Pi enum-construction site.

## Review guidance

- **Feedback requested:** Correctness of the schema-shape substitution.
- **Start here:** `packages/providers/src/community/pi/native-tools.ts:38` — the enum construction branch.
- **Review order:** `native-tools.ts` first, then the shape test in `native-tools.test.ts`.
- **Known risk or uncertainty:** The actual Vertex failure mode was not reproduced end-to-end (the issue itself flags this as unverified — no Vertex backend in CI). The added test asserts the emitted TypeBox schema shape instead, which validates the contract boundary. The existing description-wrapping branch still applies after construction; `StringEnum`'s own `description` option is unused to keep the change minimal.

## Solution

Replaced the enum branch in `jsonSchemaToTypeBox`:

```ts
// Before
field = Type.Union(values.map(v => Type.Literal(v)));
// After
field = StringEnum(values as [string, ...string[]]);
```

`StringEnum` is exported from `@earendil-works/pi-ai`, which is already a direct dependency of `@archon/providers` — no new dependency. Because `manage_run` is the only native tool and `jsonSchemaToTypeBox` its only converter, this one substitution covers the entire enum surface now and any future schema that flows through the converter.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | Enum schema fields emitted as `anyOf`/`const` union via `Type.Union(Type.Literal(...))` | Enum fields emitted as `{ type: 'string', enum: [...] }` via `StringEnum` |
| **Failure behavior** | Documented-incompatible shape for Google/Vertex backends | Shape Pi's SDK docs prescribe for Google/Vertex; no user-visible change on backends that accepted the previous shape |

## Validation

- `bun run test --filter="@archon/providers" packages/providers/src/community/pi/native-tools.test.ts` — 5 pass, 0 fail — includes the new test asserting `{ type: 'string', enum: [...] }` shape.
- `bun run type-check` (providers package) — clean.
- `bun run lint` (full repo) — clean.
- `bun run test` (providers full suite) — all pass (276 tests).
- **Not verified:** end-to-end use of `manage_run` against a live Google/Vertex backend — no such backend in CI or local environment; the schema-shape test covers the contract the backend validates against.

## Links

- Closes #2424

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility for tool parameter schemas used with Google and Vertex AI.
  - Enum-valued parameters are now represented in a format these providers can process correctly.

- **Tests**
  - Added coverage to verify that enum fields produce compatible string-enum schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->