### PR TITLE
test: name the poll-wait deadlines so no call site inherits one silently

### DIFF
--- a/packages/cli/src/commands/workflow-terminal-event.integration.spec.ts
+++ b/packages/cli/src/commands/workflow-terminal-event.integration.spec.ts
@@ -31,9 +31,20 @@ afterEach(async () => {
   }
 });
 
+/**
+ * How long the detached workflow's observable state may take to catch up with what the
+ * fixture was launched to do: write its run row, record its checkout, release the control
+ * endpoint, and commit the terminal status and event.
+ *
+ * This was the default on `waitFor`. Every site below waits on the same detached run, so
+ * one window covers them; naming it and removing the default means a wait with a
+ * different need has to state its own deadline instead of inheriting this one.
+ */
+const DETACHED_RUN_DEADLINE_MS = 15_000;
+
 async function waitFor<T>(
   read: () => T | undefined | Promise<T | undefined>,
-  timeoutMs = 15_000
+  timeoutMs: number
 ): Promise<T> {
   const deadline = Date.now() + timeoutMs;
   let lastError: unknown;
@@ -48,6 +59,13 @@ async function waitFor<T>(
   }
   const detail = lastError instanceof Error ? `: ${lastError.message}` : '';
   throw new Error(`Timed out waiting for detached workflow${detail}`);
+}
+
+/** Wait for the detached workflow under test to reach the state `read` describes. */
+async function waitForDetachedRun<T>(
+  read: () => T | undefined | Promise<T | undefined>
+): Promise<T> {
+  return waitFor(read, DETACHED_RUN_DEADLINE_MS);
 }
 
 function readRun(
@@ -193,7 +211,7 @@ nodes:
       if (typeof ackRunId !== 'string') throw new Error(`ack carried no run id: ${stdout}`);
       expect(readRunById(databasePath, ackRunId)?.id).toBe(ackRunId);
 
-      const created = await waitFor(() => readRun(databasePath, fixture.workflow));
+      const created = await waitForDetachedRun(() => readRun(databasePath, fixture.workflow));
       activeRunIds.add(created.id);
       expect(created.id).toBe(ackRunId);
       // The child fills in the checkout the parent could not know at fork time.
@@ -202,7 +220,7 @@ nodes:
       // `working_path` is whatever that function returned — a different realpath
       // variant here disagrees with it on Windows (#2927).
       const resolvedProjectRoot = await canonicalizeProjectPath(projectRoot);
-      await waitFor(() =>
+      await waitForDetachedRun(() =>
         readRunById(databasePath, created.id)?.working_path === resolvedProjectRoot
           ? true
           : undefined
@@ -212,12 +230,12 @@ nodes:
       // the loop past that. Returning from this wait is the assertion that the owner
       // released its endpoint; re-asserting the same reading on the next line could only
       // turn one such misread into a failure, which is how it failed on Windows.
-      await waitFor(async () =>
+      await waitForDetachedRun(async () =>
         (await canConnectToRunLiveOwner(runLiveOwnerPath(created.id))) ? undefined : true
       );
       activeRunIds.delete(created.id);
 
-      const terminal = await waitFor(() => {
+      const terminal = await waitForDetachedRun(() => {
         const run = readRun(databasePath, fixture.workflow);
         return run?.status === fixture.status ? run : undefined;
       });
@@ -231,7 +249,7 @@ nodes:
       // contention, and the count stays exact: the event was committed atomically with
       // the status already observed above, and the owner's endpoint is unreachable, so
       // nothing can append a second row after the first read succeeds.
-      const events = await waitFor(() => {
+      const events = await waitForDetachedRun(() => {
         const rows = readTerminalEvents(databasePath, terminal.id, fixture.event);
         return rows.length > 0 ? rows : undefined;
       });

--- a/packages/cli/src/utils/detached-run-control.integration.spec.ts
+++ b/packages/cli/src/utils/detached-run-control.integration.spec.ts
@@ -13,12 +13,26 @@ import { requestDetachedRunStop } from './detached-run-control';
 // cleanup, and an unretried removal fails a test whose assertions already passed (#2306).
 const trackTempRoot = trackTempRoots();
 
-async function waitFor(check: () => boolean, timeoutMs = 5_000): Promise<void> {
+/**
+ * How long a spawned fixture process may take to reach the state a test polls for: to
+ * signal that it is ready, or to be gone once the terminator stopped it.
+ *
+ * This was the default on `waitFor`. Naming it and removing the default means a wait that
+ * needs a different window has to state one rather than inherit this.
+ */
+const FIXTURE_STATE_DEADLINE_MS = 5_000;
+
+async function waitFor(check: () => boolean, timeoutMs: number): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (!check()) {
     if (Date.now() >= deadline) throw new Error('Timed out waiting for fixture');
     await new Promise<void>(resolve => setTimeout(resolve, 25));
   }
+}
+
+/** Wait for a spawned fixture process to reach the state `check` describes. */
+async function waitForFixtureProcess(check: () => boolean): Promise<void> {
+  await waitFor(check, FIXTURE_STATE_DEADLINE_MS);
 }
 
 function waitForExit(
@@ -114,7 +128,7 @@ describe('detached run control integration', () => {
     const exited = waitForExit(owner);
 
     try {
-      await waitFor(() => existsSync(readyPath));
+      await waitForFixtureProcess(() => existsSync(readyPath));
       const pids = JSON.parse(readFileSync(readyPath, 'utf8')) as {
         owner: number;
         leakWriter: number;
@@ -129,7 +143,7 @@ describe('detached run control integration', () => {
       await exited;
       // Event-driven proof instead of a fixed sleep: wait for the descendant's
       // observable death. A dead process cannot act on any future signal.
-      await waitFor(() => !processExists(pids.leakWriter));
+      await waitForFixtureProcess(() => !processExists(pids.leakWriter));
       writeFileSync(goPath, 'go');
       expect(existsSync(leakPath)).toBe(false);
     } finally {
@@ -158,7 +172,7 @@ describe('detached run control integration', () => {
     const gonePid = doomed.pid;
     await waitForExit(doomed);
     // The premise, asserted rather than assumed: the terminator is aimed at nothing.
-    await waitFor(() => !processExists(gonePid));
+    await waitForFixtureProcess(() => !processExists(gonePid));
 
     const server = stubOwner(gonePid);
     await listen(server, path);

--- a/packages/core/src/services/run-live-owner.test.ts
+++ b/packages/core/src/services/run-live-owner.test.ts
@@ -13,12 +13,31 @@ import {
   type RunLiveOwnerWatchEvent,
 } from './run-live-owner';
 
-async function waitFor(check: () => boolean, timeoutMs = 3_000): Promise<void> {
+/**
+ * How long an in-process live-owner transition may take to become observable.
+ *
+ * Every wait in this file polls for a state this same process reaches, because the owner
+ * and its watchers run in-process, so one deadline covers them all. It is a setup deadline,
+ * not a test budget: it bounds how long a wait retries before reporting that the
+ * transition never happened, and says nothing about what the assertions may cost.
+ *
+ * This was the default on `waitFor`, which let every site share the number without
+ * naming it. `waitFor` no longer defaults, so a wait that needs a different deadline has
+ * to state one and say why rather than inherit this.
+ */
+const LIVE_OWNER_EVENT_DEADLINE_MS = 3_000;
+
+async function waitFor(check: () => boolean, timeoutMs: number): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (!check()) {
     if (Date.now() >= deadline) throw new Error('Timed out waiting for live-owner event');
     await Bun.sleep(5);
   }
+}
+
+/** Wait for an in-process live-owner event at the deadline this file owns. */
+async function waitForOwnerEvent(check: () => boolean): Promise<void> {
+  await waitFor(check, LIVE_OWNER_EVENT_DEADLINE_MS);
 }
 
 async function listen(server: Server, path: string): Promise<void> {
@@ -85,7 +104,7 @@ describe('run live owner', () => {
     expect(secondWatch).not.toBeNull();
 
     await owner.close();
-    await waitFor(() => first.length === 1 && second.length === 1);
+    await waitForOwnerEvent(() => first.length === 1 && second.length === 1);
 
     expect(first).toEqual(['attention']);
     expect(second).toEqual(['attention']);
@@ -109,7 +128,7 @@ describe('run live owner', () => {
     }
 
     expect(rejection).toBe(executionError);
-    await waitFor(() => events.length === 1);
+    await waitForOwnerEvent(() => events.length === 1);
     expect(events).toEqual(['attention']);
     expect(await canConnectToRunLiveOwner(path)).toBe(false);
   });
@@ -138,13 +157,13 @@ describe('run live owner', () => {
       expect(lease.pid).toBe(process.pid);
       expect(owner.isStopRequested()).toBe(true);
       await lease.commit();
-      await waitFor(() => events.includes('control_handoff'));
+      await waitForOwnerEvent(() => events.includes('control_handoff'));
       expect(events).toEqual(['control_handoff']);
     } finally {
       lease.release();
       await owner.close();
     }
-    await waitFor(() => events.includes('attention'));
+    await waitForOwnerEvent(() => events.includes('attention'));
     expect(events).toEqual(['control_handoff', 'attention']);
   });
 
@@ -159,7 +178,7 @@ describe('run live owner', () => {
       client.connect(path);
     });
     client.write('stop\n');
-    await waitFor(() => owner.isStopRequested());
+    await waitForOwnerEvent(() => owner.isStopRequested());
 
     const closing = owner.close();
     expect(await canConnectToRunLiveOwner(path)).toBe(true);
@@ -237,7 +256,7 @@ describe('run live owner', () => {
     try {
       const watch = await watchRunLiveOwner(runId, event => events.push(event));
       expect(watch).not.toBeNull();
-      await waitFor(() => events.length > 0);
+      await waitForOwnerEvent(() => events.length > 0);
       expect(events).toEqual(['disconnected']);
     } finally {
       await close(server);


### PR DESCRIPTION
## Problem and outcome

`waitFor` in `packages/core/src/services/run-live-owner.test.ts` expressed its deadline as a default parameter (`timeoutMs = 3_000`), so all six call sites shared a number none of them named. The two sibling helpers the issue's review comment pointed at had the identical shape: `detached-run-control.integration.spec.ts` (`timeoutMs = 5_000`, 3 sites) and `workflow-terminal-event.integration.spec.ts` (`timeoutMs = 15_000`, 5 sites). A wait whose needs differ could not state its own window without editing the shared default, and nothing recorded why the old value was chosen.

- **Outcome:** each of the three files states its poll deadline as one named constant spent through a single wrapper. `waitFor` no longer defaults its `timeoutMs`, so a new call site cannot inherit a deadline silently — it must state one or use the wrapper.
- **Invariant:** no deadline value changed (`3_000`, `5_000`, `15_000` all preserved) and no assertion or test body moved.
- **Scope boundary:** this is not a shared or cross-package deadline utility. Each file owns a file-local constant, matching the demonstrated pattern. `waitForExit`'s inline `8_000` in `detached-run-control.integration.spec.ts` is deliberately untouched: it is a literal inside one helper, not an inherited default.
- **Root cause:** the deadline lived in the helper's default parameter, so it was shared by every call site without being owned or justified by any of them. A hand-synced pair of that kind is a present defect, not a future risk.

## Review guidance

- **Feedback requested:** correctness of the wrapper shape, and whether including the two sibling files is the right scope call.
- **Start here:** `packages/core/src/services/run-live-owner.test.ts:16` — the comment recording the old default, `LIVE_OWNER_EVENT_DEADLINE_MS`, and `waitFor`'s now-required `timeoutMs` sit together; the wrapper `waitForOwnerEvent` follows.
- **Review order:** the core file, then `packages/cli/src/utils/detached-run-control.integration.spec.ts`, then `packages/cli/src/commands/workflow-terminal-event.integration.spec.ts`.
- **Lower-attention areas:** the call-site edits are mechanical renames from `waitFor(...)` to the file's wrapper; no argument or condition changed.
- **Known risk or uncertainty:** the two sibling files were not named in the issue title, only in its review comment, which deferred the scope question. Both were included because they have multiple inheriting call sites, which is the issue's own criterion for belonging in the same change. This is the one judgment call in the diff.

## Solution

The shape is already demonstrated in-repo at `packages/cli/src/commands/workflow-wait.integration.spec.ts:360-465`, where `waitFor` has no default, `RUN_BOOT_DEADLINE_MS` is the single owner, and `waitForRunBoot` spends it. Each of the three files now follows it:

1. The old default value becomes a named `*_DEADLINE_MS` constant with the reasoning recorded beside it.
2. `waitFor` keeps its `timeoutMs` parameter but it is now required.
3. One wrapper (`waitForOwnerEvent`, `waitForFixtureProcess`, `waitForDetachedRun`) spends the constant.
4. Every existing call site goes through the wrapper rather than restating the number.

Because `timeoutMs` is required, a future site that writes `await waitFor(() => true)` fails to compile with `TS2554: Expected 2 arguments, but got 1` — the compile guard the acceptance asks for.

## Validation

- `bun run validate` — exit 0 — covers `check:*`, `type-check`, `lint --max-warnings 0`, `format:check`, `test:install`, and the full `bun run test` suite. Re-run with the exit code captured: `validate exit=0`.
- `packages/core/src/services/run-live-owner.test.ts` — 11 pass — the suite still asserts what it did before; no assertion was edited.
- `packages/cli/src/utils/detached-run-control.integration.spec.ts` + `packages/cli/src/commands/workflow-terminal-event.integration.spec.ts` — 5 pass — both sibling suites unchanged in behavior.
- Compile guard proven by probe: adding `await waitFor(() => true)` produced `error TS2554: Expected 2 arguments, but got 1.` The probe was reverted and the file restored before commit.
- `prettier --check` clean on all three files; `git status` clean after commit.
- **Not verified:** Nothing material. Every touched file is exercised by the commands above, and the deadline values are byte-for-byte the previous ones.

## Links

- Closes #3293


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of workflow, detached-run, fixture-process, and live-owner integration tests by applying explicit, consistent polling deadlines.
  * Standardized terminal status, event, checkout, shutdown, and run-creation waits to use shared timeout limits.
  * Removed implicit default timeouts from internal test wait helpers, requiring each wait to specify its deadline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->