### PR TITLE
ci(windows): attributed per-test budget and uv warm-up for the Windows leg

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,6 +140,16 @@ jobs:
       # drive root, recursively, so nothing under either was being scanned to
       # begin with. `Add-MpPreference` also cost 5s per run to change nothing.
       # Evidence: https://github.com/coleam00/Archon/pull/2943
+      # The first `uv run` on a fresh windows-latest VM costs 1.2 to 5.0 s (interpreter
+      # discovery and cache creation), measured on green legs. Paying it inside the first
+      # uv-backed test's own budget made that test a budget-edge case by itself, so it is
+      # paid here instead. Evidence on coleam00/Archon#3294.
+      - name: Warm uv
+        if: runner.os == 'Windows'
+        run: uv run python -c "print('uv warm')"
+
+      # The Windows leg runs with a 20 s default per-test budget (scripts/bun-test-command.ts)
+      # as an attributed runner-floor residual; see that file and coleam00/Archon#3294.
       - name: Run tests
         run: bun run test
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "cli": "bun src/cli.ts",
-    "test": "bun test src/commands/version.test.ts src/commands/setup.test.ts src/commands/skill.test.ts src/commands/doctor.test.ts src/commands/telemetry.test.ts && bun test src/commands/workflow.test.ts && bun test src/commands/isolation.test.ts && bun test src/commands/chat.test.ts && bun test src/commands/serve.test.ts && bun test src/commands/ai.test.ts && bun test src/commands/validate.test.ts && bun test src/cli.test.ts src/help.test.ts src/default-cwd-canonicalization.test.ts src/utils/stdout.test.ts src/utils/safe-console.test.ts && bun test src/utils/detached-run-control.test.ts && bun test src/utils/detached-run-control.integration.spec.ts && bun test src/telemetry-exit.integration.spec.ts && bun test src/commands/workflow-terminal-event.integration.spec.ts && bun test src/commands/workflow-continuation-provider.integration.spec.ts && bun test src/commands/workflow-wait.integration.spec.ts && bun test src/commands/workflow-transcript.integration.spec.ts && bun test src/commands/workflow-node-summaries.spec.ts && bun test src/adapters/cli-adapter.test.ts",
+    "test": "bun run ../../scripts/package-tests.ts",
     "test:integration": "bun test src/utils/detached-run-control.integration.spec.ts && bun test src/telemetry-exit.integration.spec.ts && bun test src/commands/workflow-terminal-event.integration.spec.ts && bun test src/commands/workflow-continuation-provider.integration.spec.ts && bun test src/commands/workflow-wait.integration.spec.ts && bun test src/commands/workflow-transcript.integration.spec.ts",
     "type-check": "bun x tsc --noEmit"
   },
@@ -26,5 +26,66 @@
   },
   "devDependencies": {
     "@types/node": "^22.0.0"
-  }
+  },
+  "testGroups": [
+    [
+      "src/commands/version.test.ts",
+      "src/commands/setup.test.ts",
+      "src/commands/skill.test.ts",
+      "src/commands/doctor.test.ts",
+      "src/commands/telemetry.test.ts"
+    ],
+    [
+      "src/commands/workflow.test.ts"
+    ],
+    [
+      "src/commands/isolation.test.ts"
+    ],
+    [
+      "src/commands/chat.test.ts"
+    ],
+    [
+      "src/commands/serve.test.ts"
+    ],
+    [
+      "src/commands/ai.test.ts"
+    ],
+    [
+      "src/commands/validate.test.ts"
+    ],
+    [
+      "src/cli.test.ts",
+      "src/help.test.ts",
+      "src/default-cwd-canonicalization.test.ts",
+      "src/utils/stdout.test.ts",
+      "src/utils/safe-console.test.ts"
+    ],
+    [
+      "src/utils/detached-run-control.test.ts"
+    ],
+    [
+      "src/utils/detached-run-control.integration.spec.ts"
+    ],
+    [
+      "src/telemetry-exit.integration.spec.ts"
+    ],
+    [
+      "src/commands/workflow-terminal-event.integration.spec.ts"
+    ],
+    [
+      "src/commands/workflow-continuation-provider.integration.spec.ts"
+    ],
+    [
+      "src/commands/workflow-wait.integration.spec.ts"
+    ],
+    [
+      "src/commands/workflow-transcript.integration.spec.ts"
+    ],
+    [
+      "src/commands/workflow-node-summaries.spec.ts"
+    ],
+    [
+      "src/adapters/cli-adapter.test.ts"
+    ]
+  ]
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "bun --watch src/index.ts",
     "start": "bun src/index.ts",
-    "test": "bun test src/scripts/generate-api-types.test.ts && bun test src/routes/api.workflows.test.ts && bun test src/routes/api.conversations.test.ts && bun test src/routes/api.codebases.test.ts && bun test src/routes/api.messages.test.ts && bun test src/routes/api.health.test.ts && bun test src/routes/api.workflow-runs.test.ts && bun test src/routes/api.providers.test.ts && bun test src/services/workflow-resume-service.test.ts && bun test src/adapters/web/transport.test.ts && bun test src/adapters/web/persistence.test.ts && bun test src/adapters/web/truncate.test.ts && bun test src/adapters/web.test.ts && bun test src/adapters/headless.test.ts && bun test src/adapters/web/dashboard-event-poller.test.ts && bun test src/adapters/web/pg-notify-listener.test.ts && bun test src/adapters/web/workflow-bridge.test.ts && bun test src/resolve-user-id.test.ts && bun test src/boot/claude-auth-posture.test.ts && bun test src/github-auth-bootstrap.test.ts && bun test src/routes/auth-poll-status.test.ts && bun test src/auth/config.test.ts && bun test src/auth/instance.test.ts && bun test src/routes/api.auth.test.ts && bun test src/routes/api.provider-keys.test.ts && bun test src/routes/api.user-ai-prefs.test.ts && bun test src/routes/webhooks.test.ts && bun test src/discord-mention.test.ts",
+    "test": "bun run ../../scripts/package-tests.ts",
     "type-check": "bun x tsc --noEmit",
     "generate:api-types": "bun src/scripts/generate-api-types.ts",
     "check:api-types": "bun src/scripts/generate-api-types.ts --check",
@@ -29,5 +29,91 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/pg": "^8.11.0"
-  }
+  },
+  "testGroups": [
+    [
+      "src/scripts/generate-api-types.test.ts"
+    ],
+    [
+      "src/routes/api.workflows.test.ts"
+    ],
+    [
+      "src/routes/api.conversations.test.ts"
+    ],
+    [
+      "src/routes/api.codebases.test.ts"
+    ],
+    [
+      "src/routes/api.messages.test.ts"
+    ],
+    [
+      "src/routes/api.health.test.ts"
+    ],
+    [
+      "src/routes/api.workflow-runs.test.ts"
+    ],
+    [
+      "src/routes/api.providers.test.ts"
+    ],
+    [
+      "src/services/workflow-resume-service.test.ts"
+    ],
+    [
+      "src/adapters/web/transport.test.ts"
+    ],
+    [
+      "src/adapters/web/persistence.test.ts"
+    ],
+    [
+      "src/adapters/web/truncate.test.ts"
+    ],
+    [
+      "src/adapters/web.test.ts"
+    ],
+    [
+      "src/adapters/headless.test.ts"
+    ],
+    [
+      "src/adapters/web/dashboard-event-poller.test.ts"
+    ],
+    [
+      "src/adapters/web/pg-notify-listener.test.ts"
+    ],
+    [
+      "src/adapters/web/workflow-bridge.test.ts"
+    ],
+    [
+      "src/resolve-user-id.test.ts"
+    ],
+    [
+      "src/boot/claude-auth-posture.test.ts"
+    ],
+    [
+      "src/github-auth-bootstrap.test.ts"
+    ],
+    [
+      "src/routes/auth-poll-status.test.ts"
+    ],
+    [
+      "src/auth/config.test.ts"
+    ],
+    [
+      "src/auth/instance.test.ts"
+    ],
+    [
+      "src/routes/api.auth.test.ts"
+    ],
+    [
+      "src/routes/api.provider-keys.test.ts"
+    ],
+    [
+      "src/routes/api.user-ai-prefs.test.ts"
+    ],
+    [
+      "src/routes/webhooks.test.ts"
+    ],
+    [
+      "src/discord-mention.test.ts"
+    ]
+  ]
 }

--- a/scripts/bun-test-command.test.ts
+++ b/scripts/bun-test-command.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'bun:test';
+import { bunTestCommand, WINDOWS_TEST_TIMEOUT_MS } from './bun-test-command';
+
+describe('bunTestCommand', () => {
+  it('widens the default per-test budget on Windows only', () => {
+    expect(bunTestCommand(['src/a.test.ts'], 'win32')).toEqual([
+      'bun',
+      'test',
+      '--timeout',
+      String(WINDOWS_TEST_TIMEOUT_MS),
+      'src/a.test.ts',
+    ]);
+    expect(bunTestCommand(['src/a.test.ts'], 'linux')).toEqual(['bun', 'test', 'src/a.test.ts']);
+    expect(bunTestCommand(['src/a.test.ts'], 'darwin')).toEqual(['bun', 'test', 'src/a.test.ts']);
+  });
+
+  it('forwards selectors and flags verbatim after the budget', () => {
+    expect(bunTestCommand(['--bail', 'logger'], 'win32')).toEqual([
+      'bun',
+      'test',
+      '--timeout',
+      String(WINDOWS_TEST_TIMEOUT_MS),
+      '--bail',
+      'logger',
+    ]);
+  });
+});

--- a/scripts/bun-test-command.test.ts
+++ b/scripts/bun-test-command.test.ts
@@ -25,3 +25,19 @@ describe('bunTestCommand', () => {
     ]);
   });
 });
+
+describe('every runner assembles its command through bunTestCommand', () => {
+  it('no runner script spells out a bun test command by hand', async () => {
+    const { readdir, readFile } = await import('node:fs/promises');
+    const { join } = await import('node:path');
+    const offenders: string[] = [];
+    for (const entry of await readdir(import.meta.dir)) {
+      if (!entry.endsWith('.ts') || entry.endsWith('.test.ts') || entry === 'bun-test-command.ts')
+        continue;
+      const source = await readFile(join(import.meta.dir, entry), 'utf8');
+      if (/\[\s*'bun'\s*,\s*'test'/.test(source)) offenders.push(entry);
+    }
+    // A hand-built command on any runner path silently drops the Windows budget for that path.
+    expect(offenders).toEqual([]);
+  });
+});

--- a/scripts/bun-test-command.ts
+++ b/scripts/bun-test-command.ts
@@ -1,0 +1,21 @@
+/**
+ * The one place a `bun test` invocation is assembled, so the per-test budget has one owner.
+ *
+ * On Windows the budget is 20 s instead of Bun's 5 s default. This is an attributed
+ * runner-floor residual, not headroom for slow tests: on the 4-vCPU `windows-latest` VM the
+ * suite's several hundred child processes periodically saturate the CPUs and the OS disk
+ * (sometimes together with Windows' own background maintenance), and any spawn issued in
+ * such a second can take 5 to 15 s regardless of which test issued it. Fifty instrumented
+ * runs found no per-test, per-package, disk-layout or service-level change that removes
+ * the class; the attribution is on coleam00/Archon#3294. A test with its own explicit
+ * budget keeps it: `--timeout` only sets the default.
+ */
+export const WINDOWS_TEST_TIMEOUT_MS = 20_000;
+
+export function bunTestCommand(
+  selectors: readonly string[],
+  platform: NodeJS.Platform = process.platform
+): string[] {
+  const budget = platform === 'win32' ? ['--timeout', String(WINDOWS_TEST_TIMEOUT_MS)] : [];
+  return ['bun', 'test', ...budget, ...selectors];
+}

--- a/scripts/package-tests.ts
+++ b/scripts/package-tests.ts
@@ -1,4 +1,5 @@
 import { join } from 'node:path';
+import { bunTestCommand } from './bun-test-command';
 
 /**
  * Runs one package's tests, from that package's directory.
@@ -30,7 +31,7 @@ if (!Array.isArray(groups) || groups.length === 0) {
 }
 
 const run = async (args: string[]): Promise<number> => {
-  const child = Bun.spawn(['bun', 'test', ...args], {
+  const child = Bun.spawn(bunTestCommand(args), {
     cwd: packageDir,
     stdio: ['inherit', 'inherit', 'inherit'],
   });

--- a/scripts/repo-tests.ts
+++ b/scripts/repo-tests.ts
@@ -1,5 +1,6 @@
 import { existsSync } from 'node:fs';
 import { join, relative, resolve } from 'node:path';
+import { bunTestCommand } from './bun-test-command';
 
 /**
  * Runs the repository's tests, from the repository root.
@@ -105,7 +106,7 @@ async function run(command: string[], cwd: string): Promise<number> {
 async function runPlan(): Promise<number> {
   for (const step of ROOT_TEST_PLAN) {
     const command =
-      step.kind === 'workspaces' ? WORKSPACE_TEST_COMMAND : ['bun', 'test', ...step.selectors];
+      step.kind === 'workspaces' ? WORKSPACE_TEST_COMMAND : bunTestCommand(step.selectors);
     const code = await run(command, REPO_ROOT);
     if (code !== 0) return code;
   }

--- a/scripts/repo-tests.ts
+++ b/scripts/repo-tests.ts
@@ -157,7 +157,7 @@ async function runRequested(requested: string[]): Promise<number> {
   }
 
   for (const { owner, args } of runs) {
-    const code = await run(['bun', 'test', ...args], owner.cwd);
+    const code = await run(bunTestCommand(args), owner.cwd);
     if (code !== 0) return code;
   }
 


### PR DESCRIPTION
## Problem and outcome

The Windows leg fails one random test per few runs at Bun's 5 s default budget, on PRs that touch nothing near the failing package. Fifty instrumented runs on #3294 attribute this to a runner floor rather than test cost: on the 4-vCPU `windows-latest` VM the suite's several hundred child processes periodically saturate the CPUs and the OS disk, sometimes together with Windows' own background maintenance, and any spawn issued in such a second takes 5 to 15 s regardless of which test issued it. Serializing packages, moving temp, moving bun, and stopping Windows services did not change the rate. The full attribution, with per-second disk, CPU, page-fault and per-process data for every stall, is in https://github.com/coleam00/Archon/issues/3294#issuecomment-5634758815.

- **Outcome:** the Windows leg runs with a 20 s default per-test budget, set in one place, and the first `uv run` is paid once by the job instead of inside the first uv-backed test. A Windows timeout again means a test that is genuinely stuck.
- **Invariant:** every test still asserts what it asserted. Explicit per-test budgets are untouched (`--timeout` only sets the default). Linux and macOS keep the 5 s default. Mock isolation between test groups is unchanged: every group still gets its own process.
- **Scope boundary:** no test is skipped or rewritten. The two `tar` skips from #3280 stay until #3286 has a trace of a real stall. The `git clone` integration test's own explicit 15 s budget, which the same floor also blew three times in the instrumented runs, is left as is and noted on #3294.

## Review guidance

- **Feedback requested:** whether a platform-scoped default budget is the right shape for an attributed residual under #2924's rule, and the cli/server migration to `testGroups`.
- **Start here:** `scripts/bun-test-command.ts` — the one owner of every `bun test` invocation and of the Windows budget, with the attribution in its comment.
- **Review order:** `scripts/bun-test-command.ts`; `scripts/package-tests.ts` and `scripts/repo-tests.ts` (both now build the command through it); `packages/cli/package.json` and `packages/server/package.json` (chains become `testGroups`, one group per former `bun test` invocation, same order); `.github/workflows/test.yml` (uv warm-up step and the pointer comment).
- **Lower-attention areas:** the `testGroups` arrays are a mechanical split of the former `&&` chains; `scripts/test-inventory.test.ts` already reads both forms and passes 6/6, which proves every test file is still executed exactly once.
- **Known risk or uncertainty:** the budget is a ceiling on a floor we measured at 5 to 15 s; a worse runner minute can still exceed 20 s. The proof runs below say how often.

## Solution

`bunTestCommand(selectors)` returns `['bun', 'test', ...selectors]`, prefixed with `--timeout 20000` when the platform is `win32`. `scripts/package-tests.ts` (nine packages) and the root plan in `scripts/repo-tests.ts` both build their commands through it. The cli and server packages still spelled their groups as `bun test a && bun test b` chains in `package.json`, which is the form `package-tests.ts` exists to replace and the one place a flag could not reach; they now declare `testGroups` and run the shared runner like every other package.

The budget is a CLI flag rather than a `bunfig.toml` `[test] timeout` key because that key is documented but silently ignored on current Bun (anomalyco/opencode#13491, Bun 1.3.9); only `bun test --timeout` takes effect.

The uv warm-up is one CI step before the suite on Windows: `uv run python -c "print('uv warm')"`. On a fresh runner that call costs 1.2 to 5.0 s on green legs because uv discovers the interpreter and creates its cache; the first uv-backed test was paying that inside its own 5 s budget.

## Validation

- `bun run test ./scripts/bun-test-command.test.ts` — 2 pass — proves the budget is added on `win32` only and selectors pass through verbatim.
- `bun run test ./scripts/test-inventory.test.ts` — 6 pass — proves every tracked test file in cli and server is still collected by the new `testGroups`, and the root plan still runs the runner.
- `bun run test src/commands/version.test.ts` in `packages/cli` and `bun run test src/routes/api.health.test.ts` in `packages/server` — pass through the shared runner.
- `bun run lint`, `bun run format:check` — clean.
- Proof runs: ten `workflow_dispatch` runs of this exact commit (`2945bbf1f`) on `windows-latest`, uninstrumented: **10 of 10 green, 0 timeouts**, Windows legs 8.5 to 10.5 min. Plain dev earlier today was 1 of 10 green-with-timeout and the instrumented arms 3 to 5 of 10. In two of the ten runs a default-budget test finished between 5 s and 20 s and passed (`generate-bundled-defaults: untracked-file guard` at 6.7 s and 5.6 s, one of the original #3294 victims), which is the budget doing exactly its job; every other pass above 5 s was a test that already carries an explicit longer budget. The uv warm-up step ran in all ten. Run IDs: 34604776896 34604779758 34604783011 34604785828 34604788355 34604791839 34604794621 34604797972 34604800995 34604803628.
- **Not verified:** the exact rate at which a runner minute exceeds 20 s; the proof runs bound it, they do not eliminate it.

## Links

- Closes #3294
- Closes #2306
- Related #2924 (residual rule), #3286, #3287, #3282

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDVDEWqYZdkqKaLcBhJ5ut



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved test execution reliability on Windows with consistent platform-appropriate timeouts.
  - Reduced delays during the first test run on fresh Windows environments by preparing the runtime in advance.

- **Chores**
  - Standardized test execution across CLI, server, and repository test suites.
  - Added validation to ensure consistent test command behavior across supported operating systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

