### PR TITLE
fix(core): REST reject route no longer records empty text for an explicit empty-string reason

### DIFF
--- a/packages/core/src/operations/workflow-operations.test.ts
+++ b/packages/core/src/operations/workflow-operations.test.ts
@@ -889,6 +889,36 @@ describe('rejectWorkflow', () => {
     expect(mockCaptureApprovalResolved).toHaveBeenCalledWith({ resolution: 'rejected' });
   });
 
+  test('explicit empty-string reason defaults to "Rejected" in structured_output and audit event', async () => {
+    const run = makePausedRun({
+      metadata: {
+        approval: {
+          nodeId: 'review',
+          message: 'Please review',
+          type: 'approval',
+          decisions: [{ id: 'approve' }, { id: 'reject' }],
+          decisionsAuthored: true,
+        },
+      },
+    });
+    mockGetWorkflowRun.mockResolvedValueOnce(run);
+
+    const result = await rejectWorkflow('run-1', '');
+
+    expect(result.newMode).toBe(true);
+    expect(result.cancelled).toBe(false);
+    expect(mockResolveApprovalGate).toHaveBeenCalled();
+    const events = mockResolveApprovalGate.mock.calls[0][2] as unknown[] as Array<
+      Record<string, unknown>
+    >;
+    const nodeCompleted = events.find(e => e.event_type === 'node_completed');
+    expect(nodeCompleted?.data).toMatchObject({
+      structured_output: { decision: 'reject', text: 'Rejected' },
+    });
+    const approvalReceived = events.find(e => e.event_type === 'approval_received');
+    expect(approvalReceived?.data).toMatchObject({ reason: 'Rejected' });
+  });
+
   test('rejects an escalated body-terminal-gate pause — node_completed lands under the namespaced <nodeId>.<bodyGateId> step_name (#2707 step 3)', async () => {
     const run = makePausedRun({
       metadata: {

--- a/packages/core/src/operations/workflow-operations.ts
+++ b/packages/core/src/operations/workflow-operations.ts
@@ -780,7 +780,7 @@ export async function rejectWorkflow(
     }
   }
 
-  const rejectReason = reason ?? 'Rejected';
+  const rejectReason = reason && reason.length > 0 ? reason : 'Rejected';
   const currentCount = (run.metadata.rejection_count as number | undefined) ?? 0;
   const maxAttempts = approval?.onRejectMaxAttempts ?? 3;
   // `!= null` (not `!== undefined`): "no on_reject" reaches this read in two stored
@@ -833,7 +833,7 @@ export async function rejectWorkflow(
   // losing the audit trail (#2146).
   let won: boolean;
   if (willResolveNewMode && approval) {
-    const structuredOutput = { decision: 'reject', text: reason ?? '' };
+    const structuredOutput = { decision: 'reject', text: rejectReason };
     const nodeCompletedEvent: workflowDb.GateResolutionEvent = {
       event_type: 'node_completed',
       step_name: resolvedNodeCompletedStepName(approval),


### PR DESCRIPTION
The `/reject` and `/respond` REST routes pass an explicit empty-string reason straight through to `rejectWorkflow`. The nullish coalescing operator (`??`) only guards against `null`/`undefined`, so `"reason": ""` in the request body lands in both the audit event and the new-mode `structured_output.text` as-is — producing an empty string where the caller intended the default "Rejected".

The fix is at the operation layer so it covers every entry point:

- **`rejectReason`** now treats empty string the same as unset (`reason && reason.length > 0 ? reason : "Rejected"` instead of `reason ?? "Rejected"`).
- **`structured_output.text`** reuses the computed `rejectReason` instead of the raw `reason` parameter, so both the audit trail and the structured output always agree.

The four non-REST call sites (CLI, manage-run-tool, command-handler, Slack bridge) were already guarded with length checks or `||` defaults, so this only affects the REST path — but landing the guard at the operation layer closes the gap for any future caller too.

Closes #2742

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Rejection actions with an empty reason now consistently display and record **“Rejected”**.
  - Updated rejection details appear in both workflow results and approval history.
  - Workflows remain resumable after this type of rejection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->