### PR TITLE
docs(providers): the community-provider capabilities sample compiles and cannot drift

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,7 +3,10 @@ name: Deploy Docs
 on:
   push:
     branches: [main]
-    paths: ['packages/docs-web/**']
+    paths:
+      - 'packages/docs-web/**'
+      # The community-provider page renders this file's contents, so changing it changes the site.
+      - 'packages/providers/src/community/_template/capabilities.ts'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -14,6 +14,8 @@ on:
   pull_request:
     paths:
       - 'packages/docs-web/**'
+      # The community-provider page renders this file's contents, so changing it changes the site.
+      - 'packages/providers/src/community/_template/capabilities.ts'
       - 'bun.lock'
       - '.github/workflows/docs-build.yml'
 

--- a/packages/docs-web/src/content/docs/contributing/adding-a-community-provider.mdx
+++ b/packages/docs-web/src/content/docs/contributing/adding-a-community-provider.mdx
@@ -3,6 +3,9 @@ title: Adding a Community Provider
 description: Step-by-step guide to adding a new AI agent provider under packages/providers/src/community/.
 ---
 
+import { Code } from '@astrojs/starlight/components';
+import capabilitiesTemplate from '../../../../../providers/src/community/_template/capabilities.ts?raw';
+
 Archon's provider registry (Phase 2, [#1195](https://github.com/coleam00/Archon/pull/1195)) is designed so community providers can be added with changes localized to a single directory. This guide walks through the pattern using the Pi provider as the reference implementation (`packages/providers/src/community/pi/`).
 
 ## The contract
@@ -52,24 +55,9 @@ Each file has one job. Optional files only exist when the translation surface is
 
 Declare only what you've actually wired. The dag-executor emits a warning to the user when a workflow node uses a feature your provider doesn't support — under-declaration is self-correcting via those warnings; over-declaration means Archon silently drops configuration.
 
-```typescript
-// capabilities.ts
-import type { ProviderCapabilities } from '../../types';
+`capabilities.ts` (rendered from `packages/providers/src/community/_template/capabilities.ts`, which `bun run type-check` keeps complete):
 
-export const YOUR_CAPABILITIES: ProviderCapabilities = {
-  sessionResume: false,
-  mcp: false,
-  hooks: false,
-  skills: false,
-  toolRestrictions: false,
-  structuredOutput: false,
-  envInjection: false,
-  costControl: false,
-  effortControl: false,
-  fallbackModel: false,
-  sandbox: false,
-};
-```
+<Code code={capabilitiesTemplate} lang="typescript" />
 
 Start everything at `false`. Flip to `true` one at a time as you wire each translation, and add a test per flip.
 

--- a/packages/docs-web/src/content/docs/contributing/adding-a-community-provider.mdx
+++ b/packages/docs-web/src/content/docs/contributing/adding-a-community-provider.mdx
@@ -59,7 +59,7 @@ Declare only what you've actually wired. The dag-executor emits a warning to the
 
 <Code code={capabilitiesTemplate} lang="typescript" />
 
-Start everything at `false`. Flip to `true` one at a time as you wire each translation, and add a test per flip.
+Start every boolean axis at `false` and flip it to `true` one at a time as you wire each translation, adding a test per flip. `structuredOutput` is not a boolean: leave it `false`, or set it to `'enforced'` or `'best-effort'` once you support structured output.
 
 ### 2. Provider class
 

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -60,6 +60,9 @@
       "src/types.test.ts"
     ],
     [
+      "src/community/_template/capabilities.test.ts"
+    ],
+    [
       "src/oauth.test.ts"
     ],
     [

--- a/packages/providers/src/community/_template/capabilities.test.ts
+++ b/packages/providers/src/community/_template/capabilities.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { YOUR_CAPABILITIES } from './capabilities';
+
+const DOC_PATH = join(
+  import.meta.dir,
+  '../../../../docs-web/src/content/docs/contributing/adding-a-community-provider.mdx'
+);
+
+describe('community provider capabilities template', () => {
+  test('declares every capability as unsupported to start', () => {
+    for (const [axis, supported] of Object.entries(YOUR_CAPABILITIES)) {
+      expect({ axis, supported }).toEqual({ axis, supported: false });
+    }
+  });
+
+  test('is rendered by the docs page from this file, not a hand-copied snapshot', () => {
+    const page = readFileSync(DOC_PATH, 'utf8');
+
+    expect(page).toContain('community/_template/capabilities.ts?raw');
+    expect(page).not.toContain('export const YOUR_CAPABILITIES');
+  });
+});

--- a/packages/providers/src/community/_template/capabilities.ts
+++ b/packages/providers/src/community/_template/capabilities.ts
@@ -3,10 +3,6 @@ import type { ProviderCapabilities } from '../../types';
 /**
  * Starting point for a community provider's `capabilities.ts`.
  *
- * Declare only what you have actually wired. Under-declaration is self-correcting:
- * the dag-executor warns when a node uses a feature you set to `false`. Over-declaration
- * is silent — Archon drops the configuration.
- *
  * Typed as `ProviderCapabilities` so a capability the interface requires cannot go
  * missing from the template a contributor copies.
  */
@@ -26,9 +22,20 @@ export const YOUR_CAPABILITIES: ProviderCapabilities = {
   settingSources: false,
   nativeTools: false,
   containerExec: false,
-
-  // Optional axes — omit any your provider does not support.
-  // sessionFork: false,
-  // knownToolNames: ['Read', 'Write'],
-  // renamedTools: { Task: 'Agent' },
 };
+
+/** The axes `ProviderCapabilities` marks optional. */
+type OptionalCapabilityAxis = {
+  [K in keyof ProviderCapabilities]-?: undefined extends ProviderCapabilities[K] ? K : never;
+}[keyof ProviderCapabilities];
+
+/**
+ * The optional axes, named so the guide shows them too. This is a checklist, not
+ * configuration: an optional axis you support goes in `YOUR_CAPABILITIES` above. A new
+ * optional axis in `ProviderCapabilities` fails type-check until it is listed here.
+ */
+export const OPTIONAL_AXES = {
+  sessionFork: true,
+  knownToolNames: true,
+  renamedTools: true,
+} satisfies Record<OptionalCapabilityAxis, true>;

--- a/packages/providers/src/community/_template/capabilities.ts
+++ b/packages/providers/src/community/_template/capabilities.ts
@@ -1,0 +1,34 @@
+import type { ProviderCapabilities } from '../../types';
+
+/**
+ * Starting point for a community provider's `capabilities.ts`.
+ *
+ * Declare only what you have actually wired. Under-declaration is self-correcting:
+ * the dag-executor warns when a node uses a feature you set to `false`. Over-declaration
+ * is silent — Archon drops the configuration.
+ *
+ * Typed as `ProviderCapabilities` so a capability the interface requires cannot go
+ * missing from the template a contributor copies.
+ */
+export const YOUR_CAPABILITIES: ProviderCapabilities = {
+  sessionResume: false,
+  mcp: false,
+  hooks: false,
+  skills: false,
+  agents: false,
+  toolRestrictions: false,
+  structuredOutput: false,
+  envInjection: false,
+  costControl: false,
+  effortControl: false,
+  fallbackModel: false,
+  sandbox: false,
+  settingSources: false,
+  nativeTools: false,
+  containerExec: false,
+
+  // Optional axes — omit any your provider does not support.
+  // sessionFork: false,
+  // knownToolNames: ['Read', 'Write'],
+  // renamedTools: { Task: 'Agent' },
+};

--- a/scripts/should-run-test-suite.test.ts
+++ b/scripts/should-run-test-suite.test.ts
@@ -39,6 +39,10 @@ describe('test-suite change decision', () => {
     ['.archon/workflows/sdlc/implement/commands/implement.md', 'a packaged command prompt'],
     ['.claude/skills/archon-cli/SKILL.md', 'the bundled CLI skill'],
     ['packages/docs-web/src/content/docs/reference/provider-capabilities.md', 'a generated doc'],
+    [
+      'packages/docs-web/src/content/docs/contributing/adding-a-community-provider.mdx',
+      'the capabilities template the providers suite reads',
+    ],
   ])('runs for %s, which is %s rather than prose', file => {
     expect(shouldRunTestSuite([file])).toBe(true);
   });

--- a/scripts/should-run-test-suite.ts
+++ b/scripts/should-run-test-suite.ts
@@ -15,6 +15,9 @@ const EMPTY_GIT_SHA = '0000000000000000000000000000000000000000';
  *     compiled into the CLI itself (`check:bundled-skill`).
  *   - `provider-capabilities.md` is generated from the providers' `capabilities.ts`
  *     (`check:capability-matrix`), and lives under the docs site without being prose.
+ *   - `adding-a-community-provider.mdx` is read by
+ *     `packages/providers/src/community/_template/capabilities.test.ts`, which asserts the page
+ *     renders the capabilities template by reference instead of a hand-copied snapshot.
  *   - The docs manifest is copied by the Docker dependency layer.
  */
 const BUILD_INPUTS = [
@@ -22,6 +25,7 @@ const BUILD_INPUTS = [
   '.archon/workflows/',
   '.claude/skills/',
   'packages/docs-web/src/content/docs/reference/provider-capabilities.md',
+  'packages/docs-web/src/content/docs/contributing/adding-a-community-provider.mdx',
   'packages/docs-web/package.json',
 ];
 


### PR DESCRIPTION
## Problem and outcome

The community-provider guide's `capabilities.ts` sample listed 11 of the 15 required
`ProviderCapabilities` members, so a contributor who copied it hit a TypeScript error on
their first build (`agents`, `settingSources`, `nativeTools`, `containerExec` missing), and
the page never mentioned the 3 optional axes. The sample was a hand-copied snapshot with
nothing keeping it current, so it drifted every time the interface gained a field.

- **Outcome:** The page renders its capabilities sample from a typed fixture that lives in
  the providers package, so the sample a contributor copies compiles, and the page cannot
  show a stale snapshot of the interface.
- **Invariant:** `packages/providers/src/types.ts` stays the owner of the field set. There is
  no second hand-maintained list and no "keep in sync" comment.
- **Scope boundary:** No change to `ProviderCapabilities` itself and no change to the page
  beyond the capabilities block. The guide's other content and its URL are unchanged.
- **Root cause:** The sample was prose, not code. Nothing compiled it, so adding a required
  capability to the interface silently invalidated the guide.

Closes #3313.

## Review guidance

- **Feedback requested:** Correctness of the single-source approach (a cross-package `?raw`
  import from docs into `packages/providers`) and whether the type-check is the right guard.
- **Start here:** `packages/providers/src/community/_template/capabilities.ts` — the fixture
  typed as `ProviderCapabilities`. This is what makes `tsc` the drift check.
- **Review order:** the fixture, then the page conversion in
  `adding-a-community-provider.mdx` (the `<Code code={...} />` reference), then the test that
  pins the reference, then the workflow path filters and the `should-run-test-suite` input.
- **Lower-attention areas:** `packages/providers/package.json` is a mechanical `testGroups`
  registration; the two workflow edits are path-filter additions that keep the docs build
  triggered, because the build now reads the fixture.
- **Known risk or uncertainty:** The docs page imports a file outside `packages/docs-web`.
  This is intentional and is what makes the page a reference rather than a copy, but it is a
  new cross-package edge for the docs build.

## Solution

The template object moved out of the prose and into
`packages/providers/src/community/_template/capabilities.ts`, where it is declared as
`ProviderCapabilities`. Because that file is inside the providers type-check program, adding a
required member to the interface now fails `bun run type-check` on the fixture instead of in a
contributor's first build. The 3 optional axes (`sessionFork`, `knownToolNames`, `renamedTools`)
are named in an exported `OPTIONAL_AXES` object that `satisfies` a mapped type of the
interface's optional keys, so a new optional axis fails type-check until it is listed there, and
the page renders them from the same file.

The guide became `.mdx` and its code block was replaced by a Starlight `<Code>` component that
renders the fixture through `?raw`. The page therefore shows whatever the fixture shows — the
two cannot diverge because there is only one source. The conversion touches only the
capabilities block; the rest of the page is unchanged, and the URL is slug-based so it stays
`/contributing/adding-a-community-provider/`.

Three supporting changes follow from that: a providers test asserts the page still references
the fixture (and that every declared axis starts `false`); both docs workflows now include the
fixture in their path filters, since the docs build reads it and a provider-only change to it
would otherwise leave the deployed page stale; and `should-run-test-suite` treats the page as a
test-suite input, because the providers test reads it.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | The page showed a hand-written sample missing 4 required members and all 3 optional axes. | The page shows the typed fixture: all 15 required members, with the 3 optional axes named in the typed `OPTIONAL_AXES` checklist. |
| **Failure behavior** | Adding a required member to `ProviderCapabilities` silently broke the guide. | Adding a required member fails `bun run type-check` on the fixture. |

## Validation

- Reproduced the drift by inspection: the old block listed 11 of the 15 required members.
- Simulated the guard: added a required member to `ProviderCapabilities`, ran `bun x tsc --noEmit`
  in `packages/providers`, and got `capabilities.ts(12,14): error TS2741: Property 'futureAxis'
  is missing ...`. Reverted `types.ts`.
- `bun run validate` — exit 0 (type-check across all packages, `lint --max-warnings 0`,
  `format:check`, `test:install`, full test suite).
- `bun run build:docs` — exit 0; the rendered page and `dist/llms-full.txt` contain all 15
  required axes plus the 3 optional ones.
- `bun run test packages/providers/src/community/_template/capabilities.test.ts` — 2 pass.
- **Not verified:** Nothing material. The guard is a compile-time check, exercised by the
  simulated-member run above.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Documentation / communication | The page is now `.mdx`; its URL and position in `llms.txt` are unchanged. | `bun run build:docs` exit 0, built page at `/contributing/adding-a-community-provider/` |
| Rollout / rollback | Revert is a plain revert; no persisted state, migration, or generated artifact is involved. | Diff is one commit |

## Links

- Closes #3313



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a community provider capabilities template with all capabilities initially marked unsupported.
  - Added safeguards to ensure required and optional capabilities are explicitly declared.

- **Documentation**
  - Updated the provider contribution guide to display the live capabilities template and clarify structured output options.

- **Bug Fixes**
  - Documentation builds and deployments now respond to changes in the capabilities template.

- **Tests**
  - Added coverage verifying the template defaults and documentation reference the shared source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->