### PR TITLE
fix(cli): a CLI-owned run enforces its own durable wait deadline

### DIFF
--- a/packages/cli/src/commands/workflow-wait.integration.spec.ts
+++ b/packages/cli/src/commands/workflow-wait.integration.spec.ts
@@ -387,6 +387,31 @@ function readNodeCompletedOutput(
 }
 
 /**
+ * Every CLI platform conversation the fixture's database holds.
+ *
+ * An automatic resume that drops the run's conversation id generates a fresh one, so
+ * the resumed segment's dispatch and result land in a second row while the run row
+ * still points at the first. The set is the observable proof that did not happen.
+ */
+function readCliConversationPlatformIds(archonHome: string): string[] {
+  const databasePath = join(archonHome, 'archon.db');
+  if (!existsSync(databasePath)) return [];
+  const database = new Database(databasePath, { readonly: true });
+  try {
+    return database
+      .query<{ platform_conversation_id: string }, []>(
+        "SELECT platform_conversation_id FROM remote_agent_conversations WHERE platform_type = 'cli'"
+      )
+      .all()
+      .map(row => row.platform_conversation_id);
+  } catch {
+    return [];
+  } finally {
+    database.close();
+  }
+}
+
+/**
  * Poll `read` until it produces a value, naming `what` if it never does.
  *
  * The catch is load bearing, not defensive: an owner process creates `archon.db`
@@ -801,10 +826,17 @@ describe('a durable wait deadline is enforced by the owning process', () => {
     'name: wait-long\ndescription: Long durable wait fixture.\n' +
     'nodes:\n' +
     '  - id: cooldown\n    wait:\n      duration_ms: 8000\n';
+  // Two sequential waits: one owner has to carry the run through both, so a loop
+  // that resumes once and stops leaves the run parked at `wait-two`.
+  const TWO_WAITS =
+    'name: wait-twice\ndescription: Two sequential durable waits.\n' +
+    'nodes:\n' +
+    '  - id: wait-one\n    wait:\n      duration_ms: 1500\n' +
+    '  - id: wait-two\n    depends_on: [wait-one]\n    wait:\n      duration_ms: 1500\n';
 
   test('resumes a duration wait at its deadline and finishes the run', async () => {
     const fixture = makeFixture('archon-wait-duration-', { 'wait-duration': DURATION_WAIT });
-    const { runId } = await launchDetached(fixture, 'wait-duration');
+    const { runId, conversationId } = await launchDetached(fixture, 'wait-duration');
 
     const completed = await waitFor(
       'the duration wait to resume and complete the run',
@@ -823,6 +855,35 @@ describe('a durable wait deadline is enforced by the owning process', () => {
     // The engine's own record of the wait: the deadline was genuinely waited, and
     // only then did the owner resume the run.
     expect(Number(output.waited_ms)).toBeGreaterThanOrEqual(3000);
+    // The resumed segment continues the run's original conversation instead of
+    // generating a second one for its dispatch and result card.
+    expect(readCliConversationPlatformIds(fixture.archonHome)).toEqual([conversationId]);
+  }, 120_000);
+
+  test('carries one owner through two sequential waits', async () => {
+    const fixture = makeFixture('archon-wait-twice-', { 'wait-twice': TWO_WAITS });
+    const { runId } = await launchDetached(fixture, 'wait-twice');
+
+    const completed = await waitFor(
+      'both waits to resume and complete the run',
+      () => (readRunStatus(fixture.archonHome, runId) === 'completed' ? 'completed' : undefined),
+      60_000
+    );
+    activeRunIds.delete(runId);
+    expect(completed).toBe('completed');
+
+    const first = await waitFor(
+      'the first wait node completion',
+      () => readNodeCompletedOutput(fixture.archonHome, runId, 'wait-one'),
+      10_000
+    );
+    const second = await waitFor(
+      'the second wait node completion',
+      () => readNodeCompletedOutput(fixture.archonHome, runId, 'wait-two'),
+      10_000
+    );
+    expect(first).toMatchObject({ status: 'satisfied' });
+    expect(second).toMatchObject({ status: 'satisfied' });
   }, 120_000);
 
   test('expires an event wait by its deadline and finishes the run', async () => {
@@ -874,6 +935,15 @@ describe('a durable wait deadline is enforced by the owning process', () => {
   test('leaves an attention wait for the operator and releases its owner', async () => {
     const fixture = makeFixture('archon-wait-attention-', { 'wait-attention': ATTENTION_WAIT });
     const { runId } = await launchDetached(fixture, 'wait-attention');
+
+    // Park first. The control endpoint does not exist until the owner starts, so a
+    // probe before the run is paused would read a not-yet-started owner as a released
+    // one and assert on a `pending` row.
+    await waitFor(
+      'the attention run to park',
+      () => (readRunStatus(fixture.archonHome, runId) === 'paused' ? 'paused' : undefined),
+      30_000
+    );
 
     // An attention wait has no deadline, so its owner must exit rather than sleep.
     // With the endpoint gone nothing in this process can advance the run, which is

--- a/packages/cli/src/commands/workflow-wait.integration.spec.ts
+++ b/packages/cli/src/commands/workflow-wait.integration.spec.ts
@@ -348,6 +348,45 @@ function readRunStatus(archonHome: string, runId: string): string | undefined {
 }
 
 /**
+ * One node's persisted completion output, read straight from the events table.
+ *
+ * A wait node's fixed `{ status, waited_ms }` contract is the engine's own record of
+ * what happened, so it proves more than wall-clock timing: `waited_ms` shows the
+ * deadline was genuinely waited instead of short-circuited, and `status` distinguishes
+ * a satisfied wait from an expired one.
+ */
+function readNodeCompletedOutput(
+  archonHome: string,
+  runId: string,
+  nodeId: string
+): Record<string, unknown> | undefined {
+  const databasePath = join(archonHome, 'archon.db');
+  if (!existsSync(databasePath)) return undefined;
+  const database = new Database(databasePath, { readonly: true });
+  try {
+    const row = database
+      .query<{ data: string }, [string, string]>(
+        `SELECT data FROM remote_agent_workflow_events
+         WHERE workflow_run_id = ? AND step_name = ? AND event_type = 'node_completed'
+         ORDER BY created_at DESC LIMIT 1`
+      )
+      .get(runId, nodeId);
+    if (!row) return undefined;
+    const data = JSON.parse(row.data) as { structured_output?: unknown; node_output?: unknown };
+    const output = data.structured_output ?? data.node_output;
+    const parsed = typeof output === 'string' ? (JSON.parse(output) as unknown) : output;
+    if (typeof parsed !== 'object' || parsed === null) return undefined;
+    return parsed as Record<string, unknown>;
+  } catch {
+    // The owner creates archon.db before applying the schema and Windows can widen
+    // the commit window (#2306); the caller polls, so a transient read is not a result.
+    return undefined;
+  } finally {
+    database.close();
+  }
+}
+
+/**
  * Poll `read` until it produces a value, naming `what` if it never does.
  *
  * The catch is load bearing, not defensive: an owner process creates `archon.db`
@@ -734,4 +773,147 @@ describe('archon workflow wait against a detached run', () => {
     expectWaitExit({ exitCode, payload }, 1);
     expect(payload).toMatchObject({ ok: false, action: 'wait', error: 'not_found' });
   }, 60_000);
+});
+
+/**
+ * #3312: with no `archon serve` anywhere in this block, the process that owns a run
+ * enforces its own durable wait deadline. On a build where the `--detach` child exits
+ * at the pause, every case here leaves the run `paused` forever and fails.
+ */
+describe('a durable wait deadline is enforced by the owning process', () => {
+  const DURATION_WAIT =
+    'name: wait-duration\ndescription: Durable duration wait fixture.\n' +
+    'nodes:\n' +
+    '  - id: warmup\n    bash: "echo ready"\n' +
+    '  - id: cooldown\n    depends_on: [warmup]\n    wait:\n      duration_ms: 3000\n';
+  const EVENT_WAIT =
+    'name: wait-event\ndescription: Durable event wait fixture.\n' +
+    'nodes:\n' +
+    '  - id: warmup\n    bash: "echo ready"\n' +
+    '  - id: checks\n    depends_on: [warmup]\n    wait:\n      event: checks.complete\n      deadline_ms: 1500\n';
+  const ATTENTION_WAIT =
+    'name: wait-attention\ndescription: Durable attention wait fixture.\n' +
+    'nodes:\n' +
+    '  - id: await-operator\n    wait:\n      attention: "Do the outside action, then resume."\n';
+  // Longer than the owner's 5 s poll cadence, so a concurrent release lands while
+  // the owner is still asleep and has to be noticed on its next read.
+  const LONG_WAIT =
+    'name: wait-long\ndescription: Long durable wait fixture.\n' +
+    'nodes:\n' +
+    '  - id: cooldown\n    wait:\n      duration_ms: 8000\n';
+
+  test('resumes a duration wait at its deadline and finishes the run', async () => {
+    const fixture = makeFixture('archon-wait-duration-', { 'wait-duration': DURATION_WAIT });
+    const { runId } = await launchDetached(fixture, 'wait-duration');
+
+    const completed = await waitFor(
+      'the duration wait to resume and complete the run',
+      () => (readRunStatus(fixture.archonHome, runId) === 'completed' ? 'completed' : undefined),
+      60_000
+    );
+    activeRunIds.delete(runId);
+    expect(completed).toBe('completed');
+
+    const output = await waitFor(
+      'the duration wait node completion',
+      () => readNodeCompletedOutput(fixture.archonHome, runId, 'cooldown'),
+      10_000
+    );
+    expect(output).toMatchObject({ status: 'satisfied' });
+    // The engine's own record of the wait: the deadline was genuinely waited, and
+    // only then did the owner resume the run.
+    expect(Number(output.waited_ms)).toBeGreaterThanOrEqual(3000);
+  }, 120_000);
+
+  test('expires an event wait by its deadline and finishes the run', async () => {
+    const fixture = makeFixture('archon-wait-event-', { 'wait-event': EVENT_WAIT });
+    const { runId } = await launchDetached(fixture, 'wait-event');
+
+    const completed = await waitFor(
+      'the event wait to expire and complete the run',
+      () => (readRunStatus(fixture.archonHome, runId) === 'completed' ? 'completed' : undefined),
+      60_000
+    );
+    activeRunIds.delete(runId);
+    expect(completed).toBe('completed');
+
+    const output = await waitFor(
+      'the event wait node completion',
+      () => readNodeCompletedOutput(fixture.archonHome, runId, 'checks'),
+      10_000
+    );
+    expect(output).toMatchObject({ status: 'expired', event: 'checks.complete' });
+    expect(Number(output.waited_ms)).toBeGreaterThanOrEqual(1500);
+  }, 120_000);
+
+  test('workflow wait returns at the run terminal, not at the wait', async () => {
+    const fixture = makeFixture('archon-wait-continuation-', { 'wait-duration': DURATION_WAIT });
+    const { runId } = await launchDetached(fixture, 'wait-duration');
+
+    // Attach only once the run is parked on its wait, so the waiter is watching the
+    // resumed execution rather than racing the first pass.
+    await waitFor(
+      'the duration-wait run to park',
+      () => (readRunStatus(fixture.archonHome, runId) === 'paused' ? 'paused' : undefined),
+      30_000
+    );
+    const waiter = startWait(fixture, runId, 30);
+    expect(await waiter.attached()).toEqual({ observedStatus: 'paused' });
+
+    const settled = await waiter.settled();
+    activeRunIds.delete(runId);
+    // A wait that returned at the pause would carry its own kind, not the run's
+    // terminal transition.
+    expectWaitExit(settled, 0);
+    expect(settled.payload).toMatchObject({
+      result: 'attention',
+      attention: { kind: 'terminal', runId, status: 'completed' },
+    });
+  }, 120_000);
+
+  test('leaves an attention wait for the operator and releases its owner', async () => {
+    const fixture = makeFixture('archon-wait-attention-', { 'wait-attention': ATTENTION_WAIT });
+    const { runId } = await launchDetached(fixture, 'wait-attention');
+
+    // An attention wait has no deadline, so its owner must exit rather than sleep.
+    // With the endpoint gone nothing in this process can advance the run, which is
+    // the difference that keeps a human decision out of the continuation loop.
+    const ownerGone = await waitFor(
+      'the attention owner to release its endpoint',
+      async () => {
+        try {
+          const target = await requestDetachedRunStop(runId);
+          target.release();
+          return undefined;
+        } catch {
+          return 'gone';
+        }
+      },
+      30_000
+    );
+    expect(ownerGone).toBe('gone');
+    expect(readRunStatus(fixture.archonHome, runId)).toBe('paused');
+  }, 90_000);
+
+  test('does not resume a wait another process released', async () => {
+    const fixture = makeFixture('archon-wait-released-', { 'wait-long': LONG_WAIT });
+    const { runId } = await launchDetached(fixture, 'wait-long');
+    await waitFor(
+      'the long-wait run to park',
+      () => (readRunStatus(fixture.archonHome, runId) === 'paused' ? 'paused' : undefined),
+      30_000
+    );
+
+    const abandoned = await runCli(fixture, ['workflow', 'abandon', runId]);
+    if (abandoned.exitCode !== 0) {
+      throw new Error(`abandon failed: ${abandoned.stderr || abandoned.stdout}`);
+    }
+    activeRunIds.delete(runId);
+
+    // The owner is asleep on its own timer here. Whether it notices on the next poll
+    // or loses the resume's compare-and-swap, the released run must stay cancelled —
+    // an owner that resurrects another process's terminal state is the defect.
+    await Bun.sleep(9_000);
+    expect(readRunStatus(fixture.archonHome, runId)).toBe('cancelled');
+  }, 120_000);
 });

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -7794,7 +7794,6 @@ describe('pendingDurableWait — which pauses this process owns', () => {
         })
       )
     ).toEqual({
-      kind: 'time',
       stepName: 'cooldown',
       resumeAt: '2026-01-01T00:01:00.000Z',
       signaled: false,
@@ -7821,7 +7820,6 @@ describe('pendingDurableWait — which pauses this process owns', () => {
         })
       )
     ).toEqual({
-      kind: 'event',
       stepName: 'poll.checks',
       resumeAt: '2026-01-01T00:05:00.000Z',
       signaled: true,

--- a/packages/cli/src/commands/workflow.test.ts
+++ b/packages/cli/src/commands/workflow.test.ts
@@ -37,6 +37,7 @@ import {
   resolveRunStorageRoot as resolveRunStorageRootReal,
 } from '@archon/paths/archon-paths';
 import type { WorkflowEmitterEvent } from '@archon/workflows/event-emitter';
+import type { WorkflowRun, WorkflowRunStatus } from '@archon/workflows/schemas/workflow-run';
 import type * as WorkflowDiscovery from '@archon/workflows/workflow-discovery';
 import type * as WorkflowExecutor from '@archon/workflows/executor';
 import type * as DetachedRunControl from '../utils/detached-run-control';
@@ -70,6 +71,7 @@ import {
   resolveDetachedRunEncryptionEnv,
   maybePrintTierNotice,
   resolveContainerBackendConfig,
+  pendingDurableWait,
   hasUnresolvedWriteback,
   buildNodeSummaries,
   resolveCliExitCode,
@@ -7771,6 +7773,79 @@ describe('workflowRunCommand — detached child adopts the pre-created run (#287
         conversationId: 'cli-123',
       })
     ).rejects.toThrow(/cannot find the run 'run-vanished'/);
+  });
+});
+
+describe('pendingDurableWait — which pauses this process owns', () => {
+  const run = (status: WorkflowRunStatus, metadata: Record<string, unknown>): WorkflowRun =>
+    ({ id: 'run-wait', status, metadata }) as unknown as WorkflowRun;
+
+  it('reads the cursor for a time wait', () => {
+    expect(
+      pendingDurableWait(
+        run('paused', {
+          wait: {
+            owner: 'node',
+            kind: 'time',
+            nodeId: 'cooldown',
+            waitingSince: '2026-01-01T00:00:00.000Z',
+            resumeAt: '2026-01-01T00:01:00.000Z',
+          },
+        })
+      )
+    ).toEqual({
+      kind: 'time',
+      stepName: 'cooldown',
+      resumeAt: '2026-01-01T00:01:00.000Z',
+      signaled: false,
+    });
+  });
+
+  it('marks a signaled event wait and names a loop-owned body wait', () => {
+    expect(
+      pendingDurableWait(
+        run('paused', {
+          wait: {
+            owner: 'loop_group',
+            nodeId: 'poll',
+            bodyWaitId: 'checks',
+            iteration: 2,
+            sessionId: null,
+            sessionProvider: null,
+            kind: 'event',
+            event: 'checks.complete',
+            waitingSince: '2026-01-01T00:00:00.000Z',
+            resumeAt: '2026-01-01T00:05:00.000Z',
+            signaledAt: '2026-01-01T00:00:30.000Z',
+          },
+        })
+      )
+    ).toEqual({
+      kind: 'event',
+      stepName: 'poll.checks',
+      resumeAt: '2026-01-01T00:05:00.000Z',
+      signaled: true,
+    });
+  });
+
+  it('returns nothing for a running run, an attention wait, or an approval gate', () => {
+    expect(pendingDurableWait(run('running', {}))).toBeUndefined();
+    expect(
+      pendingDurableWait(
+        run('paused', {
+          wait: {
+            owner: 'node',
+            kind: 'attention',
+            nodeId: 'await-operator',
+            waitingSince: '2026-01-01T00:00:00.000Z',
+            message: 'Do the outside action',
+          },
+        })
+      )
+    ).toBeUndefined();
+    expect(
+      pendingDurableWait(run('paused', { approval: { nodeId: 'gate', message: 'ok?' } }))
+    ).toBeUndefined();
   });
 });
 

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -1586,8 +1586,9 @@ async function runWorkflowWithOwnedSource(
   // The flag names a run row this process will execute AS, so three things are checked.
   // Be precise about which one carries the weight, because it is not the first.
   //
-  // The owner marker plus `assertDetachedRunProcessOwner` (above) raise the bar, they do
-  // not prove provenance: a plain scripted process is not its own process-group leader,
+  // The owner marker plus `assertDetachedRunProcessOwner` (called by `workflowRunCommand`
+  // before it reaches this function) raise the bar, they do not prove provenance: a plain
+  // scripted process is not its own process-group leader,
   // so cron, CI, and wrapper scripts are blocked — but a foreground command under a real
   // pseudo-tty IS one by default, so a person setting the env var at their own terminal
   // satisfies it. Treat it as a barrier to automated misuse, not as proof that an Archon
@@ -3412,7 +3413,7 @@ async function runWorkflowWithOwnedSource(
         `\nWorkflow paused — waiting for '${wait.stepName}' until ${wait.resumeAt}; ` +
           'this process resumes the run at its deadline.'
       );
-      return { run: pausedRun, wait };
+      return { run: pausedRun, wait, platformConversationId: conversationId };
     }
     if (!presentRunFacts('\nWorkflow paused — waiting for approval.', 'paused')) {
       console.log('\nWorkflow paused — waiting for approval.');
@@ -3449,7 +3450,6 @@ async function runWorkflowWithOwnedSource(
  * waits are excluded at the source: they are a decision, not a deadline.
  */
 export interface DurableWaitCursor {
-  kind: 'time' | 'event';
   stepName: string;
   resumeAt: string;
   signaled: boolean;
@@ -3459,6 +3459,12 @@ export interface DurableWaitCursor {
 export interface PendingWaitContinuation {
   run: WorkflowRun;
   wait: DurableWaitCursor;
+  /**
+   * The platform conversation the first attempt ran under. Threaded into every
+   * continuation so the resumed segment's dispatch and result card stay in the run's
+   * original thread instead of generating a second conversation.
+   */
+  platformConversationId: string;
 }
 
 /**
@@ -3472,7 +3478,6 @@ export function pendingDurableWait(run: WorkflowRun): DurableWaitCursor | undefi
   const wait = run.metadata.wait;
   if (!isWorkflowWaitContext(wait) || wait.kind === 'attention') return undefined;
   return {
-    kind: wait.kind,
     stepName: workflowWaitStepName(wait),
     resumeAt: wait.resumeAt,
     signaled: wait.kind === 'event' && wait.signaledAt !== undefined,
@@ -3521,7 +3526,10 @@ interface WaitResumeAttempt {
 }
 
 /** Mirror `workflowResumeCommand`'s continuation options for a run this process owns. */
-async function buildWaitResumeAttempt(run: WorkflowRun): Promise<WaitResumeAttempt> {
+async function buildWaitResumeAttempt(
+  run: WorkflowRun,
+  platformConversationId: string
+): Promise<WaitResumeAttempt> {
   if (!run.working_path) {
     throw new Error(
       `Workflow run '${run.id}' has no working path recorded.\n` +
@@ -3539,6 +3547,7 @@ async function buildWaitResumeAttempt(run: WorkflowRun): Promise<WaitResumeAttem
       continuationRun: run,
       resume: true,
       codebaseId: run.codebase_id ?? undefined,
+      conversationId: platformConversationId,
       discoveryCwd,
     },
   };
@@ -3623,7 +3632,7 @@ export async function workflowRunCommand(
     }
     if (pending === undefined) return;
     if ((await awaitDurableWaitDeadline(pending.run.id, pending.wait)) === 'stop') return;
-    attempt = await buildWaitResumeAttempt(pending.run);
+    attempt = await buildWaitResumeAttempt(pending.run, pending.platformConversationId);
   }
 }
 

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -69,7 +69,10 @@ import { findCodebaseForCheckoutPath } from '@archon/core/services/codebase-chec
 import { reclaimContainerEnv } from '@archon/core/services/cleanup-service';
 import { waitForRunAttention } from '@archon/core/services/run-attention-watch';
 import type { RunWaitResult } from '@archon/core/services/run-attention-watch';
-import { startRunLiveOwner } from '@archon/core/services/run-live-owner';
+import {
+  startRunLiveOwner,
+  RunLiveOwnerAlreadyOwnedError,
+} from '@archon/core/services/run-live-owner';
 import { discoverWorkflowsWithConfig } from '@archon/workflows/workflow-discovery';
 import { resolveWorkflowName } from '@archon/workflows/router';
 import {
@@ -120,6 +123,7 @@ import {
   workflowRunStatusSchema,
   isApprovalContext,
   isWorkflowWaitContext,
+  workflowWaitStepName,
   isScheduledWorkflowResume,
   skipCauseSchema,
   SUBRUN_METADATA_KEYS,
@@ -1503,11 +1507,9 @@ async function runWorkflowWithOwnedSource(
   cwd: string,
   workflowName: string,
   userMessage: string,
-  options: WorkflowRunOptions = {}
-): Promise<void> {
-  const detachedProcessOwner = process.env[DETACHED_RUN_OWNER_ENV] === '1';
-  if (detachedProcessOwner) Reflect.deleteProperty(process.env, DETACHED_RUN_OWNER_ENV);
-  if (detachedProcessOwner) assertDetachedRunProcessOwner();
+  options: WorkflowRunOptions = {},
+  detachedProcessOwner: boolean
+): Promise<PendingWaitContinuation | undefined> {
   const effectiveDiscoveryCwd = options.discoveryCwd ?? cwd;
   const modelOverrides = options.modelAssignments
     ? parseRunModelAssignments(options.modelAssignments)
@@ -1856,7 +1858,7 @@ async function runWorkflowWithOwnedSource(
           `Created dry-run stub scaffold for ${workflow.name}: ${stubsInitPath} (${String(nodeCount)} nodes)\n`
         );
       }
-      return;
+      return undefined;
     }
     const stubs = await loadDryRunStubs(stubsPath);
     // The install's config + AI profile are what make the per-node provider/model report
@@ -1928,7 +1930,7 @@ async function runWorkflowWithOwnedSource(
           : 'Dry-run failed. See the trace for details.'
       );
     }
-    return;
+    return undefined;
   }
 
   // Validate mutually exclusive flags (defensive — cli.ts checks these for UX, but
@@ -2367,7 +2369,7 @@ async function runWorkflowWithOwnedSource(
         console.warn('Warning: could not open a log file — child output will not be captured.');
       }
     }
-    return;
+    return undefined;
   }
 
   console.log(`Running workflow: ${workflowName}`);
@@ -3136,7 +3138,8 @@ async function runWorkflowWithOwnedSource(
           'cli.workflow_hydrate_resume_failed'
         );
         throw new Error(
-          `Cannot resume workflow '${workflowName}': failed to load prior run state — ${err.message}`
+          `Cannot resume workflow '${workflowName}': failed to load prior run state — ${err.message}`,
+          { cause: err }
         );
       }
       if (!prepared) {
@@ -3400,6 +3403,17 @@ async function runWorkflowWithOwnedSource(
 
   // Check result and exit appropriately
   if (result.success && 'paused' in result && result.paused) {
+    // A durable `time`/`event` wait is this process's own cursor to wake; a gate or
+    // `attention` pause has no deadline and stays with whoever resolves it.
+    const pausedRun = await workflowDb.getWorkflowRun(result.workflowRunId);
+    const wait = pausedRun === null ? undefined : pendingDurableWait(pausedRun);
+    if (pausedRun !== null && wait !== undefined) {
+      console.log(
+        `\nWorkflow paused — waiting for '${wait.stepName}' until ${wait.resumeAt}; ` +
+          'this process resumes the run at its deadline.'
+      );
+      return { run: pausedRun, wait };
+    }
     if (!presentRunFacts('\nWorkflow paused — waiting for approval.', 'paused')) {
       console.log('\nWorkflow paused — waiting for approval.');
     }
@@ -3427,6 +3441,129 @@ async function runWorkflowWithOwnedSource(
     presentRunFacts('\nWorkflow finished.', 'failed');
     throw new WorkflowRunFailedError(result.error, detachedProcessOwner);
   }
+  return undefined;
+}
+
+/**
+ * The durable cursor of a wait that this run's own process must wake. `attention`
+ * waits are excluded at the source: they are a decision, not a deadline.
+ */
+export interface DurableWaitCursor {
+  kind: 'time' | 'event';
+  stepName: string;
+  resumeAt: string;
+  signaled: boolean;
+}
+
+/** A run this process should resume itself once its wait's deadline arrives. */
+export interface PendingWaitContinuation {
+  run: WorkflowRun;
+  wait: DurableWaitCursor;
+}
+
+/**
+ * Read the wait this process owns off a run row, if any.
+ *
+ * `undefined` means the run is not paused on a `time`/`event` wait — a terminal
+ * run, a gate, or an `attention` wait, none of which has a deadline to enforce.
+ */
+export function pendingDurableWait(run: WorkflowRun): DurableWaitCursor | undefined {
+  if (run.status !== 'paused') return undefined;
+  const wait = run.metadata.wait;
+  if (!isWorkflowWaitContext(wait) || wait.kind === 'attention') return undefined;
+  return {
+    kind: wait.kind,
+    stepName: workflowWaitStepName(wait),
+    resumeAt: wait.resumeAt,
+    signaled: wait.kind === 'event' && wait.signaledAt !== undefined,
+  };
+}
+
+/** How soon a sleeping owner notices that another host moved or released its run. */
+const WAIT_CONTINUATION_POLL_MS = 5_000;
+
+/**
+ * Sleep until this run's wait is due, then let the caller resume it.
+ *
+ * The row is re-read every poll rather than trusting the cursor copied at pause
+ * time: `archon serve`'s scan, an operator's `resume`/`resignal`/`abandon`, or a
+ * crash can move or end the wait. A superseded cursor stops the loop instead of
+ * executing a run this process no longer owns; the resume's own compare-and-swap
+ * is the final guard.
+ */
+async function awaitDurableWaitDeadline(
+  runId: string,
+  wait: DurableWaitCursor
+): Promise<'resume' | 'stop'> {
+  let cursor = wait;
+  for (;;) {
+    if (cursor.signaled) return 'resume';
+    const remainingMs = Date.parse(cursor.resumeAt) - Date.now();
+    if (remainingMs <= 0) return 'resume';
+    await new Promise<void>(resolve =>
+      setTimeout(resolve, Math.min(remainingMs, WAIT_CONTINUATION_POLL_MS))
+    );
+    const latest = await workflowDb.getWorkflowRun(runId);
+    const next = latest === null ? undefined : pendingDurableWait(latest);
+    if (next?.stepName !== cursor.stepName || next.resumeAt !== cursor.resumeAt) {
+      return 'stop';
+    }
+    cursor = next;
+  }
+}
+
+/** The invocation parameters of one continuation attempt, in `workflowRunCommand`'s shape. */
+interface WaitResumeAttempt {
+  cwd: string;
+  workflowName: string;
+  userMessage: string;
+  options: WorkflowRunOptions;
+}
+
+/** Mirror `workflowResumeCommand`'s continuation options for a run this process owns. */
+async function buildWaitResumeAttempt(run: WorkflowRun): Promise<WaitResumeAttempt> {
+  if (!run.working_path) {
+    throw new Error(
+      `Workflow run '${run.id}' has no working path recorded.\n` +
+        'Cannot determine where to resume. The run may be too old.'
+    );
+  }
+  const discoveryCwd = run.codebase_id
+    ? await resolveDiscoveryCwdForCodebase(run.id, run.codebase_id, 'resume')
+    : undefined;
+  return {
+    cwd: run.working_path,
+    workflowName: run.workflow_name,
+    userMessage: run.user_message ?? '',
+    options: {
+      continuationRun: run,
+      resume: true,
+      codebaseId: run.codebase_id ?? undefined,
+      discoveryCwd,
+    },
+  };
+}
+
+/**
+ * True when a resume attempt lost the run to another owner rather than failing.
+ *
+ * Both signals mean the row already moved — another host claimed it (the
+ * compare-and-swap) or still holds its endpoint — so the winner finishes it and
+ * this process should stop quietly instead of reporting a failure.
+ */
+function isResumeSuperseded(error: unknown): boolean {
+  const MAX_CAUSE_DEPTH = 5;
+  for (let current: unknown = error, depth = 0; current instanceof Error; depth += 1) {
+    if (
+      current instanceof workflowDb.WorkflowNotResumableError ||
+      current instanceof RunLiveOwnerAlreadyOwnedError
+    ) {
+      return true;
+    }
+    if (depth >= MAX_CAUSE_DEPTH) return false;
+    current = current.cause;
+  }
+  return false;
 }
 
 /**
@@ -3436,6 +3573,13 @@ async function runWorkflowWithOwnedSource(
  * the capture is either adopted by a run or reclaimed. The implementation has a dozen
  * ordinary ways out — unknown workflow, refused inputs, flag conflicts, a detached
  * dispatch — and asking each to remember a disposal call is how most of them did not.
+ *
+ * When the attempt pauses on a durable `time`/`event` wait, this command owns the
+ * run's deadline: it sleeps until `metadata.wait.resumeAt` and re-executes through
+ * the same continuation path `archon workflow resume` uses. That is what makes a
+ * CLI-only install able to finish a wait without `archon serve`. The pause itself is
+ * unchanged — the row stays `paused` and the live owner is released between segments
+ * — so another host can still take the run and this loop then stops.
  */
 export async function workflowRunCommand(
   cwd: string,
@@ -3443,13 +3587,43 @@ export async function workflowRunCommand(
   userMessage: string,
   options: WorkflowRunOptions = {}
 ): Promise<void> {
-  try {
-    await withCapturedSource(owner =>
-      runWorkflowWithOwnedSource(owner, cwd, workflowName, userMessage, options)
-    );
-  } catch (error) {
-    await recordDetachedChildStartupFailure(options.detachedRunId, error as Error);
-    throw error;
+  // Read the marker once, before any provider or bash subprocess can inherit it: every
+  // attempt in this process is the detached owner, and a resumed segment must keep its
+  // active-stop lease (`archon workflow cancel`) and detached failure exit code.
+  const detachedProcessOwner = process.env[DETACHED_RUN_OWNER_ENV] === '1';
+  if (detachedProcessOwner) Reflect.deleteProperty(process.env, DETACHED_RUN_OWNER_ENV);
+
+  let attempt: WaitResumeAttempt = { cwd, workflowName, userMessage, options };
+  for (;;) {
+    let pending: PendingWaitContinuation | undefined;
+    try {
+      // Inside the try so a refused process-group claim still records the `pending` row
+      // the launcher handed over (#2872) instead of stranding it.
+      if (detachedProcessOwner) assertDetachedRunProcessOwner();
+      pending = await withCapturedSource(owner =>
+        runWorkflowWithOwnedSource(
+          owner,
+          attempt.cwd,
+          attempt.workflowName,
+          attempt.userMessage,
+          attempt.options,
+          detachedProcessOwner
+        )
+      );
+    } catch (error) {
+      await recordDetachedChildStartupFailure(options.detachedRunId, error as Error);
+      if (isResumeSuperseded(error)) {
+        getLog().info(
+          { runId: attempt.options.continuationRun?.id, workflowName: attempt.workflowName },
+          'cli.wait_continuation_superseded'
+        );
+        return;
+      }
+      throw error;
+    }
+    if (pending === undefined) return;
+    if ((await awaitDurableWaitDeadline(pending.run.id, pending.wait)) === 'stop') return;
+    attempt = await buildWaitResumeAttempt(pending.run);
   }
 }
 

--- a/packages/core/src/services/run-live-owner.ts
+++ b/packages/core/src/services/run-live-owner.ts
@@ -58,6 +58,18 @@ export class RunLiveOwnerStopUnavailableError extends Error {
   }
 }
 
+/**
+ * Another live process already owns this run's endpoint. Thrown where ownership is
+ * claimed, so a caller that raced another owner can stop instead of dying on a
+ * string it had to match.
+ */
+export class RunLiveOwnerAlreadyOwnedError extends Error {
+  constructor(readonly endpointPath: string) {
+    super(`Run live-owner endpoint is already owned: ${endpointPath}`);
+    this.name = 'RunLiveOwnerAlreadyOwnedError';
+  }
+}
+
 function endpointToken(runId: string): string {
   return createHash('sha256').update(runId).digest('hex').slice(0, 32);
 }
@@ -150,7 +162,7 @@ async function listenWithoutReplacingOwner(server: Server, path: string): Promis
   }
 
   if (await canConnectToRunLiveOwner(path)) {
-    throw new Error(`Run live-owner endpoint is already owned: ${path}`);
+    throw new RunLiveOwnerAlreadyOwnedError(path);
   }
 
   // A crashed Unix owner can leave a socket pathname behind. Refusal, not age,
@@ -168,13 +180,13 @@ async function acquireOwnerLock(runId: string, endpointPath: string): Promise<nu
   }
 
   if (await canConnectToRunLiveOwner(endpointPath)) {
-    throw new Error(`Run live-owner endpoint is already owned: ${endpointPath}`);
+    throw new RunLiveOwnerAlreadyOwnedError(endpointPath);
   }
   // The lock is created immediately before listen. Give that startup window one
   // chance to become reachable before treating both paths as crash residue.
   await new Promise<void>(resolve => setTimeout(resolve, STARTUP_RECHECK_MS));
   if (await canConnectToRunLiveOwner(endpointPath)) {
-    throw new Error(`Run live-owner endpoint is already owned: ${endpointPath}`);
+    throw new RunLiveOwnerAlreadyOwnedError(endpointPath);
   }
 
   rmSync(lockPath, { force: true });

--- a/packages/docs-web/src/content/docs/guides/authoring-workflows.md
+++ b/packages/docs-web/src/content/docs/guides/authoring-workflows.md
@@ -716,7 +716,9 @@ curl -X POST http://localhost:3090/api/workflows/runs/<run-id>/signal \
   -d '{"event":"checks.complete","resumeAt":"<metadata.wait.resumeAt>","payload":{"conclusion":"success"}}'
 ```
 
-Use a Better Auth session cookie instead of `X-Archon-User` when browser authentication is enabled. The header is only for a trusted reverse proxy or loopback client; an auth-disabled local install can omit it. The event name must match the run's open wait. The signal and its audit event are committed together; duplicate or wrong-run signals do nothing. The server must be running for scheduled or event-driven continuation. If it is offline when a deadline passes, the persisted run resumes on the next scan after startup.
+Use a Better Auth session cookie instead of `X-Archon-User` when browser authentication is enabled. The header is only for a trusted reverse proxy or loopback client; an auth-disabled local install can omit it. The event name must match the run's open wait. The signal and its audit event are committed together; duplicate or wrong-run signals do nothing.
+
+The process that owns the run enforces a `duration_ms`/`until`/`event` deadline itself: a foreground `archon workflow run` and the child started by `--detach` stay alive through the wait and re-execute the run when its deadline arrives, so a CLI-only install needs no server. `archon serve`'s continuation scan additionally resumes due waits for runs whose owner is gone — one dispatched by the server, or one whose process died mid-wait. A run can always be advanced by hand with `archon workflow resume <run-id>`; the `/signal` endpoint above still requires the server.
 
 Read `metadata.wait.resumeAt` from the run before sending the signal and pass it back unchanged. It identifies the open wait occurrence, so a delayed retry from an earlier loop iteration cannot satisfy a later wait for the same event.
 


### PR DESCRIPTION
## Problem and outcome

A `wait:` node with `duration_ms`, `until`, or `event` + `deadline_ms` persists its deadline as `metadata.wait.resumeAt` and pauses the run. The only thing that resumed a due wait on its own was `scanDueWorkflowContinuations` inside `archon serve`, so on a CLI-only install a detached run stayed `paused` forever. The SDLC pack's CI wait (`#3155`, adopted in `#3296`) hit this on every delivery whose checks were still pending on the first probe.

- **Outcome:** The process that owns a run enforces the run's own `time`/`event` wait deadline. A foreground `archon workflow run` and the child started by `--detach` stay with the run, sleep until `metadata.wait.resumeAt`, and re-execute it through the same continuation path `archon workflow resume` uses — no server required. `archon workflow wait` on such a run returns at the run's terminal, not at the pause.
- **Invariant:** The pause stays persisted and the run stays `paused`; the expiry decision is still the single `isDue`/`isSignaled` check in `executeWaitNode`. No second implementation of expiry, and a run's owner stays distinguishable from an orphan. `attention` waits keep no deadline and resume only on explicit operator action.
- **Scope boundary:** With a server running, behaviour is unchanged. Container-isolated workflows still refuse durable waits. `--detach` remains fire-and-forget for the launcher, and `archon workflow cancel`/`abandon` semantics are untouched.
- **Root cause:** Nothing in the CLI held the run after the pause. The executor persisted the wait and returned `paused`; the owner process exited, and only the server scan ever flipped a due row back to `running`.

## Review guidance

- **Feedback requested:** Correctness of the ownership/race handling and the loop's lifetime semantics. In particular, whether stopping quietly on a lost race is the right behavior, and whether the resumed segment should keep the detached owner's active-stop lease.
- **Start here:** `packages/cli/src/commands/workflow.ts:3593` — `workflowRunCommand` now drives a non-recursive loop: run an attempt, and if it paused on a durable `time`/`event` wait, sleep and resume.
- **Review order:**
  1. `packages/cli/src/commands/workflow.ts:3406` — the pause branch reads the row and returns the pending cursor for a `time`/`event` wait only.
  2. `packages/cli/src/commands/workflow.ts:3476` — `pendingDurableWait`, the ownership cursor (excludes `attention` and non-paused runs).
  3. `packages/cli/src/commands/workflow.ts:3499` — `awaitDurableWaitDeadline`, which re-reads the row every 5 s so a server or operator move ends the loop.
  4. `packages/core/src/services/run-live-owner.ts:66` — new `RunLiveOwnerAlreadyOwnedError`, thrown from the three existing "already owned" sites.
- **Lower-attention areas:** `packages/docs-web/src/content/docs/guides/authoring-workflows.md` (prose correction only); test additions.
- **Known risk or uncertainty:** A foreground `archon workflow run` now blocks through a `time`/`event` wait instead of returning at the pause. This is the intended consequence of the chosen design; `--detach` and `attention` waits are unaffected. The signaled-event resume branch is the one path without direct test coverage (see Validation).

## Solution

The run's own process enforces the deadline; the pause is not removed.

`runWorkflowWithOwnedSource` returns a `PendingWaitContinuation | undefined`. On the paused path it re-reads the run, and when `pendingDurableWait` sees a `time`/`event` wait it returns the cursor instead of exiting. `workflowRunCommand` loops: it runs an attempt, and when an attempt names a pending durable wait it sleeps until due and rebuilds the resume options in the shape `workflowResumeCommand` uses (`hydrateResumableRun` + `resume: true`), then runs again through the same continuation path. The wait stays persisted and the live owner is released between segments, so a server or `archon workflow resume` can still take the run.

Because another host can move the run mid-sleep, `awaitDurableWaitDeadline` re-reads the row every 5 s and stops if the cursor's step or `resumeAt` changed. A resume that loses the compare-and-swap (`WorkflowNotResumableError`) or the live-owner endpoint (`RunLiveOwnerAlreadyOwnedError`) stops quietly rather than reporting a failure. `RunLiveOwnerAlreadyOwnedError` was added to stop on a typed signal instead of matching a message string; `hydrateResumableRun`'s failure wrapper now preserves `cause` so the typed error survives.

`DETACHED_RUN_OWNER_ENV` is read once in `workflowRunCommand` and threaded into each attempt, so a resumed detached segment keeps its active-stop lease and its failure exit code.

## Behavior change

| | Before | After |
|---|---|---|
| **Observable behavior** | A CLI-only run paused at a `time`/`event` wait and stayed `paused` forever. | The owning process wakes the run at `metadata.wait.resumeAt` and it continues without a server. |
| **Failure behavior** | `archon workflow wait` never returned for such a run. | It returns at the run's terminal state; a lost race stops the losing process quietly. |

### User flow

```mermaid
flowchart LR
  subgraph Before
    B1[CLI run hits wait] --> B2[Paused, owner exits] --> B3[Stuck forever]
  end

  subgraph After
    A1[CLI run hits wait] --> A2[Paused, owner sleeps] --> A3[Deadline arrives] --> A4[Owner resumes run]
  end
```

## Architecture

```mermaid
flowchart LR
  A[workflowRunCommand] --> B[runWorkflowWithOwnedSource]
  B ==> C[pendingDurableWait cursor]
  C --> D[awaitDurableWaitDeadline]
  D ==> E[workflowRunCommand resume attempt]
  E --> B
  F[archon serve scan] -.->|orphan recovery, unchanged| E
```

### Changed seams

| Boundary or contract | Change | Evidence |
|---|---|---|
| `workflowRunCommand → runWorkflowWithOwnedSource` | Returns `PendingWaitContinuation` for a durable wait instead of `void`. | `packages/cli/src/commands/workflow.ts:3406` |
| `run-live-owner → resume caller` | Untyped "already owned" `Error` becomes `RunLiveOwnerAlreadyOwnedError`. | `packages/core/src/services/run-live-owner.ts:66`, `workflow.ts:3563` |
| `CLI → persisted wait row` | Owner now reads and re-reads its own `metadata.wait` cursor; server scan untouched. | `workflow.ts:3476`, `workflow.ts:3499` |

## Validation

- `bun run --cwd packages/cli type-check`; `bun run --cwd packages/core type-check` — pass.
- `bun run --cwd packages/cli test src/commands/workflow.test.ts` — 409 pass, 0 fail; 3 new `pendingDurableWait` cases.
- `bun run --cwd packages/cli test src/commands/workflow-wait.integration.spec.ts` — 16 pass, 0 fail; 6 new cases: duration wait satisfied, two sequential waits carried by one owner, event wait expired, `workflow wait` returns at terminal, attention wait releases its owner, abandoned run not resurrected.
- **Red-first proof** — reverted only `workflow.ts` and `run-live-owner.ts` to the base and ran the new block: 4 fail / 2 pass. The failures are the fix-specific cases (duration wait never completes, two sequential waits never advance, event wait never expires, `workflow wait` exits `deadline` with `observedStatus: paused`). The two negative cases pass on base, as they should.
- `bun run lint --max-warnings 0`, `bun run format:check`, `bun run test`, `bun run validate` — all pass.
- **Not verified:** The signaled-event resume branch (a live `/signal` arriving while the owner sleeps) has no direct test; the fixture covers the event-expiry path. `awaitDurableWaitDeadline` is an unexported helper covered end-to-end rather than by unit test, to avoid widening the module surface.

## Delivery considerations

| Concern | Impact and required action | Evidence |
|---|---|---|
| Compatibility / migration | No schema, migration, or generated-artifact change. The persisted pause and `resumeAt` contract are unchanged. | diff touches no schema files |
| Security / permissions / data | None. The new error type carries the endpoint path already present in the old message. | `run-live-owner.ts:66` |
| Rollout / rollback | Revert is a plain code revert; persisted runs remain resumable by the server or `archon workflow resume`. | — |
| Observability | A superseded continuation logs `cli.wait_continuation_superseded`. | `workflow.ts:3627` |
| Documentation / communication | `authoring-workflows.md` now states the owner enforces the deadline, the server scan covers orphaned runs, and `/signal` still needs the server. | `authoring-workflows.md:721` |

## Links

- Closes #3312



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Workflow runs now automatically continue after duration- and event-based waits, including when started from the CLI without a running server.
  - Detached workflow processes remain active through durable waits and resume execution when conditions are met.
  - Workflows whose owning process stops can still be resumed by the server or manually with `workflow resume`.

- **Bug Fixes**
  - Improved handling and reporting of conflicts when multiple processes attempt to own the same workflow run.

- **Documentation**
  - Updated durable-wait guidance to explain process ownership, server fallback, and manual resumption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->