### PR TITLE
fix(adapters): keep resumed nodes completed in Slack's live progress message

### DIFF
--- a/packages/adapters/src/chat/slack/workflow-bridge.test.ts
+++ b/packages/adapters/src/chat/slack/workflow-bridge.test.ts
@@ -670,6 +670,108 @@ describe('SlackWorkflowBridge', () => {
     expect(header?.text?.text).toContain('*Authored outcome:* `succeeded`');
   });
 
+  test('keeps a completed node completed when a resumed pass replays it as prior-success', async () => {
+    const { adapter, updated, triggerMap } = makeFakeAdapter();
+    triggerMap.set('C1:111.0', { channel: 'C1', ts: '111.0' });
+    mockGetConversationId.mockReturnValue('C1:111.0');
+
+    new SlackWorkflowBridge(adapter as never).attach();
+    await dispatchEvent({
+      type: 'workflow_started',
+      runId: 'r1',
+      workflowName: 'assist',
+      conversationId: 'conv-db-uuid',
+      transcriptPath: '/logs/r1.jsonl',
+    });
+    await dispatchEvent({
+      type: 'node_completed',
+      runId: 'r1',
+      nodeId: 'plan',
+      nodeName: 'plan',
+      duration: 900,
+    });
+    await dispatchEvent({
+      type: 'node_skipped_prior_success',
+      runId: 'r1',
+      nodeId: 'plan',
+      nodeName: 'plan',
+    });
+    await dispatchEvent({
+      type: 'workflow_completed',
+      runId: 'r1',
+      workflowName: 'assist',
+      duration: 1234,
+    });
+
+    const rendered = JSON.stringify(updated[updated.length - 1]);
+    expect(rendered).toContain(':white_check_mark: `plan` · 900ms');
+    expect(rendered).not.toContain(':fast_forward: `plan`');
+  });
+
+  test('reports a prior-success replay as completed when the resumed run has no prior entry', async () => {
+    const { adapter, updated, triggerMap } = makeFakeAdapter();
+    triggerMap.set('C1:111.0', { channel: 'C1', ts: '111.0' });
+    mockGetConversationId.mockReturnValue('C1:111.0');
+
+    new SlackWorkflowBridge(adapter as never).attach();
+    await dispatchEvent({
+      type: 'workflow_started',
+      runId: 'r1',
+      workflowName: 'assist',
+      conversationId: 'conv-db-uuid',
+      transcriptPath: '/logs/r1.jsonl',
+    });
+    await dispatchEvent({
+      type: 'node_skipped_prior_success',
+      runId: 'r1',
+      nodeId: 'plan',
+      nodeName: 'plan',
+    });
+    await dispatchEvent({
+      type: 'workflow_completed',
+      runId: 'r1',
+      workflowName: 'assist',
+      duration: 1234,
+    });
+
+    const rendered = JSON.stringify(updated[updated.length - 1]);
+    expect(rendered).toContain(':white_check_mark: `plan`');
+    expect(rendered).not.toContain(':fast_forward: `plan`');
+  });
+
+  test('still reports a genuine when_condition skip as skipped', async () => {
+    const { adapter, updated, triggerMap } = makeFakeAdapter();
+    triggerMap.set('C1:111.0', { channel: 'C1', ts: '111.0' });
+    mockGetConversationId.mockReturnValue('C1:111.0');
+
+    new SlackWorkflowBridge(adapter as never).attach();
+    await dispatchEvent({
+      type: 'workflow_started',
+      runId: 'r1',
+      workflowName: 'assist',
+      conversationId: 'conv-db-uuid',
+      transcriptPath: '/logs/r1.jsonl',
+    });
+    await dispatchEvent({
+      type: 'node_skipped',
+      runId: 'r1',
+      nodeId: 'plan',
+      nodeName: 'plan',
+      reason: 'when_condition',
+      cause: { kind: 'condition', expr: '$route.output == true' },
+    });
+    await dispatchEvent({
+      type: 'workflow_completed',
+      runId: 'r1',
+      workflowName: 'assist',
+      duration: 1234,
+    });
+
+    const rendered = JSON.stringify(updated[updated.length - 1]);
+    expect(rendered).toContain(':fast_forward: `plan`');
+    expect(rendered).not.toContain(':white_check_mark: `plan`');
+  });
+
   test('completed run with failed authored outcome shows both reactions and both labels', async () => {
     const { adapter, updated, reactionsAdded, triggerMap } = makeFakeAdapter();
     triggerMap.set('C1:111.0', { channel: 'C1', ts: '111.0' });

--- a/packages/adapters/src/chat/slack/workflow-bridge.test.ts
+++ b/packages/adapters/src/chat/slack/workflow-bridge.test.ts
@@ -727,6 +727,14 @@ describe('SlackWorkflowBridge', () => {
       nodeId: 'plan',
       nodeName: 'plan',
     });
+
+    // The replay alone must repaint the live message, so wait past the status-update
+    // debounce before any terminal event can mask a missing repaint.
+    await new Promise(resolve => setTimeout(resolve, 600));
+    const live = JSON.stringify(updated[updated.length - 1]);
+    expect(live).toContain(':white_check_mark: `plan`');
+    expect(live).not.toContain(':fast_forward: `plan`');
+
     await dispatchEvent({
       type: 'workflow_completed',
       runId: 'r1',

--- a/packages/adapters/src/chat/slack/workflow-bridge.ts
+++ b/packages/adapters/src/chat/slack/workflow-bridge.ts
@@ -151,6 +151,10 @@ export class SlackWorkflowBridge {
           this.upsertNode(event.runId, event.nodeId, event.nodeName, 'skipped');
           this.scheduleStatusUpdate(event.runId);
           break;
+        case 'node_skipped_prior_success':
+          this.upsertPriorSuccessNode(event.runId, event.nodeId, event.nodeName);
+          this.scheduleStatusUpdate(event.runId);
+          break;
         case 'approval_pending':
           await this.onApprovalPending(event);
           break;
@@ -404,6 +408,19 @@ export class SlackWorkflowBridge {
       durationMs: extra.durationMs,
       error: extra.error,
     });
+  }
+
+  /**
+   * A prior-success replay is evidence the node already ran and succeeded, never a
+   * skip (#2978). Keep an existing entry untouched so its duration and error survive;
+   * the resume path starts from an empty run state, so a replay with no entry still
+   * records the completed node rather than dropping it.
+   */
+  private upsertPriorSuccessNode(runId: string, nodeId: string, nodeName: string): void {
+    const run = this.runs.get(runId);
+    if (!run || run.nodes.has(nodeId)) return;
+    run.nodeOrder.push(nodeId);
+    run.nodes.set(nodeId, { nodeId, nodeName, state: 'completed' });
   }
 
   private scheduleStatusUpdate(runId: string): void {

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -10512,6 +10512,27 @@ describe('workflowRunCommand — progress rendering', () => {
     );
   });
 
+  it('should render a prior-success replay as a prior_success skip', async () => {
+    setupWorkflowMocks();
+
+    const { executeWorkflow } = require('@archon/workflows/executor');
+    (executeWorkflow as ReturnType<typeof mock>).mockImplementationOnce(async () => {
+      if (capturedSubscribeHandler) {
+        capturedSubscribeHandler({
+          type: 'node_skipped_prior_success',
+          runId: 'run-1',
+          nodeId: 'plan',
+          nodeName: 'plan',
+        });
+      }
+      return { success: true, workflowRunId: 'run-1' };
+    });
+
+    await workflowRunCommand('/test/path', 'plan', 'hello', {});
+
+    expect(stderrSpy).toHaveBeenCalledWith('[plan] Skipped (prior_success)\n');
+  });
+
   it('should render a timeout node_skipped event to stderr', async () => {
     setupWorkflowMocks();
 

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -1013,11 +1013,12 @@ function renderWorkflowEvent(event: WorkflowEmitterEvent, verbose: boolean): voi
     case 'node_failed':
       process.stderr.write(`[${event.nodeName}] Failed: ${event.error}\n`);
       break;
-    case 'node_skipped': {
-      const detail = 'cause' in event ? formatSkipCause(event.cause) : event.reason;
-      process.stderr.write(`[${event.nodeName}] Skipped (${detail})\n`);
+    case 'node_skipped':
+      process.stderr.write(`[${event.nodeName}] Skipped (${formatSkipCause(event.cause)})\n`);
       break;
-    }
+    case 'node_skipped_prior_success':
+      process.stderr.write(`[${event.nodeName}] Skipped (prior_success)\n`);
+      break;
     case 'approval_pending':
       process.stderr.write(`[${event.nodeId}] Waiting for approval: ${event.message}\n`);
       break;

--- a/packages/server/src/adapters/web/workflow-bridge.test.ts
+++ b/packages/server/src/adapters/web/workflow-bridge.test.ts
@@ -57,6 +57,25 @@ test('node skip projection preserves the live skip cause', () => {
   });
 });
 
+test('prior-success replay projects as a skipped dag_node carrying prior_success', () => {
+  const event: WorkflowEmitterEvent = {
+    type: 'node_skipped_prior_success',
+    runId: 'run-1',
+    nodeId: 'publish',
+    nodeName: 'Publish',
+  };
+
+  const payload = JSON.parse(mapWorkflowEvent(event) ?? '{}') as Record<string, unknown>;
+  expect(payload).toMatchObject({
+    type: 'dag_node',
+    runId: 'run-1',
+    nodeId: 'publish',
+    status: 'skipped',
+    reason: 'prior_success',
+  });
+  expect(payload).not.toHaveProperty('cause');
+});
+
 test('timeout skip projection preserves the live timeout cause', () => {
   const event: WorkflowEmitterEvent = {
     type: 'node_skipped',

--- a/packages/server/src/adapters/web/workflow-bridge.ts
+++ b/packages/server/src/adapters/web/workflow-bridge.ts
@@ -6,13 +6,12 @@ import {
 import {
   nodeSkipReasonSchema,
   skipCauseSchema,
+  type NodeSkipReason,
   type SkipCause,
 } from '@archon/workflows/schemas/workflow-run';
 import type { WorkflowEventRow } from '@archon/core/db/workflow-events';
 import { SSETransport } from './transport';
 import type { DagNodeSseEvent } from './workflow-event.schemas';
-
-type NodeSkipReason = Extract<WorkflowEmitterEvent, { type: 'node_skipped' }>['reason'];
 
 /** Lazy-initialized logger (deferred so test mocks can intercept createLogger) */
 let cachedLog: ReturnType<typeof createLogger> | undefined;
@@ -115,14 +114,24 @@ export function mapWorkflowEvent(event: WorkflowEmitterEvent): string | null {
         duration: event.type === 'node_completed' ? event.duration : undefined,
         error: event.type === 'node_failed' ? event.error : undefined,
         reason: event.type === 'node_skipped' ? event.reason : undefined,
-        cause:
-          event.type === 'node_skipped' && event.reason !== 'prior_success'
-            ? event.cause
-            : undefined,
+        cause: event.type === 'node_skipped' ? event.cause : undefined,
         timestamp: Date.now(),
       };
       return JSON.stringify(payload);
     }
+
+    // The dashboard's live store reconciles from the REST refetch, so the prior-success
+    // replay keeps the `skipped` status it already had; #2978 only changes how Slack renders it.
+    case 'node_skipped_prior_success':
+      return JSON.stringify({
+        type: 'dag_node',
+        runId: event.runId,
+        nodeId: event.nodeId,
+        name: event.nodeName,
+        status: 'skipped',
+        reason: 'prior_success',
+        timestamp: Date.now(),
+      } satisfies DagNodeSseEvent);
 
     case 'tool_started':
       return JSON.stringify({

--- a/packages/workflows/src/dag-executor.test.ts
+++ b/packages/workflows/src/dag-executor.test.ts
@@ -26307,11 +26307,7 @@ describe('executeDagWorkflow -- flattened include expansion', () => {
     const workflowRun = makeWorkflowRun('skip-cause-live');
     const emitted: Array<{ nodeId: string; cause: SkipCause }> = [];
     const unsubscribe = getWorkflowEventEmitter().subscribe(event => {
-      if (
-        event.type === 'node_skipped' &&
-        event.reason !== 'prior_success' &&
-        event.runId === workflowRun.id
-      ) {
+      if (event.type === 'node_skipped' && event.runId === workflowRun.id) {
         emitted.push({ nodeId: event.nodeId, cause: event.cause });
       }
     });

--- a/packages/workflows/src/event-emitter.test.ts
+++ b/packages/workflows/src/event-emitter.test.ts
@@ -295,6 +295,12 @@ describe('WorkflowEventEmitter', () => {
           error: 'fail',
         },
         makeNodeSkippedEvent(),
+        {
+          type: 'node_skipped_prior_success',
+          runId: 'run-1',
+          nodeId: 'cached-node',
+          nodeName: 'cached-node',
+        },
         makeArtifactEvent(),
         {
           type: 'task_activity',

--- a/packages/workflows/src/event-emitter.ts
+++ b/packages/workflows/src/event-emitter.ts
@@ -110,21 +110,26 @@ interface NodeFailedEvent {
   error: string;
 }
 
-interface NodeSkippedEventBase {
+interface NodeSkippedEvent {
   type: 'node_skipped';
   runId: string;
   nodeId: string;
   nodeName: string;
+  reason: Exclude<NodeSkipReason, 'prior_success'>;
+  cause: SkipCause;
 }
 
-type NodeSkippedEvent = NodeSkippedEventBase &
-  (
-    | { reason: 'prior_success' }
-    | {
-        reason: Exclude<NodeSkipReason, 'prior_success'>;
-        cause: SkipCause;
-      }
-  );
+/**
+ * A resumed pass declined to re-run a node an earlier pass completed. Mirrors the
+ * persisted `node_skipped_prior_success` event_type so a consumer switching on
+ * `type` cannot fold prior success into a genuine skip.
+ */
+interface NodeSkippedPriorSuccessEvent {
+  type: 'node_skipped_prior_success';
+  runId: string;
+  nodeId: string;
+  nodeName: string;
+}
 
 interface ToolStartedEvent {
   type: 'tool_started';
@@ -231,6 +236,7 @@ export type WorkflowEmitterEvent =
   | NodeCompletedEvent
   | NodeFailedEvent
   | NodeSkippedEvent
+  | NodeSkippedPriorSuccessEvent
   | WorkflowArtifactEvent
   | ToolStartedEvent
   | ToolCompletedEvent

--- a/packages/workflows/src/node-event-write.test.ts
+++ b/packages/workflows/src/node-event-write.test.ts
@@ -277,7 +277,7 @@ describe('node-event-write', () => {
   });
 
   describe('derivation mappings over NodeStateEventType', () => {
-    it('node_skipped_prior_success folds to node_skipped emitter event', () => {
+    it('node_skipped_prior_success derives a distinct emitter event type', () => {
       const event: NodeStateEventInput = {
         workflow_run_id: 'run-prior',
         event_type: 'node_skipped_prior_success',
@@ -294,11 +294,26 @@ describe('node-event-write', () => {
 
       const emitter = deriveEmitterEvent(step('cached-step'), event);
       expect(emitter).toEqual({
-        type: 'node_skipped',
+        type: 'node_skipped_prior_success',
         runId: 'run-prior',
         nodeId: 'cached-step',
         nodeName: 'cached-step',
-        reason: 'prior_success',
+      });
+    });
+
+    it('a node_skipped row carrying reason prior_success also derives the distinct emitter event type', () => {
+      const event: NodeStateEventInput = {
+        workflow_run_id: 'run-legacy',
+        event_type: 'node_skipped',
+        step_name: 'cached-step',
+        data: { reason: 'prior_success' },
+      };
+
+      expect(deriveEmitterEvent(step('cached-step'), event)).toEqual({
+        type: 'node_skipped_prior_success',
+        runId: 'run-legacy',
+        nodeId: 'cached-step',
+        nodeName: 'cached-step',
       });
     });
 

--- a/packages/workflows/src/node-event-write.ts
+++ b/packages/workflows/src/node-event-write.ts
@@ -163,11 +163,10 @@ export function deriveEmitterEvent(
     case 'node_skipped':
       if (event.data?.reason === 'prior_success') {
         return {
-          type: 'node_skipped',
+          type: 'node_skipped_prior_success',
           runId: event.workflow_run_id,
           nodeId: node.id,
           nodeName,
-          reason: 'prior_success',
         };
       }
       return {
@@ -181,11 +180,10 @@ export function deriveEmitterEvent(
       };
     case 'node_skipped_prior_success':
       return {
-        type: 'node_skipped',
+        type: 'node_skipped_prior_success',
         runId: event.workflow_run_id,
         nodeId: node.id,
         nodeName,
-        reason: 'prior_success',
       };
     case 'node_prior_cache_invalidated':
     case 'node_always_run_reset':


### PR DESCRIPTION
## Problem and outcome

When a workflow pauses at an approval gate and then resumes, the engine re-walks the DAG and replays a prior-success event for nodes that already succeeded. The Slack bridge folded that replay into the same `node_skipped` case as a genuine `when:`/`trigger_rule` skip, overwrote the node's `completed` entry in its last-write-wins map, and rendered a node that ran and succeeded as skipped. #2975 fixed the persisted CLI projection but left the live emitter and the Slack adapter, so the two now disagreed about the same node after every resume.

- **Outcome:** After a resume, the Slack live and final progress message shows a previously succeeded node as completed; a resume whose rebuilt state has no prior entry records the node completed rather than dropping it; a genuine skip still renders skipped.
- **Invariant:** The persisted event vocabulary and stored rows are unchanged. The live emitter grows to match the persisted `node_skipped_prior_success` event_type, not the other way around. Web live projection and CLI progress output are byte-identical to before.
- **Scope boundary:** No persisted schema, migration, API type, or transcript shape changes. The web dashboard's transient live `skipped` on resume and `onWorkflowStarted` rebuilding run state are untouched.
- **Root cause:** Prior success and a genuine skip shared one emitted type, `node_skipped`, distinguished only by `reason`. The Slack bridge switches on `type` alone, so it could not tell them apart and clobbered a completed entry.

## Review guidance

- **Feedback requested:** Correctness of the event-union split and of the non-clobber rule in the Slack bridge.
- **Start here:** `packages/adapters/src/chat/slack/workflow-bridge.ts:419` — `upsertPriorSuccessNode` is the load-bearing behavior: it leaves an existing entry untouched (preserving duration and error) and records `completed` only when the resumed run state has no entry for the node.
- **Review order:** `packages/workflows/src/event-emitter.ts:113` (union split) → `packages/workflows/src/node-event-write.ts:163` (both persisted prior-success forms now derive the new type) → `packages/adapters/src/chat/slack/workflow-bridge.ts:154` → the behavior-preserving consumer updates in the web and CLI bridges.
- **Lower-attention areas:** Test-only additions; the web and CLI arms land the same output they produced before.
- **Known risk or uncertainty:** None material. The new member is a live in-process contract; nothing persisted or over the wire changes.

## Solution

`NodeSkippedEvent` and the new `NodeSkippedPriorSuccessEvent` become separate union members with distinct `type` discriminants, mirroring the persisted `event_type` strings. `node_skipped` narrows to `reason: Exclude<NodeSkipReason, 'prior_success'>` with a required `cause`, so the type checker forces every exhaustive `WorkflowEmitterEvent` consumer to handle the replay explicitly instead of folding it into a skip.

The Slack bridge handles the new type with `upsertPriorSuccessNode`: an existing node entry is left alone, and the resume path that starts from empty state records the node as `completed`. Genuine skips still go through `upsertNode(..., 'skipped')`.

The web live projection emits the same `dag_node` payload as before (`status: 'skipped'`, `reason: 'prior_success'`, no `cause`), and the CLI prints the same text. Their now-dead `reason !== 'prior_success'` guards and the CLI's unreachable `'cause' in event` fallback are removed.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | After a resume, the Slack progress message showed a previously succeeded node as skipped. | The node stays completed; an entry that already exists keeps its original duration. |
| **Failure behavior** | A resume with no prior entry for the node dropped it from the message. | The node is recorded as completed. |
| **Genuine skips** | Rendered skipped. | Still rendered skipped. |

## Architecture

The live emitter's event union now matches the persisted event vocabulary. Consumers that switch on `type` receive a discriminant instead of string-matching `reason`.

### Changed seams

| Boundary or contract | Change | Evidence |
|---|---|---|
| `WorkflowEmitterEvent` (`node_skipped` → Slack bridge) | Narrowed to genuine skips with a required `cause`; prior success is a new `node_skipped_prior_success` member | `packages/workflows/src/event-emitter.ts:113`, `packages/adapters/src/chat/slack/workflow-bridge.ts:154` |
| persisted event row → live emitter | Both the `node_skipped_prior_success` row and a legacy `node_skipped` row carrying `data.reason === 'prior_success'` derive the new type | `packages/workflows/src/node-event-write.ts:163`, `packages/workflows/src/node-event-write.test.ts` |
| live emitter → web SSE projection | New case emits the same `dag_node` payload as before | `packages/server/src/adapters/web/workflow-bridge.ts:100`, `packages/server/src/adapters/web/workflow-bridge.test.ts` |
| live emitter → CLI progress | New case prints `[<node>] Skipped (prior_success)`; output unchanged from before | `packages/cli/src/commands/workflow.ts:1016`, `packages/cli/src/commands/workflow.test.ts` |
| live emitter → other exhaustive consumers (`terminal-record`) | Already handled `node_skipped_prior_success`; prior success continues to fold into a completed terminal record | `packages/workflows/src/terminal-record.ts:51` |

## Validation

- `bun run type-check` — passes — proves every exhaustive `WorkflowEmitterEvent` switch handles the new member.
- `bun run lint` — passes.
- `bun run validate` — the full aggregate (CLI import boundary, bundled/schema/vendor/capability checks, `check:api-types`, type-check, lint, format:check, install and full test suites) exited 0.
- Red/green proof: removing the new Slack case made `reports a prior-success replay as completed when the resumed run has no prior entry` fail (23 pass, 1 fail); restoring it passed (24 pass, 0 fail). The companion test that asserts the original `900ms` duration survives the replay guards the non-clobber rule specifically.
- **Not verified:** No run against a live Slack workspace; behavior is asserted at the bridge snapshot level, which is what `buildStatusBlocks` renders from. Nothing material is left uncovered — no persisted or wire contract changed.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | None. No persisted vocabulary, schema, migration, or API type changed; `check:api-types` is unaffected. | `packages/workflows/src/node-event-write.ts`, `check:api-types` in `bun run validate` |
| Rollout / rollback | Two commits (the fix and its live-repaint test), live in-process behavior only; reverting restores the previous rendering. | `aab37f454`, `240964c38` |

## Links

- Closes #2978
- Related #2973, #2975



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added distinct handling for nodes skipped because they already succeeded in an earlier workflow run.
  - Slack now displays replayed prior-success nodes as completed, including duration when available.
  - CLI progress output identifies these nodes as “Skipped (prior_success).”
  - Web workflow updates report prior-success skips separately from conditional skips.

- **Bug Fixes**
  - Genuine condition-based skips continue to display as skipped.
  - Improved status rendering when prior-success information is replayed or unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->